### PR TITLE
 gateway/shard/processor: emit shard events

### DIFF
--- a/gateway/DEVELOPMENT.md
+++ b/gateway/DEVELOPMENT.md
@@ -1,13 +1,13 @@
 # `twilight-http` development
 
-## Integration tests
+## Gateway tests
 
-Integration tests will connect to Discord's gateway for testing. Tests should be
-run one at a time with `-j1`. Tests will also run slowly and be intentionally
-delayed, due to ratelimits. This should be used with a delvelopment bot in only
-1 or 2 guilds at most.
+Gateway runtime tests will connect to Discord's gateway for testing. Tests
+should be run one at a time with `-j1`. Tests will also run slowly and be
+intentionally delayed, due to ratelimits. This should be used with a
+delvelopment bot in only 1 or 2 guilds at most.
 
-To run integration tests, run:
+To run gateway runtime tests, run:
 
 ```shell
 $ env DISCORD_TOKEN="your token here" cargo test -j1 -- --ignored

--- a/gateway/DEVELOPMENT.md
+++ b/gateway/DEVELOPMENT.md
@@ -1,0 +1,16 @@
+# `twilight-http` development
+
+## Integration tests
+
+Integration tests will connect to Discord's gateway for testing. Tests should be
+run one at a time with `-j1`. Tests will also run slowly and be intentionally
+delayed, due to ratelimits. This should be used with a delvelopment bot in only
+1 or 2 guilds at most.
+
+To run integration tests, run:
+
+```shell
+$ env DISCORD_TOKEN="your token here" cargo test -j1 -- --ignored
+$ # if you need to print output for testing, run:
+$ env DISCORD_TOKEN="your token here" cargo test -j1 -- --ignored --nocapture
+```

--- a/gateway/examples/shard/src/main.rs
+++ b/gateway/examples/shard/src/main.rs
@@ -7,10 +7,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     pretty_env_logger::init_timed();
 
     let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
+    let mut events = shard.events().await;
+
     shard.start().await?;
     println!("Created shard");
-
-    let mut events = shard.events().await;
 
     while let Some(event) = events.next().await {
         println!("Event: {:?}", event);

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -12,7 +12,7 @@ use super::{
 
 use crate::listener::Listeners;
 use twilight_model::gateway::{
-    event::{DispatchEvent, Event, GatewayEvent},
+    event::{shard::{Connected, Connecting, Disconnected, Reconnecting, Resuming}, DispatchEvent, Event, GatewayEvent},
     payload::{
         identify::{Identify, IdentifyInfo, IdentifyProperties},
         resume::Resume,
@@ -76,6 +76,10 @@ impl ShardProcessor {
 
         url.push_str("?v=6&compress=zlib-stream");
 
+        emit::event(listeners.clone(), Event::ShardConnecting(Connecting {
+            gateway: url.clone(),
+            shard_id: config.shard()[0],
+        }));
         let stream = connect::connect(&url).await?;
         let (forwarder, rx, tx) = SocketForwarder::new(stream);
         tokio::spawn(async move {
@@ -200,9 +204,18 @@ impl ShardProcessor {
                     DispatchEvent::Ready(ready) => {
                         self.session.set_stage(Stage::Connected);
                         self.session.set_id(&ready.session_id).await;
+
+                        emit::event(self.listeners.clone(), Event::ShardConnected(Connected {
+                            heartbeat_interval: self.session.heartbeat_interval(),
+                            shard_id: self.config.shard()[0],
+                        }));
                     }
                     DispatchEvent::Resumed => {
                         self.session.set_stage(Stage::Connected);
+                        emit::event(self.listeners.clone(), Event::ShardConnected(Connected {
+                            heartbeat_interval: self.session.heartbeat_interval(),
+                            shard_id: self.config.shard()[0],
+                        }));
                         self.session.heartbeats.receive().await;
                     }
                     _ => {}
@@ -295,6 +308,17 @@ impl ShardProcessor {
                 self.config.queue.request(shard).await;
             }
 
+            if full_reconnect {
+                emit::event(self.listeners.clone(), Event::ShardReconnecting(Reconnecting {
+                    shard_id: self.config.shard()[0],
+                }));
+            } else {
+                emit::event(self.listeners.clone(), Event::ShardResuming(Resuming {
+                    seq: self.session.seq(),
+                    shard_id: self.config.shard()[0],
+                }));
+            }
+
             let new_stream = match connect::connect(&self.url).await {
                 Ok(s) => s,
                 Err(why) => {
@@ -334,6 +358,11 @@ impl ShardProcessor {
 
             break;
         }
+
+        emit::event(self.listeners.clone(), Event::ShardConnecting(Connecting {
+            gateway: self.url.clone(),
+            shard_id: self.config.shard()[0],
+        }));
     }
 
     async fn resume(&mut self) -> Result<()> {
@@ -431,6 +460,11 @@ impl ShardProcessor {
                 }
                 Message::Close(close_frame) => {
                     log::warn!("Got close code: {:?}.", close_frame);
+                    emit::event(self.listeners.clone(), Event::ShardDisconnected(Disconnected {
+                        code: close_frame.as_ref().map(|frame| frame.code.into()),
+                        reason: close_frame.as_ref().map(|frame| frame.reason.clone().into()),
+                        shard_id: self.config.shard()[0],
+                    }));
 
                     if let Some(close_frame) = close_frame {
                         if close_frame.code == CloseCode::Library(4004) {

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -12,7 +12,7 @@ use super::{
 
 use crate::listener::Listeners;
 use twilight_model::gateway::{
-    event::{shard::{Connected, Connecting, Disconnected, Reconnecting, Resuming}, DispatchEvent, Event, GatewayEvent},
+    event::{shard::{Connected, Connecting, Disconnected, Identifying, Reconnecting, Resuming}, DispatchEvent, Event, GatewayEvent},
     payload::{
         identify::{Identify, IdentifyInfo, IdentifyProperties},
         resume::Resume,
@@ -183,6 +183,10 @@ impl ShardProcessor {
             token: self.config.token().to_owned(),
             v: 6,
         });
+        emit::event(self.listeners.clone(), Event::ShardIdentifying(Identifying {
+            shard_id: self.config.shard()[0],
+            shard_total: self.config.shard()[1],
+        }));
 
         self.send(identify).await
     }
@@ -243,7 +247,7 @@ impl ShardProcessor {
                     // Safe to unwrap so here as we have just checked that
                     // it is some.
                     let (seq, id) = self.resume.take().unwrap();
-                    warn!("Resumeing with ({}, {})!", seq, id);
+                    warn!("Resumeng with ({}, {})!", seq, id);
                     let payload = Resume::new(seq, &id, self.config.token());
 
                     // Set id so it is correct for next resume.

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -262,7 +262,7 @@ impl ShardProcessor {
                     // Safe to unwrap so here as we have just checked that
                     // it is some.
                     let (seq, id) = self.resume.take().unwrap();
-                    warn!("Resumeng with ({}, {})!", seq, id);
+                    warn!("Resuming with ({}, {})!", seq, id);
                     let payload = Resume::new(seq, &id, self.config.token());
 
                     // Set id so it is correct for next resume.

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -12,7 +12,10 @@ use super::{
 
 use crate::listener::Listeners;
 use twilight_model::gateway::{
-    event::{shard::{Connected, Connecting, Disconnected, Identifying, Reconnecting, Resuming}, DispatchEvent, Event, GatewayEvent},
+    event::{
+        shard::{Connected, Connecting, Disconnected, Identifying, Reconnecting, Resuming},
+        DispatchEvent, Event, GatewayEvent,
+    },
     payload::{
         identify::{Identify, IdentifyInfo, IdentifyProperties},
         resume::Resume,
@@ -76,10 +79,13 @@ impl ShardProcessor {
 
         url.push_str("?v=6&compress=zlib-stream");
 
-        emit::event(listeners.clone(), Event::ShardConnecting(Connecting {
-            gateway: url.clone(),
-            shard_id: config.shard()[0],
-        }));
+        emit::event(
+            listeners.clone(),
+            Event::ShardConnecting(Connecting {
+                gateway: url.clone(),
+                shard_id: config.shard()[0],
+            }),
+        );
         let stream = connect::connect(&url).await?;
         let (forwarder, rx, tx) = SocketForwarder::new(stream);
         tokio::spawn(async move {
@@ -183,10 +189,13 @@ impl ShardProcessor {
             token: self.config.token().to_owned(),
             v: 6,
         });
-        emit::event(self.listeners.clone(), Event::ShardIdentifying(Identifying {
-            shard_id: self.config.shard()[0],
-            shard_total: self.config.shard()[1],
-        }));
+        emit::event(
+            self.listeners.clone(),
+            Event::ShardIdentifying(Identifying {
+                shard_id: self.config.shard()[0],
+                shard_total: self.config.shard()[1],
+            }),
+        );
 
         self.send(identify).await
     }
@@ -209,17 +218,23 @@ impl ShardProcessor {
                         self.session.set_stage(Stage::Connected);
                         self.session.set_id(&ready.session_id).await;
 
-                        emit::event(self.listeners.clone(), Event::ShardConnected(Connected {
-                            heartbeat_interval: self.session.heartbeat_interval(),
-                            shard_id: self.config.shard()[0],
-                        }));
+                        emit::event(
+                            self.listeners.clone(),
+                            Event::ShardConnected(Connected {
+                                heartbeat_interval: self.session.heartbeat_interval(),
+                                shard_id: self.config.shard()[0],
+                            }),
+                        );
                     }
                     DispatchEvent::Resumed => {
                         self.session.set_stage(Stage::Connected);
-                        emit::event(self.listeners.clone(), Event::ShardConnected(Connected {
-                            heartbeat_interval: self.session.heartbeat_interval(),
-                            shard_id: self.config.shard()[0],
-                        }));
+                        emit::event(
+                            self.listeners.clone(),
+                            Event::ShardConnected(Connected {
+                                heartbeat_interval: self.session.heartbeat_interval(),
+                                shard_id: self.config.shard()[0],
+                            }),
+                        );
                         self.session.heartbeats.receive().await;
                     }
                     _ => {}
@@ -313,14 +328,20 @@ impl ShardProcessor {
             }
 
             if full_reconnect {
-                emit::event(self.listeners.clone(), Event::ShardReconnecting(Reconnecting {
-                    shard_id: self.config.shard()[0],
-                }));
+                emit::event(
+                    self.listeners.clone(),
+                    Event::ShardReconnecting(Reconnecting {
+                        shard_id: self.config.shard()[0],
+                    }),
+                );
             } else {
-                emit::event(self.listeners.clone(), Event::ShardResuming(Resuming {
-                    seq: self.session.seq(),
-                    shard_id: self.config.shard()[0],
-                }));
+                emit::event(
+                    self.listeners.clone(),
+                    Event::ShardResuming(Resuming {
+                        seq: self.session.seq(),
+                        shard_id: self.config.shard()[0],
+                    }),
+                );
             }
 
             let new_stream = match connect::connect(&self.url).await {
@@ -363,10 +384,13 @@ impl ShardProcessor {
             break;
         }
 
-        emit::event(self.listeners.clone(), Event::ShardConnecting(Connecting {
-            gateway: self.url.clone(),
-            shard_id: self.config.shard()[0],
-        }));
+        emit::event(
+            self.listeners.clone(),
+            Event::ShardConnecting(Connecting {
+                gateway: self.url.clone(),
+                shard_id: self.config.shard()[0],
+            }),
+        );
     }
 
     async fn resume(&mut self) -> Result<()> {
@@ -464,11 +488,16 @@ impl ShardProcessor {
                 }
                 Message::Close(close_frame) => {
                     log::warn!("Got close code: {:?}.", close_frame);
-                    emit::event(self.listeners.clone(), Event::ShardDisconnected(Disconnected {
-                        code: close_frame.as_ref().map(|frame| frame.code.into()),
-                        reason: close_frame.as_ref().map(|frame| frame.reason.clone().into()),
-                        shard_id: self.config.shard()[0],
-                    }));
+                    emit::event(
+                        self.listeners.clone(),
+                        Event::ShardDisconnected(Disconnected {
+                            code: close_frame.as_ref().map(|frame| frame.code.into()),
+                            reason: close_frame
+                                .as_ref()
+                                .map(|frame| frame.reason.clone().into()),
+                            shard_id: self.config.shard()[0],
+                        }),
+                    );
 
                     if let Some(close_frame) = close_frame {
                         if close_frame.code == CloseCode::Library(4004) {

--- a/gateway/tests/test_shard_state_events.rs
+++ b/gateway/tests/test_shard_state_events.rs
@@ -1,0 +1,43 @@
+use futures::stream::StreamExt;
+use std::{env, error::Error};
+use twilight_gateway::{Event, Shard};
+
+fn shard() -> Result<Shard, Box<dyn Error>> {
+    let token = env::var("DISCORD_TOKEN")?;
+
+    Ok(Shard::new(token))
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_shard_event_emits() -> Result<(), Box<dyn Error>> {
+    let mut shard = shard()?;
+    let mut events = shard.events().await;
+    shard.start().await?;
+
+    assert!(matches!(events.next().await.unwrap(), Event::ShardConnecting(c) if c.shard_id == 0));
+    assert!(matches!(events.next().await.unwrap(), Event::ShardIdentifying(c) if c.shard_id == 0));
+    assert!(matches!(events.next().await.unwrap(), Event::GatewayHello(x) if x > 0));
+    assert!(matches!(events.next().await.unwrap(), Event::ShardConnected(c) if c.shard_id == 0));
+    assert!(matches!(events.next().await.unwrap(), Event::Ready(_)));
+    assert!(matches!(
+        events.next().await.unwrap(),
+        Event::GuildCreate(_)
+    ));
+    shard.command(&"bad command").await?;
+    // Might have more guilds or something.
+    while let Some(event) = events.next().await {
+        if matches!(event, Event::ShardDisconnected(_)) {
+            break;
+        }
+    }
+
+    assert!(matches!(
+        events.next().await.unwrap(),
+        Event::ShardResuming(_)
+    ));
+    assert!(matches!(events.next().await.unwrap(), Event::ShardConnecting(c) if c.shard_id == 0));
+    shard.shutdown().await;
+
+    Ok(())
+}


### PR DESCRIPTION
Emit the `twilight_model::gateway::event::shard` events when something happens to the state of the shard, for example connecting, disconnect, resuming, or when the connection is fully established.

This emits events like this:

```
Created shard
Event: ShardConnecting(Connecting { gateway: "wss://gateway.discord.gg?v=6&compress=zlib-stream", shard_id: 0 })
Event: GatewayHello(41250)
Event: ShardConnected(Connected { heartbeat_interval: 41250, shard_id: 0 })
Event: Ready(Ready { gui ......
```

Closes #210.