### PR TITLE
model: make member guild ids always present

### DIFF
--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -321,16 +321,13 @@ impl UpdateCache<InMemoryCache, InMemoryCacheError> for MemberAdd {
             return Ok(());
         }
 
-        // This will always be present on members from the gateway.
-        let guild_id = match self.guild_id {
-            Some(guild_id) => guild_id,
-            None => return Ok(()),
-        };
-
-        cache.cache_member(guild_id, self.0.clone()).await;
+        cache.cache_member(self.guild_id, self.0.clone()).await;
 
         let mut guild = cache.0.guild_members.lock().await;
-        guild.entry(guild_id).or_default().insert(self.0.user.id);
+        guild
+            .entry(self.guild_id)
+            .or_default()
+            .insert(self.0.user.id);
 
         Ok(())
     }

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -1,11 +1,16 @@
 use crate::request::prelude::*;
-
+use bytes::Bytes;
+use serde::de::DeserializeSeed;
+use serde_json::Value;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
 };
 use twilight_model::{
-    guild::Member,
+    guild::member::{Member, MemberDeserializer},
     id::{GuildId, UserId},
 };
 
@@ -57,7 +62,7 @@ struct GetGuildMembersFields {
 /// ```
 pub struct GetGuildMembers<'a> {
     fields: GetGuildMembersFields,
-    fut: Option<Pending<'a, Vec<Member>>>,
+    fut: Option<Pending<'a, Bytes>>,
     guild_id: GuildId,
     http: &'a Client,
 }
@@ -107,17 +112,44 @@ impl<'a> GetGuildMembers<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetGuildMembers {
-                after: self.fields.after.map(|x| x.0),
-                guild_id: self.guild_id.0,
-                limit: self.fields.limit,
-                presences: self.fields.presences,
-            },
-        ))));
+        self.fut
+            .replace(Box::pin(self.http.request_bytes(Request::from(
+                Route::GetGuildMembers {
+                    after: self.fields.after.map(|x| x.0),
+                    guild_id: self.guild_id.0,
+                    limit: self.fields.limit,
+                    presences: self.fields.presences,
+                },
+            ))));
 
         Ok(())
     }
 }
 
