### PR TITLE
Revert "model: make member guild ids always present (#180)"

### DIFF
--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -258,13 +258,16 @@ impl UpdateCache<InMemoryCache, InMemoryCacheError> for MemberAdd {
             return Ok(());
         }
 
-        cache.cache_member(self.guild_id, self.0.clone()).await;
+        // This will always be present on members from the gateway.
+        let guild_id = match self.guild_id {
+            Some(guild_id) => guild_id,
+            None => return Ok(()),
+        };
+
+        cache.cache_member(guild_id, self.0.clone()).await;
 
         let mut guild = cache.0.guild_members.lock().await;
-        guild
-            .entry(self.guild_id)
-            .or_default()
-            .insert(self.0.user.id);
+        guild.entry(guild_id).or_default().insert(self.0.user.id);
 
         Ok(())
     }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.1.0"
 
 [dependencies]
-bytes = { version = "0.5" }
 futures = "0.3"
 twilight-model = { path = "../model" }
 log = "0.4"

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -12,7 +12,6 @@ use crate::{
         Request,
     },
 };
-use bytes::Bytes;
 use log::{debug, warn};
 use reqwest::{
     header::HeaderValue, Body, Client as ReqwestClient, ClientBuilder as ReqwestClientBuilder,
@@ -843,14 +842,6 @@ impl Client {
             body: (*bytes).to_vec(),
             source,
         })
-    }
-
-    pub async fn request_bytes(&self, request: Request) -> Result<Bytes> {
-        let resp = self.make_request(request).await?;
-
-        resp.bytes()
-            .await
-            .map_err(|source| Error::ChunkingResponse { source })
     }
 
     pub async fn verify(&self, request: Request) -> Result<()> {

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -1,16 +1,10 @@
 use crate::request::prelude::*;
-use bytes::Bytes;
-use serde::de::DeserializeSeed;
-use serde_json::Value;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
 };
 use twilight_model::{
-    guild::member::{Member, MemberDeserializer},
+    guild::Member,
     id::{GuildId, UserId},
 };
 
@@ -62,7 +56,7 @@ struct GetGuildMembersFields {
 /// ```
 pub struct GetGuildMembers<'a> {
     fields: GetGuildMembersFields,
-    fut: Option<Pending<'a, Bytes>>,
+    fut: Option<Pending<'a, Vec<Member>>>,
     guild_id: GuildId,
     http: &'a Client,
 }
@@ -112,44 +106,17 @@ impl<'a> GetGuildMembers<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetGuildMembers {
-                    after: self.fields.after.map(|x| x.0),
-                    guild_id: self.guild_id.0,
-                    limit: self.fields.limit,
-                    presences: self.fields.presences,
-                },
-            ))));
+        self.fut.replace(Box::pin(self.http.request(Request::from(
+            Route::GetGuildMembers {
+                after: self.fields.after.map(|x| x.0),
+                guild_id: self.guild_id.0,
+                limit: self.fields.limit,
+                presences: self.fields.presences,
+            },
+        ))));
 
         Ok(())
     }
 }
 
-impl Future for GetGuildMembers<'_> {
-    type Output = Result<Vec<Member>>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if self.fut.is_none() {
-            self.as_mut().start()?;
-        }
-
-        let fut = self.fut.as_mut().expect("future is created");
-
-        match fut.as_mut().poll(cx) {
-            Poll::Ready(res) => {
-                let bytes = res?;
-                let mut members = Vec::new();
-                let values = serde_json::from_slice::<Vec<Value>>(&bytes)?;
-
-                for value in values {
-                    let member_deserializer = MemberDeserializer::new(self.guild_id);
-                    members.push(member_deserializer.deserialize(value)?);
-                }
-
-                Poll::Ready(Ok(members))
-            }
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
+poll_req!(GetGuildMembers<'_>, Vec<Member>);

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -1,19 +1,11 @@
 use crate::request::prelude::*;
-use bytes::Bytes;
-use serde::de::{value::BorrowedBytesDeserializer, DeserializeSeed};
-use serde_json::Error as JsonError;
-use std::{
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-};
 use twilight_model::{
-    guild::member::{Member, MemberDeserializer},
+    guild::Member,
     id::{GuildId, UserId},
 };
 
 pub struct GetMember<'a> {
-    fut: Option<Pending<'a, Bytes>>,
+    fut: Option<Pending<'a, Option<Member>>>,
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
@@ -30,40 +22,15 @@ impl<'a> GetMember<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetMember {
-                    guild_id: self.guild_id.0,
-                    user_id: self.user_id.0,
-                },
-            ))));
+        self.fut.replace(Box::pin(self.http.request(Request::from(
+            Route::GetMember {
+                guild_id: self.guild_id.0,
+                user_id: self.user_id.0,
+            },
+        ))));
 
         Ok(())
     }
 }
 
