### PR TITLE
Lavalink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ members = [
     "http/examples/allowed-mentions",
     "http/examples/get-message",
     "http/examples/proxy",
+    "lavalink",
+    "lavalink/examples/basic-lavalink-bot",
     "model",
     "standby",
     "twilight",

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ Add this to your `Cargo.toml`'s `[dependencies]` section:
 twilight = {version = "0.0.1-alpha.0", git = "https://github.com/twilight-rs/twilight.git" }
 ```
 
-## Crates
+## Core Crates
 
-These are crates that can work together for a full application experience.
-You may not need all of these - such as `twilight-cache` - but they can be
-mixed together to accomplish just what you need.
+These are essential crates that most users will use together for a full
+development experience. You may not need all of these - such as
+`twilight-cache` - but they are often used together to accomplish most of what
+you need.
 
 ### `twilight-model`
 
@@ -75,6 +76,22 @@ proxying.
 `twilight-standby` is an event processor that allows for tasks to wait for an
 event to come in. This is useful, for example, when you have a reaction menu
 and want to wait for a reaction to it to come in.
+
+## Additional Crates
+
+These are crates that are officially supported by Twilight, but aren't
+considered core crates due to being vendor-specific or non-essential for most
+users.
+
+### `twilight-lavalink`
+
+`twilight-lavalink` is a client for [Lavalink] as part of the twilight
+ecosystem.
+
+It includes support for managing multiple nodes, a player manager for
+conveniently using players to send events and retrieve information for each
+guild, and an HTTP module for creating requests using the [`http`] crate and
+providing models to deserialize their responses.
 
 ## Examples
 
@@ -166,6 +183,8 @@ async fn handle_event(
 All first-party crates are licensed under [ISC][LICENSE.md]
 
 [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/master/LICENSE.md
+[Lavalink]: https://github.com/Frederikam/Lavalink
+[`http`]: https://crates.io/crates/http
 [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
 [license link]: https://opensource.org/licenses/ISC

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Twilight Contributors"]
 documentation = "https://docs.rs/twilight-lavalink"
 edition = "2018"
-homepage = "https://github.com/twilight-rs/twilight/tree/lavalink/lavalink"
+homepage = "https://github.com/twilight-rs/twilight/tree/master/lavalink"
 include = ["src/*.rs", "Cargo.toml"]
 keywords = ["discord", "discord-api", "twilight"]
 license = "ISC"

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+authors = ["Twilight Contributors"]
+documentation = "https://docs.rs/twilight-lavalink"
+edition = "2018"
+homepage = "https://github.com/twilight-rs/twilight/tree/lavalink/lavalink"
+include = ["src/*.rs", "Cargo.toml"]
+keywords = ["discord", "discord-api", "twilight"]
+license = "ISC"
+name = "twilight-lavalink"
+publish = false
+readme = "README.md"
+repository = "https://github.com/twilight-rs/twilight.git"
+version = "0.1.0"
+
+[dependencies]
+async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.5" }
+dashmap = { default-features = false, version = "3" }
+futures-channel = { default-features = false, features = ["std"], version = "0.3" }
+futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }
+http = { default-features = false, optional = true, version = "0.2" }
+log = { default-features = false, version = "0.4" }
+percent-encoding = { default-features = false, optional = true, version = "2" }
+serde = { default-features = false, features = ["derive", "std"], version = "1" }
+serde_json = { default-features = false, version = "1" }
+tokio = { default-features = false, features = ["net", "rt-core"], version = "0.2" }
+twilight-model = { path = "../model" }
+
+[dev-dependencies]
+static_assertions = { default-features = false, version = "1" }
+tokio = { default-features = false, features = ["macros", "rt-threaded"], version = "0.2" }
+twilight-gateway = { path = "../gateway" }
+twilight-http = { path = "../http" }
+
+[features]
+default = ["http-support"]
+http-support = ["http", "percent-encoding"]

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -22,7 +22,7 @@ log = { default-features = false, version = "0.4" }
 percent-encoding = { default-features = false, optional = true, version = "2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }
 serde_json = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["net", "rt-core"], version = "0.2" }
+tokio = { default-features = false, features = ["net", "rt-core", "time"], version = "0.2" }
 twilight-model = { path = "../model" }
 
 [dev-dependencies]

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -8,7 +8,14 @@ conveniently using players to send events and retrieve information for each
 guild, and an HTTP module for creating requests using the [`http`] crate and
 providing models to deserialize their responses.
 
-# Examples
+## Features
+
+Included is the `http-support` feature.
+
+The `http-support` feature adds support for the `http` module to return request
+types from the [`http`] crate. This is enabled by default.
+
+## Examples
 
 Create a client, add a node, and give events to the client to process events:
 

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -1,0 +1,59 @@
+# twilight-lavalink
+
+`twilight-lavalink` is a client for [Lavalink] as part of the twilight
+ecosystem.
+
+It includes support for managing multiple nodes, a player manager for
+conveniently using players to send events and retrieve information for each
+guild, and an HTTP module for creating requests using the [`http`] crate and
+providing models to deserialize their responses.
+
+# Examples
+
+Create a client, add a node, and give events to the client to process events:
+
+```rust
+use futures_util::stream::StreamExt;
+use std::{
+    convert::TryInto,
+    env,
+    error::Error,
+    future::Future,
+    net::SocketAddr,
+    str::FromStr,
+};
+use twilight_gateway::{Event, Shard};
+use twilight_http::Client as HttpClient;
+use twilight_lavalink::{http::LoadedTracks, model::Play, Lavalink};
+use twilight_model::{
+    channel::Message,
+    gateway::payload::MessageCreate,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let token = env::var("DISCORD_TOKEN")?;
+    let lavalink_host = SocketAddr::from_str(&env::var("LAVALINK_HOST")?)?;
+    let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
+    let shard_count = 1u64;
+
+    let http = HttpClient::new(&token);
+    let user_id = http.current_user().await?.id;
+
+    let lavalink = Lavalink::new(user_id, shard_count);
+    lavalink.add(lavalink_host, lavalink_auth).await?;
+
+    let shard = Shard::new(token).await?;
+
+    let mut events = shard.events().await;
+
+    while let Some(event) = events.next().await {
+        lavalink.process(&event).await?;
+    }
+
+    Ok(())
+}
+```
+
+[Lavalink]: https://github.com/Frederikam/Lavalink
+[`http`]: https://crates.io/crates/http

--- a/lavalink/examples/basic-lavalink-bot/Cargo.toml
+++ b/lavalink/examples/basic-lavalink-bot/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "twilight-lavalink-basic-lavalink-bot"
+version = "0.1.0"
+authors = ["Twilight Contributors"]
+edition = "2018"
+
+[dependencies]
+futures = "0.3"
+log = { version = "0.4" }
+pretty_env_logger = "0.4"
+reqwest = { features = ["json"], version = "0.10" }
+serde_json = { version = "1" }
+tokio = { features = ["macros", "rt-threaded"], version = "0.2" }
+twilight-command-parser = { path = "../../../command-parser" }
+twilight-gateway = { path = "../../../gateway" }
+twilight-http = { path = "../../../http" }
+twilight-lavalink = { path = "../.." }
+twilight-model = { path = "../../../model" }
+twilight-standby = { path = "../../../standby" }

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -30,7 +30,11 @@ fn spawn(
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     pretty_env_logger::init_timed();
 
+<<<<<<< Updated upstream
     let (state, _) = {
+=======
+    let (state, _rx) = {
+>>>>>>> Stashed changes
         let token = env::var("DISCORD_TOKEN")?;
         let lavalink_host = SocketAddr::from_str(&env::var("LAVALINK_HOST")?)?;
         let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
@@ -62,8 +66,17 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         state.standby.process(&event).await;
         state.lavalink.process(&event).await?;
 
+<<<<<<< Updated upstream
         match event {
             Event::MessageCreate(msg) => {
+=======
+        log::debug!("got event");
+
+        match event {
+            Event::MessageCreate(msg) => {
+                log::debug!("got msg create");
+
+>>>>>>> Stashed changes
                 if msg.guild_id.is_none() || !msg.content.starts_with("!") {
                     continue;
                 }
@@ -151,7 +164,11 @@ async fn play(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
     let loaded = res.json::<LoadedTracks>().await?;
 
     if let Some(track) = loaded.tracks.first() {
+<<<<<<< Updated upstream
         player.send(Play::from((guild_id, &track.track, 0, track.info.length)))?;
+=======
+        player.send(Play::from((guild_id, &track.track)))?;
+>>>>>>> Stashed changes
 
         let content = format!(
             "Playing **{}** by **{}**",

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -30,11 +30,7 @@ fn spawn(
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     pretty_env_logger::init_timed();
 
-<<<<<<< Updated upstream
-    let (state, _) = {
-=======
     let (state, _rx) = {
->>>>>>> Stashed changes
         let token = env::var("DISCORD_TOKEN")?;
         let lavalink_host = SocketAddr::from_str(&env::var("LAVALINK_HOST")?)?;
         let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
@@ -66,17 +62,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         state.standby.process(&event).await;
         state.lavalink.process(&event).await?;
 
-<<<<<<< Updated upstream
         match event {
             Event::MessageCreate(msg) => {
-=======
-        log::debug!("got event");
-
-        match event {
-            Event::MessageCreate(msg) => {
-                log::debug!("got msg create");
-
->>>>>>> Stashed changes
                 if msg.guild_id.is_none() || !msg.content.starts_with("!") {
                     continue;
                 }
@@ -164,11 +151,7 @@ async fn play(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
     let loaded = res.json::<LoadedTracks>().await?;
 
     if let Some(track) = loaded.tracks.first() {
-<<<<<<< Updated upstream
-        player.send(Play::from((guild_id, &track.track, 0, track.info.length)))?;
-=======
         player.send(Play::from((guild_id, &track.track)))?;
->>>>>>> Stashed changes
 
         let content = format!(
             "Playing **{}** by **{}**",

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -8,11 +8,7 @@ use twilight_lavalink::{
     model::{Destroy, Pause, Play, Seek, Stop, Volume},
     Lavalink,
 };
-use twilight_model::{
-    channel::Message,
-    gateway::payload::MessageCreate,
-    id::ChannelId,
-};
+use twilight_model::{channel::Message, gateway::payload::MessageCreate, id::ChannelId};
 use twilight_standby::Standby;
 
 #[derive(Clone, Debug)]
@@ -155,7 +151,11 @@ async fn leave(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + 
         }))
         .await?;
 
-    state.http.create_message(msg.channel_id).content("Left the channel")?.await?;
+    state
+        .http
+        .create_message(msg.channel_id)
+        .content("Left the channel")?
+        .await?;
 
     Ok(())
 }
@@ -228,7 +228,11 @@ async fn pause(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + 
 
     let action = if paused { "Unpaused " } else { "Paused" };
 
-    state.http.create_message(msg.channel_id).content(format!("{} the track", action))?.await?;
+    state
+        .http
+        .create_message(msg.channel_id)
+        .content(format!("{} the track", action))?
+        .await?;
 
     Ok(())
 }
@@ -258,7 +262,11 @@ async fn seek(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
     let player = state.lavalink.player(guild_id).await.unwrap();
     player.send(Seek::from((guild_id, position * 1000)))?;
 
-    state.http.create_message(msg.channel_id).content(format!("Seeked to {}s", position))?.await?;
+    state
+        .http
+        .create_message(msg.channel_id)
+        .content(format!("Seeked to {}s", position))?
+        .await?;
 
     Ok(())
 }
@@ -274,7 +282,11 @@ async fn stop(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
     let player = state.lavalink.player(guild_id).await.unwrap();
     player.send(Stop::from(guild_id))?;
 
-    state.http.create_message(msg.channel_id).content("Stopped the track")?.await?;
+    state
+        .http
+        .create_message(msg.channel_id)
+        .content("Stopped the track")?
+        .await?;
 
     Ok(())
 }
@@ -302,7 +314,11 @@ async fn volume(msg: Message, state: State) -> Result<(), Box<dyn Error + Send +
     let volume = msg.content.parse::<i64>()?;
 
     if volume > 1000 || volume < 0 {
-        state.http.create_message(msg.channel_id).content("That's more than 1000")?.await?;
+        state
+            .http
+            .create_message(msg.channel_id)
+            .content("That's more than 1000")?
+            .await?;
 
         return Ok(());
     }
@@ -310,7 +326,11 @@ async fn volume(msg: Message, state: State) -> Result<(), Box<dyn Error + Send +
     let player = state.lavalink.player(guild_id).await.unwrap();
     player.send(Volume::from((guild_id, volume)))?;
 
-    state.http.create_message(msg.channel_id).content(format!("Set the volume to {}", volume))?.await?;
+    state
+        .http
+        .create_message(msg.channel_id)
+        .content(format!("Set the volume to {}", volume))?
+        .await?;
 
     Ok(())
 }

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -154,7 +154,7 @@ async fn play(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
         player.send(Play::from((guild_id, &track.track)))?;
 
         let content = format!(
-            "Playing **{}** by **{}**",
+            "Playing **{:?}** by **{:?}**",
             track.info.title, track.info.author
         );
         state

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -1,0 +1,174 @@
+use futures::StreamExt;
+use reqwest::Client as ReqwestClient;
+use std::{convert::TryInto, env, error::Error, future::Future, net::SocketAddr, str::FromStr};
+use twilight_gateway::{Event, Shard};
+use twilight_http::Client as HttpClient;
+use twilight_lavalink::{http::LoadedTracks, model::Play, Lavalink};
+use twilight_model::{channel::Message, gateway::payload::MessageCreate};
+use twilight_standby::Standby;
+
+#[derive(Clone, Debug)]
+struct State {
+    http: HttpClient,
+    lavalink: Lavalink,
+    reqwest: ReqwestClient,
+    shard: Shard,
+    standby: Standby,
+}
+
+fn spawn(
+    fut: impl Future<Output = Result<(), Box<dyn Error + Send + Sync + 'static>>> + Send + 'static,
+) {
+    tokio::spawn(async move {
+        if let Err(why) = fut.await {
+            log::debug!("Got an error from a handler: {:?}", why);
+        }
+    });
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    pretty_env_logger::init_timed();
+
+    let (state, _) = {
+        let token = env::var("DISCORD_TOKEN")?;
+        let lavalink_host = SocketAddr::from_str(&env::var("LAVALINK_HOST")?)?;
+        let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
+        let shard_count = 1u64;
+
+        let http = HttpClient::new(&token);
+        let user_id = http.current_user().await?.id;
+
+        let lavalink = Lavalink::new(user_id, shard_count);
+        let rx = lavalink.add(lavalink_host, lavalink_auth).await?;
+
+        let shard = Shard::new(token).await?;
+
+        (
+            State {
+                http,
+                lavalink,
+                reqwest: ReqwestClient::new(),
+                shard,
+                standby: Standby::new(),
+            },
+            rx,
+        )
+    };
+
+    let mut events = state.shard.events().await;
+
+    while let Some(event) = events.next().await {
+        state.standby.process(&event).await;
+        state.lavalink.process(&event).await?;
+
+        match event {
+            Event::MessageCreate(msg) => {
+                if msg.guild_id.is_none() || !msg.content.starts_with("!") {
+                    continue;
+                }
+
+                match msg.content.splitn(2, ' ').next() {
+                    Some("!join") => spawn(join(msg.0, state.clone())),
+                    Some("!play") => spawn(play(msg.0, state.clone())),
+                    _ => continue,
+                };
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+async fn join(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    state
+        .http
+        .create_message(msg.channel_id)
+        .content("What's the channel ID you want me to join?")?
+        .await?;
+
+    let author_id = msg.author.id;
+    let msg = state
+        .standby
+        .wait_for_message(msg.channel_id, move |new_msg: &MessageCreate| {
+            new_msg.author.id == author_id
+        })
+        .await?;
+    let channel_id = msg.content.parse::<u64>()?;
+
+    state
+        .shard
+        .command(&serde_json::json!({
+            "op": 4,
+            "d": {
+                "channel_id": channel_id,
+                "guild_id": msg.guild_id,
+                "self_mute": false,
+                "self_deaf": false,
+            }
+        }))
+        .await?;
+
+    state
+        .http
+        .create_message(msg.channel_id)
+        .content(format!("Joined <#{}>!", channel_id))?
+        .await?;
+
+    Ok(())
+}
+
+async fn play(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    log::debug!(
+        "Got a play command in channel {} by {}",
+        msg.channel_id,
+        msg.author.name
+    );
+    state
+        .http
+        .create_message(msg.channel_id)
+        .content("What's the URL of the audio to play?")?
+        .await?;
+
+    let author_id = msg.author.id;
+    let msg = state
+        .standby
+        .wait_for_message(msg.channel_id, move |new_msg: &MessageCreate| {
+            new_msg.author.id == author_id
+        })
+        .await?;
+    let guild_id = msg.guild_id.unwrap();
+
+    let player = state.lavalink.player(guild_id).await.unwrap();
+    let req = twilight_lavalink::http::load_track(
+        player.node().config().address,
+        &msg.content,
+        &player.node().config().authorization,
+    )?
+    .try_into()?;
+    let res = state.reqwest.execute(req).await?;
+    let loaded = res.json::<LoadedTracks>().await?;
+
+    if let Some(track) = loaded.tracks.first() {
+        player.send(Play::from((guild_id, &track.track, 0, track.info.length)))?;
+
+        let content = format!(
+            "Playing **{}** by **{}**",
+            track.info.title, track.info.author
+        );
+        state
+            .http
+            .create_message(msg.channel_id)
+            .content(content)?
+            .await?;
+    } else {
+        state
+            .http
+            .create_message(msg.channel_id)
+            .content("Didn't find any results")?
+            .await?;
+    }
+
+    Ok(())
+}

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -1,0 +1,356 @@
+//! Client to manage nodes and players.
+
+use crate::{
+    model::{IncomingEvent, OutgoingEvent, VoiceUpdate},
+    node::{Node, NodeConfig, NodeError, Resume},
+    player::{Player, PlayerManager},
+};
+use dashmap::{mapref::one::Ref, DashMap};
+use futures_channel::mpsc::{TrySendError, UnboundedReceiver};
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+    net::SocketAddr,
+    sync::Arc,
+};
+use twilight_model::{
+    gateway::{
+        event::Event,
+        payload::{VoiceServerUpdate, VoiceStateUpdate},
+    },
+    id::{GuildId, UserId},
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ClientError {
+    NodesUnconfigured,
+    SendingVoiceUpdate { source: TrySendError<OutgoingEvent> },
+}
+
+impl Display for ClientError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NodesUnconfigured => f.write_str("no node has been configured"),
+            Self::SendingVoiceUpdate { .. } => f.write_str("couldn't send voice update to node"),
+        }
+    }
+}
+
+impl Error for ClientError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::NodesUnconfigured => None,
+            Self::SendingVoiceUpdate { source } => Some(source),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum VoiceStateHalf {
+    Server(VoiceServerUpdate),
+    State(Box<VoiceStateUpdate>),
+}
+
+#[derive(Debug, Default)]
+struct LavalinkRef {
+    guilds: DashMap<GuildId, SocketAddr>,
+    nodes: DashMap<SocketAddr, Node>,
+    players: PlayerManager,
+    resume: Option<Resume>,
+    shard_count: u64,
+    user_id: UserId,
+    waiting: DashMap<GuildId, VoiceStateHalf>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Lavalink(Arc<LavalinkRef>);
+
+impl Lavalink {
+    /// Create a new Lavalink client instance.
+    ///
+    /// The user ID and number of shards provided may not be modified during
+    /// runtime, and the client must be re-created. These parameters are
+    /// automatically passed to new nodes created via [`add`].
+    ///
+    /// See also [`new_with_resume`], which allows you to specify session resume
+    /// capability.
+    ///
+    /// [`add`]: #method.add
+    /// [`new_with_resume`]: #method.new_with_resume
+    pub fn new(user_id: UserId, shard_count: u64) -> Self {
+        Self::_new_with_resume(user_id, shard_count, None)
+    }
+
+    /// Like [`new`], but allows you to specify resume capability (if any).
+    ///
+    /// Provide `None` for the `resume` parameter to disable session resume
+    /// capability. See the [`Resume`] documentation for defaults.
+    ///
+    /// [`Resume`]: node/struct.Resume.html
+    /// [`new`]: #method.new
+    pub fn new_with_resume(
+        user_id: UserId,
+        shard_count: u64,
+        resume: impl Into<Option<Resume>>,
+    ) -> Self {
+        Self::_new_with_resume(user_id, shard_count, resume.into())
+    }
+
+    fn _new_with_resume(user_id: UserId, shard_count: u64, resume: Option<Resume>) -> Self {
+        Self(Arc::new(LavalinkRef {
+            guilds: DashMap::new(),
+            nodes: DashMap::new(),
+            players: PlayerManager::new(),
+            resume,
+            shard_count,
+            user_id,
+            waiting: DashMap::new(),
+        }))
+    }
+
+    /// Process an event into the Lavalink client.
+    ///
+    /// This requires the `VoiceServerUpdate` and `VoiceStateUpdate` events to
+    /// send voice updates to nodes.
+    ///
+    /// Additionally, the `Ready` event can optionally be provided to do some
+    /// cleaning of stalled voice states that never received their voice server
+    /// update half or vice versa.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::NodesUnconfigured`] if no nodes have been added
+    /// to the client when attempting to retrieve a guild's player.
+    ///
+    /// [`ClientError::NodesUnconfigured`]: enum.ClientError.html#variant.NodesUnconfigured
+    pub async fn process(&self, event: &Event) -> Result<(), ClientError> {
+        log::trace!("Processing event: {:?}", event);
+
+        let (guild_id, half) = match event {
+            Event::Ready(e) => {
+                let shard_id = e.shard.map_or(0, |[id, _]| id);
+
+                self.clear_shard_states(shard_id);
+
+                return Ok(());
+            }
+            Event::VoiceServerUpdate(e) => (e.guild_id, VoiceStateHalf::Server(e.clone())),
+            Event::VoiceStateUpdate(e) => {
+                if e.0.user_id != self.0.user_id {
+                    log::trace!("Got a voice state update from another user");
+
+                    return Ok(());
+                }
+
+                (e.0.guild_id, VoiceStateHalf::State(e.clone()))
+            }
+            _ => return Ok(()),
+        };
+
+        log::debug!(
+            "Got a voice server/state update for {:?}: {:?}",
+            guild_id,
+            half
+        );
+
+        let guild_id = match guild_id {
+            Some(guild_id) => guild_id,
+            None => {
+                log::trace!("Processed event has no guild ID: {:?}", event);
+
+                return Ok(());
+            }
+        };
+
+        let update = {
+            let existing_half = match self.0.waiting.get(&guild_id) {
+                Some(existing_half) => existing_half,
+                None => {
+                    log::debug!(
+                        "Guild {} is now waiting for other half; got: {:?}",
+                        guild_id,
+                        half
+                    );
+                    self.0.waiting.insert(guild_id, half);
+
+                    return Ok(());
+                }
+            };
+            log::debug!(
+                "Got both halves for {}: {:?}; {:?}",
+                guild_id,
+                half,
+                existing_half.value()
+            );
+
+            match (existing_half.value(), half) {
+                (VoiceStateHalf::Server(_), VoiceStateHalf::Server(server)) => {
+                    // We got the same half twice... weird, but let's just replace
+                    // the existing one.
+                    log::debug!(
+                        "Got the same server half twice for guild {}: {:?}",
+                        guild_id,
+                        server
+                    );
+                    self.0
+                        .waiting
+                        .insert(guild_id, VoiceStateHalf::Server(server));
+
+                    return Ok(());
+                }
+                (VoiceStateHalf::Server(ref server), VoiceStateHalf::State(ref state)) => {
+                    VoiceUpdate::new(guild_id, &state.0.session_id, server.clone())
+                }
+                (VoiceStateHalf::State(_), VoiceStateHalf::State(state)) => {
+                    // Just like above, we got the same half twice...
+                    log::debug!(
+                        "Got the same state half twice for guild {}: {:?}",
+                        guild_id,
+                        state
+                    );
+                    self.0
+                        .waiting
+                        .insert(guild_id, VoiceStateHalf::State(state));
+
+                    return Ok(());
+                }
+                (VoiceStateHalf::State(ref state), VoiceStateHalf::Server(ref server)) => {
+                    VoiceUpdate::new(guild_id, &state.0.session_id, server.clone())
+                }
+            }
+        };
+
+        log::debug!("Removing guild {} from waiting list", guild_id);
+        self.0.waiting.remove(&guild_id);
+
+        log::debug!("Getting player for guild {}", guild_id);
+        let player = self.player(guild_id).await?;
+        log::debug!("Sending voice update for guild {}: {:?}", guild_id, update);
+        player
+            .send(update)
+            .map_err(|source| ClientError::SendingVoiceUpdate { source })?;
+        log::debug!("Sent voice update for guild {}", guild_id);
+
+        Ok(())
+    }
+
+    /// Add a new node to be managed by the Lavalink client.
+    ///
+    /// If a node already exists with the provided address, then it will be
+    /// replaced.
+    pub async fn add(
+        &self,
+        address: SocketAddr,
+        authorization: impl Into<String>,
+    ) -> Result<(Node, UnboundedReceiver<IncomingEvent>), NodeError> {
+        let config = NodeConfig {
+            address,
+            authorization: authorization.into(),
+            resume: self.0.resume.clone(),
+            shard_count: self.0.shard_count,
+            user_id: self.0.user_id,
+        };
+
+        let (node, rx) = Node::connect(config, self.0.players.clone()).await?;
+        self.0.nodes.insert(address, node.clone());
+
+        Ok((node, rx))
+    }
+
+    /// Remove a node from the list of nodes being managed by the Lavalink
+    /// client.
+    ///
+    /// The node is returned if it existed.
+    pub async fn remove(&self, address: SocketAddr) -> Option<(SocketAddr, Node)> {
+        self.0.nodes.remove(&address)
+    }
+
+    /// Determine the "best" node for new players according to available nodes'
+    /// penalty scores.
+    ///
+    /// Refer to [`Node::penalty`] for how this is calculated.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::NodesUnconfigured`] if there are no configured
+    /// nodes available in the client.
+    ///
+    /// [`ClientError::NodesUnconfigured`]: struct.ClientError.html#variant.NodesUnconfigured
+    /// [`Node::penalty`]: ../node/struct.Node.html#method.penalty
+    pub async fn best(&self) -> Result<Node, ClientError> {
+        let mut lowest = i32::MAX;
+        let mut best = None;
+
+        for node in self.0.nodes.iter() {
+            let penalty = node.value().penalty().await;
+
+            if penalty < lowest {
+                lowest = penalty;
+                best.replace(node.clone());
+            }
+        }
+
+        best.ok_or(ClientError::NodesUnconfigured)
+    }
+
+    /// Retrieve an immutable reference to the player manager.
+    pub fn players(&self) -> &PlayerManager {
+        &self.0.players
+    }
+
+    /// Retrieve a player for the guild.
+    ///
+    /// Creates a player configured to use the best available node if a player
+    /// for the guild doesn't already exist. Use [`PlayerManager::get`] to only
+    /// retrieve and not create.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::NodesUnconfigured`] if no node has been
+    /// configured via [`add`].
+    ///
+    /// [`ClientError::NodesUnconfigured`]: enum.ClientError.html#variant.NodesUnconfigured
+    /// [`PlayerManager::get`]: player/struct.PlayerManager.html#method.get
+    /// [`add`]: #method.add
+    pub async fn player(&self, guild_id: GuildId) -> Result<Ref<'_, GuildId, Player>, ClientError> {
+        if let Some(player) = self.players().get(&guild_id) {
+            return Ok(player);
+        }
+
+        let node = self.best().await?;
+
+        Ok(self.players().get_or_insert(guild_id, node).downgrade())
+    }
+
+    /// Clear out the map of guild states/updates for a shard that are waiting
+    /// for their other half.
+    ///
+    /// We can do this by iterating over the map and removing the ones that we
+    /// can calculate came from a shard.
+    ///
+    /// This map should be small or empty, and if it isn't, then it needs to be
+    /// cleared out anyway.
+    fn clear_shard_states(&self, shard_id: u64) {
+        let shard_count = self.0.shard_count;
+
+        for r in self.0.waiting.iter() {
+            let guild_id = r.key();
+
+            if (guild_id.0 >> 22) % shard_count == shard_id {
+                self.0.waiting.remove(guild_id);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClientError, Lavalink, LavalinkRef, VoiceStateHalf};
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(ClientError: Clone, Debug, PartialEq);
+    assert_impl_all!(LavalinkRef: Debug, Default);
+    assert_impl_all!(Lavalink: Clone, Debug);
+    assert_impl_all!(VoiceStateHalf: Debug);
+}

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -21,10 +21,17 @@ use twilight_model::{
     id::{GuildId, UserId},
 };
 
+/// An error that can occur while interacting with the client.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ClientError {
+    /// A node isn't configured, so the operation isn't possible to fulfill.
     NodesUnconfigured,
-    SendingVoiceUpdate { source: TrySendError<OutgoingEvent> },
+    /// Sending a voice update event to the node failed because the node's
+    /// connection was shutdown.
+    SendingVoiceUpdate {
+        /// The source of the error.
+        source: TrySendError<OutgoingEvent>,
+    },
 }
 
 impl Display for ClientError {
@@ -62,6 +69,17 @@ struct LavalinkRef {
     waiting: DashMap<GuildId, VoiceStateHalf>,
 }
 
+/// The lavalink client that manages nodes, players, and processes events from
+/// Discord to tie it all together.
+///
+/// You can use the client to process voice events, which it will use to forward
+/// server updates and voice states to Lavalink. Additionally, you can retrieve
+/// players using the [`player`] method. Players contain information about the
+/// active playing information of a guild and allows you to send events to the
+/// connected node, such as [`Play`] events.
+///
+/// [`Play`]: ../model/struct.Play.html
+/// [`player`]: #method.player
 #[derive(Clone, Debug)]
 pub struct Lavalink(Arc<LavalinkRef>);
 

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -199,7 +199,7 @@ impl Lavalink {
                     return Ok(());
                 }
                 (VoiceStateHalf::Server(ref server), VoiceStateHalf::State(ref state)) => {
-                    VoiceUpdate::new(guild_id, &state.0.session_id, server.clone())
+                    VoiceUpdate::new(guild_id, &state.0.session_id, From::from(server.clone()))
                 }
                 (VoiceStateHalf::State(_), VoiceStateHalf::State(state)) => {
                     // Just like above, we got the same half twice...
@@ -215,7 +215,7 @@ impl Lavalink {
                     return Ok(());
                 }
                 (VoiceStateHalf::State(ref state), VoiceStateHalf::Server(ref server)) => {
-                    VoiceUpdate::new(guild_id, &state.0.session_id, server.clone())
+                    VoiceUpdate::new(guild_id, &state.0.session_id, From::from(server.clone()))
                 }
             }
         };

