### PR TITLE
cache/in-memory: remove gateway dependency

### DIFF
--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -10,7 +10,6 @@ bitflags = "1"
 futures = "0.3"
 twilight-cache-trait = { path = "../trait" }
 twilight-model = { default-features = false, path = "../../model" }
-twilight-gateway = { path = "../../gateway"}
 log = "0.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Remove the dependency on `twilight-gateway` from the `twilight-cache-inmemory` crate. This was accidentally left in after PR #177.