### PR TITLE
http: use isahc, support smol runtime 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,8 @@ jobs:
   test_http_runtimes:
     name: Test HTTP crate runtimes
     runs-on: ubuntu-latest
+    env:
+      working-directory: ./http
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -75,9 +77,9 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --package twilight-http --no-default-features --features "serde_json smol-runtime" -- --ignored
+          args: --no-default-features --features "serde_json smol-runtime" -- --ignored
       - name: Run cargo test with tokio
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --package twilight-http --no-default-features --features "serde_json tokio-runtime" -- --ignored
+          args: --no-default-features --features "serde_json tokio-runtime" -- --ignored

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,6 @@ jobs:
   test_http_runtimes:
     name: Test HTTP crate runtimes
     runs-on: ubuntu-latest
-    env:
-      working-directory: ./http
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -72,14 +70,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --package twilight-http
+          args: --manifest-path ./http/Cargo.toml
       - name: Run cargo test with smol
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features "serde_json smol-runtime" -- --ignored
+          args: --no-default-features --features "serde_json smol-runtime" --manifest-path ./http/Cargo.toml -- --ignored
       - name: Run cargo test with tokio
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features "serde_json tokio-runtime" -- --ignored
+          args: --no-default-features --features "serde_json tokio-runtime" --manifest-path ./http/Cargo.toml -- --ignored

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,47 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+  test_http_runtimes:
+    name: Test HTTP crate runtimes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-release-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-release-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run cargo test with defaults
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --package twilight-http
+      - name: Run cargo test with smol
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --package twilight-http --no-default-features --features "serde_json smol-runtime" -- --ignored
+      - name: Run cargo test with tokio
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --package twilight-http --no-default-features --features "serde_json tokio-runtime" -- --ignored

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -13,23 +13,26 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.1.0"
 
 [dependencies]
-bytes = { default-features = false, version = "0.5" }
+common-multipart-rfc7578 = { default-features = false, version = "0.2.0-rc" }
 futures = "0.3"
+futures-timer = { default-features = false, optional = true, version = "3" }
+isahc = { default-features = false, features = ["http2", "static-curl"], version = "0.9" }
 twilight-model = { path = "../model" }
 log = "0.4"
-reqwest = "0.10"
+rand = { default-features = false, features = ["getrandom", "small_rng"], version = "0.7" }
 serde = { features = ["derive"], version = "1" }
 serde_json = { version = "1", optional = true }
 serde_repr = { default-features = false, version = "0.1" }
 simd-json = { version = "0.3", optional = true }
-tokio = "0.2"
+smol = { default-features = false, optional = true, version = "0.1" }
+tokio = { default-features = false, features = ["rt-core", "time"], optional = true, version = "0.2" }
 percent-encoding = "2.1"
 url = "2"
 
 [features]
-default = ["native", "serde_json"]
-native = ["reqwest/default-tls"]
-rustls = ["reqwest/rustls-tls"]
+default = ["serde_json", "tokio-runtime"]
+smol-runtime = ["futures-timer", "smol"]
+tokio-runtime = ["tokio"]
 
 [dev-dependencies]
 serde_test = { default-features = false, version = "1" }

--- a/http/README.md
+++ b/http/README.md
@@ -6,41 +6,61 @@ HTTP support for the twilight ecosystem.
 
 ## Features
 
-`twilight-http` includes three features: `native`, `simd` and `rustls`. `native` is
-enabled by default. `native` will enable `reqwest`'s `default-tls` feature,
-which will use the TLS library native to your OS (for example, OpenSSL on
-Linux). `rustls` will enable `reqwest`'s `rustls-tls` feature, which will use
-[rustls].
+### Deserialization
 
-If you want to use Rustls instead of your native library, it's easy to switch it
-out:
+`twilight-http` supports `serde_json` and `simd-json` for deserializing
+responses. `serde_json` is enabled by default.
 
-```toml
-[dependencies]
-twilight-http = { default-features = false, features = ["rustls"], git = "https://github.com/twilight-rs/twilight" }
-```
+#### `simd-json`
 
-You can also choose to use neither feature. This is only useful if you provide
-your own configured Reqwest client to the HTTP client, otherwise you will
-encounter TLS errors.
+The `simd-json` feature enables [`simd-json`] support to use simd features of
+the modern cpus to deserialize responses faster. It is not enabled by
+default, and instead the `serde_json` feature is enabled by default.
 
-`simd` feature enables [simd-json] support to use simd features of the modern cpus
-to deserialize json data faster. It is not enabled by default since not every cpu has those features.
-To use this feature you need to also add these lines to a file in `<project root>/.cargo/config`
+To use this feature you need to also add these lines to
+`<project root>/.cargo/config`:
 ```toml
 [build]
 rustflags = ["-C", "target-cpu=native"]
 ```
