### PR TITLE
model/channel/message/kind: derive repr

### DIFF
--- a/model/src/channel/message/kind.rs
+++ b/model/src/channel/message/kind.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr)]
 #[repr(u8)]
 pub enum MessageType {
     Regular = 0,

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -51,3 +51,97 @@ pub struct Message {
     pub tts: bool,
     pub webhook_id: Option<WebhookId>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Message, MessageFlags, MessageType};
+    use crate::{
+        guild::PartialMember,
+        id::{ChannelId, GuildId, MessageId, UserId},
+        user::User,
+    };
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_message_deserialization() {
+        let input = serde_json::json!({
+            "attachments": [],
+            "author": {
+                "avatar": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "discriminator": "0001",
+                "id": "3",
+                "username": "test",
+            },
+            "channel_id": "2",
+            "content": "ping",
+            "edited_timestamp": null,
+            "embeds": [],
+            "flags": 0,
+            "guild_id": "1",
+            "id": "4",
+            "member": {
+                "deaf": false,
+                "hoisted_role": null,
+                "joined_at": "2020-01-01T00:00:00.000000+00:00",
+                "mute": false,
+                "nick": null,
+                "premium_since": null,
+                "roles": [],
+            },
+            "mention_everyone": false,
+            "mention_roles": [],
+            "mentions": [],
+            "pinned": false,
+            "timestamp": "2020-02-02T02:02:02.020000+00:00",
+            "tts": false,
+            "type": 0,
+        });
+
+        let expected = Message {
+            activity: None,
+            application: None,
+            attachments: Vec::new(),
+            author: User {
+                avatar: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned()),
+                bot: false,
+                discriminator: "0001".to_owned(),
+                email: None,
+                flags: None,
+                id: UserId(3),
+                locale: None,
+                mfa_enabled: None,
+                name: "test".to_owned(),
+                premium_type: None,
+                public_flags: None,
+                system: None,
+                verified: None,
+            },
+            channel_id: ChannelId(2),
+            content: "ping".to_owned(),
+            edited_timestamp: None,
+            embeds: Vec::new(),
+            flags: Some(MessageFlags::empty()),
+            guild_id: Some(GuildId(1)),
+            id: MessageId(4),
+            kind: MessageType::Regular,
+            member: Some(PartialMember {
+                deaf: false,
+                joined_at: Some("2020-01-01T00:00:00.000000+00:00".to_owned()),
+                mute: false,
+                roles: Vec::new(),
+            }),
+            mention_channels: Vec::new(),
+            mention_everyone: false,
+            mention_roles: Vec::new(),
+            mentions: HashMap::new(),
+            pinned: false,
+            reactions: Vec::new(),
+            reference: None,
+            timestamp: "2020-02-02T02:02:02.020000+00:00".to_owned(),
+            tts: false,
+            webhook_id: None,
+        };
+
+        assert_eq!(expected, serde_json::from_value(input).unwrap());
+    }
+}


### PR DESCRIPTION
Derive `serde_repr::{Deserialize_repr, Serialize_repr}` for the `channel::message::MessageType` type.

A test for message deserialization has been added.

Introduced in #243.

Fixes #250.