### PR TITLE
gateway: enable once_cell's 'std' feature

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -20,7 +20,7 @@ twilight-model = { default-features = false, path = "../model" }
 futures-channel = { default-features = false, version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 log = { default-features = false, version = "0.4" }
-once_cell = { default-features = false, version = "1" }
+once_cell = { default-features = false, features = ["std"], version = "1" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, optional = true, version = "1" }
 simd-json = { default-features = false, optional = true, version = "0.3" }


### PR DESCRIPTION
In the gateway, enable the `std` feature for the `once_cell` dependency. We need this for our usage, and this would only work if somewhere else in the user's tree `once_cell`'s `std` feature was enabled.