### PR TITLE
gateway/shard: handle invalid authorization

### DIFF
--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -25,6 +25,8 @@ pub type Result<T, E = Error> = StdResult<T, E>;
 /// shard.
 #[derive(Debug)]
 pub enum Error {
+    /// The provided authorization token is invalid.
+    AuthorizationInvalid { shard_id: u64, token: String },
     /// An error happened while trying to connect to the gateway.
     Connecting {
         /// The error from the WebSocket client.
@@ -72,6 +74,11 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
+            Self::AuthorizationInvalid { shard_id, .. } => write!(
+                f,
+                "The authorization token for shard {} is invalid",
+                shard_id
+            ),
             Self::Connecting { .. } => f.write_str("An issue occurred connecting to the gateway"),
             Self::GettingGatewayUrl { .. } => f.write_str("Getting the gateway URL failed"),
             Self::IdTooLarge { id, total } => {
@@ -103,7 +110,9 @@ impl StdError for Error {
             Self::PayloadSerialization { source } => Some(source),
             Self::SendingMessage { source } => Some(source),
             Self::Decompressing { source } => Some(source),
-            Self::IdTooLarge { .. } | Self::LargeThresholdInvalid { .. } => None,
+            Self::AuthorizationInvalid { .. }
+            | Self::IdTooLarge { .. }
+            | Self::LargeThresholdInvalid { .. } => None,
         }
     }
 }

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -119,7 +119,14 @@ impl Shard {
     async fn _new(config: ShardConfig) -> Result<Self> {
         let config = Arc::new(config);
 
-        let (processor, wrx) = ShardProcessor::new(Arc::clone(&config)).await?;
+        let url = config
+            .http_client()
+            .gateway()
+            .await
+            .map_err(|source| Error::GettingGatewayUrl { source })?
+            .url;
+
+        let (processor, wrx) = ShardProcessor::new(Arc::clone(&config), url).await?;
         let listeners = processor.listeners.clone();
         let (fut, handle) = future::abortable(processor.run());
 

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -122,6 +122,7 @@ impl Shard {
         let url = config
             .http_client()
             .gateway()
+            .authed()
             .await
             .map_err(|source| Error::GettingGatewayUrl { source })?
             .url;


### PR DESCRIPTION
In the gateway's Shard, handle invalid authorization both early and during processing of the shard processor's loop.

While creating the shard, get the gateway URL from the HTTP API prior to creating the processor. This allows an early return if getting the gateway URL (such as due to invalid authorization) failed. Additionally, during the processing of the shard processor's loop, if a close frame with a 4004 error (invalid authorization) is encountered, remove all of the listeners for the shard and exit the loop.

Closes #152.