### PR TITLE
project: sync readmes

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,35 @@
+name: Sync Documentation
+
+on:
+  push:
+  pull_request:
+    paths:
+      - '**/lib.rs'
+      - '**/README.md'
+
+jobs:
+  sync-readme:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/install@v0.1
+      with:
+        crate: cargo-sync-readme
+        version: latest
+        use-tool-cache: true
+    - name: Run in builders
+      run: cd builders && cargo sync-readme --check
+    - name: Run in command-parser
+      run: cd command-parser && cargo sync-readme --check
+    - name: Run in gateway
+      run: cd gateway && cargo sync-readme --check
+    - name: Run in http
+      run: cd http && cargo sync-readme --check
+    - name: Run in lavalink
+      run: cd lavalink && cargo sync-readme --check
+    - name: Run in model
+      run: cd model && cargo sync-readme --check
+    - name: Run in standby
+      run: cd standby && cargo sync-readme --check
+    - name: Run in twilight
+      run: cd twilight && cargo sync-readme --check

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,7 +16,6 @@ jobs:
       with:
         crate: cargo-sync-readme
         version: latest
-        use-tool-cache: true
     - name: Run in builders
       run: cd builders && cargo sync-readme --check
     - name: Run in command-parser

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ Most of Twilight requires at least 1.40+ (rust stable).
 Add this to your `Cargo.toml`'s `[dependencies]` section:
 
 ```toml
-twilight = { git = "https://github.com/twilight-rs/twilight" }
+twilight = { git = "https://github.com/twilight-rs/twilight.git" }
 ```
 
 ## Core Crates
 
 These are essential crates that most users will use together for a full
 development experience. You may not need all of these - such as
-`twilight-cache` - but they are often used together to accomplish most of what
-you need.
+`twilight-cache` - but they are often used together to accomplish most of
+what you need.
 
 ### `twilight-model`
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- cargo-sync-readme start -->
+
 [![license badge][]][license link] [![rust badge]][rust link]
 
 ![project logo][logo]
@@ -21,7 +23,7 @@ Most of Twilight requires at least 1.40+ (rust stable).
 Add this to your `Cargo.toml`'s `[dependencies]` section:
 
 ```toml
-twilight = {version = "0.0.1-alpha.0", git = "https://github.com/twilight-rs/twilight.git" }
+twilight = { git = "https://github.com/twilight-rs/twilight" }
 ```
 
 ## Core Crates
@@ -95,64 +97,26 @@ providing models to deserialize their responses.
 
 ## Examples
 
-```rust
-use std::{env, error::Error};
-use tokio::stream::StreamExt;
-
+```rust,no_run
 use twilight::{
-    cache::{
-        twilight_cache_inmemory::config::{InMemoryConfigBuilder, EventType},
-        InMemoryCache,
-    },
-    gateway::cluster::{config::ShardScheme, Cluster, ClusterConfig},
-    gateway::shard::Event,
+    gateway::{Cluster, ClusterConfig, Event},
     http::Client as HttpClient,
-    model::gateway::GatewayIntents,
 };
