### PR TITLE
project: update docs to point to trunk branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Most of Twilight requires at least 1.40+ (rust stable).
 Add this to your `Cargo.toml`'s `[dependencies]` section:
 
 ```toml
-twilight = { git = "https://github.com/twilight-rs/twilight.git" }
+twilight = { branch = "trunk", git = "https://github.com/twilight-rs/twilight.git" }
 ```
 
 ## Core Crates

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -34,7 +34,7 @@ disable `serde_json` if you are going to use `simd-json`. It is easy to switch t
 
 ```toml
 [dependencies]
-twilight-gateway = { default-features = false, features = ["simd-json"], git = "https://github.com/twilight-rs/twilight" }
+twilight-gateway = { branch = "trunk", default-features = false, features = ["simd-json"], git = "https://github.com/twilight-rs/twilight" }
 ```
 
 [simd-json]: https://github.com/simd-lite/simd-json

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-gateway = { default-features = false, features = ["simd-json"], git = "https://github.com/twilight-rs/twilight" }
+//! twilight-gateway = { branch = "trunk", default-features = false, features = ["simd-json"], git = "https://github.com/twilight-rs/twilight" }
 //! ```
 //!
 //! [simd-json]: https://github.com/simd-lite/simd-json

--- a/http/README.md
+++ b/http/README.md
@@ -41,7 +41,7 @@ To enable `simd-json`, do something like this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-twilight-http = { default-features = false, features = ["native", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
+twilight-http = { branch = "trunk", default-features = false, features = ["native", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
 ```
 
 ### TLS
@@ -65,7 +65,7 @@ To enable `rustls`, do something like this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-twilight-http = { default-features = false, features = ["rustls", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
+twilight-http = { branch = "trunk", default-features = false, features = ["rustls", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
 ```
 
 [`native-tls`]: https://crates.io/crates/native-tls

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-http = { default-features = false, features = ["native", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
+//! twilight-http = { branch = "trunk", default-features = false, features = ["native", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
 //! ```
 //!
 //! ### TLS
@@ -63,7 +63,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-http = { default-features = false, features = ["rustls", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
+//! twilight-http = { branch = "trunk", default-features = false, features = ["rustls", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
 //! ```
 //!
 //! [`native-tls`]: https://crates.io/crates/native-tls

--- a/model/README.md
+++ b/model/README.md
@@ -51,7 +51,7 @@ If you don't need serde support, you can disable it:
 
 ```toml
 [dependencies]
-twilight-model = { default-features = false, git = "https://github.com/twilight-rs/twilight" }
+twilight-model = { branch = "trunk", default-features = false, git = "https://github.com/twilight-rs/twilight" }
 ```
 
 ## License

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -49,7 +49,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-model = { default-features = false, git = "https://github.com/twilight-rs/twilight" }
+//! twilight-model = { branch = "trunk", default-features = false, git = "https://github.com/twilight-rs/twilight" }
 //! ```
 //!
 //! ## License

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -21,7 +21,7 @@
 //! Add this to your `Cargo.toml`'s `[dependencies]` section:
 //!
 //! ```toml
-//! twilight = { git = "https://github.com/twilight-rs/twilight.git" }
+//! twilight = { branch = "trunk", git = "https://github.com/twilight-rs/twilight.git" }
 //! ```
 //!
 //! ## Core Crates


### PR DESCRIPTION
Following issue #222, the HEAD branch for the repository was renamed to "trunk". This patch updates the documentation to point to the new branch name in dependency listings.