### PR TITLE
actions: run audit only on cargo.toml update

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,11 @@ on:
   schedule:
   - cron: "0 0 * * *"
   push:
+    paths:
+      - '**/Cargo.toml'
   pull_request:
+    paths:
+      - '**/Cargo.toml'
 
 jobs:
   audit:


### PR DESCRIPTION
Run the Audit action only when the Cargo.toml file has been updated on
pushes and PRs, instead of on every commit. There isn't a practical
reason to run this on every commit.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>