### PR TITLE
project: update to discord.com domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The main `twilight` crate is a "skeleton crate": it includes all of the
 non-vendor-specific crates in the `twilight` ecosystem.
 
 ## Installation
- 
+
 Most of Twilight requires at least 1.40+ (rust stable).
 
 Add this to your `Cargo.toml`'s `[dependencies]` section:
@@ -171,7 +171,7 @@ async fn handle_event(
 All first-party crates are licensed under [ISC][LICENSE.md]
 
 [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/master/LICENSE.md
-[docs:discord:sharding]: https://discordapp.com/developers/docs/topics/gateway#sharding
+[docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
 [license link]: https://opensource.org/licenses/ISC
 [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/master/logo.png

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -723,7 +723,7 @@ impl Client {
         } = request;
 
         let protocol = if self.state.use_http { "http" } else { "https" };
-        let url = format!("{}://discordapp.com/api/v6/{}", protocol, path);
+        let url = format!("{}://discord.com/api/v6/{}", protocol, path);
 
         debug!("URL: {:?}", url);
 
@@ -911,11 +911,11 @@ mod tests {
     #[test]
     fn parse_webhook_id() -> Result<(), Box<dyn Error>> {
         assert_eq!(
-            parse_webhook_url("https://discordapp.com/api/webhooks/123")?,
+            parse_webhook_url("https://discord.com/api/webhooks/123")?,
             (WebhookId(123), None)
         );
-        assert!(parse_webhook_url("https://discordapp.com/foo/bar/456").is_err());
-        assert!(parse_webhook_url("https://discordapp.com/api/webhooks/").is_err());
+        assert!(parse_webhook_url("https://discord.com/foo/bar/456").is_err());
+        assert!(parse_webhook_url("https://discord.com/api/webhooks/").is_err());
 
         Ok(())
     }
@@ -923,12 +923,12 @@ mod tests {
     #[test]
     fn parse_webhook_token() -> Result<(), Box<dyn Error>> {
         assert_eq!(
-            parse_webhook_url("https://discordapp.com/api/webhooks/456/token")?,
+            parse_webhook_url("https://discord.com/api/webhooks/456/token")?,
             (WebhookId(456), Some("token".into()))
         );
 
         assert_eq!(
-            parse_webhook_url("https://discordapp.com/api/webhooks/456/token/slack")?,
+            parse_webhook_url("https://discord.com/api/webhooks/456/token/slack")?,
             (WebhookId(456), Some("token".into()))
         );
 

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -132,7 +132,7 @@
 //! All first-party crates are licensed under [ISC][LICENSE.md]
 //!
 //! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/master/LICENSE.md
-//! [docs:discord:sharding]: https://discordapp.com/developers/docs/topics/gateway#sharding
+//! [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
 //! [license link]: https://opensource.org/licenses/ISC
 //! [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/master/logo.png


### PR DESCRIPTION
Update to use the discord.com domain, because discordapp.com is now
soft-deprecated but without an official notice on the docs.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>