### PR TITLE
Gateway cluster shard creations

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .build();
 
     // Start up the cluster
-    let cluster = Cluster::new(config);
+    let cluster = Cluster::new(config).await?;
     cluster.up().await;
 
     // The http client is seperate from the gateway,

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     // Start up the cluster
     let cluster = Cluster::new(config);
-    cluster.up().await?;
+    cluster.up().await;
 
     // The http client is seperate from the gateway,
     // so startup a new one

--- a/README.md
+++ b/README.md
@@ -128,7 +128,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     // Start up the cluster
     let cluster = Cluster::new(config).await?;
-    cluster.up().await;
+
+    let cluster_spawn = cluster.clone();
+
+    tokio::spawn(async move {
+        cluster_spawn.up().await;
+    });
 
     // The http client is seperate from the gateway,
     // so startup a new one
@@ -145,7 +150,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         )
         .build();
     let cache = InMemoryCache::from(cache_config);
-
 
     let mut events = cluster.events().await;
     // Startup an event loop for each event in the event stream

--- a/gateway/examples/cluster/src/main.rs
+++ b/gateway/examples/cluster/src/main.rs
@@ -25,9 +25,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let cluster_spawn = cluster.clone();
 
     tokio::spawn(async move {
-        if let Err(why) = cluster_spawn.up().await {
-            panic!("Failed to start the cluster: {:?}", why);
-        }
+        cluster_spawn.up().await;
     });
 
     while let Some((id, event)) = events.next().await {

--- a/gateway/examples/cluster/src/main.rs
+++ b/gateway/examples/cluster/src/main.rs
@@ -8,11 +8,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     pretty_env_logger::init_timed();
 
     // This is also the default.
-    let scheme = ShardScheme::Range {
-        from: 0,
-        to: 10,
-        total: 11,
-    };
+    let scheme = ShardScheme::Auto;
 
     let config = ClusterConfig::builder(env::var("DISCORD_TOKEN")?)
         .shard_scheme(scheme)

--- a/gateway/examples/intents/src/main.rs
+++ b/gateway/examples/intents/src/main.rs
@@ -15,7 +15,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         conf.build()
     };
 
-    let shard = Shard::new(config).await?;
+    let mut shard = Shard::new(config);
+    shard.start().await?;
     println!("Created shard");
 
     let mut events = shard.events().await;

--- a/gateway/examples/metrics/src/main.rs
+++ b/gateway/examples/metrics/src/main.rs
@@ -20,10 +20,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     pretty_env_logger::init_timed();
 
-    let cluster = Cluster::new(env::var("DISCORD_TOKEN")?);
+    let cluster = Cluster::new(env::var("DISCORD_TOKEN")?).await?;
     println!("Created cluster");
 
-    cluster.up().await?;
+    cluster.up().await;
     println!("Started cluster");
 
     let mut events = cluster.events().await;

--- a/gateway/examples/queue/src/main.rs
+++ b/gateway/examples/queue/src/main.rs
@@ -19,7 +19,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let token = env::var("DISCORD_TOKEN")?;
     let config = ShardConfig::builder(&token).queue(Arc::new(Box::new(BadQueue)));
 
-    let shard = Shard::new(config).await?;
+    let mut shard = Shard::new(config);
+    shard.start().await?;
     println!("Created shard");
 
     let mut events = shard.events().await;

--- a/gateway/examples/request-members/src/main.rs
+++ b/gateway/examples/request-members/src/main.rs
@@ -12,7 +12,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     pretty_env_logger::init_timed();
 
     // to interact with the gateway we first need to connect to it (with a shard or cluster)
-    let shard = Shard::new(env::var("DISCORD_TOKEN")?).await?;
+    let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
+    shard.start().await?;
     println!("Created shard");
 
     let mut events = shard.events().await;

--- a/gateway/examples/shard/src/main.rs
+++ b/gateway/examples/shard/src/main.rs
@@ -6,7 +6,8 @@ use twilight_gateway::Shard;
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     pretty_env_logger::init_timed();
 
