### PR TITLE
http: parse api errors in responses

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -17,8 +17,9 @@ futures = "0.3"
 twilight-model = { path = "../model" }
 log = "0.4"
 reqwest = "0.10"
-serde = "1"
+serde = { features = ["derive"], version = "1" }
 serde_json = "1"
+serde_repr = { default-features = false, version = "0.1" }
 tokio = "0.2"
 percent-encoding = "2.1"
 url = "2"
@@ -29,4 +30,5 @@ native = ["reqwest/default-tls"]
 rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
+serde_test = { default-features = false, version = "1" }
 tokio = { features = ["macros"], version = "0.2" }

--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -1,0 +1,452 @@
+use serde::{
+    de::{Error as DeError, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ErrorCode {
+    /// General error (such as a malformed request body, amongst other things)
+    GeneralError,
+    /// Unknown account
+    UnknownAccount,
+    /// Unknown application
+    UnknownApplication,
+    /// Unknown channel
+    UnknownChannel,
+    /// Unknown guild
+    UnknownGuild,
+    /// Unknown integration
+    UnknownIntegration,
+    /// Unknown invite
+    UnknownInvite,
+    /// Unknown member
+    UnknownMember,
+    /// Unknown message
+    UnknownMessage,
+    /// Unknown permission overwrite
+    UnknownPermissionOverwrite,
+    /// Unknown provider
+    UnknownProvider,
+    /// Unknown role
+    UnknownRole,
+    /// Unknown token
+    UnknownToken,
+    /// Unknown user
+    UnknownUser,
+    /// Unknown emoji
+    UnknownEmoji,
+    /// Unknown webhook
+    UnknownWebhook,
+    /// Unknown ban
+    UnknownBan,
+    /// Unknown SKU
+    UnknownSKU,
+    /// Unknown Store Listing
+    UnknownStoreListing,
+    /// Unknown entitlement
+    UnknownEntitlement,
+    /// Unknown build
+    UnknownBuild,
+    /// Unknown lobby
+    UnknownLobby,
+    /// Unknown branch
+    UnknownBranch,
+    /// Unknown redistributable
+    UnknownRedistributable,
+    /// Bots cannot use this endpoint
+    BotsCannotUseEndpoint,
+    /// Only bots can use this endpoint
+    OnlyBotsCanUseEndpoint,
+    /// Maximum number of guilds reached (100)
+    MaximumGuildsReached,
+    /// Maximum number of friends reached (1000)
+    MaximumFriendsReached,
+    /// Maximum number of pins reached for the channel (50)
+    MaximumPinsReached,
+    /// Maximum number of guild roles reached (250)
+    MaximumRolesReached,
+    /// Maximum number of webhooks reached (10)
+    MaximumWebhooksReached,
+    /// Maximum number of reactions reached (20)
+    MaximumReactionsReached,
+    /// Maximum number of guild channels reached (500)
+    MaximumGuildChannelsReached,
+    /// Maximum number of attachments in a message reached (10)
+    MaximumAttachmentsReached,
+    /// Maximum number of invites reached (1000)
+    MaximumInvitesReached,
+    /// Unauthorized. Provide a valid token and try again
+    Unauthorized,
+    /// You need to verify your account in order to perform this action
+    AccountNeedsVerification,
+    /// Request entity too large. Try sending something smaller in size
+    RequestEntityTooLarge,
+    /// This feature has been temporarily disabled server-side
+    FeatureTemporarilyDisabled,
+    /// The user is banned from this guild
+    UserBannedFromGuild,
+    /// Missing access
+    Missingaccess,
+    /// Invalid account type
+    InvalidAccountType,
+    /// Cannot execute action on a DM channel
+    InvalidDMChannelAction,
+    /// Guild widget disabled
+    GuildWidgetDisabled,
+    /// Cannot edit a message authored by another user
+    MessageNotAuthoredByUser,
+    /// Cannot send an empty message
+    EmptyMessage,
+    /// Cannot send messages to this user
+    CannotSendMessageToUser,
+    /// Cannot send messages in a voice channel
+    CannotSendMessagesInVoiceChannel,
+    /// Channel verification level is too high for you to gain access
+    VerificationLevelTooHigh,
+    /// OAuth2 application does not have a bot
+    OAuthApplicationHasNoBot,
+    /// OAuth2 application limit reached
+    OAuthApplicationLimitReached,
+    /// Invalid OAuth2 state
+    InvalidOAuthSstate,
+    /// You lack permissions to perform that action
+    PermissionsLacking,
+    /// Invalid authentication token provided
+    InvalidAuthenticationTokenProvided,
+    /// Note was too long
+    NoteTooLong,
+    /// Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete
+    InvalidMessageDeleteRange,
+    /// A message can only be pinned to the channel it was sent in
+    MessagePinnedInWrongChannel,
+    /// Invite code was either invalid or taken
+    InviteCodeInvalidOrTaken,
+    /// Cannot execute action on a system message
+    InvalidActionOnSystemMessage,
+    /// Invalid OAuth2 access token provided
+    InvalidOAuthAccessToken,
+    /// A message provided was too old to bulk delete
+    MessageTooOldToBulkDelete,
+    /// Invalid form body (returned for both application/json and multipart/form-data bodies), or invalid Content-Type provided
+    InvalidFormBodyOrContentType,
+    /// An invite was accepted to a guild the application's bot is not in
+    InviteAcceptedToGuildBotNotIn,
+    /// Invalid API version provided
+    InvalidApiVersion,
+    /// Reaction was blocked
+    ReactionBlocked,
+    /// API resource is currently overloaded. Try again a little later
+    ApiResourceOverloaded,
+    /// A status code that Twilight doesn't have registered.
+    ///
+    /// Please report the number if you see this variant!
+    Other(u64),
+}
+
+impl ErrorCode {
+    pub fn num(&self) -> u64 {
+        match self {
+            Self::GeneralError => 0,
+            Self::UnknownAccount => 10001,
+            Self::UnknownApplication => 10002,
+            Self::UnknownChannel => 10003,
+            Self::UnknownGuild => 10004,
+            Self::UnknownIntegration => 10005,
+            Self::UnknownInvite => 10006,
+            Self::UnknownMember => 10007,
+            Self::UnknownMessage => 10008,
+            Self::UnknownPermissionOverwrite => 10009,
+            Self::UnknownProvider => 10010,
+            Self::UnknownRole => 10011,
+            Self::UnknownToken => 10012,
+            Self::UnknownUser => 10013,
+            Self::UnknownEmoji => 10014,
+            Self::UnknownWebhook => 10015,
+            Self::UnknownBan => 10026,
+            Self::UnknownSKU => 10027,
+            Self::UnknownStoreListing => 10028,
+            Self::UnknownEntitlement => 10029,
+            Self::UnknownBuild => 10030,
+            Self::UnknownLobby => 10031,
+            Self::UnknownBranch => 10032,
+            Self::UnknownRedistributable => 10036,
+            Self::BotsCannotUseEndpoint => 20001,
+            Self::OnlyBotsCanUseEndpoint => 20002,
+            Self::MaximumGuildsReached => 30001,
+            Self::MaximumFriendsReached => 30002,
+            Self::MaximumPinsReached => 30003,
+            Self::MaximumRolesReached => 30005,
+            Self::MaximumWebhooksReached => 30007,
+            Self::MaximumReactionsReached => 30010,
+            Self::MaximumGuildChannelsReached => 30013,
+            Self::MaximumAttachmentsReached => 30015,
+            Self::MaximumInvitesReached => 30016,
+            Self::Unauthorized => 40001,
+            Self::AccountNeedsVerification => 40002,
+            Self::RequestEntityTooLarge => 40005,
+            Self::FeatureTemporarilyDisabled => 40006,
+            Self::UserBannedFromGuild => 40007,
+            Self::Missingaccess => 50001,
+            Self::InvalidAccountType => 50002,
+            Self::InvalidDMChannelAction => 50003,
+            Self::GuildWidgetDisabled => 50004,
+            Self::MessageNotAuthoredByUser => 50005,
+            Self::EmptyMessage => 50006,
+            Self::CannotSendMessageToUser => 50007,
+            Self::CannotSendMessagesInVoiceChannel => 50008,
+            Self::VerificationLevelTooHigh => 50009,
+            Self::OAuthApplicationHasNoBot => 50010,
+            Self::OAuthApplicationLimitReached => 50011,
+            Self::InvalidOAuthSstate => 50012,
+            Self::PermissionsLacking => 50013,
+            Self::InvalidAuthenticationTokenProvided => 50014,
+            Self::NoteTooLong => 50015,
+            Self::InvalidMessageDeleteRange => 50016,
+            Self::MessagePinnedInWrongChannel => 50019,
+            Self::InviteCodeInvalidOrTaken => 50020,
+            Self::InvalidActionOnSystemMessage => 50021,
+            Self::InvalidOAuthAccessToken => 50025,
+            Self::MessageTooOldToBulkDelete => 50034,
+            Self::InvalidFormBodyOrContentType => 50035,
+            Self::InviteAcceptedToGuildBotNotIn => 50036,
+            Self::InvalidApiVersion => 50041,
+            Self::ReactionBlocked => 90001,
+            Self::ApiResourceOverloaded => 130_000,
+            Self::Other(other) => *other,
+        }
+    }
+}
+
+impl From<u64> for ErrorCode {
+    fn from(int: u64) -> Self {
+        match int {
+            0 => Self::GeneralError,
+            10001 => Self::UnknownAccount,
+            10002 => Self::UnknownApplication,
+            10003 => Self::UnknownChannel,
+            10004 => Self::UnknownGuild,
+            10005 => Self::UnknownIntegration,
+            10006 => Self::UnknownInvite,
+            10007 => Self::UnknownMember,
+            10008 => Self::UnknownMessage,
+            10009 => Self::UnknownPermissionOverwrite,
+            10010 => Self::UnknownProvider,
+            10011 => Self::UnknownRole,
+            10012 => Self::UnknownToken,
+            10013 => Self::UnknownUser,
+            10014 => Self::UnknownEmoji,
+            10015 => Self::UnknownWebhook,
+            10026 => Self::UnknownBan,
+            10027 => Self::UnknownSKU,
+            10028 => Self::UnknownStoreListing,
+            10029 => Self::UnknownEntitlement,
+            10030 => Self::UnknownBuild,
+            10031 => Self::UnknownLobby,
+            10032 => Self::UnknownBranch,
+            10036 => Self::UnknownRedistributable,
+            20001 => Self::BotsCannotUseEndpoint,
+            20002 => Self::OnlyBotsCanUseEndpoint,
+            30001 => Self::MaximumGuildsReached,
+            30002 => Self::MaximumFriendsReached,
+            30003 => Self::MaximumPinsReached,
+            30005 => Self::MaximumRolesReached,
+            30007 => Self::MaximumWebhooksReached,
+            30010 => Self::MaximumReactionsReached,
+            30013 => Self::MaximumGuildChannelsReached,
+            30015 => Self::MaximumAttachmentsReached,
+            30016 => Self::MaximumInvitesReached,
+            40001 => Self::Unauthorized,
+            40002 => Self::AccountNeedsVerification,
+            40005 => Self::RequestEntityTooLarge,
+            40006 => Self::FeatureTemporarilyDisabled,
+            40007 => Self::UserBannedFromGuild,
+            50001 => Self::Missingaccess,
+            50002 => Self::InvalidAccountType,
+            50003 => Self::InvalidDMChannelAction,
+            50004 => Self::GuildWidgetDisabled,
+            50005 => Self::MessageNotAuthoredByUser,
+            50006 => Self::EmptyMessage,
+            50007 => Self::CannotSendMessageToUser,
+            50008 => Self::CannotSendMessagesInVoiceChannel,
+            50009 => Self::VerificationLevelTooHigh,
+            50010 => Self::OAuthApplicationHasNoBot,
+            50011 => Self::OAuthApplicationLimitReached,
+            50012 => Self::InvalidOAuthSstate,
+            50013 => Self::PermissionsLacking,
+            50014 => Self::InvalidAuthenticationTokenProvided,
+            50015 => Self::NoteTooLong,
+            50016 => Self::InvalidMessageDeleteRange,
+            50019 => Self::MessagePinnedInWrongChannel,
+            50020 => Self::InviteCodeInvalidOrTaken,
+            50021 => Self::InvalidActionOnSystemMessage,
+            50025 => Self::InvalidOAuthAccessToken,
+            50034 => Self::MessageTooOldToBulkDelete,
+            50035 => Self::InvalidFormBodyOrContentType,
+            50036 => Self::InviteAcceptedToGuildBotNotIn,
+            50041 => Self::InvalidApiVersion,
+            90001 => Self::ReactionBlocked,
+            130_000 => Self::ApiResourceOverloaded,
+            other => Self::Other(other),
+        }
+    }
+}
+
+impl Display for ErrorCode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::GeneralError => f.write_str("General error (such as a malformed request body, amongst other things)"),
+            Self::UnknownAccount => f.write_str("Unknown account"),
+            Self::UnknownApplication => f.write_str("Unknown application"),
+            Self::UnknownChannel => f.write_str("Unknown channel"),
+            Self::UnknownGuild => f.write_str("Unknown guild"),
+            Self::UnknownIntegration => f.write_str("Unknown integration"),
+            Self::UnknownInvite => f.write_str("Unknown invite"),
+            Self::UnknownMember => f.write_str("Unknown member"),
+            Self::UnknownMessage => f.write_str("Unknown message"),
+            Self::UnknownPermissionOverwrite => f.write_str("Unknown permission overwrite"),
+            Self::UnknownProvider => f.write_str("Unknown provider"),
+            Self::UnknownRole => f.write_str("Unknown role"),
+            Self::UnknownToken => f.write_str("Unknown token"),
+            Self::UnknownUser => f.write_str("Unknown user"),
+            Self::UnknownEmoji => f.write_str("Unknown emoji"),
+            Self::UnknownWebhook => f.write_str("Unknown webhook"),
+            Self::UnknownBan => f.write_str("Unknown ban"),
+            Self::UnknownSKU => f.write_str("Unknown SKU"),
+            Self::UnknownStoreListing => f.write_str("Unknown Store Listing"),
+            Self::UnknownEntitlement => f.write_str("Unknown entitlement"),
+            Self::UnknownBuild => f.write_str("Unknown build"),
+            Self::UnknownLobby => f.write_str("Unknown lobby"),
+            Self::UnknownBranch => f.write_str("Unknown branch"),
+            Self::UnknownRedistributable => f.write_str("Unknown redistributable"),
+            Self::BotsCannotUseEndpoint => f.write_str("Bots cannot use this endpoint"),
+            Self::OnlyBotsCanUseEndpoint => f.write_str("Only bots can use this endpoint"),
+            Self::MaximumGuildsReached => f.write_str("Maximum number of guilds reached (100)"),
+            Self::MaximumFriendsReached => f.write_str("Maximum number of friends reached (1000)"),
+            Self::MaximumPinsReached => f.write_str("Maximum number of pins reached for the channel (50)"),
+            Self::MaximumRolesReached => f.write_str("Maximum number of guild roles reached (250)"),
+            Self::MaximumWebhooksReached => f.write_str("Maximum number of webhooks reached (10)"),
+            Self::MaximumReactionsReached => f.write_str("Maximum number of reactions reached (20)"),
+            Self::MaximumGuildChannelsReached => f.write_str("Maximum number of guild channels reached (500)"),
+            Self::MaximumAttachmentsReached => f.write_str("Maximum number of attachments in a message reached (10)"),
+            Self::MaximumInvitesReached => f.write_str("Maximum number of invites reached (1000)"),
+            Self::Unauthorized => f.write_str("Unauthorized. Provide a valid token and try again"),
+            Self::AccountNeedsVerification => f.write_str("You need to verify your account in order to perform this action"),
+            Self::RequestEntityTooLarge => f.write_str("Request entity too large. Try sending something smaller in size"),
+            Self::FeatureTemporarilyDisabled => f.write_str("This feature has been temporarily disabled server-side"),
+            Self::UserBannedFromGuild => f.write_str("The user is banned from this guild"),
+            Self::Missingaccess => f.write_str("Missing access"),
+            Self::InvalidAccountType => f.write_str("Invalid account type"),
+            Self::InvalidDMChannelAction => f.write_str("Cannot execute action on a DM channel"),
+            Self::GuildWidgetDisabled => f.write_str("Guild widget disabled"),
+            Self::MessageNotAuthoredByUser => f.write_str("Cannot edit a message authored by another user"),
+            Self::EmptyMessage => f.write_str("Cannot send an empty message"),
+            Self::CannotSendMessageToUser => f.write_str("Cannot send messages to this user"),
+            Self::CannotSendMessagesInVoiceChannel => f.write_str("Cannot send messages in a voice channel"),
+            Self::VerificationLevelTooHigh => f.write_str("Channel verification level is too high for you to gain access"),
+            Self::OAuthApplicationHasNoBot => f.write_str("OAuth2 application does not have a bot"),
+            Self::OAuthApplicationLimitReached => f.write_str("OAuth2 application limit reached"),
+            Self::InvalidOAuthSstate => f.write_str("Invalid OAuth2 state"),
+            Self::PermissionsLacking => f.write_str("You lack permissions to perform that action"),
+            Self::InvalidAuthenticationTokenProvided => f.write_str("Invalid authentication token provided"),
+            Self::NoteTooLong => f.write_str("Note was too long"),
+            Self::InvalidMessageDeleteRange => f.write_str("Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete"),
+            Self::MessagePinnedInWrongChannel => f.write_str("A message can only be pinned to the channel it was sent in"),
+            Self::InviteCodeInvalidOrTaken => f.write_str("Invite code was either invalid or taken"),
+            Self::InvalidActionOnSystemMessage => f.write_str("Cannot execute action on a system message"),
+            Self::InvalidOAuthAccessToken => f.write_str("Invalid OAuth2 access token provided"),
+            Self::MessageTooOldToBulkDelete => f.write_str("A message provided was too old to bulk delete"),
+            Self::InvalidFormBodyOrContentType => f.write_str("Invalid form body (returned for both application/json and multipart/form-data bodies), or invalid Content-Type provided"),
+            Self::InviteAcceptedToGuildBotNotIn => f.write_str("An invite was accepted to a guild the application's bot is not in"),
+            Self::InvalidApiVersion => f.write_str("Invalid API version provided"),
+            Self::ReactionBlocked => f.write_str("Reaction was blocked"),
+            Self::ApiResourceOverloaded => f.write_str("API resource is currently overloaded. Try again a little later"),
+            Self::Other(number) => write!(f, "An error code Twilight doesn't have registered: {}", number),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ErrorCode {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ErrorCodeVisitor;
+
+        impl<'de> Visitor<'de> for ErrorCodeVisitor {
+            type Value = ErrorCode;
+
+            fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+                f.write_str("a positive integer")
+            }
+
+            fn visit_u8<E: DeError>(self, value: u8) -> Result<Self::Value, E> {
+                self.visit_u64(u64::from(value))
+            }
+
+            fn visit_u16<E: DeError>(self, value: u16) -> Result<Self::Value, E> {
+                self.visit_u64(u64::from(value))
+            }
+
+            fn visit_u32<E: DeError>(self, value: u32) -> Result<Self::Value, E> {
+                self.visit_u64(u64::from(value))
+            }
+
+            fn visit_u64<E: DeError>(self, int: u64) -> Result<Self::Value, E> {
+                Ok(ErrorCode::from(int))
+            }
+        }
+
+        deserializer.deserialize_u64(ErrorCodeVisitor)
+    }
+}
+
+impl Serialize for ErrorCode {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u64(self.num())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct ApiError {
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+impl Display for ApiError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_fmt(format_args!(
+            "Error code {}: {}",
+            self.code.num(),
+            self.message
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ApiError, ErrorCode};
+    use serde_test::Token;
+
+    #[test]
+    fn test_api_error_deser() {
+        let expected = ApiError {
+            code: ErrorCode::UnknownAccount,
+            message: "Unknown account".to_owned(),
+        };
+
+        serde_test::assert_tokens(
+            &expected,
+            &[
+                Token::Struct {
+                    name: "ApiError",
+                    len: 2,
+                },
+                Token::Str("code"),
+                Token::U64(10001),
+                Token::Str("message"),
+                Token::Str("Unknown account"),
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -14,16 +14,14 @@
     clippy::missing_errors_doc
 )]
 
+pub mod api_error;
 pub mod client;
 pub mod error;
 pub mod ratelimiting;
 pub mod request;
 pub mod routing;
 
-mod api_error;
-
 pub use crate::{
-    api_error::ApiError,
     client::Client,
     error::{Error, Result},
 };

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -20,7 +20,10 @@ pub mod ratelimiting;
 pub mod request;
 pub mod routing;
 
+mod api_error;
+
 pub use crate::{
+    api_error::ApiError,
     client::Client,
     error::{Error, Result},
 };


### PR DESCRIPTION
When an error occurs, instead of just giving the user a slightly nested
response around a client/server error enum, provide an error variant
containing the status code, body, and parsed API error.

The API error contains an error code (a number, like 10001, 10002, or
30001) parsed as an enum and the description of the error provided by
the API.

In total, the type schema of a response error looks like this now:

```
Error::Response {
  body: [ bytes... ],
  error: ApiError {
    code: ErrorCode,
    message: String,
  },
  status: StatusCode,
}
```

Closes #28.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>