--- a/lavalink/src/http.rs
+++ b/lavalink/src/http.rs
@@ -9,150 +9,231 @@ use percent_encoding::NON_ALPHANUMERIC;
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, SocketAddr};
 
+/// The type of search result given.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum LoadType {
+    /// Loading the results failed.
     LoadFailed,
+    /// There were no matches.
     NoMatches,
+    /// A playlist was found.
     PlaylistLoaded,
+    /// Some results were found.
     SearchResult,
+    /// A single track was found.
     TrackLoaded,
 }
 
+/// A track within a search result.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Track {
+    /// Details about a track, such as the author and title.
     pub info: TrackInfo,
+    /// The base64 track string that you use in the [`Play`] event.
+    ///
+    /// [`Play`]: ../model/struct.Play.html
     pub track: String,
 }
 
+/// Additional information about a track, such as the author.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct TrackInfo {
-    pub author: String,
+    /// The name of the author, if provided.
+    pub author: Option<String>,
+    /// The identifier of the source of the track.
     pub identifier: String,
+    /// Whether the source is seekable.
     pub is_seekable: bool,
+    /// Whether the source is a stream.
     pub is_stream: bool,
+    /// The length of the audio in milliseconds.
     pub length: u64,
+    /// The position of the audio.
     pub position: u64,
