### PR TITLE
gateway/cluster: fix command dispatching

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -20,11 +20,12 @@ twilight-model = { default-features = false, path = "../model" }
 futures-channel = { default-features = false, version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 log = { default-features = false, version = "0.4" }
+once_cell = { default-features = false, version = "1" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, optional = true, version = "1" }
 simd-json = { default-features = false, optional = true, version = "0.3" }
 serde-value = { default-features = false, version = "0.6" }
-tokio = { default-features = false, features = ["net", "rt-core"], version = "0.2" }
+tokio = { default-features = false, features = ["net", "rt-core", "sync"], version = "0.2" }
 tokio-tungstenite = { default-features = false, features = ["connect", "tls"], version = "0.10" }
 url = { default-features = false, version = "2" }
 # The default backend for flate2; miniz-oxide, works differently


### PR DESCRIPTION
When the cluster would start a shard, it clones the shard to reduce the time it holds on to the map. The shard didn't hold everything behind an Arc, so some of the data would be cloned and, in *that new clone of the shard*, would be modified. This means that the shard temporarily cloned by the cluster would be in a different state from that of the one stored in the cluster's internal map.

To solve this, put everything behind an Arc. Since we need to lazily initiate some values of the shard after initialization, put it behind a OnceCell.