### PR TITLE
standby: add trace level logging

### DIFF
--- a/standby/Cargo.toml
+++ b/standby/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.1.0"
 [dependencies]
 futures-channel = { default-features = false, features = ["std"], version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
+log = { default-features = false, version = "0.4" }
 twilight-model = { default-features = false, path = "../model" }
 
 [dev-dependencies]

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -406,6 +406,7 @@ impl Standby {
             let sender = match bystander.sender.take() {
                 Some(sender) => sender,
                 None => {
+                    idx += 1;
                     log::trace!("Bystander has no sender, removing");
                     bystanders.remove(idx);
 


### PR DESCRIPTION
Add a lot of TRACE level logging to the standby crate, which can help users figure out application flow.