-    pub title: String,
+    /// The title, if provided.
+    pub title: Option<String>,
+    /// The source URI of the track.
     pub uri: String,
 }
 
+/// Information about a playlist from a search result.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct PlaylistInfo {
+    /// The name of the playlist, if available.
     pub name: Option<String>,
+    /// The selected track, if one was selected.
     pub selected_track: Option<String>,
 }
 
+/// Possible track results for a query.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct LoadedTracks {
+    /// The type of search result, such as a list of tracks or a playlist.
     pub load_type: LoadType,
+    /// Information about the playlist, if provided.
     pub playlist_info: PlaylistInfo,
+    /// The list of tracks returned for the search query.
     pub tracks: Vec<Track>,
 }
 
+/// A failing IP address within the planner.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct FailingAddress {
+    /// The IP address.
     pub address: String,
+    /// The time that the address started failing in unixtime.
     pub failing_timestamp: u64,
+    /// The time that the address started failing as a timestamp.
     pub failing_time: String,
 }
 
+/// The IP version in use by the block.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 pub enum IpBlockType {
+    /// An IPv4 block type.
     #[serde(rename = "Inet4Address")]
     Inet4,
+    /// An IPv6 block type.
     #[serde(rename = "Inet6Address")]
     Inet6,
 }
 