+use futures::StreamExt;
+use std::{env, error::Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let token = env::var("DISCORD_TOKEN")?;
-
-    // This is also the default.
-    let scheme = ShardScheme::Auto;
-
-    let config = ClusterConfig::builder(&token)
-        .shard_scheme(scheme)
-        // Use intents to only listen to GUILD_MESSAGES events
-        .intents(Some(
-            GatewayIntents::GUILD_MESSAGES | GatewayIntents::DIRECT_MESSAGES,
-        ))
-        .build();
-
-    // Start up the cluster
-    let cluster = Cluster::new(config);
-    cluster.up().await?;
-
-    // The http client is seperate from the gateway,
-    // so startup a new one
     let http = HttpClient::new(&token);
 
-    // Since we only care about messages, make the cache only
-    // cache message related events
-    let cache_config = InMemoryConfigBuilder::new()
-        .event_types(
-            EventType::MESSAGE_CREATE
-                | EventType::MESSAGE_DELETE
-                | EventType::MESSAGE_DELETE_BULK
-                | EventType::MESSAGE_UPDATE,
-        )
-        .build();
-    let cache = InMemoryCache::from(cache_config);
-
+    let cluster_config = ClusterConfig::builder(&token).build();
+    let cluster = Cluster::new(cluster_config);
+    cluster.up().await?;
 
     let mut events = cluster.events().await;
-    // Startup an event loop for each event in the event stream
-    while let Some(event) = events.next().await {
-        // Update the cache
-        cache.update(&event.1).await.expect("Cache failed, OhNoe");
 
-        // Spawn a new task to handle the event
+    while let Some(event) = events.next().await {
         tokio::spawn(handle_event(event, http.clone()));
     }
 
@@ -164,11 +128,13 @@ async fn handle_event(
     http: HttpClient,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     match event {
-        (_, Event::MessageCreate(msg)) if msg.content == "!ping" => {
-            http.create_message(msg.channel_id).content("Pong!").await?;
-        }
-        (id, Event::ShardConnected(_)) => {
+        (id, Event::Ready(_)) => {
             println!("Connected on shard {}", id);
+        }
+        (_, Event::MessageCreate(msg)) => {
+            if msg.content == "!ping" {
+                http.create_message(msg.channel_id).content("Pong!")?.await?;
+            }
         }
         _ => {}
     }
@@ -176,7 +142,6 @@ async fn handle_event(
     Ok(())
 }
 ```
-
 
 ## License
 
@@ -191,3 +156,5 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/master/logo.png
 [rust badge]: https://img.shields.io/badge/rust-1.40+%20(stable)-93450a.svg?style=flat-square
 [rust link]: https://github.com/rust-lang/rust/milestone/66
+
+<!-- cargo-sync-readme end -->

--- a/command-parser/README.md
+++ b/command-parser/README.md
@@ -1,3 +1,5 @@
+<!-- cargo-sync-readme start -->
+
 [![license badge][]][license link] [![rust badge]][rust link]
 
 # twilight-command-parser
@@ -5,8 +7,8 @@
 `twilight-command-parser` is a command parser for the [`twilight`] ecosystem.
 
 Included is a mutable configuration that allows you to specify the command
-names and prefixes. The parser parses out commands matching an available command
-and prefix and provides the command arguments to you.
+names and prefixes. The parser parses out commands matching an available
+command and prefix and provides the command arguments to you.
 
 # Installation
 
@@ -30,8 +32,8 @@ use twilight_command_parser::{Command, CommandParserConfig, Parser};
 let mut config = CommandParserConfig::new();
 
 // (Use `CommandParserConfig::add_command` to add a single command)
-config.add_command("echo");
-config.add_command("ping");
+config.command("echo").add();
+config.command("ping").add();
 
 // Add the prefix `"!"`.
 // (Use `CommandParserConfig::add_prefixes` to add multiple prefixes)
@@ -59,4 +61,6 @@ match parser.parse("!echo a message") {
 [license link]: https://opensource.org/licenses/ISC
 [rust badge]: https://img.shields.io/badge/rust-1.36+-93450a.svg?style=flat-square
 [rust link]: https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html
-[`twilight`]: https://github.com/twilight-rs/twilight
+[`twilight`]: https://twilight.valley.cafe
+
+<!-- cargo-sync-readme end -->

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -8,7 +8,7 @@ and sending *some* stateful information.
 
 It includes two primary types: the Shard and Cluster.
 
-The Shard handles a single WebSocket connection and can manage up to 2500
+The Shard handles a single websocket connection and can manage up to 2500
 guilds. If you manage a small bot in under about 2000 guilds, then this is
 what you use. See the [Discord docs][docs:discord:sharding] for more
 information on sharding.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,3 +1,5 @@
+<!-- cargo-sync-readme start -->
+
 # twilight-gateway
 
 `twilight-gateway` is an implementation of Discord's sharding gateway sessions.
@@ -26,7 +28,7 @@ To use this feature you need to also add these lines to a file in `<project root
 [build]
 rustflags = ["-C", "target-cpu=native"]
 ```
-you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`. If you enable both 
+you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`. If you enable both
 `serde_json` and `simd-json` at the same time; this crate uses `simd-json`. But it is recommended to
 disable `serde_json` if you are going to use `simd-json`. It is easy to switch to out:
 
@@ -36,3 +38,5 @@ twilight-gateway = { default-features = false, features = ["simd-json"], git = "
 ```
 
 [simd-json]: https://github.com/simd-lite/simd-json
+
+<!-- cargo-sync-readme end -->

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! It includes two primary types: the Shard and Cluster.
 //!
-//! The Shard handles a single WebSocket connection and can manage up to 2500
+//! The Shard handles a single websocket connection and can manage up to 2500
 //! guilds. If you manage a small bot in under about 2000 guilds, then this is
 //! what you use. See the [Discord docs][docs:discord:sharding] for more
 //! information on sharding.

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -1,3 +1,42 @@
+//! # twilight-gateway
+//!
+//! `twilight-gateway` is an implementation of Discord's sharding gateway sessions.
+//! This is responsible for receiving stateful events in real-time from Discord
+//! and sending *some* stateful information.
+//!
+//! It includes two primary types: the Shard and Cluster.
+//!
+//! The Shard handles a single WebSocket connection and can manage up to 2500
+//! guilds. If you manage a small bot in under about 2000 guilds, then this is
+//! what you use. See the [Discord docs][docs:discord:sharding] for more
+//! information on sharding.
+//!
+//! The Cluster is an interface which manages the health of the shards it
+//! manages and proxies all of their events under one unified stream. This is
+//! useful to use if you have a large bot in over 1000 or 2000 guilds.
+//!
+//! ## Features
+//!
+//! `twilight-gateway` includes only a feature: `simd-json`.
+//!
+//! `simd` feature enables [simd-json] support to use simd features of the modern cpus
+//! to deserialize json data faster. It is not enabled by default since not every cpu has those features.
+//! To use this feature you need to also add these lines to a file in `<project root>/.cargo/config`
+//! ```toml
+//! [build]
+//! rustflags = ["-C", "target-cpu=native"]
+//! ```
+//! you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`. If you enable both
+//! `serde_json` and `simd-json` at the same time; this crate uses `simd-json`. But it is recommended to
+//! disable `serde_json` if you are going to use `simd-json`. It is easy to switch to out:
+//!
+//! ```toml
+//! [dependencies]
+//! twilight-gateway = { default-features = false, features = ["simd-json"], git = "https://github.com/twilight-rs/twilight" }
+//! ```
+//!
+//! [simd-json]: https://github.com/simd-lite/simd-json
+
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/http/README.md
+++ b/http/README.md
@@ -1,3 +1,5 @@
+<!-- cargo-sync-readme start -->
+
 # twilight-http
 
 HTTP support for the twilight ecosystem.
@@ -8,7 +10,7 @@ HTTP support for the twilight ecosystem.
 enabled by default. `native` will enable `reqwest`'s `default-tls` feature,
 which will use the TLS library native to your OS (for example, OpenSSL on
 Linux). `rustls` will enable `reqwest`'s `rustls-tls` feature, which will use
-[rustls]. 
+[rustls].
 
 If you want to use Rustls instead of your native library, it's easy to switch it
 out:
@@ -29,7 +31,7 @@ To use this feature you need to also add these lines to a file in `<project root
 [build]
 rustflags = ["-C", "target-cpu=native"]
 ```
-you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`. If you enable both 
+you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`. If you enable both
 `serde_json` and `simd-json` at the same time; this crate uses `simd-json`. But it is recommended to
 disable `serde_json` if you are going to use `simd-json`. It is easy to switch to out:
 
@@ -40,3 +42,5 @@ twilight-gateway = { default-features = false, features = ["simd-json"], git = "
 
 [rustls]: https://github.com/ctz/rustls
 [simd-json]: https://github.com/simd-lite/simd-json
+
+<!-- cargo-sync-readme end -->

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -1,3 +1,46 @@
+//! # twilight-http
+//!
+//! HTTP support for the twilight ecosystem.
+//!
+//! ## Features
+//!
+//! `twilight-http` includes three features: `native`, `simd` and `rustls`. `native` is
+//! enabled by default. `native` will enable `reqwest`'s `default-tls` feature,
+//! which will use the TLS library native to your OS (for example, OpenSSL on
+//! Linux). `rustls` will enable `reqwest`'s `rustls-tls` feature, which will use
+//! [rustls].
+//!
+//! If you want to use Rustls instead of your native library, it's easy to switch it
+//! out:
+//!
+//! ```toml
+//! [dependencies]
+//! twilight-http = { default-features = false, features = ["rustls"], git = "https://github.com/twilight-rs/twilight" }
+//! ```
+//!
+//! You can also choose to use neither feature. This is only useful if you provide
+//! your own configured Reqwest client to the HTTP client, otherwise you will
+//! encounter TLS errors.
+//!
+//! `simd` feature enables [simd-json] support to use simd features of the modern cpus
+//! to deserialize json data faster. It is not enabled by default since not every cpu has those features.
+//! To use this feature you need to also add these lines to a file in `<project root>/.cargo/config`
+//! ```toml
+//! [build]
+//! rustflags = ["-C", "target-cpu=native"]
+//! ```
+//! you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`. If you enable both
+//! `serde_json` and `simd-json` at the same time; this crate uses `simd-json`. But it is recommended to
+//! disable `serde_json` if you are going to use `simd-json`. It is easy to switch to out:
+//!
+//! ```toml
+//! [dependencies]
+//! twilight-gateway = { default-features = false, features = ["simd-json"], git = "https://github.com/twilight-rs/twilight" }
+//! ```
+//!
+//! [rustls]: https://github.com/ctz/rustls
+//! [simd-json]: https://github.com/simd-lite/simd-json
+
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -1,3 +1,5 @@
+<!-- cargo-sync-readme start -->
+
 # twilight-lavalink
 
 `twilight-lavalink` is a client for [Lavalink] as part of the twilight
@@ -12,14 +14,15 @@ providing models to deserialize their responses.
 
 Included is the `http-support` feature.
 
-The `http-support` feature adds support for the `http` module to return request
-types from the [`http`] crate. This is enabled by default.
+The `http-support` feature adds support for the `http` module to return
+request types from the [`http`] crate. This is enabled by default.
 
 ## Examples
 
-Create a client, add a node, and give events to the client to process events:
+Create a [client], add a [node], and give events to the client to [process]
+events:
 
-```rust
+```rust,no_run
 use futures_util::stream::StreamExt;
 use std::{
     convert::TryInto,
@@ -63,4 +66,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 ```
 
 [Lavalink]: https://github.com/Frederikam/Lavalink
+[client]: client/struct.Lavalink.html
+[node]: node/struct.Node.html
+[process]: client/struct.Lavalink.html#method.process
 [`http`]: https://crates.io/crates/http
+
+<!-- cargo-sync-readme end -->

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -66,24 +66,21 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         state.standby.process(&event).await;
         state.lavalink.process(&event).await?;
 
-        match event {
-            Event::MessageCreate(msg) => {
-                if msg.guild_id.is_none() || !msg.content.starts_with("!") {
-                    continue;
-                }
-
-                match msg.content.splitn(2, ' ').next() {
-                    Some("!join") => spawn(join(msg.0, state.clone())),
-                    Some("!leave") => spawn(leave(msg.0, state.clone())),
-                    Some("!pause") => spawn(pause(msg.0, state.clone())),
-                    Some("!play") => spawn(play(msg.0, state.clone())),
-                    Some("!seek") => spawn(seek(msg.0, state.clone())),
-                    Some("!stop") => spawn(stop(msg.0, state.clone())),
-                    Some("!volume") => spawn(volume(msg.0, state.clone())),
-                    _ => continue,
-                };
+        if let Event::MessageCreate(msg) = event {
+            if msg.guild_id.is_none() || !msg.content.starts_with('!') {
+                continue;
             }
-            _ => {}
+
+            match msg.content.splitn(2, ' ').next() {
+                Some("!join") => spawn(join(msg.0, state.clone())),
+                Some("!leave") => spawn(leave(msg.0, state.clone())),
+                Some("!pause") => spawn(pause(msg.0, state.clone())),
+                Some("!play") => spawn(play(msg.0, state.clone())),
+                Some("!seek") => spawn(seek(msg.0, state.clone())),
+                Some("!stop") => spawn(stop(msg.0, state.clone())),
+                Some("!volume") => spawn(volume(msg.0, state.clone())),
+                _ => continue,
+            }
         }
     }
 

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -20,7 +20,7 @@
 //! Create a [client], add a [node], and give events to the client to [process]
 //! events:
 //!
-//! ```no_run
+//! ```rust,no_run
 //! use futures_util::stream::StreamExt;
 //! use std::{
 //!     convert::TryInto,

--- a/model/README.md
+++ b/model/README.md
@@ -1,3 +1,5 @@
+<!-- cargo-sync-readme start -->
+
 [![license badge][]][license link] [![rust badge]][rust link]
 
 # twilight-model
@@ -41,6 +43,10 @@ This enables serde support of the models, which brings in four dependencies:
 - `serde-mappable-seq`
 - `serde_repr`
 
+Enabling only the `serde` dependency will do nothing: all of them need to be
+enabled for correct (de)serialization, so you need to enable
+`serde-support`.
+
 If you don't need serde support, you can disable it:
 
 ```toml
@@ -58,3 +64,5 @@ twilight-model = { default-features = false, git = "https://github.com/twilight-
 [license link]: https://opensource.org/licenses/ISC
 [rust badge]: https://img.shields.io/badge/rust-1.31+-93450a.svg?style=flat-square
 [rust link]: https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html
+
+<!-- cargo-sync-readme end -->

--- a/standby/README.md
+++ b/standby/README.md
@@ -1,0 +1,45 @@
+<!-- cargo-sync-readme start -->
+
+# twilight-standby
+
+Standby is a utility to wait for an event to happen based on a predicate
+check. For example, you may have a command that has a reaction menu of ✅ and
+❌. If you want to handle a reaction to these, using something like an
+application-level state or event stream may not suit your use case. It may
+be cleaner to wait for a reaction inline to your function. This is where
+Twilight Standby comes in.
+
+Standby allows you to wait for things like an event in a certain guild
+([`Standby::wait_for`]), a new message in a channel
+([`Standby::wait_for_message`]), a new reaction on a message
+([`Standby::wait_for_reaction`]), and any event that might not take place in
+a guild, such as a new `Ready` event ([`Standby::wait_for_event`]).
+
+To use Standby, you must process events with it in your main event loop.
+Check out the [`Standby::process`] method.
+
+# Examples
+
+Wait for a message in channel 123 by user 456 with the content "test":
+
+```no_run
+use futures_util::future;
+use twilight_model::{gateway::payload::MessageCreate, id::{ChannelId, UserId}};
+use twilight_standby::Standby;
+
+let standby = Standby::new();
+
+let message = standby.wait_for_message(ChannelId(123), |event: &MessageCreate| {
+    event.author.id == UserId(456) && event.content == "test"
+}).await?;
+```
+
+For more examples, check out each method.
+
+[`Standby::process`]: struct.Standby.html#method.process
+[`Standby::wait_for`]: struct.Standby.html#method.wait_for
+[`Standby::wait_for_event`]: struct.Standby.html#method.wait_for_event
+[`Standby::wait_for_message`]: struct.Standby.html#method.wait_for_message
+[`Standby::wait_for_reaction`]: struct.Standby.html#method.wait_for_reaction
+
+<!-- cargo-sync-readme end -->

--- a/twilight/README.md
+++ b/twilight/README.md
@@ -1,0 +1,1 @@
+./README.md

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -1,4 +1,7 @@
 //! [![license badge][]][license link] [![rust badge]][rust link]
+//!
+//! ![project logo][logo]
+//!
 //! # twilight
 //!
 //! `twilight` is an asynchronous, simple, and extensible set of libraries which can
@@ -13,12 +16,12 @@
 //!
 //! ## Installation
 //!
-//! Most of twilight requires at least 1.39+ (rust beta).
+//! Most of Twilight requires at least 1.40+ (rust stable).
 //!
 //! Add this to your `Cargo.toml`'s `[dependencies]` section:
 //!
 //! ```toml
-//! twilight = "0.0.1-alpha.0"
+//! twilight = {version = "0.0.1-alpha.0", git = "https://github.com/twilight-rs/twilight.git" }
 //! ```
 //!
 //! ## Crates
@@ -55,17 +58,6 @@
 //! This is responsible for receiving stateful events in real-time from Discord
 //! and sending *some* stateful information.
 //!
-//! It includes two primary types: the Shard and Cluster.
-//!
-//! The Shard handles a single WebSocket connection and can manage up to 2500
-//! guilds. If you manage a small bot in under about 2000 guilds, then this is
-//! what you use. See the [Discord docs][docs:discord:sharding] for more
-//! information on sharding.
-//!
-//! The Cluster is an interface which manages the health of the shards it
-//! manages and proxies all of their events under one unified stream. This is
-//! useful to use if you have a large bot in over 1000 or 2000 guilds.
-//!
 //! ### `twilight-command-parser`
 //!
 //! `twilight-command-parser` is a crate for parsing commands out of messages
@@ -80,13 +72,13 @@
 //!
 //! ### `twilight-standby`
 //!
-//! `twilight-standby` is an event processor that allows for tasks to wait for
-//! an event to come in. This is useful, for example, when you have a reaction
-//! menu and want to wait for a reaction to it to come in.
+//! `twilight-standby` is an event processor that allows for tasks to wait for an
+//! event to come in. This is useful, for example, when you have a reaction menu
+//! and want to wait for a reaction to it to come in.
 //!
 //! ## Examples
 //!
-//! ```no_run
+//! ```rust,no_run
 //! use twilight::{
 //!     gateway::{Cluster, ClusterConfig, Event},
 //!     http::Client as HttpClient,
@@ -141,7 +133,7 @@
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
 //! [license link]: https://opensource.org/licenses/ISC
 //! [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/master/logo.png
-//! [rust badge]: https://img.shields.io/badge/rust-1.39+%20(beta)-93450a.svg?style=flat-square
+//! [rust badge]: https://img.shields.io/badge/rust-1.40+%20(stable)-93450a.svg?style=flat-square
 //! [rust link]: https://github.com/rust-lang/rust/milestone/66
 
 #[cfg(feature = "builders")]

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -21,14 +21,15 @@
 //! Add this to your `Cargo.toml`'s `[dependencies]` section:
 //!
 //! ```toml
-//! twilight = {version = "0.0.1-alpha.0", git = "https://github.com/twilight-rs/twilight.git" }
+//! twilight = { git = "https://github.com/twilight-rs/twilight.git" }
 //! ```
 //!
-//! ## Crates
+//! ## Core Crates
 //!
-//! These are crates that can work together for a full application experience.
-//! You may not need all of these - such as `twilight-cache` - but they can be
-//! mixed together to accomplish just what you need.
+//! These are essential crates that most users will use together for a full
+//! development experience. You may not need all of these - such as
+//! `twilight-cache` - but they are often used together to accomplish most of
+//! what you need.
 //!
 //! ### `twilight-model`
 //!
@@ -75,6 +76,22 @@
 //! `twilight-standby` is an event processor that allows for tasks to wait for an
 //! event to come in. This is useful, for example, when you have a reaction menu
 //! and want to wait for a reaction to it to come in.
+//!
+//! ## Additional Crates
+//!
+//! These are crates that are officially supported by Twilight, but aren't
+//! considered core crates due to being vendor-specific or non-essential for most
+//! users.
+//!
+//! ### `twilight-lavalink`
+//!
+//! `twilight-lavalink` is a client for [Lavalink] as part of the twilight
+//! ecosystem.
+//!
+//! It includes support for managing multiple nodes, a player manager for
+//! conveniently using players to send events and retrieve information for each
+//! guild, and an HTTP module for creating requests using the [`http`] crate and
+//! providing models to deserialize their responses.
 //!
 //! ## Examples
 //!
@@ -129,6 +146,8 @@
 //! All first-party crates are licensed under [ISC][LICENSE.md]
 //!
 //! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/master/LICENSE.md
+//! [Lavalink]: https://github.com/Frederikam/Lavalink
+//! [`http`]: https://crates.io/crates/http
 //! [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
 //! [license link]: https://opensource.org/licenses/ISC


### PR DESCRIPTION
Sync the readmes in README.md files and in lib.rs files. This also adds a CI workflow for checking that all readmes are synced using [`cargo-sync-readme`].

[`cargo-sync-readme`]: https://crates.io/crates/cargo-sync-readme

Closes #97.