### PR TITLE
http: add optional future outputs for requests

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.1.0"
 
 [dependencies]
+bytes = { default-features = false, version = "0.5" }
 futures = "0.3"
 twilight-model = { path = "../model" }
 log = "0.4"

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -12,6 +12,7 @@ use crate::{
         Request,
     },
 };
+use bytes::Bytes;
 use log::{debug, warn};
 use reqwest::{
     header::HeaderValue, Body, Client as ReqwestClient, ClientBuilder as ReqwestClientBuilder,
@@ -842,6 +843,14 @@ impl Client {
             body: (*bytes).to_vec(),
             source,
         })
+    }
+
+    pub(crate) async fn request_bytes(&self, request: Request) -> Result<Bytes> {
+        let resp = self.make_request(request).await?;
+
+        resp.bytes()
+            .await
+            .map_err(|source| Error::ChunkingResponse { source })
     }
 
     pub async fn verify(&self, request: Request) -> Result<()> {

--- a/http/src/request/channel/get_channel.rs
+++ b/http/src/request/channel/get_channel.rs
@@ -3,7 +3,7 @@ use twilight_model::{channel::Channel, id::ChannelId};
 
 pub struct GetChannel<'a> {
     channel_id: ChannelId,
-    fut: Option<Pending<'a, Option<Channel>>>,
+    fut: Option<PendingOption<'a>>,
     http: &'a Client,
 }
 
@@ -17,14 +17,15 @@ impl<'a> GetChannel<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetChannel {
-                channel_id: self.channel_id.0,
-            },
-        ))));
+        self.fut
+            .replace(Box::pin(self.http.request_bytes(Request::from(
+                Route::GetChannel {
+                    channel_id: self.channel_id.0,
+                },
+            ))));
 
         Ok(())
     }
 }
 
-poll_req!(GetChannel<'_>, Option<Channel>);
+poll_req!(opt, GetChannel<'_>, Channel);

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -9,7 +9,7 @@ struct GetInviteFields {
 pub struct GetInvite<'a> {
     code: String,
     fields: GetInviteFields,
-    fut: Option<Pending<'a, Option<Invite>>>,
+    fut: Option<PendingOption<'a>>,
     http: &'a Client,
 }
 
@@ -30,15 +30,16 @@ impl<'a> GetInvite<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetInvite {
-                code: self.code.clone(),
-                with_counts: self.fields.with_counts,
-            },
-        ))));
+        self.fut
+            .replace(Box::pin(self.http.request_bytes(Request::from(
+                Route::GetInvite {
+                    code: self.code.clone(),
+                    with_counts: self.fields.with_counts,
+                },
+            ))));
 
         Ok(())
     }
 }
 
-poll_req!(GetInvite<'_>, Option<Invite>);
+poll_req!(opt, GetInvite<'_>, Invite);

--- a/http/src/request/channel/message/get_message.rs
+++ b/http/src/request/channel/message/get_message.rs
@@ -6,7 +6,7 @@ use twilight_model::{
 
 pub struct GetMessage<'a> {
     channel_id: ChannelId,
-    fut: Option<Pending<'a, Option<Message>>>,
+    fut: Option<PendingOption<'a>>,
     http: &'a Client,
     message_id: MessageId,
 }
@@ -22,15 +22,16 @@ impl<'a> GetMessage<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetMessage {
-                channel_id: self.channel_id.0,
-                message_id: self.message_id.0,
-            },
-        ))));
+        self.fut
+            .replace(Box::pin(self.http.request_bytes(Request::from(
+                Route::GetMessage {
+                    channel_id: self.channel_id.0,
+                    message_id: self.message_id.0,
+                },
+            ))));
 
         Ok(())
     }
 }
 
-poll_req!(GetMessage<'_>, Option<Message>);
+poll_req!(opt, GetMessage<'_>, Message);

--- a/http/src/request/channel/webhook/get_webhook.rs
+++ b/http/src/request/channel/webhook/get_webhook.rs
@@ -8,7 +8,7 @@ struct GetWebhookFields {
 
 pub struct GetWebhook<'a> {
     fields: GetWebhookFields,
-    fut: Option<Pending<'a, Option<Webhook>>>,
+    fut: Option<PendingOption<'a>>,
     http: &'a Client,
     id: WebhookId,
 }
@@ -30,15 +30,16 @@ impl<'a> GetWebhook<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetWebhook {
-                token: self.fields.token.clone(),
-                webhook_id: self.id.0,
-            },
-        ))));
+        self.fut
+            .replace(Box::pin(self.http.request_bytes(Request::from(
+                Route::GetWebhook {
+                    token: self.fields.token.clone(),
+                    webhook_id: self.id.0,
+                },
+            ))));
 
         Ok(())
     }
 }
 
-poll_req!(GetWebhook<'_>, Option<Webhook>);
+poll_req!(opt, GetWebhook<'_>, Webhook);

--- a/http/src/request/guild/ban/get_ban.rs
+++ b/http/src/request/guild/ban/get_ban.rs
@@ -5,7 +5,7 @@ use twilight_model::{
 };
 
 pub struct GetBan<'a> {
-    fut: Option<Pending<'a, Option<Ban>>>,
+    fut: Option<PendingOption<'a>>,
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
@@ -23,13 +23,15 @@ impl<'a> GetBan<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut
-            .replace(Box::pin(self.http.request(Request::from(Route::GetBan {
-                guild_id: self.guild_id.0,
-                user_id: self.user_id.0,
-            }))));
+            .replace(Box::pin(self.http.request_bytes(Request::from(
+                Route::GetBan {
+                    guild_id: self.guild_id.0,
+                    user_id: self.user_id.0,
+                },
+            ))));
 
         Ok(())
     }
 }
 