+/// A block of IP addresses.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 pub struct IpBlock {
+    /// The IP version of the IP block.
     pub kind: IpBlockType,
+    /// The size of the block's addresses.
     pub size: u64,
 }
 
+/// The type of route planner in use.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "PascalCase")]
 pub enum RoutePlannerType {
+    /// A Nano IP route planner.
     NanoIp,
+    /// A Rotating IP route planner.
     RotatingIp,
+    /// A Rotating Nano IP route planner.
     RotatingNanoIp,
 }
 
+/// The route planner in use.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(untagged)]
 pub enum RoutePlanner {
+    /// Information about a Nano IP route planner.
     NanoIp(NanoIpRoutePlanner),
+    /// Information about a Rotating IP route planner.
     RotatingIp(RotatingIpRoutePlanner),
+    /// Information about a Rotating Nano IP route planner.
     RotatingNanoIp(RotatingNanoIpRoutePlanner),
 }
 
+/// A Nano IP planner.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct NanoIpRoutePlanner {
+    /// The type of planner that is currently active.
+    ///
+    /// For this planner, thsi is always [`RoutePlannerType::NanoIp`]
+    ///
+    /// [`RoutePlannerType::NanoIp`]: enum.RoutePlannerType.html#variant.NanoIp
     pub class: RoutePlannerType,
+    /// The details of the currently active Nano IP route planner.
     pub details: NanoIpDetails,
 }
 
+/// Information about a Nano IP planner.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct NanoIpDetails {
-    pub failing_addresses: Vec<FailingAddress>,
-    pub ip_block: IpBlock,
+    /// The active offset within the IP block.
     pub current_address_index: u64,
+    /// A list of IP addresses in the range that are failing.
+    pub failing_addresses: Vec<FailingAddress>,
+    /// The associated IP block.
+    pub ip_block: IpBlock,
 }
 
+/// A Rotating IP planner.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct RotatingIpRoutePlanner {
+    /// The type of planner that is currently active.
+    ///
+    /// For this planner, thsi is always [`RoutePlannerType::RotatingIp`]
+    ///
+    /// [`RoutePlannerType::RotatingIp`]: enum.RoutePlannerType.html#variant.RotatingIp
     pub class: RoutePlannerType,
+    /// The details of the currently active rotating IP route planner.
     pub details: RotatingIpDetails,
 }
 
+/// Information about a Rotating IP planner.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct RotatingIpDetails {
+    /// The currently used IP address.
     pub current_address: String,
+    /// A list of IP addresses in the range that are failing.
     pub failing_addresses: Vec<FailingAddress>,
+    /// The associated IP block.
     pub ip_block: IpBlock,
+    /// The current offset used within the IP block.
     pub ip_index: u64,
+    /// The number of rotations that have happened since the server started.
     pub rotate_index: u64,
 }
 
+/// A Rotating Nano IP planner.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct RotatingNanoIpRoutePlanner {
+    /// The type of planner that is currently active.
+    ///
+    /// For this planner, thsi is always [`RoutePlannerType::RotatingNanoIp`]
+    ///
+    /// [`RoutePlannerType::RotatingNanoIp`]: enum.RoutePlannerType.html#variant.RotatingNanoIp
     pub class: RoutePlannerType,
+    /// The details of the currently active rotating nano IP route planner.
     pub details: RotatingNanoIpDetails,
 }
 
+/// Information about a Rotating Nano IP planner.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct RotatingNanoIpDetails {
+    /// The block IPs that are chosen.
     pub block_index: String,
+    /// The current IP address on rotation.
     pub current_address_index: u64,
+    /// A list of IP addresses in the range that are failing.
     pub failing_addresses: Vec<FailingAddress>,
+    /// The associated IP block.
     pub ip_block: IpBlock,
 }
 
@@ -197,6 +278,9 @@ pub fn get_route_planner(
     req.body(b"")
 }
 