-    let shard = Shard::new(env::var("DISCORD_TOKEN")?).await?;
+    let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
+    shard.start().await?;
     println!("Created shard");
 
     let mut events = shard.events().await;

--- a/gateway/src/cluster/mod.rs
+++ b/gateway/src/cluster/mod.rs
@@ -14,9 +14,9 @@
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 ///     let token = env::var("DISCORD_TOKEN")?;
-///     let cluster = Cluster::new(token);
+///     let cluster = Cluster::new(token).await?;
 ///
-///     cluster.up().await?;
+///     cluster.up().await;
 ///
 ///     let mut events = cluster.events().await;
 ///
@@ -39,9 +39,9 @@
 ///         },
 ///         Event::MessageCreate(msg) if msg.content == "!latency" => {
 ///             if let Some(shard) = cluster.shard(shard_id).await {
-///                 let info = shard.info().await;
-///
-///                 println!("Shard {}'s latency is {:?}", shard_id, info.latency());
+///                 if let Ok(info) = shard.info().await {
+///                     println!("Shard {}'s latency is {:?}", shard_id, info.latency());
+///                 }
 ///             }
 ///         },
 ///         Event::MessageCreate(msg) if msg.content == "!shutdown" => {

--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -67,6 +67,8 @@ pub enum Error {
         /// The reason for the error.
         source: TrySendError<TungsteniteMessage>,
     },
+    /// The shard hasn't been started, so there is no active session.
+    Stopped,
     /// There was a error decompressing a frame from discord.
     Decompressing { source: DecompressError },
 }
@@ -96,6 +98,7 @@ impl Display for Error {
             Self::SendingMessage { .. } => {
                 f.write_str("The message couldn't be sent because the receiver half dropped")
             }
+            Self::Stopped { .. } => f.write_str("the shard hasn't been started yet"),
             Self::Decompressing { .. } => f.write_str("A frame could not be decompressed"),
         }
     }
