### PR TITLE
model/gateway: export reaction_remove_emoji

### DIFF
--- a/model/src/gateway/payload/mod.rs
+++ b/model/src/gateway/payload/mod.rs
@@ -1,4 +1,5 @@
 pub mod identify;
+pub mod reaction_remove_emoji;
 pub mod resume;
 pub mod update_status;
 
@@ -28,7 +29,6 @@ mod presence_update;
 mod reaction_add;
 mod reaction_remove;
 mod reaction_remove_all;
-mod reaction_remove_emoji;
 mod ready;
 mod request_guild_members;
 mod role_create;

--- a/model/src/gateway/payload/reaction_remove_emoji.rs
+++ b/model/src/gateway/payload/reaction_remove_emoji.rs
@@ -9,7 +9,7 @@ pub struct ReactionRemoveEmoji {
     pub channel_id: ChannelId,
     pub message_id: MessageId,
     pub guild_id: GuildId,
-    pub emoji: ParitalEmoji,
+    pub emoji: PartialEmoji,
 }
 
 #[cfg_attr(
@@ -17,7 +17,7 @@ pub struct ReactionRemoveEmoji {
     derive(serde::Deserialize, serde::Serialize)
 )]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct ParitalEmoji {
+pub struct PartialEmoji {
     id: Option<EmojiId>,
     name: String,
 }


### PR DESCRIPTION
In the gateway's payload module, export the `reaction_remove_emoji`
module. The `payload` module already re-exports the
`ReactionRemoveEmoji` struct within it, but that struct contains a
`PartialEmoji` local to its module. The `PartialEmoji` wasn't
re-exported, so the type couldn't be named.

`PartialEmoji` isn't important enough to export from the `payload`
module, so this exports the `reaction_remove_emoji` module.
Also, this fixes a typo in `PartialEmoji`'s name from `ParitalEmoji`.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>