### PR TITLE
project: reduce selected dependency features

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ providing models to deserialize their responses.
 ```rust,no_run
 use std::{env, error::Error};
 use tokio::stream::StreamExt;
-
 use twilight::{
     cache::{
         twilight_cache_inmemory::config::{InMemoryConfigBuilder, EventType},

--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -5,13 +5,13 @@ name = "twilight-cache-inmemory"
 version = "0.1.0"
 
 [dependencies]
-async-trait = "0.1"
-bitflags = "1"
-futures = "0.3"
-twilight-cache-trait = { path = "../trait" }
+async-trait = { default-features = false, version = "0.1" }
+bitflags = { default-features = false, version = "1" }
+futures-util = { default-features = false, features = ["std"], version = "0.3" }
+twilight-cache-trait = { default-features = false, path = "../trait" }
 twilight-model = { default-features = false, path = "../../model" }
-log = "0.4"
+log = { default-features = false, version = "0.4" }
 
 [dev-dependencies]
-static_assertions = "1"
-tokio = "0.2"
+static_assertions = { default-features = false, version = "1" }
+tokio = { default-features = false, features = ["rt-core", "macros"], version = "0.2" }

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -5,7 +5,7 @@ mod updates;
 
 use self::model::*;
 use config::InMemoryConfig;
-use futures::{future, lock::Mutex};
+use futures_util::{future, lock::Mutex};
 use std::{
     collections::{
         hash_map::{Entry, HashMap},

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -1,6 +1,6 @@
 use super::{config::EventType, InMemoryCache, InMemoryCacheError};
 use async_trait::async_trait;
-use futures::lock::Mutex;
+use futures_util::lock::Mutex;
 #[allow(unused_imports)]
 use log::debug;
 use std::{

--- a/cache/trait/Cargo.toml
+++ b/cache/trait/Cargo.toml
@@ -13,8 +13,8 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.1.0"
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { default-features = false, version = "0.1" }
 twilight-model = { default-features = false, path = "../../model" }
 
 [dev-dependencies]
-static_assertions = "1"
+static_assertions = { default-features = false, version = "1" }

--- a/command-parser/Cargo.toml
+++ b/command-parser/Cargo.toml
@@ -13,4 +13,4 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.1.0"
 
 [dependencies]
-unicase = "2"
+unicase = { default-features = false, version = "2" }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -13,32 +13,32 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.1.0"
 
 [dependencies]
-async-trait = "0.1"
-bitflags = "1"
+async-trait = { default-features = false, version = "0.1" }
+bitflags = { default-features = false, version = "1" }
 twilight-http = { path = "../http" }
-twilight-model = { path = "../model" }
-futures = "0.3"
-log = "0.4"
-serde = { features = ["derive"], version = "1" }
-serde_json = { version = "1", optional = true }
-simd-json = { version = "0.3", optional = true }
-serde-value = "0.6"
-# Make it use less features at a later time.
-tokio = { version = "0.2", features = ["full"] }
-tokio-tungstenite = { version = "0.10.1", features = ["tls"] }
-url = "2"
+twilight-model = { default-features = false, path = "../model" }
+futures-channel = { default-features = false, version = "0.3" }
+futures-util = { default-features = false, features = ["std"], version = "0.3" }
+log = { default-features = false, version = "0.4" }
+serde = { default-features = false, features = ["derive"], version = "1" }
+serde_json = { default-features = false, optional = true, version = "1" }
+simd-json = { default-features = false, optional = true, version = "0.3" }
+serde-value = { default-features = false, version = "0.6" }
+tokio = { default-features = false, features = ["net", "rt-core"], version = "0.2" }
+tokio-tungstenite = { default-features = false, features = ["connect", "tls"], version = "0.10" }
+url = { default-features = false, version = "2" }
 # The default backend for flate2; miniz-oxide, works differently
 # from the C-backed backend zlib, When you give it the sync argument
 # it does not seem to update the total_in of the function to have an offset
 # https://github.com/alexcrichton/flate2-rs/issues/217
-flate2 = { version = "1.0", default-features = false, features = ["zlib"] }
+flate2 = { default-features = false, features = ["zlib"], version = "1.0" }
 
 #optional
-metrics = { version = "0.12.1", optional = true }
+metrics = { default-features = false, optional = true, version = "0.12.1" }
 
 [dev-dependencies]
-futures = "0.3"
-tokio = "0.2"
+futures = { default-features = false, version = "0.3" }
+tokio = { default-features = false, features = ["rt-core", "macros"], version = "0.2" }
 
 [features]
 default = ["serde_json"]

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -7,7 +7,7 @@ use crate::{
     shard::{Information, Shard},
     EventTypeFlags,
 };
-use futures::{
+use futures_util::{
     future,
     lock::Mutex,
     stream::{SelectAll, Stream, StreamExt},

--- a/gateway/src/listener.rs
+++ b/gateway/src/listener.rs
@@ -1,8 +1,6 @@
 use crate::EventTypeFlags;
-use futures::{
-    channel::mpsc::{self, UnboundedReceiver, UnboundedSender},
-    lock::Mutex,
-};
+use futures_channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use futures_util::lock::Mutex;
 use std::{
     collections::HashMap,
     sync::{

--- a/gateway/src/queue.rs
+++ b/gateway/src/queue.rs
@@ -5,14 +5,11 @@ pub use large_bot_queue::LargeBotQueue;
 
 use async_trait::async_trait;
 use day_limiter::DayLimiter;
-use futures::{
-    channel::{
-        mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
-        oneshot::{self, Sender},
-    },
-    sink::SinkExt,
-    stream::StreamExt,
+use futures_channel::{
+    mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
+    oneshot::{self, Sender},
 };
+use futures_util::{sink::SinkExt, stream::StreamExt};
 #[allow(unused_imports)]
 use log::{info, warn};
 use std::{fmt::Debug, time::Duration};

--- a/gateway/src/queue/large_bot_queue.rs
+++ b/gateway/src/queue/large_bot_queue.rs
@@ -1,13 +1,10 @@
 use super::{DayLimiter, Queue};
 use async_trait::async_trait;
-use futures::{
-    channel::{
-        mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
-        oneshot::{self, Sender},
-    },
-    sink::SinkExt,
-    stream::StreamExt,
+use futures_channel::{
+    mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
+    oneshot::{self, Sender},
 };
+use futures_util::{sink::SinkExt, stream::StreamExt};
 use log::{info, warn};
 use std::{fmt::Debug, time::Duration};
 

--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -1,7 +1,7 @@
 //! The error type of why errors occur in the shard module.
 
 use flate2::DecompressError;
-use futures::channel::mpsc::TrySendError;
+use futures_channel::mpsc::TrySendError;
 #[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
 use serde_json::Error as JsonError;
 #[cfg(feature = "simd-json")]

--- a/gateway/src/shard/event.rs
+++ b/gateway/src/shard/event.rs
@@ -14,10 +14,8 @@
 //! [`Shard::some_events`]: ../struct.Shard.html#method.some_events
 
 use crate::EventTypeFlags;
-use futures::{
-    channel::mpsc::UnboundedReceiver,
-    stream::{Stream, StreamExt},
-};
+use futures_channel::mpsc::UnboundedReceiver;
+use futures_util::stream::{Stream, StreamExt};
 use std::{
     pin::Pin,
     task::{Context, Poll},

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -7,9 +7,9 @@ use super::{
     stage::Stage,
 };
 use crate::{listener::Listeners, EventTypeFlags};
-use futures::{
+use futures_util::{
     future::{self, AbortHandle},
-    Stream,
+    stream::Stream,
 };
 
 use log::debug;

--- a/gateway/src/shard/processor/heartbeat.rs
+++ b/gateway/src/shard/processor/heartbeat.rs
@@ -1,5 +1,6 @@
 use super::super::error::{Error, Result};
-use futures::{channel::mpsc::UnboundedSender, lock::Mutex};
+use futures_channel::mpsc::UnboundedSender;
+use futures_util::lock::Mutex;
 use log::{debug, error, warn};
 use std::{
     collections::VecDeque,

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -19,7 +19,8 @@ use twilight_model::gateway::{
     },
 };
 
-use futures::{channel::mpsc::UnboundedReceiver, stream::StreamExt};
+use futures_channel::mpsc::UnboundedReceiver;
+use futures_util::stream::StreamExt;
 #[allow(unused_imports)]
 use log::{debug, info, trace, warn};
 use serde::Serialize;

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -5,8 +5,8 @@ use super::{
     },
     heartbeat::{Heartbeater, Heartbeats},
 };
-use futures::{
-    channel::mpsc::UnboundedSender,
+use futures_channel::mpsc::UnboundedSender;
+use futures_util::{
     future::{self, AbortHandle},
     lock::Mutex,
 };

--- a/gateway/src/shard/processor/socket_forwarder.rs
+++ b/gateway/src/shard/processor/socket_forwarder.rs
@@ -1,6 +1,6 @@
 use super::super::ShardStream;
-use futures::{
-    channel::mpsc::{self, UnboundedReceiver, UnboundedSender},
+use futures_channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use futures_util::{
     future::{self, Either},
     sink::SinkExt,
     stream::StreamExt,

--- a/gateway/src/shard/sink.rs
+++ b/gateway/src/shard/sink.rs
@@ -1,7 +1,5 @@
-use futures::{
-    channel::mpsc::{SendError, TrySendError, UnboundedSender},
-    sink::Sink,
-};
+use futures_channel::mpsc::{SendError, TrySendError, UnboundedSender};
+use futures_util::sink::Sink;
 use std::{
     pin::Pin,
     task::{Context, Poll},

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -14,17 +14,18 @@ version = "0.1.0"
 
 [dependencies]
 bytes = { default-features = false, version = "0.5" }
-futures = "0.3"
-twilight-model = { path = "../model" }
-log = "0.4"
-reqwest = "0.10"
-serde = { features = ["derive"], version = "1" }
-serde_json = { version = "1", optional = true }
+futures-channel = { default-features = false, version = "0.3" }
+futures-util = { default-features = false, features = ["std"], version = "0.3" }
+twilight-model = { default-features = false, features = ["serde-support"], path = "../model" }
+log = { default-features = false, version = "0.4" }
+reqwest = { default-features = false, version = "0.10" }
+serde = { default-features = false, features = ["derive"], version = "1" }
+serde_json = { default-features = false, optional = true, version = "1" }
 serde_repr = { default-features = false, version = "0.1" }
-simd-json = { version = "0.3", optional = true }
-tokio = "0.2"
-percent-encoding = "2.1"
-url = "2"
+simd-json = { default-features = false, optional = true, version = "0.3" }
+tokio = { default-features = false, version = "0.2" }
+percent-encoding = { default-features = false, version = "2" }
+url = { default-features = false, version = "2" }
 
 [features]
 default = ["native", "serde_json"]
@@ -33,4 +34,4 @@ rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 serde_test = { default-features = false, version = "1" }
-tokio = { features = ["macros"], version = "0.2" }
+tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -1,5 +1,5 @@
 use crate::{api_error::ApiError, ratelimiting::RatelimitError};
-use futures::channel::oneshot::Canceled;
+use futures_channel::oneshot::Canceled;
 use reqwest::{header::InvalidHeaderValue, Error as ReqwestError, StatusCode};
 #[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
 use serde_json::Error as JsonError;

--- a/http/src/ratelimiting/bucket.rs
+++ b/http/src/ratelimiting/bucket.rs
@@ -1,13 +1,10 @@
 use super::{headers::RatelimitHeaders, GlobalLockPair};
 use crate::routing::Path;
-use futures::{
-    channel::{
-        mpsc::{self, UnboundedReceiver, UnboundedSender},
-        oneshot::{self, Sender},
-    },
-    lock::Mutex,
-    stream::StreamExt,
+use futures_channel::{
+    mpsc::{self, UnboundedReceiver, UnboundedSender},
+    oneshot::{self, Sender},
 };
+use futures_util::{lock::Mutex, stream::StreamExt};
 use log::debug;
 use std::{
     collections::HashMap,

--- a/http/src/ratelimiting/mod.rs
+++ b/http/src/ratelimiting/mod.rs
@@ -10,10 +10,8 @@ pub use self::{
 
 use self::bucket::{Bucket, BucketQueueTask};
 use crate::routing::Path;
-use futures::{
-    channel::oneshot::{self, Receiver, Sender},
-    lock::Mutex,
-};
+use futures_channel::oneshot::{self, Receiver, Sender};
+use futures_util::lock::Mutex;
 use log::debug;
 use std::{
     collections::hash_map::{Entry, HashMap},

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -23,11 +23,11 @@ percent-encoding = { default-features = false, optional = true, version = "2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }
 serde_json = { default-features = false, version = "1" }
 tokio = { default-features = false, features = ["net", "rt-core", "time"], version = "0.2" }
-twilight-model = { path = "../model" }
+twilight-model = { default-features = false, features = ["serde-support"], path = "../model" }
 
 [dev-dependencies]
 static_assertions = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["macros", "rt-threaded"], version = "0.2" }
+tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }
 twilight-gateway = { path = "../gateway" }
 twilight-http = { path = "../http" }
 

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -13,16 +13,16 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.1.0"
 
 [dependencies]
-bitflags = "1"
-log = { version = "0.4" }
-serde = { features = ["derive"], optional = true, version = "1" }
-serde-mappable-seq = { optional = true, version = "0.1" }
-serde_repr = { optional = true, version = "0.1" }
-serde-value = { optional = true, version = "0.6" }
+bitflags = { default-features = false, version = "1" }
+log = { default-features = false, version = "0.4" }
+serde = { default-features = false, features = ["derive"], optional = true, version = "1" }
+serde-mappable-seq = { default-features = false, optional = true, version = "0.1" }
+serde_repr = { default-features = false, optional = true, version = "0.1" }
+serde-value = { default-features = false, optional = true, version = "0.6" }
 
 [dev-dependencies]
-serde_json = "1"
-serde_test = "1"
+serde_json = { default-features = false, features = ["alloc"], version = "1" }
+serde_test = { default-features = false, version = "1" }
 
 [features]
 default = ["serde-support"]

--- a/twilight/Cargo.toml
+++ b/twilight/Cargo.toml
@@ -22,8 +22,7 @@ twilight-model = { optional = true, path = "../model" }
 twilight-standby = { optional = true, path = "../standby" }
 
 [dev-dependencies]
-futures = "0.3"
-tokio = "0.2"
+tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }
 
 [features]
 default = ["all"]

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -98,7 +98,6 @@
 //! ```rust,no_run
 //! use std::{env, error::Error};
 //! use tokio::stream::StreamExt;
-//!
 //! use twilight::{
 //!     cache::{
 //!         twilight_cache_inmemory::config::{InMemoryConfigBuilder, EventType},


### PR DESCRIPTION
Reduce the selected features of dependencies, mostly by disabling all default features and only selecting what we need.

This reduces the unique dependency tree of the default feature build of the main 'twilight' crate by 2.

Closes #211.