@@ -112,7 +115,8 @@ impl StdError for Error {
             Self::Decompressing { source } => Some(source),
             Self::AuthorizationInvalid { .. }
             | Self::IdTooLarge { .. }
-            | Self::LargeThresholdInvalid { .. } => None,
+            | Self::LargeThresholdInvalid { .. }
+            | Self::Stopped { .. } => None,
         }
     }
 }

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -22,14 +22,6 @@ use tokio_tungstenite::tungstenite::protocol::{frame::coding::CloseCode, CloseFr
 use tokio_tungstenite::tungstenite::Message;
 use twilight_model::gateway::event::Event;
 
-#[derive(Debug)]
-pub struct ShardRef {
-    config: Arc<ShardConfig>,
-    listeners: Listeners<Event>,
-    processor_handle: AbortHandle,
-    session: WatchReceiver<Arc<Session>>,
-}
-
 /// Information about a shard, including its latency, current session sequence,
 /// and connection stage.
 #[derive(Clone, Debug)]
@@ -83,7 +75,12 @@ pub struct ResumeSession {
 }
 
 #[derive(Clone, Debug)]
-pub struct Shard(Arc<ShardRef>);
+pub struct Shard {
+    config: Arc<ShardConfig>,
+    listeners: Listeners<Event>,
+    processor_handle: Option<AbortHandle>,
+    session: Option<WatchReceiver<Arc<Session>>>,
+}
 
 impl Shard {
     /// Creates a new shard, which will automatically connect to the gateway.
@@ -100,26 +97,44 @@ impl Shard {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    /// let shard = Shard::new(env::var("DISCORD_TOKEN")?).await?;
+    /// let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
+    /// shard.start().await?;
     ///
     /// tokio_time::delay_for(Duration::from_secs(1)).await;
     ///
-    /// let info = shard.info().await;
+    /// let info = shard.info().await?;
     /// println!("Shard stage: {}", info.stage());
     /// # Ok(()) }
     /// ```
+    pub fn new(config: impl Into<ShardConfig>) -> Self {
+        Self::_new(config.into())
+    }
+
+    fn _new(config: ShardConfig) -> Self {
+        let config = Arc::new(config);
+
+        Self {
+            config,
+            listeners: Listeners::default(),
+            processor_handle: None,
+            session: None,
+        }
+    }
+
+    /// Returns an immutable reference to the configuration used for this client.
+    pub fn config(&self) -> &ShardConfig {
+        &self.config
+    }
+
+    /// Start the shard, connecting it to the gateway and starting the process
+    /// of receiving and processing events.
     ///
     /// # Errors
     ///
     /// Errors if the `ShardProcessor` could not be started.
-    pub async fn new(config: impl Into<ShardConfig>) -> Result<Self> {
-        Self::_new(config.into()).await
-    }
-
-    async fn _new(config: ShardConfig) -> Result<Self> {
-        let config = Arc::new(config);
-
-        let url = config
+    pub async fn start(&mut self) -> Result<()> {
+        let url = self
+            .config
             .http_client()
             .gateway()
             .authed()
@@ -127,8 +142,9 @@ impl Shard {
             .map_err(|source| Error::GettingGatewayUrl { source })?
             .url;
 
-        let (processor, wrx) = ShardProcessor::new(Arc::clone(&config), url).await?;
-        let listeners = processor.listeners.clone();
+        let listeners = self.listeners.clone();
+        let (processor, wrx) =
+            ShardProcessor::new(Arc::clone(&self.config), url, listeners).await?;
         let (fut, handle) = future::abortable(processor.run());
 
         tokio::spawn(async move {
@@ -137,41 +153,10 @@ impl Shard {
             debug!("[Shard] Shard processor future ended");
         });
 
-        Ok(Self(Arc::new(ShardRef {
-            config,
-            listeners,
-            processor_handle: handle,
-            session: wrx,
-        })))
-    }
+        self.processor_handle.replace(handle);
+        self.session.replace(wrx);
 
-    /// Returns an immutable reference to the configuration used for this client.
-    pub fn config(&self) -> &ShardConfig {
-        &self.0.config
-    }
-
-    /// Returns information about the running of the shard, such as the current
-    /// connection stage.
-    pub async fn info(&self) -> Information {
-        let session = self.session();
-
-        Information {
-            id: self.config().shard()[0],
-            latency: session.heartbeats.latency().await,
-            seq: session.seq(),
-            stage: session.stage(),
-        }
-    }
-
-    /// Returns a handle to the current session
-    ///
-    /// # Note
-    ///
-    /// This session can be invalidated if it is kept around
-    /// under a reconnect or resume. In consequence this call
-    /// should not be cached.
-    pub fn session(&self) -> Arc<Session> {
-        Arc::clone(&self.0.session.borrow())
+        Ok(())
     }
 
     /// Creates a new stream of events from the shard.
@@ -185,7 +170,7 @@ impl Shard {
     /// [`EventType::SHARD_PAYLOAD`]: events/struct.EventType.html#const.SHARD_PAYLOAD
     /// [`some_events`]: #method.some_events
     pub async fn events(&self) -> impl Stream<Item = Event> {
-        let rx = self.0.listeners.add(EventTypeFlags::default()).await;
+        let rx = self.listeners.add(EventTypeFlags::default()).await;
 
         Events::new(EventTypeFlags::default(), rx)
     }
@@ -206,7 +191,8 @@ impl Shard {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    /// let shard = Shard::new(env::var("DISCORD_TOKEN")?).await?;
+    /// let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
+    /// shard.start().await?;
     ///
     /// let event_types = EventTypeFlags::SHARD_CONNECTED | EventTypeFlags::SHARD_DISCONNECTED;
     /// let mut events = shard.some_events(event_types).await;
@@ -222,9 +208,47 @@ impl Shard {
     /// # Ok(()) }
     /// ```
     pub async fn some_events(&self, event_types: EventTypeFlags) -> impl Stream<Item = Event> {
-        let rx = self.0.listeners.add(event_types).await;
+        let rx = self.listeners.add(event_types).await;
 
         Events::new(event_types, rx)
+    }
+
+    /// Returns information about the running of the shard, such as the current
+    /// connection stage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Shutdown`] if the shard isn't actively running.
+    ///
+    /// [`Error::Shutdown`]: error/enum.Error.html
+    pub async fn info(&self) -> Result<Information> {
+        let session = self.session()?;
+
+        Ok(Information {
+            id: self.config().shard()[0],
+            latency: session.heartbeats.latency().await,
+            seq: session.seq(),
+            stage: session.stage(),
+        })
+    }
+
+    /// Returns a handle to the current session
+    ///
+    /// # Note
+    ///
+    /// This session can be invalidated if it is kept around
+    /// under a reconnect or resume. In consequence this call
+    /// should not be cached.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Shutdown`] if the shard isn't actively running.
+    ///
+    /// [`Error::Shutdown`]: error/enum.Error.html
+    pub fn session(&self) -> Result<Arc<Session>> {
+        let session = self.session.as_ref().ok_or_else(|| Error::Stopped)?;
+
+        Ok(Arc::clone(&session.borrow()))
     }
 
     /// Returns an interface implementing the `Sink` trait which can be used to
@@ -235,10 +259,16 @@ impl Shard {
     /// This call should not be cached for too long
     /// as it will be invalidated by reconnects and
     /// resumes.
-    pub fn sink(&self) -> ShardSink {
-        let session = self.session();
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Shutdown`] if the shard isn't actively running.
+    ///
+    /// [`Error::Shutdown`]: error/enum.Error.html
+    pub fn sink(&self) -> Result<ShardSink> {
+        let session = self.session()?;
 
-        ShardSink(session.tx.clone())
+        Ok(ShardSink(session.tx.clone()))
     }
 
     /// Send a command over the gateway.
@@ -246,12 +276,16 @@ impl Shard {
     /// # Errors
     /// Fails if command could not be serialized, or if the command could
     /// not be sent.
+    ///
+    /// Returns [`Error::Shutdown`] if the shard isn't actively running.
+    ///
+    /// [`Error::Shutdown`]: error/enum.Error.html
     pub async fn command(&self, com: &impl serde::Serialize) -> Result<()> {
         let payload = Message::Text(
             crate::json_to_string(&com)
                 .map_err(|err| Error::PayloadSerialization { source: err })?,
         );
-        let session = self.session();
+        let session = self.session()?;
 
         // Tick ratelimiter.
         session.ratelimit.lock().await.tick().await;
@@ -267,28 +301,42 @@ impl Shard {
     ///
     /// This will cleanly close the connection, causing discord to end the session and show the bot offline
     pub async fn shutdown(&self) {
-        let session = self.session();
-        // Since we're shutting down now, we don't care if it sends or not.
-        let _ = session.tx.unbounded_send(Message::Close(None));
+        self.listeners.remove_all().await;
 
-        self.0.processor_handle.abort();
-        self.0.listeners.remove_all().await;
-        session.stop_heartbeater().await;
+        if let Some(processor_handle) = self.processor_handle.as_ref() {
+            processor_handle.abort();
+        }
+
+        if let Ok(session) = self.session() {
+            // Since we're shutting down now, we don't care if it sends or not.
+            let _ = session.tx.unbounded_send(Message::Close(None));
+            session.stop_heartbeater().await;
+        }
     }
 
     /// This will shut down the shard in a resumable way and return shard id and optional session info to resume with later if this shard is resumable
     pub async fn shutdown_resumable(&self) -> (u64, Option<ResumeSession>) {
-        let session = self.session();
+        self.listeners.remove_all().await;
+
+        if let Some(processor_handle) = self.processor_handle.as_ref() {
+            processor_handle.abort();
+        }
+
+        let shard_id = self.config().shard()[0];
+
+        let session = match self.session() {
+            Ok(session) => session,
+            Err(_) => return (shard_id, None),
+        };
+
         let _ = session.tx.unbounded_send(Message::Close(Some(CloseFrame {
             code: CloseCode::Restart,
             reason: Cow::from("Closing in a resumable way"),
         })));
-        let shard_id = self.config().shard[0];
+
         let session_id = session.id.lock().await.clone();
         let sequence = session.seq.load(Ordering::Relaxed);
 
-        self.0.processor_handle.abort();
-        self.0.listeners.remove_all().await;
         session.stop_heartbeater().await;
 
         let data = match session_id {

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -59,6 +59,7 @@ impl ShardProcessor {
     pub async fn new(
         config: Arc<ShardConfig>,
         mut url: String,
+        listeners: Listeners<Event>,
     ) -> Result<(Self, WatchReceiver<Arc<Session>>)> {
         //if we got resume info we don't need to wait
         let shard_id = config.shard();
@@ -96,7 +97,7 @@ impl ShardProcessor {
 
         let mut processor = Self {
             config,
-            listeners: Listeners::default(),
+            listeners,
             properties,
             rx,
             session,

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -53,7 +53,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let lavalink = Lavalink::new(user_id, shard_count);
     lavalink.add(lavalink_host, lavalink_auth).await?;
 
-    let shard = Shard::new(token).await?;
+    let mut shard = Shard::new(token);
+    shard.start().await?;
 
     let mut events = shard.events().await;
 

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -46,7 +46,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let lavalink = Lavalink::new(user_id, shard_count);
         let rx = lavalink.add(lavalink_host, lavalink_auth).await?;
 
-        let shard = Shard::new(token).await?;
+        let mut shard = Shard::new(token);
+        shard.start().await?;
 
         (
             State {

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -51,7 +51,8 @@
 //!     let lavalink = Lavalink::new(user_id, shard_count);
 //!     lavalink.add(lavalink_host, lavalink_auth).await?;
 //!
-//!     let shard = Shard::new(token).await?;
+//!     let mut shard = Shard::new(token);
+//!     shard.start().await?;
 //!
 //!     let mut events = shard.events().await;
 //!

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -126,7 +126,12 @@
 //!
 //!     // Start up the cluster
 //!     let cluster = Cluster::new(config).await?;
-//!     cluster.up().await;
+//!
+//!     let cluster_spawn = cluster.clone();
+//!
+//!     tokio::spawn(async move {
+//!         cluster_spawn.up().await;
+//!     });
 //!
 //!     // The http client is seperate from the gateway,
 //!     // so startup a new one
@@ -143,7 +148,6 @@
 //!         )
 //!         .build();
 //!     let cache = InMemoryCache::from(cache_config);
-//!
 //!
 //!     let mut events = cluster.events().await;
 //!     // Startup an event loop for each event in the event stream

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -125,8 +125,8 @@
 //!         .build();
 //!
 //!     // Start up the cluster
-//!     let cluster = Cluster::new(config);
-//!     cluster.up().await?;
+//!     let cluster = Cluster::new(config).await?;
+//!     cluster.up().await;
 //!
 //!     // The http client is seperate from the gateway,
 //!     // so startup a new one


### PR DESCRIPTION
Separate the booting of a Shard (connecting to the gateway, aka "running") from the initialisation of the struct.

This means that this code:

```rust
let shard = Shard::new(config).await?;
```

is now:

```rust
let mut shard = Shard::new(config);
shard.start().await?;
```

This is useful for separating the concerns of state initialisation and the processing of an event loop.

Additionally, in the Cluster, instead of creating shards in `Cluster::up`, create the shards on initialisation in the `Cluster::new` method, which is now an async function due to being able to automatically retrieve the total shard count from the gateway.

This means that cluster code may look like:

```rust
let cluster = Cluster::new(config).await?;
let mut events = cluster.events().await;

let cluster_spawn = cluster.clone();
tokio::spawn(async move {
    cluster_spawn.up().await;
});

while let Some(event) = events.next().await {
    // ...
}
```

Additionally, this means that the stream of events can now be retrieved before starting and waiting on the cluster to boot shards, so events can be received and processed while the cluster is still booting in the background.

This is a successor to PR #148.

Closes #153.