### PR TITLE
Add webhook_*_from_url methods

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -21,6 +21,7 @@ serde = "1"
 serde_json = "1"
 tokio = "0.2"
 percent-encoding = "2.1"
+url = "2"
 
 [dev-dependencies]
 tokio = "0.2"


### PR DESCRIPTION
This PR adds webhook url parsing to `http::Client`, allowing you to for example:
```rust
client.execute_webhook_from_url("https://discordapp.com/api/webhooks/123456")?
```

Adds `url = "2"` into Cargo.toml, but reqwest already depends on url so no new dependencies were added