### PR TITLE
standby: use dashmap, return future structs

### DIFF
--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let mut events = state.shard.events().await;
 
     while let Some(event) = events.next().await {
-        state.standby.process(&event).await;
+        state.standby.process(&event);
         state.lavalink.process(&event).await?;
 
         if let Event::MessageCreate(msg) = event {

--- a/standby/Cargo.toml
+++ b/standby/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.1.0"
 
 [dependencies]
+dashmap = { default-features = false, version = "3" }
 futures-channel = { default-features = false, features = ["std"], version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 log = { default-features = false, version = "0.4" }

--- a/standby/src/futures.rs
+++ b/standby/src/futures.rs
@@ -1,6 +1,10 @@
 use futures_channel::oneshot::{Canceled, Receiver};
 use futures_util::future::FutureExt;
-use std::{future::Future, pin::Pin, task::{Context, Poll}};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use twilight_model::gateway::{
     event::Event,
     payload::{MessageCreate, ReactionAdd},

--- a/standby/src/futures.rs
+++ b/standby/src/futures.rs
@@ -1,0 +1,71 @@
+use futures_channel::oneshot::{Canceled, Receiver};
+use futures_util::future::FutureExt;
+use std::{future::Future, pin::Pin, task::{Context, Poll}};
+use twilight_model::gateway::{
+    event::Event,
+    payload::{MessageCreate, ReactionAdd},
+};
+
+/// The future returned from [`Standby::wait_for_event`].
+///
+/// [`Standby::wait_for_event`]: struct.Standby.html#method.wait_for_event
+#[derive(Debug)]
+pub struct WaitForEventFuture {
+    pub(crate) rx: Receiver<Event>,
+}
+
+impl Future for WaitForEventFuture {
+    type Output = Result<Event, Canceled>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.rx.poll_unpin(cx)
+    }
+}
+
+/// The future returned from [`Standby::wait_for`].
+///
+/// [`Standby::wait_for`]: struct.Standby.html#method.wait_for
+#[derive(Debug)]
+pub struct WaitForGuildEventFuture {
+    pub(crate) rx: Receiver<Event>,
+}
+
+impl Future for WaitForGuildEventFuture {
+    type Output = Result<Event, Canceled>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.rx.poll_unpin(cx)
+    }
+}
+
+/// The future returned from [`Standby::wait_for_message`].
+///
+/// [`Standby::wait_for_message`]: struct.Standby.html#method.wait_for_message
+#[derive(Debug)]
+pub struct WaitForMessageFuture {
+    pub(crate) rx: Receiver<MessageCreate>,
+}
+
+impl Future for WaitForMessageFuture {
+    type Output = Result<MessageCreate, Canceled>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.rx.poll_unpin(cx)
+    }
+}
+
+/// The future returned from [`Standby::wait_for_reaction`].
+///
+/// [`Standby::wait_for_reaction`]: struct.Standby.html#method.wait_for_reaction
+#[derive(Debug)]
+pub struct WaitForReactionFuture {
+    pub(crate) rx: Receiver<ReactionAdd>,
+}
+
+impl Future for WaitForReactionFuture {
+    type Output = Result<ReactionAdd, Canceled>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.rx.poll_unpin(cx)
+    }
+}

