### PR TITLE
implement cold resuming

### DIFF
--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -1,5 +1,5 @@
 use super::error::{Error, Result};
-use crate::shard::ShardResumeData;
+use crate::shard::ResumeSession;
 use crate::{
     queue::{LocalQueue, Queue},
     shard::config::{ShardConfig, ShardConfigBuilder},
@@ -95,7 +95,7 @@ pub struct ClusterConfig {
     shard_config: ShardConfig,
     shard_scheme: ShardScheme,
     queue: Arc<Box<dyn Queue>>,
-    resume_sessions: HashMap<u64, ShardResumeData>,
+    resume_sessions: HashMap<u64, ResumeSession>,
 }
 
 impl ClusterConfig {
@@ -145,7 +145,7 @@ impl ClusterConfig {
     /// Refer to [`ClusterConfigBuilder::resume_sessions`] for the default value.
     ///
     /// [`ClusterConfigBuilder::resume_sessions`]: struct.ClusterConfigBuilder.html#method.resume_sessions
-    pub fn resume_sessions(&self) -> &HashMap<u64, ShardResumeData> {
+    pub fn resume_sessions(&self) -> &HashMap<u64, ResumeSession> {
         &self.resume_sessions
     }
 }
@@ -323,7 +323,7 @@ impl ClusterConfigBuilder {
     ///
     /// This requires having recovered the resume data when shutting down the cluster
     /// NOTE: this does not guarantee these shards will be able to resume. If their sessions are invalid they will have to re-identify as normal
-    pub fn resume_sessions(mut self, resume_sessions: HashMap<u64, ShardResumeData>) -> Self {
+    pub fn resume_sessions(mut self, resume_sessions: HashMap<u64, ResumeSession>) -> Self {
         self.0.resume_sessions = resume_sessions;
         self
     }

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -1,4 +1,5 @@
 use super::error::{Error, Result};
+use crate::shard::ShardResumeData;
 use crate::{
     queue::{LocalQueue, Queue},
     shard::config::{ShardConfig, ShardConfigBuilder},
@@ -11,7 +12,6 @@ use std::{
 };
 use twilight_http::Client;
 use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, GatewayIntents};
-use crate::shard::ShardResumeData;
 
 /// The method of sharding to use.
 ///

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -95,7 +95,7 @@ pub struct ClusterConfig {
     shard_config: ShardConfig,
     shard_scheme: ShardScheme,
     queue: Arc<Box<dyn Queue>>,
-    resume_data: HashMap<u64, ShardResumeData>,
+    resume_sessions: HashMap<u64, ShardResumeData>,
 }
 
 impl ClusterConfig {
@@ -142,11 +142,11 @@ impl ClusterConfig {
 
     /// Returns the resume data to resume shards for this cluster
     ///
-    /// Refer to [`ClusterConfigBuilder::resume_data`] for the default value.
+    /// Refer to [`ClusterConfigBuilder::resume_sessions`] for the default value.
     ///
-    /// [`ClusterConfigBuilder::resume_data`]: struct.ClusterConfigBuilder.html#method.resume_data
-    pub fn resume_data(&self) -> &HashMap<u64, ShardResumeData> {
-        &self.resume_data
+    /// [`ClusterConfigBuilder::resume_sessions`]: struct.ClusterConfigBuilder.html#method.resume_sessions
+    pub fn resume_sessions(&self) -> &HashMap<u64, ShardResumeData> {
+        &self.resume_sessions
     }
 }
 
@@ -189,7 +189,7 @@ impl ClusterConfigBuilder {
                 shard_config: ShardConfig::from(token.clone()),
                 shard_scheme: ShardScheme::Auto,
                 queue: Arc::new(Box::new(LocalQueue::new())),
-                resume_data: HashMap::new(),
+                resume_sessions: HashMap::new(),
             },
             ShardConfigBuilder::new(token),
         )
@@ -319,12 +319,12 @@ impl ClusterConfigBuilder {
         self
     }
 
-    /// Sets the resume data to resume shards with
+    /// Sets the session information to resume shards with
     ///
     /// This requires having recovered the resume data when shutting down the cluster
     /// NOTE: this does not guarantee these shards will be able to resume. If their sessions are invalid they will have to re-identify as normal
-    pub fn resume_data(mut self, resume_data: HashMap<u64, ShardResumeData>) -> Self {
-        self.0.resume_data = resume_data;
+    pub fn resume_sessions(mut self, resume_sessions: HashMap<u64, ShardResumeData>) -> Self {
+        self.0.resume_sessions = resume_sessions;
         self
     }
 }

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -11,6 +11,7 @@ use std::{
 };
 use twilight_http::Client;
 use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, GatewayIntents};
+use crate::shard::ShardResumeData;
 
 /// The method of sharding to use.
 ///
@@ -94,7 +95,7 @@ pub struct ClusterConfig {
     shard_config: ShardConfig,
     shard_scheme: ShardScheme,
     queue: Arc<Box<dyn Queue>>,
-    resume_data: HashMap<u64, (String, u64)>,
+    resume_data: HashMap<u64, ShardResumeData>,
 }
 
 impl ClusterConfig {
@@ -144,7 +145,7 @@ impl ClusterConfig {
     /// Refer to [`ClusterConfigBuilder::resume_data`] for the default value.
     ///
     /// [`ClusterConfigBuilder::resume_data`]: struct.ClusterConfigBuilder.html#method.resume_data
-    pub fn resume_data(&self) -> &HashMap<u64, (String, u64)> {
+    pub fn resume_data(&self) -> &HashMap<u64, ShardResumeData> {
         &self.resume_data
     }
 }
@@ -322,7 +323,7 @@ impl ClusterConfigBuilder {
     ///
     /// This requires having recovered the resume data when shutting down the cluster
     /// NOTE: this does not guarantee these shards will be able to resume. If their sessions are invalid they will have to re-identify as normal
-    pub fn resume_data(mut self, resume_data: HashMap<u64, (String, u64)>) -> Self {
+    pub fn resume_data(mut self, resume_data: HashMap<u64, ShardResumeData>) -> Self {
         self.0.resume_data = resume_data;
         self
     }

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -11,7 +11,6 @@ use futures::{
     lock::Mutex,
     stream::{SelectAll, Stream, StreamExt},
 };
-use std::sync::atomic::AtomicU64;
 use std::{
     collections::HashMap,
     sync::{Arc, Weak},
@@ -135,9 +134,7 @@ impl Cluster {
             .map(Shard::shutdown_resumable)
             .collect::<Vec<_>>();
 
-        let temp = future::join_all(tasks).await;
-
-        temp
+        future::join_all(tasks).await
     }
 
     /// Returns a Shard by its ID.

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -11,6 +11,7 @@ use futures::{
     lock::Mutex,
     stream::{SelectAll, Stream, StreamExt},
 };
+use std::sync::atomic::AtomicU64;
 use std::{
     collections::HashMap,
     sync::{Arc, Weak},
@@ -121,6 +122,22 @@ impl Cluster {
         let tasks = lock.values().map(Shard::shutdown).collect::<Vec<_>>();
 
         future::join_all(tasks).await;
+    }
+
+    /// Brings down the cluster in a resumable way and returns all info needed for resuming
+    ///
+    /// Note discord only allows resuming for a few minutes after disconnection. You can also not resume if you missed too many events already
+    pub async fn down_resumable(&self) -> Vec<(u64, Option<String>, u64)> {
+        let lock = self.0.shards.lock().await;
+
+        let tasks = lock
+            .values()
+            .map(Shard::shutdown_resumable)
+            .collect::<Vec<_>>();
+
+        let temp = future::join_all(tasks).await;
+
+        temp
     }
 
     /// Returns a Shard by its ID.
@@ -241,7 +258,7 @@ impl Cluster {
     /// accepts the request.
     ///
     /// Accepts weak references to the queue and map of shards, because by the
-    /// time the future is polled the cluter may have already dropped, bringing
+    /// time the future is polled the cluster may have already dropped, bringing
     /// down the queue and shards with it.
     async fn start(cluster: Weak<ClusterRef>, shard_id: u64, shard_total: u64) -> Option<Shard> {
         let cluster = cluster.upgrade()?;
@@ -249,6 +266,13 @@ impl Cluster {
         let mut config = cluster.config.shard_config().clone();
 
         config.shard = [shard_id, shard_total];
+        let resume_data = cluster.config.resume_data().get(&shard_id);
+        let (session_id, sequence) = match &resume_data {
+            Some(data) => (Some(data.0.clone()), Some(data.1)),
+            None => (None, None),
+        };
+        config.session_id = session_id;
+        config.sequence = sequence;
 
         let shard = Shard::new(config).await.ok()?;
 

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -264,8 +264,8 @@ impl Cluster {
         let mut config = cluster.config.shard_config().clone();
 
         config.shard = [shard_id, shard_total];
-        let resume_data = cluster.config.resume_data().get(&shard_id);
-        if let Some(data) = resume_data {
+        let resume_sessions = cluster.config.resume_sessions().get(&shard_id);
+        if let Some(data) = resume_sessions {
             config.session_id = Some(data.session_id.clone());
             config.sequence = Some(data.sequence);
         };

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -2,7 +2,7 @@ use super::{
     config::{ClusterConfig, ShardScheme},
     error::{Error, Result},
 };
-use crate::shard::ShardResumeData;
+use crate::shard::ResumeSession;
 use crate::{
     shard::{Information, Shard},
     EventTypeFlags,
@@ -127,7 +127,7 @@ impl Cluster {
     /// Brings down the cluster in a resumable way and returns all info needed for resuming
     ///
     /// Note discord only allows resuming for a few minutes after disconnection. You can also not resume if you missed too many events already
-    pub async fn down_resumable(&self) -> Vec<(u64, Option<ShardResumeData>)> {
+    pub async fn down_resumable(&self) -> Vec<(u64, Option<ResumeSession>)> {
         let lock = self.0.shards.lock().await;
 
         let tasks = lock

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -2,6 +2,7 @@ use super::{
     config::{ClusterConfig, ShardScheme},
     error::{Error, Result},
 };
+use crate::shard::ShardResumeData;
 use crate::{
     shard::{Information, Shard},
     EventTypeFlags,
@@ -16,7 +17,6 @@ use std::{
     sync::{Arc, Weak},
 };
 use twilight_model::gateway::event::Event;
-use crate::shard::ShardResumeData;
 
 #[derive(Debug)]
 struct ClusterRef {

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -20,6 +20,8 @@ pub struct ShardConfig {
     pub(crate) queue: Arc<Box<dyn Queue>>,
     pub(crate) shard: [u64; 2],
     token: String,
+    pub(crate) session_id: Option<String>,
+    pub(crate) sequence: Option<u64>,
 }
 
 impl ShardConfig {
@@ -113,6 +115,8 @@ impl ShardConfigBuilder {
             queue: Arc::new(Box::new(LocalQueue::new())),
             shard: [0, 1],
             token,
+            session_id: None,
+            sequence: None,
         })
     }
 

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -79,7 +79,7 @@ impl Information {
 #[derive(Clone, Debug)]
 pub struct ShardResumeData {
     pub session_id: String,
-    pub sequence: u64
+    pub sequence: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -286,13 +286,11 @@ impl Shard {
         let data = match session_id {
             Some(id) => Some(ShardResumeData {
                 session_id: id,
-                sequence
+                sequence,
             }),
-            None => None
+            None => None,
         };
 
         (shard_id, data)
-
-
     }
 }

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -75,9 +75,9 @@ impl Information {
         self.stage
     }
 }
-/// holds the sessions id and sequence number to resume this shard's session with with
+/// Holds the sessions id and sequence number to resume this shard's session with with
 #[derive(Clone, Debug)]
-pub struct ShardResumeData {
+pub struct ResumeSession {
     pub session_id: String,
     pub sequence: u64,
 }
@@ -269,7 +269,7 @@ impl Shard {
     }
 
     /// This will shut down the shard in a resumable way and return shard id and optional session info to resume with later if this shard is resumable
-    pub async fn shutdown_resumable(&self) -> (u64, Option<ShardResumeData>) {
+    pub async fn shutdown_resumable(&self) -> (u64, Option<ResumeSession>) {
         let session = self.session();
         let _ = session.tx.unbounded_send(Message::Close(Some(CloseFrame {
             code: CloseCode::Restart,
@@ -284,7 +284,7 @@ impl Shard {
         session.stop_heartbeater().await;
 
         let data = match session_id {
-            Some(id) => Some(ShardResumeData {
+            Some(id) => Some(ResumeSession {
                 session_id: id,
                 sequence,
             }),

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -35,7 +35,7 @@ pub use self::{
     config::ShardConfig,
     error::{Error, Result},
     processor::heartbeat::Latency,
-    r#impl::{Information, Shard, ShardResumeData},
+    r#impl::{Information, Shard, ResumeSession},
     sink::ShardSink,
     stage::Stage,
 };

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -35,7 +35,7 @@ pub use self::{
     config::ShardConfig,
     error::{Error, Result},
     processor::heartbeat::Latency,
-    r#impl::{Information, Shard, ResumeSession},
+    r#impl::{Information, ResumeSession, Shard},
     sink::ShardSink,
     stage::Stage,
 };

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -35,7 +35,7 @@ pub use self::{
     config::ShardConfig,
     error::{Error, Result},
     processor::heartbeat::Latency,
-    r#impl::{Information, Shard},
+    r#impl::{Information, Shard, ShardResumeData},
     sink::ShardSink,
     stage::Stage,
 };

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -111,7 +111,7 @@ impl ShardProcessor {
 
         if resumable {
             debug!("Shard {:?} resuming", shard_id);
-            processor.resume().await;
+            processor.resume().await?;
         }
 
         Ok((processor, wrx))


### PR DESCRIPTION
allows to close the shard without terminating the session and getting it's resume information
this info can then be passed on startup to the new cluster to resume instead of identify

note that while this correctly resumes bots can't receive these events due to twilight dropping events on startup