### PR TITLE
Fix lost events

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         ))
         .build();
 
-    // Start up the cluster
+    // Create the cluster
     let cluster = Cluster::new(config);
-    cluster.up().await?;
 
     // The http client is seperate from the gateway,
     // so startup a new one
@@ -133,8 +132,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .build();
     let cache = InMemoryCache::from(cache_config);
 
-
-    let mut events = cluster.events().await;
+    // Start the cluster
+    let mut events = cluster.events().await?;
     // Startup an event loop for each event in the event stream
     while let Some(event) = events.next().await {
         // Update the cache

--- a/gateway/examples/cluster/src/main.rs
+++ b/gateway/examples/cluster/src/main.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let cluster = Cluster::new(config);
 
-    cluster.up().await?;
-
-    let mut events = cluster.events().await;
+    let mut events = cluster.events().await?;
 
     while let Some((id, event)) = events.next().await {
         println!("Shard: {}, Event: {:?}", id, event.event_type());

--- a/gateway/examples/metrics/src/main.rs
+++ b/gateway/examples/metrics/src/main.rs
@@ -23,10 +23,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let cluster = Cluster::new(env::var("DISCORD_TOKEN")?);
     println!("Created cluster");
 
-    cluster.up().await?;
-    println!("Started cluster");
-
-    let mut events = cluster.events().await;
+    let mut events = cluster.events().await?;
 
     // Start exporter in a seperate task
     tokio::task::spawn_blocking(move || exporter.run());

--- a/gateway/src/cluster/mod.rs
+++ b/gateway/src/cluster/mod.rs
@@ -16,9 +16,7 @@
 ///     let token = env::var("DISCORD_TOKEN")?;
 ///     let cluster = Cluster::new(token);
 ///
-///     cluster.up().await?;
-///
-///     let mut events = cluster.events().await;
+///     let mut events = cluster.events().await?;
 ///
 ///     while let Some((shard_id, event)) = events.next().await {
 ///         tokio::spawn(handle_event(cluster.clone(), shard_id, event));

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -180,6 +180,7 @@ impl ShardProcessor {
 
                 match dispatch.deref() {
                     DispatchEvent::Ready(ready) => {
+                        println!("Ready sent [{:?}]", self.config.shard());
                         self.session.set_stage(Stage::Connected);
                         self.session.set_id(&ready.session_id).await;
                     },

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -96,9 +96,8 @@
 //!
 //!     let cluster_config = ClusterConfig::builder(&token).build();
 //!     let cluster = Cluster::new(cluster_config);
-//!     cluster.up().await?;
 //!
-//!     let mut events = cluster.events().await;
+//!     let mut events = cluster.events().await?;
 //!
 //!     while let Some(event) = events.next().await {
 //!         tokio::spawn(handle_event(event, http.clone()));


### PR DESCRIPTION
This change happens because some events were
getting lost especially from the first started
shards. This removes the `up(&self)` method which
started the cluster and replaces it with the `event`
and `some_event` methods which starts the cluster
and returns a stream.

------------------
### Note

This should be seen as a temporary solution, we have to figure out a way where you can start receiving messages while the shards are getting started. This way and the way it was before does
not allow them to start forwarding events before all the shards have started. While it may not be an
issue for smaller bot. it will certainly be an issue for larger bots.