### PR TITLE
gateway,http: fix stable clippy

### DIFF
--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -6,7 +6,15 @@
     rust_2018_idioms,
     unsafe_code
 )]
-#![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
+#![allow(
+    clippy::explicit_deref_methods,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    // This issue made it into a stable clippy:
+    //
+    // <https://github.com/rust-lang/rust-clippy/issues/5360>
+    clippy::used_underscore_binding
+)]
 
 pub mod cluster;
 pub mod queue;

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -7,7 +7,6 @@
     unsafe_code
 )]
 #![allow(
-    clippy::explicit_deref_methods,
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
     // This issue made it into a stable clippy:

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -165,6 +165,8 @@ impl ShardProcessor {
                 counter!("GatewayEvent", 1, "GatewayEvent" => "Dispatch");
                 self.session.set_seq(*seq);
 
+                // this lint is wrong and generates invalid code
+                #[allow(clippy::explicit_deref_methods)]
                 match dispatch.deref() {
                     DispatchEvent::Ready(ready) => {
                         self.session.set_stage(Stage::Connected);

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -11,7 +11,11 @@
     clippy::module_name_repetitions,
     clippy::pub_enum_variant_names,
     clippy::must_use_candidate,
-    clippy::missing_errors_doc
+    clippy::missing_errors_doc,
+    // This issue made it into a stable clippy:
+    //
+    // <https://github.com/rust-lang/rust-clippy/issues/5360>
+    clippy::used_underscore_binding
 )]
 
 pub mod api_error;


### PR DESCRIPTION
Fix stable clippy which introduced a regression into stable that gives
this error message for all awaits:

```
warning: used binding `_task_context` which is prefixed with an
underscore. A leading underscore signals that a binding will not be
used.
```

See clippy issue 5360.

Additionally, allow an unrelated clippy lint that's incorrect.