+/// Unmark an IP address as being failed, meaning that it can be used again.
+///
+/// The response will not include a body on success.
 pub fn unmark_failed_address(
     node_address: impl Into<SocketAddr>,
     authorization: impl AsRef<str>,

--- a/lavalink/src/http.rs
+++ b/lavalink/src/http.rs
@@ -1,0 +1,317 @@
+//! Models to deserialize responses into and functions to create `http` crate
+//! requests.
+
+use http::{
+    header::{HeaderValue, AUTHORIZATION},
+    Error as HttpError, Request,
+};
+use percent_encoding::NON_ALPHANUMERIC;
+use serde::{Deserialize, Serialize};
+use std::net::{IpAddr, SocketAddr};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum LoadType {
+    LoadFailed,
+    NoMatches,
+    PlaylistLoaded,
+    SearchResult,
+    TrackLoaded,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct Track {
+    pub info: TrackInfo,
+    pub track: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct TrackInfo {
+    pub author: String,
+    pub identifier: String,
+    pub is_seekable: bool,
+    pub is_stream: bool,
+    pub length: u64,
+    pub position: u64,
+    pub title: String,
+    pub uri: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct PlaylistInfo {
+    pub name: Option<String>,
+    pub selected_track: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct LoadedTracks {
+    pub load_type: LoadType,
+    pub playlist_info: PlaylistInfo,
+    pub tracks: Vec<Track>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct FailingAddress {
+    pub address: String,
+    pub failing_timestamp: u64,
+    pub failing_time: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+pub enum IpBlockType {
+    #[serde(rename = "Inet4Address")]
+    Inet4,
+    #[serde(rename = "Inet6Address")]
+    Inet6,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct IpBlock {
+    pub kind: IpBlockType,
+    pub size: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "PascalCase")]
+pub enum RoutePlannerType {
+    NanoIp,
+    RotatingIp,
+    RotatingNanoIp,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(untagged)]
+pub enum RoutePlanner {
+    NanoIp(NanoIpRoutePlanner),
+    RotatingIp(RotatingIpRoutePlanner),
+    RotatingNanoIp(RotatingNanoIpRoutePlanner),
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct NanoIpRoutePlanner {
+    pub class: RoutePlannerType,
+    pub details: NanoIpDetails,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct NanoIpDetails {
+    pub failing_addresses: Vec<FailingAddress>,
+    pub ip_block: IpBlock,
+    pub current_address_index: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct RotatingIpRoutePlanner {
+    pub class: RoutePlannerType,
+    pub details: RotatingIpDetails,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct RotatingIpDetails {
+    pub current_address: String,
+    pub failing_addresses: Vec<FailingAddress>,
+    pub ip_block: IpBlock,
+    pub ip_index: u64,
+    pub rotate_index: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct RotatingNanoIpRoutePlanner {
+    pub class: RoutePlannerType,
+    pub details: RotatingNanoIpDetails,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct RotatingNanoIpDetails {
+    pub block_index: String,
+    pub current_address_index: u64,
+    pub failing_addresses: Vec<FailingAddress>,
+    pub ip_block: IpBlock,
+}
+
+/// Get a list of tracks that match an identifier.
+///
+/// The response will include a body which can be deserialized into a
+/// [`LoadedTracks`].
+///
+/// [`LoadedTracks`]: struct.LoadedTracks.html
+pub fn load_track(
+    address: SocketAddr,
+    identifier: impl AsRef<str>,
+    authorization: impl AsRef<str>,
+) -> Result<Request<&'static [u8]>, HttpError> {
+    let identifier =
+        percent_encoding::percent_encode(identifier.as_ref().as_bytes(), NON_ALPHANUMERIC);
+    let url = format!("http://{}/loadtracks?identifier={}", address, identifier);
+
+    let mut req = Request::get(url);
+
+    let auth_value = HeaderValue::from_str(authorization.as_ref())?;
+    req = req.header(AUTHORIZATION, auth_value);
+
+    req.body(b"")
+}
+
+/// Get the configured route planner for a node by address.
+///
+/// The response will include a body which can be deserialized into a
+/// [`RoutePlanner`].
+///
+/// [`RoutePlanner`]: enum.RoutePlanner.html
+pub fn get_route_planner(
+    address: SocketAddr,
+    authorization: impl AsRef<str>,
+) -> Result<Request<&'static [u8]>, HttpError> {
+    let mut req = Request::get(format!("{}/routeplanner/status", address));
+
+    let auth_value = HeaderValue::from_str(authorization.as_ref())?;
+    req = req.header(AUTHORIZATION, auth_value);
+
+    req.body(b"")
+}
+
+pub fn unmark_failed_address(
+    node_address: impl Into<SocketAddr>,
+    authorization: impl AsRef<str>,
+    route_address: impl Into<IpAddr>,
+) -> Result<Request<Vec<u8>>, HttpError> {
+    let mut req = Request::post(format!("{}/routeplanner/status", node_address.into()));
+
+    let auth_value = HeaderValue::from_str(authorization.as_ref())?;
+    req = req.header(AUTHORIZATION, auth_value);
+
+    req.body(
+        serde_json::to_vec(&serde_json::json!({
+            "address": route_address.into(),
+        }))
+        .unwrap(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        FailingAddress, IpBlock, IpBlockType, NanoIpDetails, NanoIpRoutePlanner, RotatingIpDetails,
+        RotatingIpRoutePlanner, RotatingNanoIpDetails, RotatingNanoIpRoutePlanner, RoutePlanner,
+        RoutePlannerType,
+    };
+    use serde::{Deserialize, Serialize};
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(
+        FailingAddress: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        IpBlockType: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        IpBlock: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        NanoIpDetails: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        NanoIpRoutePlanner: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        RotatingIpDetails: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        RotatingIpRoutePlanner: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        RotatingNanoIpDetails: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        RotatingNanoIpRoutePlanner: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        RoutePlannerType: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        RoutePlanner: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+}

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -1,0 +1,82 @@
+//! # twilight-lavalink
+//!
+//! `twilight-lavalink` is a client for [Lavalink] as part of the twilight
+//! ecosystem.
+//!
+//! It includes support for managing multiple nodes, a player manager for
+//! conveniently using players to send events and retrieve information for each
+//! guild, and an HTTP module for creating requests using the [`http`] crate and
+//! providing models to deserialize their responses.
+//!
+//! # Examples
+//!
+//! Create a [client], add a [node], and give events to the client to [process]
+//! events:
+//!
+//! ```no_run
+//! use futures_util::stream::StreamExt;
+//! use std::{
+//!     convert::TryInto,
+//!     env,
+//!     error::Error,
+//!     future::Future,
+//!     net::SocketAddr,
+//!     str::FromStr,
+//! };
+//! use twilight_gateway::{Event, Shard};
+//! use twilight_http::Client as HttpClient;
+//! use twilight_lavalink::{http::LoadedTracks, model::Play, Lavalink};
+//! use twilight_model::{
+//!     channel::Message,
+//!     gateway::payload::MessageCreate,
+//! };
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+//!     let token = env::var("DISCORD_TOKEN")?;
+//!     let lavalink_host = SocketAddr::from_str(&env::var("LAVALINK_HOST")?)?;
+//!     let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
+//!     let shard_count = 1u64;
+//!
+//!     let http = HttpClient::new(&token);
+//!     let user_id = http.current_user().await?.id;
+//!
+//!     let lavalink = Lavalink::new(user_id, shard_count);
+//!     lavalink.add(lavalink_host, lavalink_auth).await?;
+//!
+//!     let shard = Shard::new(token).await?;
+//!
+//!     let mut events = shard.events().await;
+//!
+//!     while let Some(event) = events.next().await {
+//!         lavalink.process(&event).await?;
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! [Lavalink]: https://github.com/Frederikam/Lavalink
+//! [client]: client/struct.Lavalink.html
+//! [node]: node/struct.Node.html
+//! [process]: client/struct.Lavalink.html#method.process
+//! [`http`]: https://crates.io/crates/http
+
+#![deny(
+    clippy::all,
+    future_incompatible,
+    nonstandard_style,
+    rust_2018_idioms,
+    unused,
+    warnings
+)]
+
+pub mod client;
+pub mod model;
+pub mod node;
+pub mod player;
+
+#[cfg(feature = "http")]
+pub mod http;
+
+pub use self::{client::Lavalink, node::Node, player::PlayerManager};

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -8,7 +8,14 @@
 //! guild, and an HTTP module for creating requests using the [`http`] crate and
 //! providing models to deserialize their responses.
 //!
-//! # Examples
+//! ## Features
+//!
+//! Included is the `http-support` feature.
+//!
+//! The `http-support` feature adds support for the `http` module to return
+//! request types from the [`http`] crate. This is enabled by default.
+//!
+//! ## Examples
 //!
 //! Create a [client], add a [node], and give events to the client to [process]
 //! events:

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -65,6 +65,7 @@
 #![deny(
     clippy::all,
     future_incompatible,
+    missing_docs,
     nonstandard_style,
     rust_2018_idioms,
     unused,

--- a/lavalink/src/model.rs
+++ b/lavalink/src/model.rs
@@ -483,7 +483,10 @@ pub use self::{incoming::*, outgoing::*};
 #[cfg(test)]
 mod tests {
     use super::{
-        incoming::{IncomingEvent, PlayerUpdate, PlayerUpdateState, Stats, StatsCpu, StatsMemory, TrackEventType, TrackEnd, TrackStart},
+        incoming::{
+            IncomingEvent, PlayerUpdate, PlayerUpdateState, Stats, StatsCpu, StatsMemory, TrackEnd,
+            TrackEventType, TrackStart,
+        },
         outgoing::{
             Destroy, Equalizer, EqualizerBand, OutgoingEvent, Pause, Play, Seek,
             SlimVoiceServerUpdate, Stop, VoiceUpdate, Volume,

--- a/lavalink/src/model.rs
+++ b/lavalink/src/model.rs
@@ -519,6 +519,9 @@ mod incoming {
     pub struct Stats {
         /// CPU information about the node's host.
         pub cpu: StatsCpu,
+        /// Statistics about audio frames.
+        #[serde(rename = "frameStats")]
+        pub frames: StatsFrames,
         /// Memory information about the node's host.
         pub memory: StatsMemory,
         /// The current number of total players (active and not active) within
@@ -543,6 +546,19 @@ mod incoming {
         pub lavalink_load: f64,
         /// The load of the system as a whole.
         pub system_load: f64,
+    }
+
+    /// CPU information about a node and its host.
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct StatsFrames {
+        /// The number of CPU cores.
+        pub sent: u64,
+        /// The load of the Lavalink server.
+        pub nulled: u64,
+        /// The load of the system as a whole.
+        pub deficit: u64,
     }
 
     /// Memory information about a node and its host.
@@ -615,7 +631,7 @@ pub use self::{incoming::*, outgoing::*};
 mod tests {
     use super::{
         incoming::{
-            IncomingEvent, PlayerUpdate, PlayerUpdateState, Stats, StatsCpu, StatsMemory, TrackEnd,
+            IncomingEvent, PlayerUpdate, PlayerUpdateState, Stats, StatsCpu, StatsFrames, StatsMemory, TrackEnd,
             TrackEventType, TrackStart,
         },
         outgoing::{
@@ -720,6 +736,13 @@ mod tests {
     );
     assert_impl_all!(
         StatsCpu: Clone,
+        Debug,
+        Deserialize<'static>,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        StatsFrames: Clone,
         Debug,
         Deserialize<'static>,
         PartialEq,

--- a/lavalink/src/model.rs
+++ b/lavalink/src/model.rs
@@ -1,0 +1,563 @@
+//! Models to (de)serialize incoming/outgoing websocket events and HTTP
+//! responses.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub enum Opcode {
+    Destroy,
+    Equalizer,
+    Pause,
+    Play,
+    PlayerUpdate,
+    Seek,
+    Stats,
+    Stop,
+    VoiceUpdate,
+    Volume,
+}
+
+mod outgoing {
+    use super::Opcode;
+    use serde::{Deserialize, Serialize};
+    use twilight_model::{gateway::payload::VoiceServerUpdate, id::GuildId};
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(untagged)]
+    pub enum OutgoingEvent {
+        Destroy(Destroy),
+        Equalizer(Equalizer),
+        Pause(Pause),
+        Play(Play),
+        Seek(Seek),
+        Stop(Stop),
+        VoiceUpdate(VoiceUpdate),
+        Volume(Volume),
+    }
+
+    impl From<Destroy> for OutgoingEvent {
+        fn from(event: Destroy) -> OutgoingEvent {
+            Self::Destroy(event)
+        }
+    }
+
+    impl From<Equalizer> for OutgoingEvent {
+        fn from(event: Equalizer) -> OutgoingEvent {
+            Self::Equalizer(event)
+        }
+    }
+
+    impl From<Pause> for OutgoingEvent {
+        fn from(event: Pause) -> OutgoingEvent {
+            Self::Pause(event)
+        }
+    }
+
+    impl From<Play> for OutgoingEvent {
+        fn from(event: Play) -> OutgoingEvent {
+            Self::Play(event)
+        }
+    }
+
+    impl From<Seek> for OutgoingEvent {
+        fn from(event: Seek) -> OutgoingEvent {
+            Self::Seek(event)
+        }
+    }
+
+    impl From<Stop> for OutgoingEvent {
+        fn from(event: Stop) -> OutgoingEvent {
+            Self::Stop(event)
+        }
+    }
+
+    impl From<VoiceUpdate> for OutgoingEvent {
+        fn from(event: VoiceUpdate) -> OutgoingEvent {
+            Self::VoiceUpdate(event)
+        }
+    }
+
+    impl From<Volume> for OutgoingEvent {
+        fn from(event: Volume) -> OutgoingEvent {
+            Self::Volume(event)
+        }
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct Destroy {
+        op: Opcode,
+        pub guild_id: GuildId,
+    }
+
+    impl Destroy {
+        pub fn new(guild_id: GuildId) -> Self {
+            Self {
+                guild_id,
+                op: Opcode::Destroy,
+            }
+        }
+    }
+
+    impl From<GuildId> for Destroy {
+        fn from(guild_id: GuildId) -> Self {
+            Self {
+                guild_id,
+                op: Opcode::Destroy,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct Equalizer {
+        op: Opcode,
+        pub bands: Vec<EqualizerBand>,
+        pub guild_id: GuildId,
+    }
+
+    impl Equalizer {
+        pub fn new(guild_id: GuildId, bands: Vec<EqualizerBand>) -> Self {
+            Self::from((guild_id, bands))
+        }
+    }
+
+    impl From<(GuildId, Vec<EqualizerBand>)> for Equalizer {
+        fn from((guild_id, bands): (GuildId, Vec<EqualizerBand>)) -> Self {
+            Self {
+                bands,
+                guild_id,
+                op: Opcode::Equalizer,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct EqualizerBand {
+        pub band: i64,
+        pub gain: f64,
+    }
+
+    impl EqualizerBand {
+        pub fn new(band: i64, gain: f64) -> Self {
+            Self::from((band, gain))
+        }
+    }
+
+    impl From<(i64, f64)> for EqualizerBand {
+        fn from((band, gain): (i64, f64)) -> Self {
+            Self { band, gain }
+        }
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct Pause {
+        op: Opcode,
+        pub guild_id: GuildId,
+        pub pause: bool,
+    }
+
+    impl Pause {
+        pub fn new(guild_id: GuildId, pause: bool) -> Self {
+            Self::from((guild_id, pause))
+        }
+    }
+
+    impl From<(GuildId, bool)> for Pause {
+        fn from((guild_id, pause): (GuildId, bool)) -> Self {
+            Self {
+                guild_id,
+                op: Opcode::Pause,
+                pause,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct Play {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub end_time: Option<u64>,
+        pub guild_id: GuildId,
+        pub no_replace: bool,
+        op: Opcode,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub start_time: Option<u64>,
+        pub track: String,
+    }
+
+    impl Play {
+        pub fn new(
+            guild_id: GuildId,
+            track: impl Into<String>,
+            start_time: impl Into<Option<u64>>,
+            end_time: impl Into<Option<u64>>,
+            no_replace: bool,
+        ) -> Self {
+            Self::from((guild_id, track, start_time, end_time, no_replace))
+        }
+    }
+
+    impl<T: Into<String>> From<(GuildId, T)> for Play {
+        fn from((guild_id, track): (GuildId, T)) -> Self {
+            Self::from((guild_id, track, None, None, true))
+        }
+    }
+
+    impl<T: Into<String>, S: Into<Option<u64>>> From<(GuildId, T, S)> for Play {
+        fn from((guild_id, track, start_time): (GuildId, T, S)) -> Self {
+            Self::from((guild_id, track, start_time, None, true))
+        }
+    }
+
+    impl<T: Into<String>, S: Into<Option<u64>>, E: Into<Option<u64>>> From<(GuildId, T, S, E)>
+        for Play
+    {
+        fn from((guild_id, track, start_time, end_time): (GuildId, T, S, E)) -> Self {
+            Self::from((guild_id, track, start_time, end_time, true))
+        }
+    }
+
+    impl<T: Into<String>, S: Into<Option<u64>>, E: Into<Option<u64>>> From<(GuildId, T, S, E, bool)>
+        for Play
+    {
+        fn from(
+            (guild_id, track, start_time, end_time, no_replace): (GuildId, T, S, E, bool),
+        ) -> Self {
+            Self {
+                end_time: end_time.into(),
+                guild_id,
+                no_replace,
+                op: Opcode::Play,
+                start_time: start_time.into(),
+                track: track.into(),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct Seek {
+        op: Opcode,
+        pub guild_id: GuildId,
+        pub position: i64,
+    }
+
+    impl Seek {
+        pub fn new(guild_id: GuildId, position: i64) -> Self {
+            Self::from((guild_id, position))
+        }
+    }
+
+    impl From<(GuildId, i64)> for Seek {
+        fn from((guild_id, position): (GuildId, i64)) -> Self {
+            Self {
+                guild_id,
+                op: Opcode::Seek,
+                position,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct Stop {
+        op: Opcode,
+        pub guild_id: GuildId,
+    }
+
+    impl Stop {
+        pub fn new(guild_id: GuildId) -> Self {
+            Self::from(guild_id)
+        }
+    }
+
+    impl From<GuildId> for Stop {
+        fn from(guild_id: GuildId) -> Self {
+            Self {
+                guild_id,
+                op: Opcode::Stop,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct VoiceUpdate {
+        op: Opcode,
+        pub guild_id: GuildId,
+        pub session_id: String,
+        pub event: VoiceServerUpdate,
+    }
+
+    impl VoiceUpdate {
+        pub fn new(
+            guild_id: GuildId,
+            session_id: impl Into<String>,
+            event: VoiceServerUpdate,
+        ) -> Self {
+            Self::from((guild_id, session_id, event))
+        }
+    }
+
+    impl<T: Into<String>> From<(GuildId, T, VoiceServerUpdate)> for VoiceUpdate {
+        fn from((guild_id, session_id, event): (GuildId, T, VoiceServerUpdate)) -> Self {
+            Self {
+                event,
+                guild_id,
+                op: Opcode::VoiceUpdate,
+                session_id: session_id.into(),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct Volume {
+        op: Opcode,
+        pub guild_id: GuildId,
+        pub volume: i64,
+    }
+
+    impl Volume {
+        pub fn new(guild_id: GuildId, volume: i64) -> Self {
+            Self::from((guild_id, volume))
+        }
+    }
+
+    impl From<(GuildId, i64)> for Volume {
+        fn from((guild_id, volume): (GuildId, i64)) -> Self {
+            Self {
+                guild_id,
+                op: Opcode::Volume,
+                volume,
+            }
+        }
+    }
+}
+
+mod incoming {
+    use super::Opcode;
+    use serde::{Deserialize, Serialize};
+    use twilight_model::id::GuildId;
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(untagged)]
+    pub enum IncomingEvent {
+        PlayerUpdate(PlayerUpdate),
+        Stats(Stats),
+    }
+
+    impl From<PlayerUpdate> for IncomingEvent {
+        fn from(event: PlayerUpdate) -> IncomingEvent {
+            Self::PlayerUpdate(event)
+        }
+    }
+
+    impl From<Stats> for IncomingEvent {
+        fn from(event: Stats) -> IncomingEvent {
+            Self::Stats(event)
+        }
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct PlayerUpdate {
+        pub op: Opcode,
+        pub guild_id: GuildId,
+        pub state: PlayerUpdateState,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct PlayerUpdateState {
+        pub time: i64,
+        pub position: i64,
+    }
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct Stats {
+        pub cpu: StatsCpu,
+        pub memory: StatsMemory,
+        pub players: u64,
+        pub playing_players: u64,
+        pub op: Opcode,
+        pub uptime: u64,
+    }
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct StatsCpu {
+        pub cores: usize,
+        pub lavalink_load: f64,
+        pub system_load: f64,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct StatsMemory {
+        pub allocated: u64,
+        pub free: u64,
+        pub reservable: u64,
+        pub used: u64,
+    }
+}
+
+pub use self::{incoming::*, outgoing::*};
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        incoming::{IncomingEvent, PlayerUpdate, PlayerUpdateState, Stats, StatsCpu, StatsMemory},
+        outgoing::{
+            Destroy, Equalizer, EqualizerBand, OutgoingEvent, Pause, Play, Seek, Stop, VoiceUpdate,
+            Volume,
+        },
+    };
+    use serde::{Deserialize, Serialize};
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(
+        Destroy: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        EqualizerBand: Clone,
+        Debug,
+        Deserialize<'static>,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        Equalizer: Clone,
+        Debug,
+        Deserialize<'static>,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        IncomingEvent: Clone,
+        Debug,
+        Deserialize<'static>,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        OutgoingEvent: Clone,
+        Debug,
+        Deserialize<'static>,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        Pause: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        PlayerUpdateState: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        PlayerUpdate: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        Play: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        Seek: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        Stats: Clone,
+        Debug,
+        Deserialize<'static>,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        StatsCpu: Clone,
+        Debug,
+        Deserialize<'static>,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        StatsMemory: Clone,
+        Debug,
+        Deserialize<'static>,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        Stop: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        VoiceUpdate: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+    assert_impl_all!(
+        Volume: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Serialize
+    );
+}

--- a/lavalink/src/model.rs
+++ b/lavalink/src/model.rs
@@ -631,8 +631,8 @@ pub use self::{incoming::*, outgoing::*};
 mod tests {
     use super::{
         incoming::{
-            IncomingEvent, PlayerUpdate, PlayerUpdateState, Stats, StatsCpu, StatsFrames, StatsMemory, TrackEnd,
-            TrackEventType, TrackStart,
+            IncomingEvent, PlayerUpdate, PlayerUpdateState, Stats, StatsCpu, StatsFrames,
+            StatsMemory, TrackEnd, TrackEventType, TrackStart,
         },
         outgoing::{
             Destroy, Equalizer, EqualizerBand, OutgoingEvent, Pause, Play, Seek,

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -247,11 +247,17 @@ impl Node {
     }
 
     /// Retrieve an immutable reference to the node's configuration.
+    ///
+    /// Note that sending player events through the node's sender won't update
+    /// player states, such as whether it's paused.
     pub fn send(&self, event: OutgoingEvent) -> Result<(), TrySendError<OutgoingEvent>> {
         self.sender().unbounded_send(event)
     }
 
     /// Retrieve a unique sender to send events to the Lavalink server.
+    ///
+    /// Note that sending player events through the node's sender won't update
+    /// player states, such as whether it's paused.
     pub fn sender(&self) -> UnboundedSender<OutgoingEvent> {
         self.0.lavalink_tx.clone()
     }

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -331,13 +331,13 @@ impl Connection {
                 log::warn!("Unknown message from Lavalink node: {}", text);
 
                 return Ok(true);
-            },
+            }
         };
 
         match event {
             IncomingEvent::PlayerUpdate(ref update) => self.player_update(update).await?,
             IncomingEvent::Stats(ref stats) => self.stats(stats).await?,
-            _ => {},
+            _ => {}
         }
 
         // It's fine if the rx end dropped, often users don't need to care about

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -20,7 +20,7 @@
 //! [`VoiceUpdate`]: ../model/struct.VoiceUpdate.html
 
 use crate::{
-    model::{IncomingEvent, Opcode, OutgoingEvent, PlayerUpdate, Stats, StatsCpu, StatsMemory},
+    model::{IncomingEvent, Opcode, OutgoingEvent, PlayerUpdate, Stats, StatsCpu, StatsFrames, StatsMemory},
     player::PlayerManager,
 };
 use async_tungstenite::{
@@ -232,6 +232,11 @@ impl Node {
                 lavalink_load: 0f64,
                 system_load: 0f64,
             },
+            frames: StatsFrames {
+                deficit: 0,
+                nulled: 0,
+                sent: 0,
+            },
             memory: StatsMemory {
                 allocated: 0,
                 free: 0,
@@ -300,7 +305,12 @@ impl Node {
         let stats = self.0.stats.lock().await;
         let cpu = 1.05f64.powf(100f64 * stats.cpu.system_load) * 10f64 - 10f64;
 
-        stats.playing_players as i32 + cpu as i32
+        let (deficit_frame, null_frame) = (
+            1.03f64.powf(500f64 * (stats.frames.deficit as f64 / 3000f64)) * 300f64 - 300f64,
+            (1.03f64.powf(500f64 * (stats.frames.nulled as f64 / 3000f64)) * 300f64 - 300f64) * 2f64,
+        );
+
+        stats.playing_players as i32 + cpu as i32 + deficit_frame as i32 + null_frame as i32
     }
 }
 

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -1,0 +1,419 @@
+use crate::{
+    model::{IncomingEvent, Opcode, OutgoingEvent, PlayerUpdate, Stats, StatsCpu, StatsMemory},
+    player::PlayerManager,
+};
+use async_tungstenite::{tokio::TokioAdapter, tungstenite::Message, WebSocketStream};
+use futures_channel::mpsc::{self, TrySendError, UnboundedReceiver, UnboundedSender};
+use futures_util::{
+    future::{self, Either},
+    lock::BiLock,
+    sink::SinkExt,
+    stream::StreamExt,
+};
+use http::{header::HeaderName, Error as HttpError, Request};
+use serde_json::Error as JsonError;
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+    net::SocketAddr,
+    sync::Arc,
+};
+use tokio::net::TcpStream;
+use twilight_model::id::UserId;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum NodeError {
+    BuildingConnectionRequest {
+        source: HttpError,
+    },
+    IncomingMessageInvalid {
+        source: JsonError,
+        text: String,
+    },
+    SerializingMessage {
+        message: OutgoingEvent,
+        source: JsonError,
+    },
+}
+
+impl Display for NodeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::BuildingConnectionRequest { .. } => {
+                f.write_str("failed to build connection request")
+            }
+            Self::IncomingMessageInvalid { .. } => {
+                f.write_str("the incoming message is invalid json or unsupported")
+            }
+            Self::SerializingMessage { .. } => {
+                f.write_str("failed to serialize outgoing message as json")
+            }
+        }
+    }
+}
+
+impl Error for NodeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::BuildingConnectionRequest { source } => Some(source),
+            Self::IncomingMessageInvalid { source, .. } => Some(source),
+            Self::SerializingMessage { source, .. } => Some(source),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct NodeConfig {
+    pub address: SocketAddr,
+    pub authorization: String,
+    pub resume: Option<Resume>,
+    pub shard_count: u64,
+    pub user_id: UserId,
+}
+
+/// Configuration for a session which can be resumed.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct Resume {
+    /// The number of seconds that the Lavalink server will allow the session to
+    /// be resumed for after a disconnect.
+    ///
+    /// The default is 60.
+    pub timeout: u64,
+}
+
+impl Resume {
+    pub fn new(seconds: u64) -> Self {
+        Self { timeout: seconds }
+    }
+}
+
+impl Default for Resume {
+    fn default() -> Self {
+        Self { timeout: 60 }
+    }
+}
+
+impl NodeConfig {
+    pub fn new(
+        user_id: UserId,
+        shard_count: u64,
+        address: impl Into<SocketAddr>,
+        authorization: impl Into<String>,
+        resume: impl Into<Option<Resume>>,
+    ) -> Self {
+        Self::_new(
+            user_id,
+            shard_count,
+            address.into(),
+            authorization.into(),
+            resume.into(),
+        )
+    }
+
+    fn _new(
+        user_id: UserId,
+        shard_count: u64,
+        address: SocketAddr,
+        authorization: String,
+        resume: Option<Resume>,
+    ) -> Self {
+        Self {
+            address,
+            authorization,
+            resume,
+            shard_count,
+            user_id,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct NodeRef {
+    config: NodeConfig,
+    lavalink_tx: UnboundedSender<OutgoingEvent>,
+    players: PlayerManager,
+    stats: BiLock<Stats>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Node(Arc<NodeRef>);
+
+impl Node {
+    pub async fn connect(
+        config: NodeConfig,
+        players: PlayerManager,
+    ) -> Result<(Self, UnboundedReceiver<IncomingEvent>), NodeError> {
+        let (bilock_left, bilock_right) = BiLock::new(Stats {
+            cpu: StatsCpu {
+                cores: 0,
+                lavalink_load: 0f64,
+                system_load: 0f64,
+            },
+            memory: StatsMemory {
+                allocated: 0,
+                free: 0,
+                used: 0,
+                reservable: 0,
+            },
+            players: 0,
+            playing_players: 0,
+            op: Opcode::Stats,
+            uptime: 0,
+        });
+        log::debug!("Starting connection to {}", config.address);
+        let (conn_loop, lavalink_tx, lavalink_rx) =
+            Connection::connect(config.clone(), players.clone(), bilock_right).await?;
+        log::debug!("Started connection to {}", config.address);
+
+        tokio::spawn(conn_loop.run());
+
+        Ok((
+            Self(Arc::new(NodeRef {
+                config,
+                lavalink_tx,
+                players,
+                stats: bilock_left,
+            })),
+            lavalink_rx,
+        ))
+    }
+
+    pub fn config(&self) -> &NodeConfig {
+        &self.0.config
+    }
+
+    pub async fn players(&self) -> &PlayerManager {
+        &self.0.players
+    }
+
+    pub fn send(&self, event: OutgoingEvent) -> Result<(), TrySendError<OutgoingEvent>> {
+        self.sender().unbounded_send(event)
+    }
+
+    pub fn sender(&self) -> UnboundedSender<OutgoingEvent> {
+        self.0.lavalink_tx.clone()
+    }
+
+    pub async fn stats(&self) -> Stats {
+        (*self.0.stats.lock().await).clone()
+    }
+
+    pub async fn penalty(&self) -> i32 {
+        let stats = self.0.stats.lock().await;
+        let cpu = 1.05f64.powf(100f64 * stats.cpu.system_load) * 10f64 - 10f64;
+
+        stats.playing_players as i32 + cpu as i32
+    }
+}
+
+struct Connection {
+    config: NodeConfig,
+    connection: WebSocketStream<TokioAdapter<TcpStream>>,
+    node_from: UnboundedReceiver<OutgoingEvent>,
+    node_to: UnboundedSender<IncomingEvent>,
+    players: PlayerManager,
+    stats: BiLock<Stats>,
+}
+
+impl Connection {
+    async fn connect(
+        config: NodeConfig,
+        players: PlayerManager,
+        stats: BiLock<Stats>,
+    ) -> Result<
+        (
+            Self,
+            UnboundedSender<OutgoingEvent>,
+            UnboundedReceiver<IncomingEvent>,
+        ),
+        NodeError,
+    > {
+        let connection = reconnect(&config).await?;
+
+        let (to_node, from_lavalink) = mpsc::unbounded();
+        let (to_lavalink, from_node) = mpsc::unbounded();
+
+        Ok((
+            Self {
+                config,
+                connection,
+                node_from: from_node,
+                node_to: to_node,
+                players,
+                stats,
+            },
+            to_lavalink,
+            from_lavalink,
+        ))
+    }
+
+    async fn run(mut self) -> Result<(), NodeError> {
+        loop {
+            if self.node_to.is_closed() {
+                break;
+            }
+
+            let from_lavalink = self.connection.next();
+            let to_lavalink = self.node_from.next();
+
+            match future::select(from_lavalink, to_lavalink).await {
+                Either::Left((Some(Ok(incoming)), _)) => {
+                    self.incoming(incoming).await?;
+                }
+                Either::Left((_, _)) => {
+                    log::debug!("Connection to {} closed, reconnecting", self.config.address);
+                    self.connection = reconnect(&self.config).await?;
+                }
+                Either::Right((Some(outgoing), _)) => {
+                    log::debug!(
+                        "Forwarding event to {}: {:?}",
+                        self.config.address,
+                        outgoing
+                    );
+
+                    let payload = serde_json::to_string(&outgoing).map_err(|source| {
+                        NodeError::SerializingMessage {
+                            message: outgoing,
+                            source,
+                        }
+                    })?;
+                    let msg = Message::Text(payload);
+                    self.connection.send(msg).await.unwrap();
+                }
+                Either::Right((_, _)) => {
+                    log::debug!("Node {} closed, ending connection", self.config.address);
+
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn incoming(&mut self, incoming: Message) -> Result<bool, NodeError> {
+        log::debug!(
+            "Received message from {}: {:?}",
+            self.config.address,
+            incoming
+        );
+
+        let text = match incoming {
+            Message::Close(_) => {
+                let _ = self.connection.send(Message::Close(None)).await;
+
+                return Ok(false);
+            }
+            Message::Ping(data) => {
+                let msg = Message::Pong(data);
+
+                // We don't need to immediately care if a pong fails.
+                let _ = self.connection.send(msg).await;
+
+                return Ok(true);
+            }
+            Message::Text(text) => text,
+            other => {
+                log::info!("Got a pong or bytes payload: {:?}", other);
+
+                return Ok(true);
+            }
+        };
+
+        let event = serde_json::from_str(&text)
+            .map_err(|source| NodeError::IncomingMessageInvalid { source, text })?;
+
+        match event {
+            IncomingEvent::PlayerUpdate(ref update) => self.player_update(update).await?,
+            IncomingEvent::Stats(ref stats) => self.stats(stats).await?,
+        }
+
+        // It's fine if the rx end dropped, often users don't need to care about
+        // these events.
+        if !self.node_to.is_closed() {
+            let _ = self.node_to.unbounded_send(event);
+        }
+
+        Ok(true)
+    }
+
+    async fn player_update(&self, update: &PlayerUpdate) -> Result<(), NodeError> {
+        let mut player = match self.players.get_mut(&update.guild_id) {
+            Some(player) => player,
+            None => {
+                log::warn!(
+                    "Got invalid player update for guild {}: {:?}",
+                    update.guild_id,
+                    update,
+                );
+
+                return Ok(());
+            }
+        };
+
+        *player.value_mut().position_mut() = update.state.position;
+        *player.value_mut().time_mut() = update.state.time;
+
+        Ok(())
+    }
+
+    async fn stats(&self, stats: &Stats) -> Result<(), NodeError> {
+        *self.stats.lock().await = stats.clone();
+
+        Ok(())
+    }
+}
+
+async fn reconnect(
+    state: &NodeConfig,
+) -> Result<WebSocketStream<TokioAdapter<TcpStream>>, NodeError> {
+    let mut builder = Request::get(format!("ws://{}", state.address));
+    builder = builder.header("Authorization", &state.authorization);
+    builder = builder.header("Num-Shards", state.shard_count);
+    builder = builder.header("User-Id", state.user_id.0);
+
+    if state.resume.is_some() {
+        builder = builder.header("Resume-Key", state.address.to_string());
+    }
+
+    let req = builder
+        .body(())
+        .map_err(|source| NodeError::BuildingConnectionRequest { source })?;
+
+    let (mut stream, res) = async_tungstenite::tokio::connect_async(req).await.unwrap();
+    let headers = res.headers();
+
+    if let Some(resume) = state.resume.as_ref() {
+        let header = HeaderName::from_static("session-resumed");
+
+        if let Some(value) = headers.get(header) {
+            if value.as_bytes() == b"false" {
+                let payload = serde_json::json!({
+                    "op": "configureResuming",
+                    "key": state.address,
+                    "timeout": resume.timeout,
+                });
+                let msg = Message::Text(serde_json::to_string(&payload).unwrap());
+
+                stream.send(msg).await.unwrap();
+            }
+        }
+    }
+
+    Ok(stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Node, NodeConfig, NodeError, NodeRef};
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(NodeConfig: Clone, Debug, Send, Sync);
+    assert_impl_all!(NodeError: Debug, Send, Sync);
+    assert_impl_all!(NodeRef: Debug, Send, Sync);
+    assert_impl_all!(Node: Clone, Debug, Send, Sync);
+}

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -77,9 +77,7 @@ impl Display for NodeError {
             Self::BuildingConnectionRequest { .. } => {
                 f.write_str("failed to build connection request")
             }
-            Self::Connecting { .. } => {
-                f.write_str("Failed to connect to the node")
-            }
+            Self::Connecting { .. } => f.write_str("Failed to connect to the node"),
             Self::SerializingMessage { .. } => {
                 f.write_str("failed to serialize outgoing message as json")
             }
@@ -535,9 +533,9 @@ async fn backoff(
                 seconds *= 2;
 
                 continue;
-            },
+            }
         }
-    };
+    }
 }
 
 #[cfg(test)]

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -20,7 +20,10 @@
 //! [`VoiceUpdate`]: ../model/struct.VoiceUpdate.html
 
 use crate::{
-    model::{IncomingEvent, Opcode, OutgoingEvent, PlayerUpdate, Stats, StatsCpu, StatsFrames, StatsMemory},
+    model::{
+        IncomingEvent, Opcode, OutgoingEvent, PlayerUpdate, Stats, StatsCpu, StatsFrames,
+        StatsMemory,
+    },
     player::PlayerManager,
 };
 use async_tungstenite::{
@@ -307,7 +310,8 @@ impl Node {
 
         let (deficit_frame, null_frame) = (
             1.03f64.powf(500f64 * (stats.frames.deficit as f64 / 3000f64)) * 300f64 - 300f64,
-            (1.03f64.powf(500f64 * (stats.frames.nulled as f64 / 3000f64)) * 300f64 - 300f64) * 2f64,
+            (1.03f64.powf(500f64 * (stats.frames.nulled as f64 / 3000f64)) * 300f64 - 300f64)
+                * 2f64,
         );
 
         stats.playing_players as i32 + cpu as i32 + deficit_frame as i32 + null_frame as i32

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -1,0 +1,156 @@
+use crate::{model::*, node::Node};
+use dashmap::{
+    mapref::one::{Ref, RefMut},
+    DashMap,
+};
+use futures_channel::mpsc::TrySendError;
+use std::fmt::Debug;
+use twilight_model::id::{ChannelId, GuildId};
+
+#[derive(Clone, Debug, Default)]
+pub struct PlayerManager {
+    pub(crate) players: DashMap<GuildId, Player>,
+}
+
+impl PlayerManager {
+    /// Create a new player manager.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return an immutable reference to a player by guild ID.
+    pub fn get(&self, guild_id: &GuildId) -> Option<Ref<'_, GuildId, Player>> {
+        self.players.get(guild_id)
+    }
+
+    /// Return a mutable reference to a player by guild ID.
+    pub(crate) fn get_mut(&self, guild_id: &GuildId) -> Option<RefMut<'_, GuildId, Player>> {
+        self.players.get_mut(guild_id)
+    }
+
+    /// Return a mutable reference to a player by guild ID or insert a new
+    /// player linked to a given node.
+    pub fn get_or_insert(&self, guild_id: GuildId, node: Node) -> RefMut<'_, GuildId, Player> {
+        self.players
+            .entry(guild_id)
+            .or_insert_with(|| Player::new(guild_id, node))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Player {
+    channel_id: Option<ChannelId>,
+    guild_id: GuildId,
+    node: Node,
+    paused: bool,
+    playing: Option<()>,
+    position: i64,
+    time: i64,
+    volume: u16,
+}
+
+impl Player {
+    pub(crate) fn new(guild_id: GuildId, node: Node) -> Self {
+        Self {
+            channel_id: None,
+            guild_id,
+            node,
+            paused: false,
+            playing: None,
+            position: 0,
+            time: 0,
+            volume: 0,
+        }
+    }
+
+    /// Send an event to the player's node.
+    ///
+    /// Returns a `futures_channel` `TrySendError` if the node has been removed.
+    ///
+    /// # Examples
+    ///
+    /// Send a [`Play`] and [`Pause`] event:
+    ///
+    /// ```
+    /// use twilight_lavalink::{model::{Play, Pause}, Lavalink};
+    /// # use twilight_model::id::{GuildId, UserId};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let (guild_id, user_id) = (GuildId(1), UserId(2));
+    /// # let track = String::new();
+    ///
+    /// let lavalink = Lavalink::new(user_id, 10);
+    /// let players = lavalink.players();
+    ///
+    /// if let Some(player) = players.get(&guild_id) {
+    ///     player.send(Play::from((guild_id, track)))?;
+    ///     player.send(Pause::from((guild_id, true)))?;
+    /// }
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [`Pause`]: ../model/struct.Pause.html
+    /// [`Play`]: ../model/struct.Play.html
+    pub fn send(
+        &self,
+        event: impl Into<OutgoingEvent> + Debug,
+    ) -> Result<(), TrySendError<OutgoingEvent>> {
+        log::debug!(
+            "Sending event on guild player {}: {:?}",
+            self.guild_id,
+            event
+        );
+        let event = event.into();
+
+        self.node.send(event)
+    }
+
+    /// Return an immutable reference to the node linked to the player.
+    pub fn node(&self) -> &Node {
+        &self.node
+    }
+
+    /// Return an immutable reference to the player's channel ID.
+    pub fn channel_id_ref(&self) -> Option<&ChannelId> {
+        self.channel_id.as_ref()
+    }
+
+    /// Return an immutable reference to whether the player is paused.
+    pub fn is_paused_ref(&self) -> &bool {
+        &self.paused
+    }
+
+    /// Return an immutable reference to the player's position.
+    pub fn position_ref(&self) -> &i64 {
+        &self.position
+    }
+
+    /// Return a mmutable reference to the player's channel ID.
+    pub(crate) fn position_mut(&mut self) -> &mut i64 {
+        &mut self.position
+    }
+
+    /// Return an immutable reference to the player's time.
+    pub fn time_ref(&mut self) -> &i64 {
+        &self.time
+    }
+
+    /// Return a mutable reference to the player's channel ID.
+    pub(crate) fn time_mut(&mut self) -> &mut i64 {
+        &mut self.time
+    }
+
+    /// Return an immutable reference to the player's volume.
+    pub fn volume_ref(&self) -> &u16 {
+        &self.volume
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Player, PlayerManager};
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(PlayerManager: Clone, Debug, Default, Send, Sync);
+    assert_impl_all!(Player: Clone, Debug, Send, Sync);
+}

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -4,12 +4,12 @@ use dashmap::{
     DashMap,
 };
 use futures_channel::mpsc::TrySendError;
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 use twilight_model::id::{ChannelId, GuildId};
 
 #[derive(Clone, Debug, Default)]
 pub struct PlayerManager {
-    pub(crate) players: DashMap<GuildId, Player>,
+    pub(crate) players: Arc<DashMap<GuildId, Player>>,
 }
 
 impl PlayerManager {

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -15,7 +15,13 @@ use dashmap::{
     DashMap,
 };
 use futures_channel::mpsc::TrySendError;
-use std::{fmt::Debug, sync::{atomic::{AtomicBool, Ordering}, Arc}};
+use std::{
+    fmt::Debug,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 use twilight_model::id::{ChannelId, GuildId};
 
 /// Retrieve and create players for guilds.


### PR DESCRIPTION
`twilight-lavalink` is a client for [Lavalink] as part of the twilight
ecosystem.

It includes support for managing multiple nodes, a player manager for
conveniently using players to send events and retrieve information for each
guild, and an HTTP module for creating requests using the [`http`] crate and
providing models to deserialize their responses.

Example

Create a client, add a node, and give events to the client to process
events:

```rust
use futures_util::stream::StreamExt;
use std::{
    convert::TryInto,
    env,
    error::Error,
    future::Future,
    net::SocketAddr,
    str::FromStr,
};
use twilight_gateway::{Event, Shard};
use twilight_http::Client as HttpClient;
use twilight_lavalink::{http::LoadedTracks, model::Play, Lavalink};
use twilight_model::{
    channel::Message,
    gateway::payload::MessageCreate,
};

async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
    let token = env::var("DISCORD_TOKEN")?;
    let lavalink_host = SocketAddr::from_str(&env::var("LAVALINK_HOST")?)?;
    let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
    let shard_count = 1u64;

    let http = HttpClient::new(&token);
    let user_id = http.current_user().await?.id;

    let lavalink = Lavalink::new(user_id, shard_count);
    lavalink.add(lavalink_host, lavalink_auth).await?;

    let shard = Shard::new(token).await?;

    let mut events = shard.events().await;

    while let Some(event) = events.next().await {
        lavalink.process(&event).await?;
    }

    Ok(())
}
```

You can see a full example in the crate's examples directory.

[Lavalink]: https://github.com/Frederikam/Lavalink
[`http`]: https://crates.io/crates/http