--- a/standby/src/futures.rs
+++ b/standby/src/futures.rs
@@ -14,6 +14,7 @@ use twilight_model::gateway::{
 ///
 /// [`Standby::wait_for_event`]: struct.Standby.html#method.wait_for_event
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct WaitForEventFuture {
     pub(crate) rx: Receiver<Event>,
 }
@@ -30,6 +31,7 @@ impl Future for WaitForEventFuture {
 ///
 /// [`Standby::wait_for`]: struct.Standby.html#method.wait_for
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct WaitForGuildEventFuture {
     pub(crate) rx: Receiver<Event>,
 }
@@ -46,6 +48,7 @@ impl Future for WaitForGuildEventFuture {
 ///
 /// [`Standby::wait_for_message`]: struct.Standby.html#method.wait_for_message
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct WaitForMessageFuture {
     pub(crate) rx: Receiver<MessageCreate>,
 }
@@ -62,6 +65,7 @@ impl Future for WaitForMessageFuture {
 ///
 /// [`Standby::wait_for_reaction`]: struct.Standby.html#method.wait_for_reaction
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct WaitForReactionFuture {
     pub(crate) rx: Receiver<ReactionAdd>,
 }

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -44,7 +44,9 @@
 
 mod futures;
 
-pub use futures::{WaitForEventFuture, WaitForGuildEventFuture, WaitForMessageFuture, WaitForReactionFuture};
+pub use futures::{
+    WaitForEventFuture, WaitForGuildEventFuture, WaitForMessageFuture, WaitForReactionFuture,
+};
 
 use dashmap::DashMap;
 use futures_channel::oneshot::{self, Sender};

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -42,10 +42,13 @@
 //! [`Standby::wait_for_message`]: struct.Standby.html#method.wait_for_message
 //! [`Standby::wait_for_reaction`]: struct.Standby.html#method.wait_for_reaction
 
-use futures_channel::oneshot::{self, Canceled, Sender};
-use futures_util::lock::Mutex;
+mod futures;
+
+pub use futures::{WaitForEventFuture, WaitForGuildEventFuture, WaitForMessageFuture, WaitForReactionFuture};
+
+use dashmap::DashMap;
+use futures_channel::oneshot::{self, Sender};
 use std::{
-    collections::HashMap,
     fmt::{Debug, Formatter, Result as FmtResult},
     sync::Arc,
 };
@@ -59,7 +62,7 @@ use twilight_model::{
 };
 
 struct Bystander<E> {
-    func: Box<dyn Fn(&E) -> bool + Send>,
+    func: Box<dyn Fn(&E) -> bool + Send + Sync>,
     sender: Option<Sender<E>>,
 }
 
@@ -74,10 +77,10 @@ impl<E> Debug for Bystander<E> {
 
 #[derive(Debug, Default)]
 struct StandbyRef {
-    events: Mutex<HashMap<EventType, Vec<Bystander<Event>>>>,
-    guilds: Mutex<HashMap<GuildId, Vec<Bystander<Event>>>>,
-    messages: Mutex<HashMap<ChannelId, Vec<Bystander<MessageCreate>>>>,
-    reactions: Mutex<HashMap<MessageId, Vec<Bystander<ReactionAdd>>>>,
+    events: DashMap<EventType, Vec<Bystander<Event>>>,
+    guilds: DashMap<GuildId, Vec<Bystander<Event>>>,
+    messages: DashMap<ChannelId, Vec<Bystander<MessageCreate>>>,
+    reactions: DashMap<MessageId, Vec<Bystander<ReactionAdd>>>,
 }
 
 /// The `Standby` struct, used by the main event loop to process events and by
@@ -97,25 +100,24 @@ impl Standby {
     ///
     /// When a bystander checks to see if an event is what it's waiting for, it
     /// will receive the event by cloning it.
-    pub async fn process(&self, event: &Event) {
+    pub fn process(&self, event: &Event) {
         log::trace!("Processing event: {:?}", event);
 
         match event {
-            Event::MessageCreate(e) => return self.process_message(e.0.channel_id, &e).await,
-            Event::ReactionAdd(e) => return self.process_reaction(e.0.message_id, &e).await,
+            Event::MessageCreate(e) => return self.process_message(e.0.channel_id, &e),
+            Event::ReactionAdd(e) => return self.process_reaction(e.0.message_id, &e),
             _ => {}
         }
 
         match event_guild_id(event) {
-            Some(guild_id) => self.process_guild(guild_id, event).await,
-            None => self.process_event(event).await,
+            Some(guild_id) => self.process_guild(guild_id, event),
+            None => self.process_event(event),
         }
     }
 
     /// Wait for an event in a certain guild.
     ///
-    /// Returns `None` if the `Standby` instance was dropped or this waiter was
-    /// dropped before an event could be found.
+    /// Returns a Canceled error if the Standby struct was dropped.
     ///
     /// # Examples
     ///
@@ -139,32 +141,29 @@ impl Standby {
     /// ```
     ///
     /// [`Standby`]: struct.Standby.html
-    pub async fn wait_for<F: Fn(&Event) -> bool + Send + 'static>(
+    pub fn wait_for<F: Fn(&Event) -> bool + Send + Sync + 'static>(
         &self,
         guild_id: GuildId,
         check: impl Into<Box<F>>,
-    ) -> Result<Event, Canceled> {
+    ) -> WaitForGuildEventFuture {
         log::trace!("Waiting for event in guild {}", guild_id);
         let (tx, rx) = oneshot::channel();
 
         {
-            let mut guilds = self.0.guilds.lock().await;
-
-            let guild = guilds.entry(guild_id).or_default();
+            let mut guild = self.0.guilds.entry(guild_id).or_default();
             guild.push(Bystander {
                 func: check.into(),
                 sender: Some(tx),
             });
         }
 
-        rx.await
+        WaitForGuildEventFuture { rx }
     }
 
     /// Wait for an event not in a certain guild. This must be filtered by an
     /// event type.
     ///
-    /// Returns `None` if the `Standby` instance was dropped or this waiter was
-    /// dropped before an event could be found.
+    /// Returns a `Canceled` error if the `Standby` struct was dropped.
     ///
     /// # Examples
     ///
@@ -189,31 +188,28 @@ impl Standby {
     /// ```
     ///
     /// [`Standby`]: struct.Standby.html
-    pub async fn wait_for_event<F: Fn(&Event) -> bool + Send + 'static>(
+    pub fn wait_for_event<F: Fn(&Event) -> bool + Send + Sync + 'static>(
         &self,
         event_type: EventType,
         check: impl Into<Box<F>>,
-    ) -> Result<Event, Canceled> {
+    ) -> WaitForEventFuture {
         log::trace!("Waiting for event {:?}", event_type);
         let (tx, rx) = oneshot::channel();
 
         {
-            let mut events = self.0.events.lock().await;
-
-            let guild = events.entry(event_type).or_default();
+            let mut guild = self.0.events.entry(event_type).or_default();
             guild.push(Bystander {
                 func: check.into(),
                 sender: Some(tx),
             });
         }
 
-        rx.await
+        WaitForEventFuture { rx }
     }
 
     /// Wait for a message in a certain channel.
     ///
-    /// Returns `None` if the `Standby` instance was dropped or this waiter was
-    /// dropped before an event could be found.
+    /// Returns a `Canceled` error if the `Standby` struct was dropped.
     ///
     /// # Examples
     ///
@@ -234,31 +230,28 @@ impl Standby {
     /// ```
     ///
     /// [`Standby`]: struct.Standby.html
-    pub async fn wait_for_message<F: Fn(&MessageCreate) -> bool + Send + 'static>(
+    pub fn wait_for_message<F: Fn(&MessageCreate) -> bool + Send + Sync + 'static>(
         &self,
         channel_id: ChannelId,
         check: impl Into<Box<F>>,
-    ) -> Result<MessageCreate, Canceled> {
+    ) -> WaitForMessageFuture {
         log::trace!("Waiting for message in channel {}", channel_id);
         let (tx, rx) = oneshot::channel();
 
         {
-            let mut messages = self.0.messages.lock().await;
-
-            let guild = messages.entry(channel_id).or_default();
+            let mut guild = self.0.messages.entry(channel_id).or_default();
             guild.push(Bystander {
                 func: check.into(),
                 sender: Some(tx),
             });
         }
 
-        rx.await
+        WaitForMessageFuture { rx }
     }
 
     /// Wait for a reaction on a certain message.
     ///
-    /// Returns `None` if the `Standby` instance was dropped or this waiter was
-    /// dropped before an event could be found.
+    /// Returns a `Canceled` error if the `Standby` struct was dropped.
     ///
     /// # Examples
     ///
@@ -279,33 +272,30 @@ impl Standby {
     /// ```
     ///
     /// [`Standby`]: struct.Standby.html
-    pub async fn wait_for_reaction<F: Fn(&ReactionAdd) -> bool + Send + 'static>(
+    pub fn wait_for_reaction<F: Fn(&ReactionAdd) -> bool + Send + Sync + 'static>(
         &self,
         message_id: MessageId,
         check: impl Into<Box<F>>,
-    ) -> Result<ReactionAdd, Canceled> {
+    ) -> WaitForReactionFuture {
         log::trace!("Waiting for reaction on message {}", message_id);
         let (tx, rx) = oneshot::channel();
 
         {
-            let mut reactions = self.0.reactions.lock().await;
-
-            let guild = reactions.entry(message_id).or_default();
+            let mut guild = self.0.reactions.entry(message_id).or_default();
             guild.push(Bystander {
                 func: check.into(),
                 sender: Some(tx),
             });
         }
 
-        rx.await
+        WaitForReactionFuture { rx }
     }
 
-    async fn process_event(&self, event: &Event) {
+    fn process_event(&self, event: &Event) {
         log::trace!("Processing event type {:?}", event);
         let kind = event.kind();
-        let mut events = self.0.events.lock().await;
 
-        let remove = match events.get_mut(&kind) {
+        let remove = match self.0.events.get_mut(&kind) {
             Some(mut bystanders) => {
                 self.iter_bystanders(&mut bystanders, event);
 
@@ -321,14 +311,12 @@ impl Standby {
         if remove {
             log::trace!("Removing event type {:?}", kind);
 
-            events.remove(&kind);
+            self.0.events.remove(&kind);
         }
     }
 
-    async fn process_guild(&self, guild_id: GuildId, event: &Event) {
-        let mut guilds = self.0.guilds.lock().await;
-
-        let remove = match guilds.get_mut(&guild_id) {
+    fn process_guild(&self, guild_id: GuildId, event: &Event) {
+        let remove = match self.0.guilds.get_mut(&guild_id) {
             Some(mut bystanders) => {
                 self.iter_bystanders(&mut bystanders, event);
 
@@ -344,14 +332,12 @@ impl Standby {
         if remove {
             log::trace!("Removing guild {}", guild_id);
 
-            guilds.remove(&guild_id);
+            self.0.guilds.remove(&guild_id);
         }
     }
 
-    async fn process_message(&self, channel_id: ChannelId, event: &MessageCreate) {
-        let mut messages = self.0.messages.lock().await;
-
-        let remove = match messages.get_mut(&channel_id) {
+    fn process_message(&self, channel_id: ChannelId, event: &MessageCreate) {
+        let remove = match self.0.messages.get_mut(&channel_id) {
             Some(mut bystanders) => {
                 self.iter_bystanders(&mut bystanders, event);
 
@@ -367,14 +353,12 @@ impl Standby {
         if remove {
             log::trace!("Removing channel {}", channel_id);
 
-            messages.remove(&channel_id);
+            self.0.messages.remove(&channel_id);
         }
     }
 
-    async fn process_reaction(&self, message_id: MessageId, event: &ReactionAdd) {
-        let mut reactions = self.0.reactions.lock().await;
-
-        let remove = match reactions.get_mut(&message_id) {
+    fn process_reaction(&self, message_id: MessageId, event: &ReactionAdd) {
+        let remove = match self.0.reactions.get_mut(&message_id) {
             Some(mut bystanders) => {
                 self.iter_bystanders(&mut bystanders, event);
 
@@ -389,7 +373,7 @@ impl Standby {
 
         if remove {
             log::trace!("Removing message {}", message_id);
-            reactions.remove(&message_id);
+            self.0.reactions.remove(&message_id);
         }
     }
 
@@ -505,7 +489,6 @@ fn channel_guild_id(channel: &Channel) -> Option<GuildId> {
 #[cfg(test)]
 mod tests {
     use super::Standby;
-    use futures_util::future;
     use std::collections::HashMap;
     use twilight_model::{
         channel::{
@@ -527,22 +510,19 @@ mod tests {
             Event::RoleDelete(e) => e.guild_id == GuildId(1),
             _ => false,
         });
-        let process = standby.process(&Event::RoleDelete(RoleDelete {
+        standby.process(&Event::RoleDelete(RoleDelete {
             guild_id: GuildId(1),
             role_id: RoleId(2),
         }));
 
-        // wait always gets polled first
-        let (res, _) = future::join(wait, process).await;
-
         assert!(matches!(
-            res,
+            wait.await,
             Ok(Event::RoleDelete(RoleDelete {
                 guild_id: GuildId(1),
                 role_id: RoleId(2),
             }))
         ));
-        assert!(standby.0.guilds.lock().await.is_empty());
+        assert!(standby.0.guilds.is_empty());
     }
 
     #[tokio::test]
@@ -570,13 +550,10 @@ mod tests {
             Event::Ready(ready) => ready.shard.map(|[id, _]| id == 5).unwrap_or(false),
             _ => false,
         });
-        let process = standby.process(&event);
+        standby.process(&event);
 
-        // wait always gets polled first
-        let (res, _) = future::join(wait, process).await;
-
-        assert_eq!(Ok(event), res);
-        assert!(standby.0.events.lock().await.is_empty());
+        assert_eq!(Ok(event), wait.await);
+        assert!(standby.0.events.is_empty());
     }
 
     #[tokio::test]
@@ -626,14 +603,10 @@ mod tests {
         let wait = standby.wait_for_message(ChannelId(1), |message: &MessageCreate| {
             message.author.id == UserId(2)
         });
+        standby.process(&event);
 
-        let process = standby.process(&event);
-
-        // wait always gets polled first
-        let (res, _) = future::join(wait, process).await;
-
-        assert_eq!(Ok(MessageId(3)), res.map(|msg| msg.id));
-        assert!(standby.0.messages.lock().await.is_empty());
+        assert_eq!(Ok(MessageId(3)), wait.await.map(|msg| msg.id));
+        assert!(standby.0.messages.is_empty());
     }
 
     #[tokio::test]
@@ -655,13 +628,10 @@ mod tests {
             reaction.user_id == UserId(3)
         });
 
-        let process = standby.process(&event);
+        standby.process(&event);
 
-        // wait always gets polled first
-        let (res, _) = future::join(wait, process).await;
-
-        assert_eq!(Ok(UserId(3)), res.map(|reaction| reaction.user_id));
-        assert!(standby.0.reactions.lock().await.is_empty());
+        assert_eq!(Ok(UserId(3)), wait.await.map(|reaction| reaction.user_id));
+        assert!(standby.0.reactions.is_empty());
     }
 
     #[tokio::test]
@@ -671,12 +641,10 @@ mod tests {
             matches!(event, Event::Resumed)
         });
 
-        standby.process(&Event::PresencesReplace).await;
-        standby.process(&Event::PresencesReplace).await;
-        let process = standby.process(&Event::Resumed);
+        standby.process(&Event::PresencesReplace);
+        standby.process(&Event::PresencesReplace);
+        standby.process(&Event::Resumed);
 
-        // wait always gets polled first
-        let (res, _) = future::join(wait, process).await;
-        assert!(res.is_ok());
+        assert_eq!(Ok(Event::Resumed), wait.await);
     }
 }


### PR DESCRIPTION
In Standby, use DashMap for internal maps, which avoids the need for locking and many of the functions needing to be asynchronous.

The waiting methods, such as `Standby::wait_for`, now return futures which resolve to the same return type that they did before. "Voldemort types", or types that can't be named (such as async fns, or `impl Future`s), are sub-par due to needing to be boxed when stored somewhere. By having named structs, this can make handling futures more efficient for users.

This PR could have been separated into two, but that would have nearly doubled work and would end up in conflicts between the two, so it was simpler to combine them together.
