### PR TITLE
[http] validate request parameters

### DIFF
--- a/http/examples/allowed-mentions/src/main.rs
+++ b/http/examples/allowed-mentions/src/main.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     client
         .create_message(channel_id)
-        .content(format!("Hi <@{}>", user_id.0))
+        .content(format!("Hi <@{}>", user_id.0))?
         .allowed_mentions()
         .parse_specific_users(vec![user_id])
         .build()

--- a/http/examples/get-message/src/main.rs
+++ b/http/examples/get-message/src/main.rs
@@ -14,6 +14,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         client
             .create_message(channel_id)
             .content(format!("Ping #{}", x))
+            .expect("content not a valid length")
     }))
     .await;
 

--- a/http/examples/proxy/src/main.rs
+++ b/http/examples/proxy/src/main.rs
@@ -19,6 +19,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         client
             .create_message(channel_id)
             .content(format!("Ping #{}", x))
+            .expect("content not a valid length")
     }))
     .await;
 

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -4,7 +4,11 @@ use self::config::ClientConfigBuilder;
 use crate::{
     error::{Error, ResponseError, Result, UrlError},
     ratelimiting::{RatelimitHeaders, Ratelimiter},
-    request::{prelude::*, Request},
+    request::{
+        guild::{create_guild::CreateGuildError, create_guild_channel::CreateGuildChannelError},
+        prelude::*,
+        Request,
+    },
 };
 use log::{debug, warn};
 use reqwest::{
@@ -20,6 +24,7 @@ use std::{
     convert::TryFrom,
     fmt::{Debug, Formatter, Result as FmtResult},
     ops::{Deref, DerefMut},
+    result::Result as StdResult,
     sync::Arc,
 };
 use twilight_model::{
@@ -170,7 +175,7 @@ impl Client {
     /// let guild_id = GuildId(377840580245585931);
     /// let user_id = UserId(114941315417899012);
     /// client.create_ban(guild_id, user_id)
-    ///     .delete_message_days(1)
+    ///     .delete_message_days(1)?
     ///     .reason("memes")
     ///     .await?;
     ///
@@ -258,7 +263,7 @@ impl Client {
     /// let guilds = client.current_user_guilds()
     ///     .after(after)
     ///     .before(before)
-    ///     .limit(25)
+    ///     .limit(25)?
     ///     .await?;
     ///
     /// println!("{:?}", guilds);
@@ -352,7 +357,21 @@ impl Client {
         GetGuild::new(self, guild_id)
     }
 
-    pub fn create_guild(&self, name: impl Into<String>) -> CreateGuild<'_> {
+    /// Create a new request to create a guild.
+    ///
+    /// The minimum length of the name is 2 UTF-8 characters and the maximum is
+    /// 100 UTF-8 characters.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CreateGuildError::NameInvalid`] if the name length is too
+    /// short or too long.
+    ///
+    /// [`CreateGuildError::NameInvalid`]: ../request/guild/enum.CreateGuildError.html#variant.NameInvalid
+    pub fn create_guild(
+        &self,
+        name: impl Into<String>,
+    ) -> StdResult<CreateGuild<'_>, CreateGuildError> {
         CreateGuild::new(self, name)
     }
 
@@ -372,11 +391,22 @@ impl Client {
         GetGuildChannels::new(self, guild_id)
     }
 
+    /// Create a new request to create a guild channel.
+    ///
+    /// The minimum length of the name is 2 UTF-8 characters and the maximum is
+    /// 100 UTF-8 characters.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CreateGuildChannelError::NameInvalid`] if the name length is too
+    /// short or too long.
+    ///
+    /// [`CreateGuildChannelError::NameInvalid`]: ../request/guild/enum.CreateGuildChannelError.html#variant.NameInvalid
     pub fn create_guild_channel(
         &self,
         guild_id: GuildId,
         name: impl Into<String>,
-    ) -> CreateGuildChannel<'_> {
+    ) -> StdResult<CreateGuildChannel<'_>, CreateGuildChannelError> {
         CreateGuildChannel::new(self, guild_id, name)
     }
 

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -10,7 +10,7 @@ use std::{
 };
 use url::ParseError as UrlParseError;
 
-pub type Result<T> = StdResult<T, Error>;
+pub type Result<T, E = Error> = StdResult<T, E>;
 
 #[derive(Debug)]
 pub enum ResponseError {

--- a/http/src/request/channel/message/mod.rs
+++ b/http/src/request/channel/message/mod.rs
@@ -1,11 +1,12 @@
 pub mod allowed_mentions;
-mod create_message;
+pub mod create_message;
+pub mod get_channel_messages;
+pub mod get_channel_messages_configured;
+pub mod update_message;
+
 mod delete_message;
 mod delete_messages;
-mod get_channel_messages;
-mod get_channel_messages_configured;
 mod get_message;
-mod update_message;
 
 pub use self::{
     create_message::CreateMessage,

--- a/http/src/request/channel/mod.rs
+++ b/http/src/request/channel/mod.rs
@@ -1,6 +1,7 @@
 pub mod invite;
 pub mod message;
 pub mod reaction;
+pub mod update_channel;
 pub mod webhook;
 
 mod create_pin;
@@ -10,7 +11,6 @@ mod delete_channel_permission;
 mod delete_pin;
 mod get_channel;
 mod get_pins;
-mod update_channel;
 mod update_channel_permission;
 mod update_channel_permission_configured;
 

--- a/http/src/request/channel/reaction/mod.rs
+++ b/http/src/request/channel/reaction/mod.rs
@@ -1,8 +1,9 @@
+pub mod get_reactions;
+
 mod create_reaction;
 mod delete_all_reaction;
 mod delete_all_reactions;
 mod delete_reaction;
-mod get_reactions;
 
 pub use self::{
     create_reaction::CreateReaction,

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -170,7 +170,7 @@ impl<'a> UpdateChannel<'a> {
             return Err(UpdateChannelError::TopicInvalid);
         }
 
-        self.fields.topic.replace(topic.into());
+        self.fields.topic.replace(topic);
 
         Ok(self)
     }

--- a/http/src/request/guild/ban/mod.rs
+++ b/http/src/request/guild/ban/mod.rs
@@ -1,4 +1,5 @@
-mod create_ban;
+pub mod create_ban;
+
 mod delete_ban;
 mod get_ban;
 mod get_bans;

--- a/http/src/request/guild/create_guild.rs
+++ b/http/src/request/guild/create_guild.rs
@@ -1,4 +1,8 @@
 use crate::request::prelude::*;
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
 use twilight_model::{
     channel::GuildChannel,
     guild::{
@@ -9,6 +13,33 @@ use twilight_model::{
         VerificationLevel,
     },
 };
+
+#[derive(Clone, Debug)]
+pub enum CreateGuildError {
+    /// The name of the guild is either fewer than 2 UTF-8 characters or more
+    /// than 100 UTF-8 characters.
+    NameInvalid,
+    /// The number of channels provided is too many.
+    ///
+    /// The maximum amount is 500.
+    TooManyChannels,
+    /// The number of roles provided is too many.
+    ///
+    /// The maximum amount is 250.
+    TooManyRoles,
+}
+
+impl Display for CreateGuildError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NameInvalid => f.write_str("the guild name is invalid"),
+            Self::TooManyChannels => f.write_str("too many channels were provided"),
+            Self::TooManyRoles => f.write_str("too many roles were provided"),
+        }
+    }
+}
+
+impl Error for CreateGuildError {}
 
 #[derive(Serialize)]
 struct CreateGuildFields {
@@ -29,8 +60,16 @@ pub struct CreateGuild<'a> {
 }
 
 impl<'a> CreateGuild<'a> {
-    pub(crate) fn new(http: &'a Client, name: impl Into<String>) -> Self {
-        Self {
+    pub(crate) fn new(http: &'a Client, name: impl Into<String>) -> Result<Self, CreateGuildError> {
+        Self::_new(http, name.into())
+    }
+
+    fn _new(http: &'a Client, name: String) -> Result<Self, CreateGuildError> {
+        if !validate::guild_name(&name) {
+            return Err(CreateGuildError::NameInvalid);
+        }
+
+        Ok(Self {
             fields: CreateGuildFields {
                 channels: None,
                 default_message_notifications: None,
@@ -43,13 +82,29 @@ impl<'a> CreateGuild<'a> {
             },
             fut: None,
             http,
-        }
+        })
     }
 
-    pub fn channels(mut self, channels: Vec<GuildChannel>) -> Self {
+    /// Set the channels to create with the guild.
+    ///
+    /// The maximum number of channels that can be provided is 500.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CreateGuildError::TooManyChannels`] if the number of channels
+    /// is over 500.
+    ///
+    /// [`CreateGuildError::TooManyChannels`]: enum.CreateGuildError.html#variant.TooManyChannels
+    pub fn channels(mut self, channels: Vec<GuildChannel>) -> Result<Self, CreateGuildError> {
+        // Error 30013
+        // <https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#json>
+        if channels.len() > 500 {
+            return Err(CreateGuildError::TooManyChannels);
+        }
+
         self.fields.channels.replace(channels);
 
-        self
+        Ok(self)
     }
 
     pub fn default_message_notifications(
@@ -86,10 +141,24 @@ impl<'a> CreateGuild<'a> {
         self
     }
 
-    pub fn roles(mut self, roles: Vec<Role>) -> Self {
+    /// Set the roles to create with the guild.
+    ///
+    /// The maximum number of roles that can be provided is 250.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CreateGuildError::TooManyRoles`] if the number of roles is
+    /// over 250.
+    ///
+    /// [`CreateGuildError::TooManyRoles`]: enum.CreateGuildError.html#variant.TooManyRoles
+    pub fn roles(mut self, roles: Vec<Role>) -> Result<Self, CreateGuildError> {
+        if roles.len() > 250 {
+            return Err(CreateGuildError::TooManyRoles);
+        }
+
         self.fields.roles.replace(roles);
 
-        self
+        Ok(self)
     }
 
     fn start(&mut self) -> Result<()> {

--- a/http/src/request/guild/create_guild.rs
+++ b/http/src/request/guild/create_guild.rs
@@ -75,7 +75,7 @@ impl<'a> CreateGuild<'a> {
                 default_message_notifications: None,
                 explicit_content_filter: None,
                 icon: None,
-                name: name.into(),
+                name,
                 region: None,
                 roles: None,
                 verification_level: None,

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -76,7 +76,7 @@ impl<'a> CreateGuildChannel<'a> {
             fields: CreateGuildChannelFields {
                 bitrate: None,
                 kind: None,
-                name: name.into(),
+                name,
                 nsfw: None,
                 parent_id: None,
                 permission_overwrites: None,

--- a/http/src/request/guild/member/mod.rs
+++ b/http/src/request/guild/member/mod.rs
@@ -1,9 +1,10 @@
+pub mod get_guild_members;
+pub mod update_guild_member;
+
 mod add_role_to_member;
-mod get_guild_members;
 mod get_member;
 mod remove_member;
 mod remove_role_from_member;
-mod update_guild_member;
 
 pub use self::{
     add_role_to_member::AddRoleToMember,

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -93,7 +93,7 @@ impl<'a> UpdateGuildMember<'a> {
             return Err(UpdateGuildMemberError::NicknameInvalid);
         }
 
-        self.fields.nick.replace(nick.into());
+        self.fields.nick.replace(nick);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -1,8 +1,29 @@
 use crate::request::prelude::*;
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
 use twilight_model::{
     guild::Member,
     id::{ChannelId, GuildId, RoleId, UserId},
 };
+
+#[derive(Clone, Debug)]
+pub enum UpdateGuildMemberError {
+    /// The nickname is either empty or the length is more than 32 UTF-8
+    /// characters.
+    NicknameInvalid,
+}
+
+impl Display for UpdateGuildMemberError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NicknameInvalid => f.write_str("the nickname length is invalid"),
+        }
+    }
+}
+
+impl Error for UpdateGuildMemberError {}
 
 #[derive(Default, Serialize)]
 struct UpdateGuildMemberFields {
@@ -52,10 +73,29 @@ impl<'a> UpdateGuildMember<'a> {
         self
     }
 
-    pub fn nick(mut self, nick: impl Into<String>) -> Self {
+    /// Set the nickname.
+    ///
+    /// The minimum length is 1 UTF-8 character and the maximum is 32 UTF-8
+    /// characters.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UpdateGuildMemberError::NicknameInvalid`] if the nickname
+    /// length is too short or too long.
+    ///
+    /// [`UpdateGuildMemberError::NicknameInvalid`]: enum.UpdateGuildMemberError.html#variant.NicknameInvalid
+    pub fn nick(self, nick: impl Into<String>) -> Result<Self, UpdateGuildMemberError> {
+        self._nick(nick.into())
+    }
+
+    fn _nick(mut self, nick: String) -> Result<Self, UpdateGuildMemberError> {
+        if !validate::nickname(&nick) {
+            return Err(UpdateGuildMemberError::NicknameInvalid);
+        }
+
         self.fields.nick.replace(nick.into());
 
-        self
+        Ok(self)
     }
 
     pub fn roles(mut self, roles: Vec<RoleId>) -> Self {

--- a/http/src/request/guild/mod.rs
+++ b/http/src/request/guild/mod.rs
@@ -1,20 +1,20 @@
 pub mod ban;
+pub mod create_guild;
+pub mod create_guild_channel;
+pub mod create_guild_prune;
 pub mod emoji;
+pub mod get_audit_log;
+pub mod get_guild_prune_count;
 pub mod integration;
 pub mod member;
 pub mod role;
 
-mod create_guild;
-mod create_guild_channel;
-mod create_guild_prune;
 mod delete_guild;
-mod get_audit_log;
 mod get_guild;
 mod get_guild_channels;
 mod get_guild_embed;
 mod get_guild_invites;
 mod get_guild_preview;
-mod get_guild_prune_count;
 mod get_guild_vanity_url;
 mod get_guild_voice_regions;
 mod get_guild_webhooks;

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -1,4 +1,8 @@
 use crate::request::prelude::*;
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
 use twilight_model::{
     guild::{
         DefaultMessageNotificationLevel,
@@ -8,6 +12,23 @@ use twilight_model::{
     },
     id::{ChannelId, GuildId, UserId},
 };
+
+#[derive(Clone, Debug)]
+pub enum UpdateGuildError {
+    /// The name length is either fewer than 2 UTF-8 characters or more than
+    /// 100 UTF-8 characters.
+    NameInvalid,
+}
+
+impl Display for UpdateGuildError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NameInvalid => f.write_str("the name's length is invalid"),
+        }
+    }
+}
+
+impl Error for UpdateGuildError {}
 
 #[derive(Default, Serialize)]
 struct UpdateGuildFields {
@@ -86,10 +107,29 @@ impl<'a> UpdateGuild<'a> {
         self
     }
 
-    pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.fields.name.replace(name.into());
+    /// Set the name of the guild.
+    ///
+    /// The minimum length is 2 UTF-8 characters and the maximum is 100 UTF-8
+    /// characters.
+    ///
+    /// # Erroors
+    ///
+    /// Returns [`UpdateGuildError::NameInvalid`] if the name length is too
+    /// short or too long.
+    ///
+    /// [`UpdateGuildError::NameInvalid`]: enum.UpdateGuildError.html#variant.NameInvalid
+    pub fn name(self, name: impl Into<String>) -> Result<Self, UpdateGuildError> {
+        self._name(name.into())
+    }
 
-        self
+    fn _name(mut self, name: String) -> Result<Self, UpdateGuildError> {
+        if !validate::guild_name(&name) {
+            return Err(UpdateGuildError::NameInvalid);
+        }
+
+        self.fields.name.replace(name);
+
+        Ok(self)
     }
 
     pub fn owner_id(mut self, owner_id: impl Into<UserId>) -> Self {

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -29,6 +29,7 @@ pub mod user;
 mod get_gateway;
 mod get_gateway_authed;
 mod get_voice_regions;
+mod validate;
 
 pub use self::{
     get_gateway::GetGateway,

--- a/http/src/request/prelude.rs
+++ b/http/src/request/prelude.rs
@@ -1,4 +1,4 @@
-pub(super) use super::{audit_header, Pending, Request};
+pub(super) use super::{audit_header, validate, Pending, Request};
 pub use super::{
     channel::{invite::*, message::*, reaction::*, webhook::*, *},
     get_gateway::GetGateway,

--- a/http/src/request/user/mod.rs
+++ b/http/src/request/user/mod.rs
@@ -1,3 +1,5 @@
+pub mod update_current_user;
+
 mod create_private_channel;
 mod get_current_user;
 mod get_current_user_connections;
@@ -5,7 +7,6 @@ mod get_current_user_guilds;
 mod get_current_user_private_channels;
 mod get_user;
 mod leave_guild;
-mod update_current_user;
 
 pub use self::{
     create_private_channel::CreatePrivateChannel,

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -1,0 +1,205 @@
+/// Contains all of the input validation functions for requests.
+///
+/// This is in a centralised place so that the validation parameters can be kept
+/// up-to-date more easily and because some of the checks are re-used across
+/// different modules.
+
+pub fn ban_delete_message_days(value: u64) -> bool {
+    // <https://discordapp.com/developers/docs/resources/guild#create-guild-ban-query-string-params>
+    value <= 7
+}
+
+pub fn channel_name(value: impl AsRef<str>) -> bool {
+    _channel_name(value.as_ref())
+}
+
+fn _channel_name(value: &str) -> bool {
+    let len = value.chars().count();
+
+    // <https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure>
+    len >= 2 && len <= 100
+}
+
+pub fn content_limit(value: impl AsRef<str>) -> bool {
+    _content_limit(value.as_ref())
+}
+
+fn _content_limit(value: &str) -> bool {
+    // <https://discordapp.com/developers/docs/resources/channel#create-message-params>
+    value.chars().count() <= 2000
+}
+
+pub fn get_audit_log_limit(value: u64) -> bool {
+    // <https://discordapp.com/developers/docs/resources/audit-log#get-guild-audit-log-query-string-parameters>
+    value > 0 && value <= 100
+}
+
+pub fn get_channel_messages_limit(value: u64) -> bool {
+    // <https://discordapp.com/developers/docs/resources/channel#get-channel-messages-query-string-params>
+    value > 0 && value <= 100
+}
+
+pub fn get_current_user_guilds_limit(value: u64) -> bool {
+    // <https://discordapp.com/developers/docs/resources/user#get-current-user-guilds-query-string-params>
+    value > 0 && value <= 100
+}
+
+pub fn get_guild_members_limit(value: u64) -> bool {
+    // <https://discordapp.com/developers/docs/resources/guild#list-guild-members-query-string-params>
+    value > 0 && value <= 1000
+}
+
+pub fn get_reactions_limit(value: u64) -> bool {
+    // <https://discordapp.com/developers/docs/resources/channel#get-reactions-query-string-params>
+    value > 0 && value <= 100
+}
+
+pub fn guild_name(value: impl AsRef<str>) -> bool {
+    _guild_name(value.as_ref())
+}
+
+fn _guild_name(value: &str) -> bool {
+    let len = value.chars().count();
+
+    // <https://discordapp.com/developers/docs/resources/guild#guild-object-guild-structure>
+    len >= 2 && len <= 100
+}
+
+pub fn guild_prune_days(value: u64) -> bool {
+    // <https://discordapp.com/developers/docs/resources/guild#get-guild-prune-count-query-string-params>
+    value > 0
+}
+
+pub fn nickname(value: impl AsRef<str>) -> bool {
+    _nickname(value.as_ref())
+}
+
+fn _nickname(value: &str) -> bool {
+    let len = value.chars().count();
+
+    // <https://discordapp.com/developers/docs/resources/user#usernames-and-nicknames>
+    len > 0 && len <= 32
+}
+
+pub fn username(value: impl AsRef<str>) -> bool {
+    // <https://discordapp.com/developers/docs/resources/user#usernames-and-nicknames>
+    _username(value.as_ref())
+}
+
+fn _username(value: &str) -> bool {
+    let len = value.chars().count();
+
+    len >= 2 && len <= 32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ban_delete_message_days() {
+        assert!(ban_delete_message_days(0));
+        assert!(ban_delete_message_days(1));
+        assert!(ban_delete_message_days(7));
+
+        assert!(!ban_delete_message_days(8));
+    }
+
+    #[test]
+    fn test_channel_name() {
+        assert!(channel_name("aa"));
+        assert!(channel_name("a".repeat(100)));
+
+        assert!(!channel_name(""));
+        assert!(!channel_name("a"));
+        assert!(!channel_name("a".repeat(101)));
+    }
+
+    #[test]
+    fn test_content_limit() {
+        assert!(content_limit(""));
+        assert!(content_limit("a".repeat(2000)));
+
+        assert!(!content_limit("a".repeat(2001)));
+    }
+
+    #[test]
+    fn test_get_audit_log_limit() {
+        assert!(get_audit_log_limit(1));
+        assert!(get_audit_log_limit(100));
+
+        assert!(!get_audit_log_limit(0));
+        assert!(!get_audit_log_limit(101));
+    }
+
+    #[test]
+    fn test_get_channels_limit() {
+        assert!(get_channel_messages_limit(1));
+        assert!(get_channel_messages_limit(100));
+
+        assert!(!get_channel_messages_limit(0));
+        assert!(!get_channel_messages_limit(101));
+    }
+
+    #[test]
+    fn test_get_current_user_guilds_limit() {
+        assert!(get_current_user_guilds_limit(1));
+        assert!(get_current_user_guilds_limit(100));
+
+        assert!(!get_current_user_guilds_limit(0));
+        assert!(!get_current_user_guilds_limit(101));
+    }
+
+    #[test]
+    fn test_get_guild_members_limit() {
+        assert!(get_guild_members_limit(1));
+        assert!(get_guild_members_limit(1000));
+
+        assert!(!get_guild_members_limit(0));
+        assert!(!get_guild_members_limit(1001));
+    }
+
+    #[test]
+    fn test_get_reactions_limit() {
+        assert!(get_reactions_limit(1));
+        assert!(get_reactions_limit(100));
+
+        assert!(!get_reactions_limit(0));
+        assert!(!get_reactions_limit(101));
+    }
+
+    #[test]
+    fn test_guild_name() {
+        assert!(guild_name("aa"));
+        assert!(guild_name("a".repeat(100)));
+
+        assert!(!guild_name(""));
+        assert!(!guild_name("a"));
+        assert!(!guild_name("a".repeat(101)));
+    }
+
+    #[test]
+    fn test_guild_prune_days() {
+        assert!(!guild_prune_days(0));
+        assert!(guild_prune_days(1));
+        assert!(guild_prune_days(100));
+    }
+
+    #[test]
+    fn test_nickname() {
+        assert!(nickname("a"));
+        assert!(nickname("a".repeat(32)));
+
+        assert!(!nickname(""));
+        assert!(!nickname("a".repeat(33)));
+    }
+
+    #[test]
+    fn test_username() {
+        assert!(username("aa"));
+        assert!(username("a".repeat(32)));
+
+        assert!(!username("a"));
+        assert!(!username("a".repeat(33)));
+    }
+}


### PR DESCRIPTION
When creating HTTP requests, validate the request parameters. This
includes things like checking that the content length of a message is
less than or equal to 2000 characters[1], that a new channel's name is
within the range of 2-100 characters[2], and more.

The request methods that do validation now return results with an error
type that is local to the module. For example, the
`http::request::channel::UpdateChannel::name` method can return an
error, which is defined at
`http::request::channel::update_channel::UpdateChannelError`.

Validation functions are located in `http::request::validation`, which
includes functions that simply return booleans of whether the input is
valid or not. Each of these sources where the validation limits are
documented. Some things, such as custom emoji names, don't have a
documented length limit[3], so validation isn't done for them.

[1]: https://discordapp.com/developers/docs/resources/channel#create-message-params
[2]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure
[3]: https://discordapp.com/developers/docs/resources/emoji#create-guild-emoji-json-params

Closes issue #29.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>