### PR TITLE
Fix voice state cache panic

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -706,11 +706,10 @@ impl InMemoryCache {
             // To avoid the dead voice states from going stale and clogging up the cache,
             // we do an iteration over the keys and find the one with the matching session ID,
             // grab the full key, and remove the old key from the cache.
-            let mut lock = self.0.voice_states
-                .lock()
-                .await;
+            let mut lock = self.0.voice_states.lock().await;
             
-            let stale_k_search = lock.keys()
+            let stale_k_search = lock
+                .keys()
                 .find(|k| k.1 == vs.user_id)
                 .and_then(|k| Some(k.clone()));
 

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -112,14 +112,13 @@ struct InMemoryCacheRef {
     guild_members: Mutex<HashMap<GuildId, HashSet<UserId>>>,
     guild_presences: Mutex<HashMap<GuildId, HashSet<UserId>>>,
     guild_roles: Mutex<HashMap<GuildId, HashSet<RoleId>>>,
-    guild_voice_states: Mutex<HashMap<GuildId, HashSet<UserId>>>,
+    guild_voice_states: Mutex<HashMap<GuildId, HashMap<UserId, Arc<VoiceState>>>>,
     members: LockedArcMap<(GuildId, UserId), CachedMember>,
     messages: Mutex<HashMap<ChannelId, BTreeMap<MessageId, Arc<CachedMessage>>>>,
     presences: LockedArcMap<(Option<GuildId>, UserId), CachedPresence>,
     roles: Mutex<HashMap<RoleId, GuildItem<Role>>>,
     unavailable_guilds: Mutex<HashSet<GuildId>>,
     users: LockedArcMap<UserId, User>,
-    voice_states: LockedArcMap<UserId, CachedVoiceState>,
 }
 
 /// A thread-safe, in-memory-process cache of Discord data. It can be cloned and
@@ -343,14 +342,14 @@ impl InMemoryCache {
     pub async fn voice_state(
         &self,
         user_id: UserId,
-    ) -> Result<Option<Arc<CachedVoiceState>>> {
-        Ok(self
-            .0
-            .voice_states
-            .lock()
-            .await
-            .get(&user_id)
-            .cloned())
+        guild_id: GuildId,
+    ) -> Result<Option<Arc<VoiceState>>> {
+        if let Some(guild_map) = self.0.guild_voice_states.lock().await.get(&guild_id) {
+            let vs = guild_map.get(&user_id).cloned();
+            Ok(vs)
+        } else {
+            Ok(None)
+        }
     }
 
     /// Clears the entire state of the Cache. This is equal to creating a new
@@ -363,7 +362,7 @@ impl InMemoryCache {
         self.0.presences.lock().await.clear();
         self.0.roles.lock().await.clear();
         self.0.users.lock().await.clear();
-        self.0.voice_states.lock().await.clear();
+        self.0.guild_voice_states.lock().await.clear();
 
         Ok(())
     }
@@ -482,36 +481,43 @@ impl InMemoryCache {
             .await;
         self.cache_voice_states(guild.voice_states.into_iter().map(|(_, v)| v))
             .await;
+
         self.0
             .guild_channels
             .lock()
             .await
             .insert(guild.id, HashSet::new());
+
         self.0
             .guild_emojis
             .lock()
             .await
             .insert(guild.id, HashSet::new());
+
         self.0
             .guild_members
             .lock()
             .await
             .insert(guild.id, HashSet::new());
+
         self.0
             .guild_presences
             .lock()
             .await
             .insert(guild.id, HashSet::new());
+
         self.0
             .guild_roles
             .lock()
             .await
             .insert(guild.id, HashSet::new());
+
         self.0
             .guild_voice_states
             .lock()
             .await
-            .insert(guild.id, HashSet::new());
+            .insert(guild.id, HashMap::new());
+
         let guild = CachedGuild {
             id: guild.id,
             afk_channel_id: guild.afk_channel_id,
@@ -696,31 +702,41 @@ impl InMemoryCache {
         HashSet::from_iter(ids)
     }
 
-    async fn cache_voice_state(&self, vs: VoiceState) -> Option<Arc<CachedVoiceState>> {
-        let k = vs.user_id;
+    async fn cache_voice_state(&self, vs: VoiceState) -> Option<Arc<VoiceState>> {
+        // This should always exist, but just incase use a match
+        let guild_id = match vs.guild_id {
+            Some(id) => id,
+            None => return None,
+        };
+
+        let user_id = vs.user_id;
+
+        let mut lock = self.0.guild_voice_states.lock().await;
+        // This won't panic because we always insert a hashmap for each guild that the bot knows
+        // about, and to even receive events for them, we must have a key for them already.
+        let guild_states = lock.get_mut(&guild_id).unwrap();
 
         // If a user leaves a voice channel, then the `VoiceState` object received contains no
         // channel id.
         if vs.channel_id.is_none() {
             // To avoid the dead voice states from going stale and clogging up the cache,
-            // we do an iteration over the keys and find the one with the matching session ID,
-            // grab the full key, and remove the old key from the cache.
-            let mut lock = self.0.voice_states.lock().await;
-            
-            lock.remove(&k);
+            // we remove it.
+            guild_states.remove(&user_id);
 
             return None;
         }
 
-        match self.0.voice_states.lock().await.get(&k) {
+        // This won't panic for the reason above.
+        match guild_states.get(&user_id) {
             Some(v) if **v == vs => return Some(Arc::clone(v)),
-            Some(_) | None => {},
+            Some(_) | None => {}
         }
 
-        let state = Arc::new(CachedVoiceState {
+        let state = Arc::new(VoiceState {
             channel_id: vs.channel_id,
             deaf: vs.deaf,
             guild_id: vs.guild_id,
+            member: vs.member,
             mute: vs.mute,
             self_deaf: vs.self_deaf,
             self_mute: vs.self_mute,
@@ -731,11 +747,7 @@ impl InMemoryCache {
             user_id: vs.user_id,
         });
 
-        self.0
-            .voice_states
-            .lock()
-            .await
-            .insert(k, Arc::clone(&state));
+        guild_states.insert(user_id, Arc::clone(&state));
 
         Some(state)
     }

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -336,7 +336,7 @@ impl InMemoryCache {
         Ok(self.0.users.lock().await.get(&user_id).cloned())
     }
 
-    /// Gets a voice state by user ID.
+    /// Gets a voice state by user ID and Guild ID.
     ///
     /// This is an O(1) operation.
     pub async fn voice_state(

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -219,7 +219,8 @@ impl UpdateCache<InMemoryCache, InMemoryCacheError> for GuildDelete {
         remove_ids(&cache.0.guild_channels, &cache.0.channels_guild, id).await;
         remove_ids(&cache.0.guild_emojis, &cache.0.emojis, id).await;
         remove_ids(&cache.0.guild_roles, &cache.0.roles, id).await;
-        remove_ids(&cache.0.guild_voice_states, &cache.0.voice_states, id).await;
+        // Clear out a guilds voice states when a guild leaves
+        cache.0.guild_voice_states.lock().await.remove(&id);
 
         if let Some(ids) = cache.0.guild_members.lock().await.remove(&id) {
             let mut members = cache.0.members.lock().await;


### PR DESCRIPTION
Closes #161. The `cache_voice_state` function of the in memory cache now returns an option, because the voice state updates don't always contain an `channel_id`. The new behavior is to act as before when it exists, and when it doesn't, it finds the full key of that now dead voice state and removes it from the cache so it doesn't fill up with dead voice states. 

One thing to consider is that is the `user_id` alone enough to look for the dead state's key? I didn't think that a user could be in more then one voice channel at once, so technically with dead states being removed it should be a "unique" key in the underlying `HashMap`.