-poll_req!(GetGuildMembers<'_>, Vec<Member>);
+impl Future for GetGuildMembers<'_> {
+    type Output = Result<Vec<Member>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.fut.is_none() {
+            self.as_mut().start()?;
+        }
+
+        let fut = self.fut.as_mut().expect("future is created");
+
+        match fut.as_mut().poll(cx) {
+            Poll::Ready(res) => {
+                let bytes = res?;
+                let mut members = Vec::new();
+                let values = serde_json::from_slice::<Vec<Value>>(&bytes)?;
+
+                for value in values {
+                    let member_deserializer = MemberDeserializer::new(self.guild_id);
+                    members.push(member_deserializer.deserialize(value)?);
+                }
+
+                Poll::Ready(Ok(members))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -1,6 +1,13 @@
 use crate::request::prelude::*;
+use serde::de::{value::BorrowedBytesDeserializer, DeserializeSeed};
+use serde_json::Error as JsonError;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use twilight_model::{
-    guild::Member,
+    guild::member::{Member, MemberDeserializer},
     id::{GuildId, UserId},
 };
 
@@ -34,4 +41,34 @@ impl<'a> GetMember<'a> {
     }
 }
 
-poll_req!(opt, GetMember<'_>, Member);
+impl Future for GetMember<'_> {
+    type Output = Result<Option<Member>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {
+            if let Some(fut) = self.as_mut().fut.as_mut() {
+                let bytes = match fut.as_mut().poll(cx) {
+                    Poll::Ready(Ok(bytes)) => bytes,
+                    Poll::Ready(Err(crate::Error::Response { status, .. }))
+                        if status == reqwest::StatusCode::NOT_FOUND =>
+                    {
+                        return Poll::Ready(Ok(None));
+                    }
+                    Poll::Ready(Err(why)) => return Poll::Ready(Err(why)),
+                    Poll::Pending => return Poll::Pending,
+                };
+
+                let member_deserializer = MemberDeserializer::new(self.guild_id);
+                let deserializer: BorrowedBytesDeserializer<'_, JsonError> =
+                    BorrowedBytesDeserializer::new(&bytes);
+                let member = member_deserializer.deserialize(deserializer)?;
+
+                return Poll::Ready(Ok(Some(member)));
+            }
+
+            if let Err(why) = self.as_mut().start() {
+                return Poll::Ready(Err(why));
+            }
+        }
+    }
+}

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.1.0"
 
 [dependencies]
 bitflags = "1"
+log = { version = "0.4" }
 serde = { features = ["derive"], optional = true, version = "1" }
 serde-mappable-seq = { optional = true, version = "0.1" }
 serde_repr = { optional = true, version = "0.1" }

--- a/model/src/gateway/payload/member_add.rs
+++ b/model/src/gateway/payload/member_add.rs
@@ -35,7 +35,7 @@ mod tests {
     fn test_member_add() {
         let member_add = MemberAdd(Member {
             deaf: false,
-            guild_id: Some(GuildId(1)),
+            guild_id: GuildId(1),
             hoisted_role: None,
             joined_at: None,
             mute: false,
@@ -70,7 +70,6 @@ mod tests {
                 Token::Str("deaf"),
                 Token::Bool(false),
                 Token::Str("guild_id"),
-                Token::Some,
                 Token::NewtypeStruct { name: "GuildId" },
                 Token::Str("1"),
                 Token::Str("hoisted_role"),

--- a/model/src/gateway/payload/voice_state_update.rs
+++ b/model/src/gateway/payload/voice_state_update.rs
@@ -26,7 +26,7 @@ mod tests {
             guild_id: Some(GuildId(1)),
             member: Some(Member {
                 deaf: false,
-                guild_id: None,
+                guild_id: GuildId(1),
                 hoisted_role: Some(RoleId(4)),
                 joined_at: None,
                 mute: false,
@@ -86,7 +86,8 @@ mod tests {
                 Token::Str("deaf"),
                 Token::Bool(false),
                 Token::Str("guild_id"),
-                Token::None,
+                Token::NewtypeStruct { name: "GuildId" },
+                Token::Str("1"),
                 Token::Str("hoisted_role"),
                 Token::Some,
                 Token::NewtypeStruct { name: "RoleId" },

--- a/model/src/guild/member.rs
+++ b/model/src/guild/member.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde-support")]
+pub use self::if_serde_support::MemberDeserializer;
+
 use crate::{
     id::{GuildId, RoleId},
     user::User,
@@ -10,7 +13,7 @@ use crate::{
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Member {
     pub deaf: bool,
-    pub guild_id: Option<GuildId>,
+    pub guild_id: GuildId,
     pub hoisted_role: Option<RoleId>,
     pub joined_at: Option<String>,
     pub mute: bool,
@@ -21,14 +24,173 @@ pub struct Member {
 }
 
 #[cfg(feature = "serde-support")]
-mod serde_support {
+pub(super) mod if_serde_support {
     use super::Member;
-    use crate::id::UserId;
+    use crate::{
+        id::{GuildId, RoleId, UserId},
+        user::User,
+    };
+    use serde::{
+        de::{value::MapAccessDeserializer, DeserializeSeed, Deserializer, MapAccess, Visitor},
+        Deserialize, Serialize,
+    };
     use serde_mappable_seq::Key;
+    use std::fmt::{Formatter, Result as FmtResult};
 
     impl Key<'_, UserId> for Member {
         fn key(&self) -> UserId {
             self.user.id
+        }
+    }
+    // Used in the guild deserializer.
+    #[derive(Deserialize, Serialize)]
+    pub struct MemberIntermediary {
+        pub deaf: bool,
+        pub hoisted_role: Option<RoleId>,
+        pub joined_at: Option<String>,
+        pub mute: bool,
+        pub nick: Option<String>,
+        pub premium_since: Option<String>,
+        pub roles: Vec<RoleId>,
+        pub user: User,
+    }
+
+    /// Deserialize a member when the payload doesn't have the guild ID but
+    /// you already know the guild ID.
+    ///
+    /// Member payloads from the HTTP API, for example, don't have the guild
+    /// ID.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct MemberDeserializer(GuildId);
+
+    impl MemberDeserializer {
+        /// Create a new deserializer for a member when you know the ID but the
+        /// payload probably doesn't contain it.
+        pub fn new(guild_id: GuildId) -> Self {
+            Self(guild_id)
+        }
+    }
+
+    impl<'de> DeserializeSeed<'de> for MemberDeserializer {
+        type Value = Member;
+
+        fn deserialize<D: Deserializer<'de>>(
+            self,
+            deserializer: D,
+        ) -> Result<Self::Value, D::Error> {
+            struct MemberDeserializerVisitor(GuildId);
+
+            impl<'de> Visitor<'de> for MemberDeserializerVisitor {
+                type Value = Member;
+
+                fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+                    f.write_str("a map of member fields")
+                }
+
+                fn visit_map<M: MapAccess<'de>>(self, map: M) -> Result<Self::Value, M::Error> {
+                    let deser = MapAccessDeserializer::new(map);
+                    let member = MemberIntermediary::deserialize(deser)?;
+
+                    Ok(Member {
+                        deaf: member.deaf,
+                        guild_id: self.0,
+                        hoisted_role: member.hoisted_role,
+                        joined_at: member.joined_at,
+                        mute: member.mute,
+                        nick: member.nick,
+                        premium_since: member.premium_since,
+                        roles: member.roles,
+                        user: member.user,
+                    })
+                }
+            }
+
+            deserializer.deserialize_map(MemberDeserializerVisitor(self.0))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "serde-support")]
+    mod if_serde {
+        use super::super::{Member, MemberDeserializer};
+        use crate::{
+            id::{GuildId, UserId},
+            user::User,
+        };
+        use serde::de::DeserializeSeed;
+        use serde_value::Value;
+        use std::collections::BTreeMap;
+
+        #[test]
+        fn test_member_deserializer() {
+            let mut user = BTreeMap::new();
+            user.insert(
+                Value::String("discriminator".to_owned()),
+                Value::String("0001".to_owned()),
+            );
+            user.insert(
+                Value::String("id".to_owned()),
+                Value::String("2".to_owned()),
+            );
+            user.insert(
+                Value::String("username".to_owned()),
+                Value::String("twilight".to_owned()),
+            );
+
+            let mut map = BTreeMap::new();
+            map.insert(Value::String("deaf".to_owned()), Value::Bool(false));
+            map.insert(
+                Value::String("hoisted_role".to_owned()),
+                Value::Option(None),
+            );
+            map.insert(
+                Value::String("joined_at".to_owned()),
+                Value::String(String::new()),
+            );
+            map.insert(Value::String("mute".to_owned()), Value::Bool(true));
+            map.insert(
+                Value::String("nick".to_owned()),
+                Value::Option(Some(Box::new(Value::String("twilight".to_owned())))),
+            );
+            map.insert(
+                Value::String("premium_since".to_owned()),
+                Value::Option(None),
+            );
+            map.insert(Value::String("roles".to_owned()), Value::Seq(Vec::new()));
+            map.insert(Value::String("user".to_owned()), Value::Map(user));
+            let value = Value::Map(map);
+
+            let expected = Member {
+                deaf: false,
+                guild_id: GuildId(1),
+                hoisted_role: None,
+                joined_at: Some(String::new()),
+                mute: true,
+                nick: Some("twilight".to_owned()),
+                premium_since: None,
+                roles: Vec::new(),
+                user: User {
+                    avatar: None,
+                    bot: false,
+                    discriminator: "0001".to_owned(),
+                    locale: None,
+                    email: None,
+                    flags: None,
+                    id: UserId(2),
+                    mfa_enabled: None,
+                    name: "twilight".to_owned(),
+                    premium_type: None,
+                    public_flags: None,
+                    system: None,
+                    verified: None,
+                },
+            };
+
+            let deserializer = MemberDeserializer::new(GuildId(1));
+
+            assert_eq!(expected, deserializer.deserialize(value).unwrap());
         }
     }
 }

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -301,8 +301,10 @@ mod if_serde_support {
                                 }
 
                                 let raw_channels = map.next_value::<Value>()?;
-                                channels =
-                                    Some(serde_mappable_seq::deserialize(raw_channels).map_err(DeError::custom)?);
+                                channels = Some(
+                                    serde_mappable_seq::deserialize(raw_channels)
+                                        .map_err(DeError::custom)?,
+                                );
                             }
                             Field::DefaultMessageNotifications => {
                                 if default_message_notifications.is_some() {
@@ -347,7 +349,10 @@ mod if_serde_support {
                                 }
 
                                 let raw_emojis = map.next_value::<Value>()?;
-                                emojis = Some(serde_mappable_seq::deserialize(raw_emojis).map_err(DeError::custom)?);
+                                emojis = Some(
+                                    serde_mappable_seq::deserialize(raw_emojis)
+                                        .map_err(DeError::custom)?,
+                                );
                             }
                             Field::ExplicitContentFilter => {
                                 if explicit_content_filter.is_some() {
@@ -501,8 +506,10 @@ mod if_serde_support {
                                 }
 
                                 let raw_presences = map.next_value::<Value>()?;
-                                presences =
-                                    Some(serde_mappable_seq::deserialize(raw_presences).map_err(DeError::custom)?);
+                                presences = Some(
+                                    serde_mappable_seq::deserialize(raw_presences)
+                                        .map_err(DeError::custom)?,
+                                );
                             }
                             Field::Region => {
                                 if region.is_some() {
@@ -517,7 +524,10 @@ mod if_serde_support {
                                 }
 
                                 let raw_roles = map.next_value::<Value>()?;
-                                roles = Some(serde_mappable_seq::deserialize(raw_roles).map_err(DeError::custom)?);
+                                roles = Some(
+                                    serde_mappable_seq::deserialize(raw_roles)
+                                        .map_err(DeError::custom)?,
+                                );
                             }
                             Field::Splash => {
                                 if splash.is_some() {
@@ -568,7 +578,8 @@ mod if_serde_support {
 
                                 let raw_voice_states = map.next_value::<Value>()?;
                                 voice_states = Some(
-                                    serde_mappable_seq::deserialize(raw_voice_states).map_err(DeError::custom)?,
+                                    serde_mappable_seq::deserialize(raw_voice_states)
+                                        .map_err(DeError::custom)?,
                                 );
                             }
                             Field::VanityUrlCode => {

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -41,10 +41,7 @@ use crate::{
 };
 use std::collections::HashMap;
 
-#[cfg_attr(
-    feature = "serde-support",
-    derive(serde::Serialize)
-)]
+#[cfg_attr(feature = "serde-support", derive(serde::Serialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Guild {
     pub id: GuildId,
@@ -107,12 +104,22 @@ pub struct Guild {
 
 #[cfg(feature = "serde-support")]
 mod if_serde_support {
-    use super::{member::{if_serde_support::MemberIntermediary, Member}, Guild};
-    use serde::{de::{Deserializer, Error as DeError, MapAccess, Visitor}, Deserialize};
+    use super::{
+        member::{if_serde_support::MemberIntermediary, Member},
+        Guild,
+    };
+    use serde::{
+        de::{Deserializer, Error as DeError, MapAccess, Visitor},
+        Deserialize,
+    };
     use serde_value::Value;
-    use std::{collections::HashMap, fmt::{Formatter, Result as FmtResult}};
+    use std::{
+        collections::HashMap,
+        fmt::{Formatter, Result as FmtResult},
+    };
 
     impl<'de> Deserialize<'de> for Guild {
+        #[allow(clippy::too_many_lines)]
         fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             #[derive(Debug, Deserialize)]
             #[serde(field_identifier, rename_all = "snake_case")]
@@ -174,7 +181,7 @@ mod if_serde_support {
                     f.write_str("struct Guild")
                 }
 
-                #[allow(unreachable_code, unused)]
+                #[allow(clippy::too_many_lines)]
                 fn visit_map<V: MapAccess<'de>>(self, mut map: V) -> Result<Self::Value, V::Error> {
                     let mut afk_channel_id = None::<Option<_>>;
                     let mut afk_timeout = None;
@@ -230,13 +237,13 @@ mod if_serde_support {
                                 log::debug!("breaking");
 
                                 break;
-                            },
+                            }
                             Err(_) => {
                                 // Encountered when we run into an unknown key.
                                 log::debug!("continuing");
 
                                 continue;
-                            },
+                            }
                         };
 
                         log::debug!("key {:?}", key);
@@ -265,14 +272,18 @@ mod if_serde_support {
                             }
                             Field::ApproximateMemberCount => {
                                 if approximate_member_count.is_some() {
-                                    return Err(DeError::duplicate_field("approximate_member_count"));
+                                    return Err(DeError::duplicate_field(
+                                        "approximate_member_count",
+                                    ));
                                 }
 
                                 approximate_member_count = Some(map.next_value()?);
                             }
                             Field::ApproximatePresenceCount => {
                                 if approximate_presence_count.is_some() {
-                                    return Err(DeError::duplicate_field("approximate_presence_count"));
+                                    return Err(DeError::duplicate_field(
+                                        "approximate_presence_count",
+                                    ));
                                 }
 
                                 approximate_presence_count = Some(map.next_value()?);
@@ -290,11 +301,14 @@ mod if_serde_support {
                                 }
 
                                 let raw_channels = map.next_value::<Value>()?;
-                                channels = Some(serde_mappable_seq::deserialize(raw_channels).unwrap());
+                                channels =
+                                    Some(serde_mappable_seq::deserialize(raw_channels).unwrap());
                             }
                             Field::DefaultMessageNotifications => {
                                 if default_message_notifications.is_some() {
-                                    return Err(DeError::duplicate_field("default_message_notifications"));
+                                    return Err(DeError::duplicate_field(
+                                        "default_message_notifications",
+                                    ));
                                 }
 
                                 default_message_notifications = Some(map.next_value()?);
@@ -337,7 +351,9 @@ mod if_serde_support {
                             }
                             Field::ExplicitContentFilter => {
                                 if explicit_content_filter.is_some() {
-                                    return Err(DeError::duplicate_field("explicit_content_filter"));
+                                    return Err(DeError::duplicate_field(
+                                        "explicit_content_filter",
+                                    ));
                                 }
 
                                 explicit_content_filter = Some(map.next_value()?);
@@ -400,7 +416,9 @@ mod if_serde_support {
                             }
                             Field::MaxVideoChannelUsers => {
                                 if max_video_channel_users.is_some() {
-                                    return Err(DeError::duplicate_field("max_video_channel_users"));
+                                    return Err(DeError::duplicate_field(
+                                        "max_video_channel_users",
+                                    ));
                                 }
 
                                 max_video_channel_users = Some(map.next_value()?);
@@ -463,7 +481,9 @@ mod if_serde_support {
                             }
                             Field::PremiumSubscriptionCount => {
                                 if premium_subscription_count.is_some() {
-                                    return Err(DeError::duplicate_field("premium_subscription_count"));
+                                    return Err(DeError::duplicate_field(
+                                        "premium_subscription_count",
+                                    ));
                                 }
 
                                 premium_subscription_count = Some(map.next_value()?);
@@ -481,7 +501,8 @@ mod if_serde_support {
                                 }
 
                                 let raw_presences = map.next_value::<Value>()?;
-                                presences = Some(serde_mappable_seq::deserialize(raw_presences).unwrap());
+                                presences =
+                                    Some(serde_mappable_seq::deserialize(raw_presences).unwrap());
                             }
                             Field::Region => {
                                 if region.is_some() {
@@ -546,7 +567,9 @@ mod if_serde_support {
                                 }
 
                                 let raw_voice_states = map.next_value::<Value>()?;
-                                voice_states = Some(serde_mappable_seq::deserialize(raw_voice_states).unwrap());
+                                voice_states = Some(
+                                    serde_mappable_seq::deserialize(raw_voice_states).unwrap(),
+                                );
                             }
                             Field::VanityUrlCode => {
                                 if vanity_url_code.is_some() {
@@ -573,19 +596,22 @@ mod if_serde_support {
                     }
 
                     let afk_channel_id = afk_channel_id.unwrap_or_default();
-                    let afk_timeout = afk_timeout.ok_or_else(|| DeError::missing_field("afk_timeout"))?;
+                    let afk_timeout =
+                        afk_timeout.ok_or_else(|| DeError::missing_field("afk_timeout"))?;
                     let application_id = application_id.unwrap_or_default();
                     let approximate_member_count = approximate_member_count.unwrap_or_default();
                     let approximate_presence_count = approximate_presence_count.unwrap_or_default();
                     let banner = banner.unwrap_or_default();
                     let channels = channels.unwrap_or_default();
-                    let default_message_notifications = default_message_notifications.ok_or_else(|| DeError::missing_field("default_message_notifications"))?;
+                    let default_message_notifications = default_message_notifications
+                        .ok_or_else(|| DeError::missing_field("default_message_notifications"))?;
                     let description = description.unwrap_or_default();
                     let discovery_splash = discovery_splash.unwrap_or_default();
                     let embed_channel_id = embed_channel_id.unwrap_or_default();
                     let embed_enabled = embed_enabled.unwrap_or_default();
                     let emojis = emojis.unwrap_or_default();
-                    let explicit_content_filter = explicit_content_filter.ok_or_else(|| DeError::missing_field("explicit_content_filter"))?;
+                    let explicit_content_filter = explicit_content_filter
+                        .ok_or_else(|| DeError::missing_field("explicit_content_filter"))?;
                     let features = features.ok_or_else(|| DeError::missing_field("features"))?;
                     let icon = icon.unwrap_or_default();
                     let id = id.ok_or_else(|| DeError::missing_field("id"))?;
@@ -601,7 +627,8 @@ mod if_serde_support {
                     let owner_id = owner_id.ok_or_else(|| DeError::missing_field("owner_id"))?;
                     let owner = owner.unwrap_or_default();
                     let permissions = permissions.unwrap_or_default();
-                    let preferred_locale = preferred_locale.ok_or_else(|| DeError::missing_field("preferred_locale"))?;
+                    let preferred_locale = preferred_locale
+                        .ok_or_else(|| DeError::missing_field("preferred_locale"))?;
                     let premium_subscription_count = premium_subscription_count.unwrap_or_default();
                     let premium_tier = premium_tier.unwrap_or_default();
                     let presences = presences.unwrap_or_default();
@@ -609,31 +636,42 @@ mod if_serde_support {
                     let roles = roles.ok_or_else(|| DeError::missing_field("roles"))?;
                     let rules_channel_id = rules_channel_id.unwrap_or_default();
                     let splash = splash.unwrap_or_default();
-                    let system_channel_flags = system_channel_flags.ok_or_else(|| DeError::missing_field("system_channel_flags"))?;
+                    let system_channel_flags = system_channel_flags
+                        .ok_or_else(|| DeError::missing_field("system_channel_flags"))?;
                     let system_channel_id = system_channel_id.unwrap_or_default();
                     let unavailable = unavailable.unwrap_or_default();
                     let vanity_url_code = vanity_url_code.unwrap_or_default();
-                    let verification_level = verification_level.ok_or_else(|| DeError::missing_field("verification_level"))?;
+                    let verification_level = verification_level
+                        .ok_or_else(|| DeError::missing_field("verification_level"))?;
                     let voice_states = voice_states.unwrap_or_default();
                     let widget_channel_id = widget_channel_id.unwrap_or_default();
                     let widget_enabled = widget_enabled.unwrap_or_default();
 
                     let members = match members {
                         Some(value) => {
-                            let members = value.deserialize_into::<Vec<MemberIntermediary>>().unwrap();
+                            let members =
+                                value.deserialize_into::<Vec<MemberIntermediary>>().unwrap();
 
-                            members.into_iter().map(|member| (member.user.id, Member {
-                                deaf: member.deaf,
-                                guild_id: id,
-                                hoisted_role: member.hoisted_role,
-                                joined_at: member.joined_at,
-                                mute: member.mute,
-                                nick: member.nick,
-                                premium_since: member.premium_since,
-                                roles: member.roles,
-                                user: member.user,
-                            })).collect::<HashMap<_, _>>()
-                        },
+                            members
+                                .into_iter()
+                                .map(|member| {
+                                    (
+                                        member.user.id,
+                                        Member {
+                                            deaf: member.deaf,
+                                            guild_id: id,
+                                            hoisted_role: member.hoisted_role,
+                                            joined_at: member.joined_at,
+                                            mute: member.mute,
+                                            nick: member.nick,
+                                            premium_since: member.premium_since,
+                                            roles: member.roles,
+                                            user: member.user,
+                                        },
+                                    )
+                                })
+                                .collect::<HashMap<_, _>>()
+                        }
                         None => HashMap::default(),
                     };
 
@@ -688,7 +726,7 @@ mod if_serde_support {
                 }
             }
 
-            const FIELDS: &'static [&'static str] = &[
+            const FIELDS: &[&str] = &[
                 "afk_channel_id",
                 "afk_timeout",
                 "application_id",

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit_log;
+pub mod member;
 
 mod ban;
 mod default_message_notification_level;
@@ -7,7 +8,6 @@ mod explicit_content_filter;
 mod info;
 mod integration;
 mod integration_account;
-mod member;
 mod mfa_level;
 mod partial_guild;
 mod partial_member;
@@ -43,7 +43,7 @@ use std::collections::HashMap;
 
 #[cfg_attr(
     feature = "serde-support",
-    derive(serde::Deserialize, serde::Serialize)
+    derive(serde::Serialize)
 )]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Guild {
@@ -103,4 +103,641 @@ pub struct Guild {
     pub max_video_channel_users: Option<u64>,
     pub approximate_member_count: Option<u64>,
     pub approximate_presence_count: Option<u64>,
+}
+
+#[cfg(feature = "serde-support")]
+mod if_serde_support {
+    use super::{member::{if_serde_support::MemberIntermediary, Member}, Guild};
+    use serde::{de::{Deserializer, Error as DeError, MapAccess, Visitor}, Deserialize};
+    use serde_value::Value;
+    use std::{collections::HashMap, fmt::{Formatter, Result as FmtResult}};
+
+    impl<'de> Deserialize<'de> for Guild {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            #[derive(Debug, Deserialize)]
+            #[serde(field_identifier, rename_all = "snake_case")]
+            enum Field {
+                AfkChannelId,
+                AfkTimeout,
+                ApplicationId,
+                ApproximateMemberCount,
+                ApproximatePresenceCount,
+                Banner,
+                Channels,
+                DefaultMessageNotifications,
+                Description,
+                DiscoverySplash,
+                EmbedChannelId,
+                EmbedEnabled,
+                Emojis,
+                ExplicitContentFilter,
+                Features,
+                Icon,
+                Id,
+                JoinedAt,
+                Large,
+                Lazy,
+                MaxMembers,
+                MaxPresences,
+                MaxVideoChannelUsers,
+                MemberCount,
+                Members,
+                MfaLevel,
+                Name,
+                OwnerId,
+                Owner,
+                Permissions,
+                PreferredLocale,
+                PremiumSubscriptionCount,
+                PremiumTier,
+                Presences,
+                Region,
+                Roles,
+                Splash,
+                SystemChannelFlags,
+                SystemChannelId,
+                RulesChannelId,
+                Unavailable,
+                VerificationLevel,
+                VoiceStates,
+                VanityUrlCode,
+                WidgetChannelId,
+                WidgetEnabled,
+            }
+
+            struct GuildVisitor;
+
+            impl<'de> Visitor<'de> for GuildVisitor {
+                type Value = Guild;
+
+                fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+                    f.write_str("struct Guild")
+                }
+
+                #[allow(unreachable_code, unused)]
+                fn visit_map<V: MapAccess<'de>>(self, mut map: V) -> Result<Self::Value, V::Error> {
+                    let mut afk_channel_id = None::<Option<_>>;
+                    let mut afk_timeout = None;
+                    let mut application_id = None::<Option<_>>;
+                    let mut approximate_member_count = None::<Option<_>>;
+                    let mut approximate_presence_count = None::<Option<_>>;
+                    let mut banner = None::<Option<_>>;
+                    let mut channels = None;
+                    let mut default_message_notifications = None;
+                    let mut description = None::<Option<_>>;
+                    let mut discovery_splash = None::<Option<_>>;
+                    let mut embed_channel_id = None::<Option<_>>;
+                    let mut embed_enabled = None::<Option<_>>;
+                    let mut emojis = None;
+                    let mut explicit_content_filter = None;
+                    let mut features = None;
+                    let mut icon = None::<Option<_>>;
+                    let mut id = None;
+                    let mut joined_at = None::<Option<_>>;
+                    let mut large = None;
+                    let mut lazy = None::<Option<_>>;
+                    let mut max_members = None::<Option<_>>;
+                    let mut max_presences = None::<Option<_>>;
+                    let mut max_video_channel_users = None::<Option<_>>;
+                    let mut member_count = None::<Option<_>>;
+                    let mut members = None;
+                    let mut mfa_level = None;
+                    let mut name = None;
+                    let mut owner = None::<Option<_>>;
+                    let mut owner_id = None;
+                    let mut permissions = None::<Option<_>>;
+                    let mut preferred_locale = None;
+                    let mut premium_subscription_count = None::<Option<_>>;
+                    let mut premium_tier = None;
+                    let mut presences = None;
+                    let mut region = None;
+                    let mut roles = None;
+                    let mut splash = None::<Option<_>>;
+                    let mut system_channel_id = None::<Option<_>>;
+                    let mut system_channel_flags = None;
+                    let mut rules_channel_id = None::<Option<_>>;
+                    let mut unavailable = None;
+                    let mut verification_level = None;
+                    let mut voice_states = None;
+                    let mut vanity_url_code = None::<Option<_>>;
+                    let mut widget_channel_id = None::<Option<_>>;
+                    let mut widget_enabled = None::<Option<_>>;
+
+                    loop {
+                        let key = match map.next_key() {
+                            Ok(Some(key)) => key,
+                            Ok(None) => {
+                                log::debug!("breaking");
+
+                                break;
+                            },
+                            Err(_) => {
+                                // Encountered when we run into an unknown key.
+                                log::debug!("continuing");
+
+                                continue;
+                            },
+                        };
+
+                        log::debug!("key {:?}", key);
+
+                        match key {
+                            Field::AfkChannelId => {
+                                if afk_channel_id.is_some() {
+                                    return Err(DeError::duplicate_field("afk_channel_id"));
+                                }
+
+                                afk_channel_id = Some(map.next_value()?);
+                            }
+                            Field::AfkTimeout => {
+                                if afk_timeout.is_some() {
+                                    return Err(DeError::duplicate_field("afk_timeout"));
+                                }
+
+                                afk_timeout = Some(map.next_value()?);
+                            }
+                            Field::ApplicationId => {
+                                if application_id.is_some() {
+                                    return Err(DeError::duplicate_field("application_id"));
+                                }
+
+                                application_id = Some(map.next_value()?);
+                            }
+                            Field::ApproximateMemberCount => {
+                                if approximate_member_count.is_some() {
+                                    return Err(DeError::duplicate_field("approximate_member_count"));
+                                }
+
+                                approximate_member_count = Some(map.next_value()?);
+                            }
+                            Field::ApproximatePresenceCount => {
+                                if approximate_presence_count.is_some() {
+                                    return Err(DeError::duplicate_field("approximate_presence_count"));
+                                }
+
+                                approximate_presence_count = Some(map.next_value()?);
+                            }
+                            Field::Banner => {
+                                if banner.is_some() {
+                                    return Err(DeError::duplicate_field("banner"));
+                                }
+
+                                banner = Some(map.next_value()?);
+                            }
+                            Field::Channels => {
+                                if channels.is_some() {
+                                    return Err(DeError::duplicate_field("channels"));
+                                }
+
+                                let raw_channels = map.next_value::<Value>()?;
+                                channels = Some(serde_mappable_seq::deserialize(raw_channels).unwrap());
+                            }
+                            Field::DefaultMessageNotifications => {
+                                if default_message_notifications.is_some() {
+                                    return Err(DeError::duplicate_field("default_message_notifications"));
+                                }
+
+                                default_message_notifications = Some(map.next_value()?);
+                            }
+                            Field::Description => {
+                                if description.is_some() {
+                                    return Err(DeError::duplicate_field("description"));
+                                }
+
+                                description = Some(map.next_value()?);
+                            }
+                            Field::DiscoverySplash => {
+                                if discovery_splash.is_some() {
+                                    return Err(DeError::duplicate_field("discovery_splash"));
+                                }
+
+                                discovery_splash = Some(map.next_value()?);
+                            }
+                            Field::EmbedChannelId => {
+                                if embed_channel_id.is_some() {
+                                    return Err(DeError::duplicate_field("embed_channel_id"));
+                                }
+
+                                embed_channel_id = Some(map.next_value()?);
+                            }
+                            Field::EmbedEnabled => {
+                                if embed_enabled.is_some() {
+                                    return Err(DeError::duplicate_field("embed_enabled"));
+                                }
+
+                                embed_enabled = Some(map.next_value()?);
+                            }
+                            Field::Emojis => {
+                                if emojis.is_some() {
+                                    return Err(DeError::duplicate_field("emojis"));
+                                }
+
+                                let raw_emojis = map.next_value::<Value>()?;
+                                emojis = Some(serde_mappable_seq::deserialize(raw_emojis).unwrap());
+                            }
+                            Field::ExplicitContentFilter => {
+                                if explicit_content_filter.is_some() {
+                                    return Err(DeError::duplicate_field("explicit_content_filter"));
+                                }
+
+                                explicit_content_filter = Some(map.next_value()?);
+                            }
+                            Field::Features => {
+                                if features.is_some() {
+                                    return Err(DeError::duplicate_field("features"));
+                                }
+
+                                features = Some(map.next_value()?);
+                            }
+                            Field::Icon => {
+                                if icon.is_some() {
+                                    return Err(DeError::duplicate_field("icon"));
+                                }
+
+                                icon = Some(map.next_value()?);
+                            }
+                            Field::Id => {
+                                if id.is_some() {
+                                    return Err(DeError::duplicate_field("id"));
+                                }
+
+                                id = Some(map.next_value()?);
+                            }
+                            Field::JoinedAt => {
+                                if joined_at.is_some() {
+                                    return Err(DeError::duplicate_field("joined_at"));
+                                }
+
+                                joined_at = Some(map.next_value()?);
+                            }
+                            Field::Large => {
+                                if large.is_some() {
+                                    return Err(DeError::duplicate_field("large"));
+                                }
+
+                                large = Some(map.next_value()?);
+                            }
+                            Field::Lazy => {
+                                if lazy.is_some() {
+                                    return Err(DeError::duplicate_field("lazy"));
+                                }
+
+                                lazy = Some(map.next_value()?);
+                            }
+                            Field::MaxMembers => {
+                                if max_members.is_some() {
+                                    return Err(DeError::duplicate_field("max_members"));
+                                }
+
+                                max_members = Some(map.next_value()?);
+                            }
+                            Field::MaxPresences => {
+                                if max_presences.is_some() {
+                                    return Err(DeError::duplicate_field("max_presences"));
+                                }
+
+                                max_presences = Some(map.next_value()?);
+                            }
+                            Field::MaxVideoChannelUsers => {
+                                if max_video_channel_users.is_some() {
+                                    return Err(DeError::duplicate_field("max_video_channel_users"));
+                                }
+
+                                max_video_channel_users = Some(map.next_value()?);
+                            }
+                            Field::MemberCount => {
+                                if member_count.is_some() {
+                                    return Err(DeError::duplicate_field("member_count"));
+                                }
+
+                                member_count = Some(map.next_value()?);
+                            }
+                            Field::Members => {
+                                if members.is_some() {
+                                    return Err(DeError::duplicate_field("members"));
+                                }
+
+                                members = Some(map.next_value::<Value>()?);
+                            }
+                            Field::MfaLevel => {
+                                if mfa_level.is_some() {
+                                    return Err(DeError::duplicate_field("mfa_level"));
+                                }
+
+                                mfa_level = Some(map.next_value()?);
+                            }
+                            Field::Name => {
+                                if name.is_some() {
+                                    return Err(DeError::duplicate_field("name"));
+                                }
+
+                                name = Some(map.next_value()?);
+                            }
+                            Field::Owner => {
+                                if owner.is_some() {
+                                    return Err(DeError::duplicate_field("owner"));
+                                }
+
+                                owner = Some(map.next_value()?);
+                            }
+                            Field::OwnerId => {
+                                if owner_id.is_some() {
+                                    return Err(DeError::duplicate_field("owner_id"));
+                                }
+
+                                owner_id = Some(map.next_value()?);
+                            }
+                            Field::Permissions => {
+                                if permissions.is_some() {
+                                    return Err(DeError::duplicate_field("permissions"));
+                                }
+
+                                permissions = Some(map.next_value()?);
+                            }
+                            Field::PreferredLocale => {
+                                if preferred_locale.is_some() {
+                                    return Err(DeError::duplicate_field("preferred_locale"));
+                                }
+
+                                preferred_locale = Some(map.next_value()?);
+                            }
+                            Field::PremiumSubscriptionCount => {
+                                if premium_subscription_count.is_some() {
+                                    return Err(DeError::duplicate_field("premium_subscription_count"));
+                                }
+
+                                premium_subscription_count = Some(map.next_value()?);
+                            }
+                            Field::PremiumTier => {
+                                if premium_tier.is_some() {
+                                    return Err(DeError::duplicate_field("premium_tier"));
+                                }
+
+                                premium_tier = Some(map.next_value()?);
+                            }
+                            Field::Presences => {
+                                if presences.is_some() {
+                                    return Err(DeError::duplicate_field("presences"));
+                                }
+
+                                let raw_presences = map.next_value::<Value>()?;
+                                presences = Some(serde_mappable_seq::deserialize(raw_presences).unwrap());
+                            }
+                            Field::Region => {
+                                if region.is_some() {
+                                    return Err(DeError::duplicate_field("region"));
+                                }
+
+                                region = Some(map.next_value()?);
+                            }
+                            Field::Roles => {
+                                if roles.is_some() {
+                                    return Err(DeError::duplicate_field("roles"));
+                                }
+
+                                let raw_roles = map.next_value::<Value>()?;
+                                roles = Some(serde_mappable_seq::deserialize(raw_roles).unwrap());
+                            }
+                            Field::Splash => {
+                                if splash.is_some() {
+                                    return Err(DeError::duplicate_field("splash"));
+                                }
+
+                                splash = Some(map.next_value()?);
+                            }
+                            Field::SystemChannelId => {
+                                if system_channel_id.is_some() {
+                                    return Err(DeError::duplicate_field("system_channel_id"));
+                                }
+
+                                system_channel_id = Some(map.next_value()?);
+                            }
+                            Field::SystemChannelFlags => {
+                                if system_channel_flags.is_some() {
+                                    return Err(DeError::duplicate_field("system_channel_flags"));
+                                }
+
+                                system_channel_flags = Some(map.next_value()?);
+                            }
+                            Field::RulesChannelId => {
+                                if rules_channel_id.is_some() {
+                                    return Err(DeError::duplicate_field("rules_channel_id"));
+                                }
+
+                                rules_channel_id = Some(map.next_value()?);
+                            }
+                            Field::Unavailable => {
+                                if unavailable.is_some() {
+                                    return Err(DeError::duplicate_field("unavailable"));
+                                }
+
+                                unavailable = Some(map.next_value()?);
+                            }
+                            Field::VerificationLevel => {
+                                if verification_level.is_some() {
+                                    return Err(DeError::duplicate_field("verification_level"));
+                                }
+
+                                verification_level = Some(map.next_value()?);
+                            }
+                            Field::VoiceStates => {
+                                if voice_states.is_some() {
+                                    return Err(DeError::duplicate_field("voice_states"));
+                                }
+
+                                let raw_voice_states = map.next_value::<Value>()?;
+                                voice_states = Some(serde_mappable_seq::deserialize(raw_voice_states).unwrap());
+                            }
+                            Field::VanityUrlCode => {
+                                if vanity_url_code.is_some() {
+                                    return Err(DeError::duplicate_field("vanity_url_code"));
+                                }
+
+                                vanity_url_code = Some(map.next_value()?);
+                            }
+                            Field::WidgetChannelId => {
+                                if widget_channel_id.is_some() {
+                                    return Err(DeError::duplicate_field("widget_channel_id"));
+                                }
+
+                                widget_channel_id = Some(map.next_value()?);
+                            }
+                            Field::WidgetEnabled => {
+                                if widget_enabled.is_some() {
+                                    return Err(DeError::duplicate_field("widget_enabled"));
+                                }
+
+                                widget_enabled = Some(map.next_value()?);
+                            }
+                        }
+                    }
+
+                    let afk_channel_id = afk_channel_id.unwrap_or_default();
+                    let afk_timeout = afk_timeout.ok_or_else(|| DeError::missing_field("afk_timeout"))?;
+                    let application_id = application_id.unwrap_or_default();
+                    let approximate_member_count = approximate_member_count.unwrap_or_default();
+                    let approximate_presence_count = approximate_presence_count.unwrap_or_default();
+                    let banner = banner.unwrap_or_default();
+                    let channels = channels.unwrap_or_default();
+                    let default_message_notifications = default_message_notifications.ok_or_else(|| DeError::missing_field("default_message_notifications"))?;
+                    let description = description.unwrap_or_default();
+                    let discovery_splash = discovery_splash.unwrap_or_default();
+                    let embed_channel_id = embed_channel_id.unwrap_or_default();
+                    let embed_enabled = embed_enabled.unwrap_or_default();
+                    let emojis = emojis.unwrap_or_default();
+                    let explicit_content_filter = explicit_content_filter.ok_or_else(|| DeError::missing_field("explicit_content_filter"))?;
+                    let features = features.ok_or_else(|| DeError::missing_field("features"))?;
+                    let icon = icon.unwrap_or_default();
+                    let id = id.ok_or_else(|| DeError::missing_field("id"))?;
+                    let large = large.unwrap_or_default();
+                    let joined_at = joined_at.unwrap_or_default();
+                    let lazy = lazy.unwrap_or_default();
+                    let max_members = max_members.unwrap_or_default();
+                    let max_presences = max_presences.unwrap_or_default();
+                    let max_video_channel_users = max_video_channel_users.unwrap_or_default();
+                    let member_count = member_count.unwrap_or_default();
+                    let mfa_level = mfa_level.ok_or_else(|| DeError::missing_field("mfa_level"))?;
+                    let name = name.ok_or_else(|| DeError::missing_field("name"))?;
+                    let owner_id = owner_id.ok_or_else(|| DeError::missing_field("owner_id"))?;
+                    let owner = owner.unwrap_or_default();
+                    let permissions = permissions.unwrap_or_default();
+                    let preferred_locale = preferred_locale.ok_or_else(|| DeError::missing_field("preferred_locale"))?;
+                    let premium_subscription_count = premium_subscription_count.unwrap_or_default();
+                    let premium_tier = premium_tier.unwrap_or_default();
+                    let presences = presences.unwrap_or_default();
+                    let region = region.ok_or_else(|| DeError::missing_field("region"))?;
+                    let roles = roles.ok_or_else(|| DeError::missing_field("roles"))?;
+                    let rules_channel_id = rules_channel_id.unwrap_or_default();
+                    let splash = splash.unwrap_or_default();
+                    let system_channel_flags = system_channel_flags.ok_or_else(|| DeError::missing_field("system_channel_flags"))?;
+                    let system_channel_id = system_channel_id.unwrap_or_default();
+                    let unavailable = unavailable.unwrap_or_default();
+                    let vanity_url_code = vanity_url_code.unwrap_or_default();
+                    let verification_level = verification_level.ok_or_else(|| DeError::missing_field("verification_level"))?;
+                    let voice_states = voice_states.unwrap_or_default();
+                    let widget_channel_id = widget_channel_id.unwrap_or_default();
+                    let widget_enabled = widget_enabled.unwrap_or_default();
+
+                    let members = match members {
+                        Some(value) => {
+                            let members = value.deserialize_into::<Vec<MemberIntermediary>>().unwrap();
+
+                            members.into_iter().map(|member| (member.user.id, Member {
+                                deaf: member.deaf,
+                                guild_id: id,
+                                hoisted_role: member.hoisted_role,
+                                joined_at: member.joined_at,
+                                mute: member.mute,
+                                nick: member.nick,
+                                premium_since: member.premium_since,
+                                roles: member.roles,
+                                user: member.user,
+                            })).collect::<HashMap<_, _>>()
+                        },
+                        None => HashMap::default(),
+                    };
+
+                    Ok(Guild {
+                        afk_channel_id,
+                        afk_timeout,
+                        application_id,
+                        approximate_member_count,
+                        approximate_presence_count,
+                        banner,
+                        channels,
+                        default_message_notifications,
+                        description,
+                        discovery_splash,
+                        embed_channel_id,
+                        embed_enabled,
+                        emojis,
+                        explicit_content_filter,
+                        features,
+                        icon,
+                        id,
+                        joined_at,
+                        large,
+                        lazy,
+                        max_members,
+                        max_presences,
+                        max_video_channel_users,
+                        member_count,
+                        members,
+                        mfa_level,
+                        name,
+                        owner,
+                        owner_id,
+                        permissions,
+                        preferred_locale,
+                        premium_subscription_count,
+                        premium_tier,
+                        presences,
+                        region,
+                        roles,
+                        splash,
+                        system_channel_id,
+                        system_channel_flags,
+                        rules_channel_id,
+                        unavailable,
+                        verification_level,
+                        voice_states,
+                        vanity_url_code,
+                        widget_channel_id,
+                        widget_enabled,
+                    })
+                }
+            }
+
+            const FIELDS: &'static [&'static str] = &[
+                "afk_channel_id",
+                "afk_timeout",
+                "application_id",
+                "approximate_member_count",
+                "approximate_presence_count",
+                "banner",
+                "channels",
+                "default_message_notifications",
+                "description",
+                "discovery_splash",
+                "embed_channel_id",
+                "embed_enabled",
+                "emojis",
+                "explicit_content_filter",
+                "features",
+                "icon",
+                "id",
+                "joined_at",
+                "large",
+                "lazy",
+                "max_members",
+                "max_presences",
+                "max_video_channel_users",
+                "member_count",
+                "members",
+                "mfa_level",
+                "name",
+                "owner",
+                "owner_id",
+                "permissions",
+                "preferred_locale",
+                "premium_subscription_count",
+                "premium_tier",
+                "presences",
+                "region",
+                "roles",
+                "splash",
+                "system_channel_id",
+                "system_channel_flags",
+                "rules_channel_id",
+                "unavailable",
+                "verification_level",
+                "voice_states",
+                "vanity_url_code",
+                "widget_channel_id",
+                "widget_enabled",
+            ];
+
+            deserializer.deserialize_struct("Guild", FIELDS, GuildVisitor)
+        }
+    }
 }

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -302,7 +302,7 @@ mod if_serde_support {
 
                                 let raw_channels = map.next_value::<Value>()?;
                                 channels =
-                                    Some(serde_mappable_seq::deserialize(raw_channels).unwrap());
+                                    Some(serde_mappable_seq::deserialize(raw_channels).map_err(DeError::custom)?);
                             }
                             Field::DefaultMessageNotifications => {
                                 if default_message_notifications.is_some() {
@@ -347,7 +347,7 @@ mod if_serde_support {
                                 }
 
                                 let raw_emojis = map.next_value::<Value>()?;
-                                emojis = Some(serde_mappable_seq::deserialize(raw_emojis).unwrap());
+                                emojis = Some(serde_mappable_seq::deserialize(raw_emojis).map_err(DeError::custom)?);
                             }
                             Field::ExplicitContentFilter => {
                                 if explicit_content_filter.is_some() {
@@ -502,7 +502,7 @@ mod if_serde_support {
 
                                 let raw_presences = map.next_value::<Value>()?;
                                 presences =
-                                    Some(serde_mappable_seq::deserialize(raw_presences).unwrap());
+                                    Some(serde_mappable_seq::deserialize(raw_presences).map_err(DeError::custom)?);
                             }
                             Field::Region => {
                                 if region.is_some() {
@@ -517,7 +517,7 @@ mod if_serde_support {
                                 }
 
                                 let raw_roles = map.next_value::<Value>()?;
-                                roles = Some(serde_mappable_seq::deserialize(raw_roles).unwrap());
+                                roles = Some(serde_mappable_seq::deserialize(raw_roles).map_err(DeError::custom)?);
                             }
                             Field::Splash => {
                                 if splash.is_some() {
@@ -568,7 +568,7 @@ mod if_serde_support {
 
                                 let raw_voice_states = map.next_value::<Value>()?;
                                 voice_states = Some(
-                                    serde_mappable_seq::deserialize(raw_voice_states).unwrap(),
+                                    serde_mappable_seq::deserialize(raw_voice_states).map_err(DeError::custom)?,
                                 );
                             }
                             Field::VanityUrlCode => {

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -456,7 +456,7 @@ fn event_guild_id(event: &Event) -> Option<GuildId> {
         Event::GuildUpdate(e) => Some(e.id),
         Event::InviteCreate(e) => Some(e.guild_id),
         Event::InviteDelete(e) => Some(e.guild_id),
-        Event::MemberAdd(e) => e.guild_id,
+        Event::MemberAdd(e) => Some(e.guild_id),
         Event::MemberChunk(e) => Some(e.guild_id),
         Event::MemberRemove(e) => Some(e.guild_id),
         Event::MemberUpdate(e) => Some(e.guild_id),


### PR DESCRIPTION
This PR is another try at #180, which had to be reverted in #185 due to not supporting deserialising guilds from the gateway. In addition to the previous PR, this adds support by manually implementing Deserialize for Guild, and in the case of a members key deserializing each element via the MemberDeserializer.

Change the `model::guild::Member`'s `guild_id` field from an `Option<GuildId>` to just a `GuildId`. The reason that this was an option before is because this was a naive serde-derived
(de)serialization implementation. The HTTP API doesn't return members with guild IDs, but the gateway does. This made working with members from the gateway awkward since you know the guild ID is there but had to go through an extra pattern match to get it.

We can fix this by making a separate seeded deserializer implementation if you already know the guild ID. The deserializer will just deserialize into an intermediary member struct and create a real member with the stored guild ID.

The `http` crate has been updated to do these deserializations and other crates are updated to work with a guild ID that's always there.

Closes #42.