-poll_req!(GetBan<'_>, Option<Ban>);
+poll_req!(opt, GetBan<'_>, Ban);

--- a/http/src/request/guild/emoji/get_emoji.rs
+++ b/http/src/request/guild/emoji/get_emoji.rs
@@ -6,7 +6,7 @@ use twilight_model::{
 
 pub struct GetEmoji<'a> {
     emoji_id: EmojiId,
-    fut: Option<Pending<'a, Option<Emoji>>>,
+    fut: Option<PendingOption<'a>>,
     guild_id: GuildId,
     http: &'a Client,
 }
@@ -22,15 +22,16 @@ impl<'a> GetEmoji<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetEmoji {
-                emoji_id: self.emoji_id.0,
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        self.fut
+            .replace(Box::pin(self.http.request_bytes(Request::from(
+                Route::GetEmoji {
+                    emoji_id: self.emoji_id.0,
+                    guild_id: self.guild_id.0,
+                },
+            ))));
 
         Ok(())
     }
 }
 
-poll_req!(GetEmoji<'_>, Option<Emoji>);
+poll_req!(opt, GetEmoji<'_>, Emoji);

--- a/http/src/request/guild/get_guild_widget.rs
+++ b/http/src/request/guild/get_guild_widget.rs
@@ -2,7 +2,7 @@ use crate::request::prelude::*;
 use twilight_model::{guild::GuildWidget, id::GuildId};
 
 pub struct GetGuildWidget<'a> {
-    fut: Option<Pending<'a, Option<GuildWidget>>>,
+    fut: Option<PendingOption<'a>>,
     guild_id: GuildId,
     http: &'a Client,
 }
@@ -17,14 +17,15 @@ impl<'a> GetGuildWidget<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetGuildWidget {
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        self.fut
+            .replace(Box::pin(self.http.request_bytes(Request::from(
+                Route::GetGuildWidget {
+                    guild_id: self.guild_id.0,
+                },
+            ))));
 
         Ok(())
     }
 }
 
-poll_req!(GetGuildWidget<'_>, Option<GuildWidget>);
+poll_req!(opt, GetGuildWidget<'_>, GuildWidget);

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -5,7 +5,7 @@ use twilight_model::{
 };
 
 pub struct GetMember<'a> {
-    fut: Option<Pending<'a, Option<Member>>>,
+    fut: Option<PendingOption<'a>>,
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
@@ -22,15 +22,16 @@ impl<'a> GetMember<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetMember {
-                guild_id: self.guild_id.0,
-                user_id: self.user_id.0,
-            },
-        ))));
+        self.fut
+            .replace(Box::pin(self.http.request_bytes(Request::from(
+                Route::GetMember {
+                    guild_id: self.guild_id.0,
+                    user_id: self.user_id.0,
+                },
+            ))));
 
         Ok(())
     }
 }
 
-poll_req!(GetMember<'_>, Option<Member>);
+poll_req!(opt, GetMember<'_>, Member);

--- a/http/src/request/prelude.rs
+++ b/http/src/request/prelude.rs
@@ -1,4 +1,4 @@
-pub(super) use super::{audit_header, validate, Pending, Request};
+pub(super) use super::{audit_header, validate, Pending, PendingOption, Request};
 pub use super::{
     channel::{invite::*, message::*, reaction::*, webhook::*, *},
     get_gateway::GetGateway,

--- a/http/src/request/user/get_user.rs
+++ b/http/src/request/user/get_user.rs
@@ -2,7 +2,7 @@ use crate::request::prelude::*;
 use twilight_model::user::User;
 
 pub struct GetUser<'a> {
-    fut: Option<Pending<'a, Option<User>>>,
+    fut: Option<PendingOption<'a>>,
     http: &'a Client,
     target_user: String,
 }
@@ -18,12 +18,14 @@ impl<'a> GetUser<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut
-            .replace(Box::pin(self.http.request(Request::from(Route::GetUser {
-                target_user: self.target_user.clone(),
-            }))));
+            .replace(Box::pin(self.http.request_bytes(Request::from(
+                Route::GetUser {
+                    target_user: self.target_user.clone(),
+                },
+            ))));
 
         Ok(())
     }
 }
 
-poll_req!(GetUser<'_>, Option<User>);
+poll_req!(opt, GetUser<'_>, User);


### PR DESCRIPTION
When the user uses a retrieval request, like getting a user by ID, the future output is a `Result<Option<T>>`. The code to handle 404 response status codes didn't actually exist, so it'd always either be `Ok(Some(T))` or `Err(E)`.

This patch adds support for handling 404 responses and returning `Ok(None)` where encountered on select retrieval routes.

Here's an example of output:

```
Getting guild member for user 1
Ok(None)
Getting guild member for user 640434332485287936
Ok(Some(Member { deaf: false, guild_id: None, hoisted_role: Non.....
```

Closes #157.