-impl Future for GetMember<'_> {
-    type Output = Result<Option<Member>>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if self.fut.is_none() {
-            self.as_mut().start()?;
-        }
-
-        let fut = self.fut.as_mut().expect("future is created");
-
-        match fut.as_mut().poll(cx) {
-            Poll::Ready(res) => {
-                let bytes = res?;
-
-                let member_deserializer = MemberDeserializer::new(self.guild_id);
-                let deserializer: BorrowedBytesDeserializer<'_, JsonError> =
-                    BorrowedBytesDeserializer::new(&bytes);
-                let member = member_deserializer.deserialize(deserializer)?;
-
-                Poll::Ready(Ok(Some(member)))
-            }
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
+poll_req!(GetMember<'_>, Option<Member>);

--- a/model/src/gateway/payload/member_add.rs
+++ b/model/src/gateway/payload/member_add.rs
@@ -35,7 +35,7 @@ mod tests {
     fn test_member_add() {
         let member_add = MemberAdd(Member {
             deaf: false,
-            guild_id: GuildId(1),
+            guild_id: Some(GuildId(1)),
             hoisted_role: None,
             joined_at: None,
             mute: false,
@@ -70,6 +70,7 @@ mod tests {
                 Token::Str("deaf"),
                 Token::Bool(false),
                 Token::Str("guild_id"),
+                Token::Some,
                 Token::NewtypeStruct { name: "GuildId" },
                 Token::Str("1"),
                 Token::Str("hoisted_role"),

--- a/model/src/gateway/payload/voice_state_update.rs
+++ b/model/src/gateway/payload/voice_state_update.rs
@@ -26,7 +26,7 @@ mod tests {
             guild_id: Some(GuildId(1)),
             member: Some(Member {
                 deaf: false,
-                guild_id: GuildId(1),
+                guild_id: None,
                 hoisted_role: Some(RoleId(4)),
                 joined_at: None,
                 mute: false,
@@ -86,8 +86,7 @@ mod tests {
                 Token::Str("deaf"),
                 Token::Bool(false),
                 Token::Str("guild_id"),
-                Token::NewtypeStruct { name: "GuildId" },
-                Token::Str("1"),
+                Token::None,
                 Token::Str("hoisted_role"),
                 Token::Some,
                 Token::NewtypeStruct { name: "RoleId" },

--- a/model/src/guild/member.rs
+++ b/model/src/guild/member.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "serde-support")]
-pub use self::if_serde_support::MemberDeserializer;
-
 use crate::{
     id::{GuildId, RoleId},
     user::User,
@@ -13,7 +10,7 @@ use crate::{
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Member {
     pub deaf: bool,
-    pub guild_id: GuildId,
+    pub guild_id: Option<GuildId>,
     pub hoisted_role: Option<RoleId>,
     pub joined_at: Option<String>,
     pub mute: bool,
@@ -24,173 +21,14 @@ pub struct Member {
 }
 
 #[cfg(feature = "serde-support")]
-mod if_serde_support {
+mod serde_support {
     use super::Member;
-    use crate::{
-        id::{GuildId, RoleId, UserId},
-        user::User,
-    };
-    use serde::{
-        de::{value::MapAccessDeserializer, DeserializeSeed, Deserializer, MapAccess, Visitor},
-        Deserialize, Serialize,
-    };
+    use crate::id::UserId;
     use serde_mappable_seq::Key;
-    use std::fmt::{Formatter, Result as FmtResult};
 
     impl Key<'_, UserId> for Member {
         fn key(&self) -> UserId {
             self.user.id
-        }
-    }
-
-    #[derive(Deserialize, Serialize)]
-    struct MemberIntermediary {
-        deaf: bool,
-        hoisted_role: Option<RoleId>,
-        joined_at: Option<String>,
-        mute: bool,
-        nick: Option<String>,
-        premium_since: Option<String>,
-        roles: Vec<RoleId>,
-        user: User,
-    }
-
-    /// Deserialize a member when the payload doesn't have the guild ID but
-    /// you already know the guild ID.
-    ///
-    /// Member payloads from the HTTP API, for example, don't have the guild
-    /// ID.
-    #[derive(Clone, Debug, Eq, PartialEq)]
-    pub struct MemberDeserializer(GuildId);
-
-    impl MemberDeserializer {
-        /// Create a new deserializer for a member when you know the ID but the
-        /// payload probably doesn't contain it.
-        pub fn new(guild_id: GuildId) -> Self {
-            Self(guild_id)
-        }
-    }
-
-    impl<'de> DeserializeSeed<'de> for MemberDeserializer {
-        type Value = Member;
-
-        fn deserialize<D: Deserializer<'de>>(
-            self,
-            deserializer: D,
-        ) -> Result<Self::Value, D::Error> {
-            struct MemberDeserializerVisitor(GuildId);
-
-            impl<'de> Visitor<'de> for MemberDeserializerVisitor {
-                type Value = Member;
-
-                fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
-                    f.write_str("a map of member fields")
-                }
-
-                fn visit_map<M: MapAccess<'de>>(self, map: M) -> Result<Self::Value, M::Error> {
-                    let deser = MapAccessDeserializer::new(map);
-                    let member = MemberIntermediary::deserialize(deser)?;
-
-                    Ok(Member {
-                        deaf: member.deaf,
-                        guild_id: self.0,
-                        hoisted_role: member.hoisted_role,
-                        joined_at: member.joined_at,
-                        mute: member.mute,
-                        nick: member.nick,
-                        premium_since: member.premium_since,
-                        roles: member.roles,
-                        user: member.user,
-                    })
-                }
-            }
-
-            deserializer.deserialize_map(MemberDeserializerVisitor(self.0))
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    #[cfg(feature = "serde-support")]
-    mod if_serde {
-        use super::super::{Member, MemberDeserializer};
-        use crate::{
-            id::{GuildId, UserId},
-            user::User,
-        };
-        use serde::de::DeserializeSeed;
-        use serde_value::Value;
-        use std::collections::BTreeMap;
-
-        #[test]
-        fn test_member_deserializer() {
-            let mut user = BTreeMap::new();
-            user.insert(
-                Value::String("discriminator".to_owned()),
-                Value::String("0001".to_owned()),
-            );
-            user.insert(
-                Value::String("id".to_owned()),
-                Value::String("2".to_owned()),
-            );
-            user.insert(
-                Value::String("username".to_owned()),
-                Value::String("twilight".to_owned()),
-            );
-
-            let mut map = BTreeMap::new();
-            map.insert(Value::String("deaf".to_owned()), Value::Bool(false));
-            map.insert(
-                Value::String("hoisted_role".to_owned()),
-                Value::Option(None),
-            );
-            map.insert(
-                Value::String("joined_at".to_owned()),
-                Value::String(String::new()),
-            );
-            map.insert(Value::String("mute".to_owned()), Value::Bool(true));
-            map.insert(
-                Value::String("nick".to_owned()),
-                Value::Option(Some(Box::new(Value::String("twilight".to_owned())))),
-            );
-            map.insert(
-                Value::String("premium_since".to_owned()),
-                Value::Option(None),
-            );
-            map.insert(Value::String("roles".to_owned()), Value::Seq(Vec::new()));
-            map.insert(Value::String("user".to_owned()), Value::Map(user));
-            let value = Value::Map(map);
-
-            let expected = Member {
-                deaf: false,
-                guild_id: GuildId(1),
-                hoisted_role: None,
-                joined_at: Some(String::new()),
-                mute: true,
-                nick: Some("twilight".to_owned()),
-                premium_since: None,
-                roles: Vec::new(),
-                user: User {
-                    avatar: None,
-                    bot: false,
-                    discriminator: "0001".to_owned(),
-                    locale: None,
-                    email: None,
-                    flags: None,
-                    id: UserId(2),
-                    mfa_enabled: None,
-                    name: "twilight".to_owned(),
-                    premium_type: None,
-                    public_flags: None,
-                    system: None,
-                    verified: None,
-                },
-            };
-
-            let deserializer = MemberDeserializer::new(GuildId(1));
-
-            assert_eq!(expected, deserializer.deserialize(value).unwrap());
         }
     }
 }

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -1,5 +1,4 @@
 pub mod audit_log;
-pub mod member;
 
 mod ban;
 mod default_message_notification_level;
@@ -8,6 +7,7 @@ mod explicit_content_filter;
 mod info;
 mod integration;
 mod integration_account;
+mod member;
 mod mfa_level;
 mod partial_guild;
 mod partial_member;

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -417,7 +417,7 @@ fn event_guild_id(event: &Event) -> Option<GuildId> {
         Event::GuildUpdate(e) => Some(e.id),
         Event::InviteCreate(e) => Some(e.guild_id),
         Event::InviteDelete(e) => Some(e.guild_id),
-        Event::MemberAdd(e) => Some(e.guild_id),
+        Event::MemberAdd(e) => e.guild_id,
         Event::MemberChunk(e) => Some(e.guild_id),
         Event::MemberRemove(e) => Some(e.guild_id),
         Event::MemberUpdate(e) => Some(e.guild_id),


### PR DESCRIPTION
Revert #180 for now due to not including support for guild members that
don't have a guild ID over the gateway.

Related to #42.

This reverts commit 3ea9cd53e93953eba0836af4adb462571ae34f27.