### PR TITLE
http: make request initialisers non-public

### DIFF
--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -24,7 +24,7 @@ pub struct CreateInvite<'a> {
 }
 
 impl<'a> CreateInvite<'a> {
-    pub fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
         Self {
             channel_id,
             fields: CreateInviteFields::default(),

--- a/http/src/request/get_gateway_authed.rs
+++ b/http/src/request/get_gateway_authed.rs
@@ -7,7 +7,7 @@ pub struct GetGatewayAuthed<'a> {
 }
 
 impl<'a> GetGatewayAuthed<'a> {
-    pub fn new(http: &'a Client) -> Self {
+    pub(crate) fn new(http: &'a Client) -> Self {
         Self { fut: None, http }
     }
 


### PR DESCRIPTION
Make all of the HTTP request structs' initialisers non-public, i.e. `pub(crate)` instead. These are the requests for `CreateInvite`, which is created through the client, and `GetGatewayAuthed`, which is created via `GetGateway`.

Closes #219.