-you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`. If you enable both
-`serde_json` and `simd-json` at the same time; this crate uses `simd-json`. But it is recommended to
-disable `serde_json` if you are going to use `simd-json`. It is easy to switch to out:
+
+You can also set the environment variable
+`RUSTFLAGS="-C target-cpu=native"`. If you enable both `serde_json` and
+`simd-json` at the same time, then `simd-json` will be used.
+
+#### `serde_json`
+
+`serde_json` is the inverse of `simd-json` and will use the `serde_json`
+crate to deserialize responses.
+
+### Runtimes
+
+`twilight-http` supports some of the popular async runtimes. The
+`tokio-runtime` feature is enabled by default.
+
+#### `smol-runtime`
+
+Use [`smol`] as an asynchronous executor for background tasks. The
+[`futures-timer`] crate will be used for asynchronous timing. If you're
+using `smol` in your runtime, then you'll want to disable the
+`tokio-runtime` feature and enable this, like so:
 
 ```toml
-[dependencies]
-twilight-gateway = { default-features = false, features = ["simd-json"], git = "https://github.com/twilight-rs/twilight" }
+[dependencies.twilight-http]
+default-features = false
+features = ["serde_json", "smol-runtime"]
+git = "https://github.com/twilight-rs/twilight"
 ```
 
-[rustls]: https://github.com/ctz/rustls
-[simd-json]: https://github.com/simd-lite/simd-json
+#### `tokio-runtime`
+
+Use [`tokio`] as an asynchronous executor for background tasks and
+asynchronous timing. If you're using `tokio` in your application, this is
+what you want and you don't need to change anything in your dependencies.
+
+[`futures-timer`]: https://crates.io/crates/futures-timer
+[`simd-json`]: https://crates.io/crates/simd-json
+[`smol`]: https://crates.io/crates/smol
+[`tokio`]: https://crates.io/crates/tokio
 
 <!-- cargo-sync-readme end -->

--- a/http/examples/proxy/src/main.rs
+++ b/http/examples/proxy/src/main.rs
@@ -1,6 +1,6 @@
 use futures::future;
-use std::error::Error;
-use twilight_http::client::{config::Proxy, Client};
+use std::{error::Error, str::FromStr};
+use twilight_http::client::{config::Uri, Client};
 use twilight_model::id::ChannelId;
 
 #[tokio::main]
@@ -9,7 +9,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let mut config = Client::builder();
     config
-        .proxy(Proxy::all("http://localhost:3000")?)
+        .proxy(Uri::from_str("http://localhost:3000")?)
         .proxy_http(true)
         .skip_ratelimiter(true);
     let client = config.build()?;

--- a/http/src/client/config.rs
+++ b/http/src/client/config.rs
@@ -1,14 +1,14 @@
-pub use reqwest::Proxy;
+pub use isahc::http::Uri;
 
 use crate::request::channel::message::allowed_mentions::AllowedMentions;
-use reqwest::Client as ReqwestClient;
+use isahc::HttpClient;
 use std::time::Duration;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ClientConfig {
-    pub(crate) proxy: Option<Proxy>,
+    pub(crate) isahc_client: Option<HttpClient>,
+    pub(crate) proxy: Option<Uri>,
     pub(crate) proxy_http: bool,
-    pub(crate) reqwest_client: Option<ReqwestClient>,
     pub(crate) skip_ratelimiter: bool,
     pub(crate) timeout: Duration,
     pub(crate) token: Option<String>,
@@ -22,7 +22,7 @@ impl ClientConfig {
     }
 
     /// Returns an immutable reference to the proxy.
-    pub fn proxy(&self) -> Option<&Proxy> {
+    pub fn proxy(&self) -> Option<&Uri> {
         self.proxy.as_ref()
     }
 
@@ -30,9 +30,9 @@ impl ClientConfig {
         self.proxy_http
     }
 
-    /// Returns an immutable reference to the reqwest client, if any.
-    pub fn reqwest_client(&self) -> Option<&ReqwestClient> {
-        self.reqwest_client.as_ref()
+    /// Returns an immutable reference to the isahc client, if any.
+    pub fn isahc_client(&self) -> Option<&HttpClient> {
+        self.isahc_client.as_ref()
     }
 
     pub fn skip_ratelimiter(&self) -> bool {
@@ -55,7 +55,7 @@ impl ClientConfig {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ClientConfigBuilder(ClientConfig);
 
 impl ClientConfigBuilder {
@@ -73,8 +73,8 @@ impl ClientConfigBuilder {
 
     /// Sets the proxy to use for all HTTP requests.
     ///
-    /// This accepts a `reqwest::Proxy`.
-    pub fn proxy(&mut self, proxy: Proxy) -> &mut Self {
+    /// This accepts a `http::Uri`.
+    pub fn proxy(&mut self, proxy: Uri) -> &mut Self {
         self.0.proxy.replace(proxy);
 
         self
@@ -86,14 +86,14 @@ impl ClientConfigBuilder {
         self
     }
 
-    /// Sets the reqwest client to use.
+    /// Sets the isahc client to use.
     ///
     /// All of the settings in the client will be overwritten by the settings
     /// in this configuration, if specified.
     ///
     /// The default client is a RusTLS-backed client.
-    pub fn reqwest_client(&mut self, client: ReqwestClient) -> &mut Self {
-        self.0.reqwest_client.replace(client);
+    pub fn isahc_client(&mut self, client: HttpClient) -> &mut Self {
+        self.0.isahc_client.replace(client);
 
         self
     }
@@ -141,7 +141,7 @@ impl Default for ClientConfigBuilder {
         Self(ClientConfig {
             proxy: None,
             proxy_http: false,
-            reqwest_client: None,
+            isahc_client: None,
             skip_ratelimiter: false,
             timeout: Duration::from_secs(10),
             token: None,

--- a/http/src/ratelimiting/error.rs
+++ b/http/src/ratelimiting/error.rs
@@ -1,4 +1,4 @@
-use reqwest::header::ToStrError;
+use isahc::http::header::ToStrError;
 use std::{
     error::Error as StdError,
     fmt::{Display, Formatter, Result as FmtResult},

--- a/http/src/ratelimiting/headers.rs
+++ b/http/src/ratelimiting/headers.rs
@@ -1,5 +1,5 @@
 use super::error::{RatelimitError, RatelimitResult};
-use reqwest::header::{HeaderMap, HeaderValue};
+use isahc::http::header::{HeaderMap, HeaderValue};
 use std::convert::TryFrom;
 
 #[derive(Clone, Debug)]

--- a/http/src/ratelimiting/mod.rs
+++ b/http/src/ratelimiting/mod.rs
@@ -62,7 +62,7 @@ impl Ratelimiter {
         let (bucket, fresh) = self.entry(path.clone(), tx).await;
 
         if fresh {
-            tokio::spawn(
+            crate::spawn(
                 BucketQueueTask::new(
                     bucket,
                     Arc::clone(&self.buckets),

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -48,7 +48,7 @@ impl Future for GetGuildVanityUrl<'_> {
                 let bytes = match fut.as_mut().poll(cx) {
                     Poll::Ready(Ok(bytes)) => bytes,
                     Poll::Ready(Err(crate::Error::Response { status, .. }))
-                        if status == reqwest::StatusCode::NOT_FOUND =>
+                        if status == isahc::http::StatusCode::NOT_FOUND =>
                     {
                         return Poll::Ready(Ok(None));
                     }

--- a/http/src/request/multipart.rs
+++ b/http/src/request/multipart.rs
@@ -1,0 +1,13 @@
+use common_multipart_rfc7578::client::multipart::BoundaryGenerator;
+use rand::{distributions::Alphanumeric, rngs::SmallRng, Rng, SeedableRng};
+
+pub struct TwilightBoundaryGenerator;
+
+impl BoundaryGenerator for TwilightBoundaryGenerator {
+    fn generate_boundary() -> String {
+        let rng = SmallRng::from_entropy();
+        let bytes = rng.sample_iter(&Alphanumeric);
+
+        bytes.take(10).collect()
+    }
+}

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -1,4 +1,4 @@
-use reqwest::Method;
+use isahc::http::Method;
 use std::{
     borrow::Cow,
     convert::TryFrom,
@@ -1168,7 +1168,7 @@ impl Route {
 #[cfg(test)]
 mod tests {
     use super::{Path, PathParseError};
-    use reqwest::Method;
+    use isahc::http::Method;
     use std::{convert::TryFrom, error::Error, str::FromStr};
 
     #[test]

--- a/http/tests/test_runtimes.rs
+++ b/http/tests/test_runtimes.rs
@@ -1,0 +1,18 @@
+use twilight_http::Client;
+
+#[cfg(feature = "smol-runtime")]
+#[ignore]
+#[test]
+fn test_runtime_smol() {
+    let client = Client::new("foo");
+
+    assert!(smol::run(client.gateway()).is_ok());
+}
+
+#[cfg(feature = "tokio-runtime")]
+#[ignore]
+#[tokio::test]
+async fn test_runtime_tokio() {
+    let client = Client::new("foo");
+    assert!(client.gateway().await.is_ok());
+}


### PR DESCRIPTION
Switch from the `reqwest` crate to the `isahc` crate. The `isahc` crate is more minimal and requires much fewer dependencies compared to `reqwest`.

Additionally, this allows us to now support the `smol` runtime due to `isahc` being runtime-agnostic.

There are now two more feature flags: `smol` and `tokio`. They are mutually exclusive, and one must be chosen. `tokio` is enabled by default. Enabling `smol` will use `smol` for spawning background tasks and `futures-timer` for timing capability, while enabling `tokio` will just use `tokio::time` for timing capability.

This is a part of #86.