### PR TITLE
Enable cargo-audit tool cache

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Install cargo-audit
-      run: cargo install cargo-audit
+    - uses: actions-rs/install@v0.1
+      with:
+        crate: cargo-audit
+        version: latest
+        use-tool-cache: true
     - name: Run cargo-audit
       run: cargo audit


### PR DESCRIPTION
This should drastically speed up CI times, as cargo-audit is currently the slowest task to run when it does run.

For information on how this works, see this:
https://github.com/actions-rs/install#tool-cache