### PR TITLE
http: add native and rustls features

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -25,7 +25,7 @@ url = "2"
 
 [features]
 default = ["native"]
-native = ["reqwest/native-tls"]
+native = ["reqwest/default-tls"]
 rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -23,5 +23,10 @@ tokio = "0.2"
 percent-encoding = "2.1"
 url = "2"
 
+[features]
+default = ["native"]
+native = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls-tls"]
+
 [dev-dependencies]
 tokio = { features = ["macros"], version = "0.2" }

--- a/http/README.md
+++ b/http/README.md
@@ -5,7 +5,7 @@ HTTP support for the twilight ecosystem.
 ## Features
 
 `twilight-http` includes two features: `native` and `rustls`. `native` is
-enabled by default. `native` will enable `reqwest`'s `native-tls` feature,
+enabled by default. `native` will enable `reqwest`'s `default-tls` feature,
 which will use the TLS library native to your OS (for example, OpenSSL on
 Linux). `rustls` will enable `reqwest`'s `rustls-tls` feature, which will use
 [rustls].

--- a/http/README.md
+++ b/http/README.md
@@ -1,0 +1,25 @@
+# twilight-http
+
+HTTP support for the twilight ecosystem.
+
+## Features
+
+`twilight-http` includes two features: `native` and `rustls`. `native` is
+enabled by default. `native` will enable `reqwest`'s `native-tls` feature,
+which will use the TLS library native to your OS (for example, OpenSSL on
+Linux). `rustls` will enable `reqwest`'s `rustls-tls` feature, which will use
+[rustls].
+
+If you want to use Rustls instead of your native library, it's easy to switch it
+out:
+
+```toml
+[dependencies]
+twilight-http = { default-features = false, features = ["rustls"], git = "https://github.com/twilight-rs/twilight" }
+```
+
+You can also choose to use neither feature. This is only useful if you provide
+your own configured Reqwest client to the HTTP client, otherwise you will
+encounter TLS errors.
+
+[rustls]: https://github.com/ctz/rustls


### PR DESCRIPTION
Add two features to the `http` crate: `native` and `rustls`. `native`
enables `reqwest`'s `default-tls` feature, while `rustls` enables
`reqwest`'s `rustls-tls` feature. `native` is enabled by default.

This is a part of issue #124.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>