### PR TITLE
model/member_chunk: optimise deserialisation

### DIFF
--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -21,5 +21,10 @@ serde_repr = { default-features = false, version = "0.1" }
 serde-value = { default-features = false, version = "0.6" }
 
 [dev-dependencies]
+criterion = "0.3"
 serde_json = { default-features = false, features = ["alloc"], version = "1" }
 serde_test = { default-features = false, version = "1" }
+
+[[bench]]
+name = "member_chunk"
+harness = false

--- a/model/benches/member_chunk.rs
+++ b/model/benches/member_chunk.rs
@@ -1,4 +1,4 @@
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use twilight_model::gateway::payload::MemberChunk;
 

--- a/model/benches/member_chunk.rs
+++ b/model/benches/member_chunk.rs
@@ -103,7 +103,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         }]
     }"#;
 
-    c.bench_function("member chunks", |b| b.iter(|| member_chunk(input)));
+    c.bench_function("member chunk", |b| b.iter(|| member_chunk(input)));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/model/benches/member_chunk.rs
+++ b/model/benches/member_chunk.rs
@@ -1,11 +1,12 @@
-#![feature(test)]
-
-extern crate test;
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use twilight_model::gateway::payload::MemberChunk;
 
-#[bench]
-fn bench_member_chunk(b: &mut test::Bencher) {
+fn member_chunk(input: &str) {
+    serde_json::from_str::<MemberChunk>(input).unwrap();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
     let input = r#"{
         "chunk_count": 1,
         "chunk_index": 0,
@@ -102,7 +103,8 @@ fn bench_member_chunk(b: &mut test::Bencher) {
         }]
     }"#;
 
-    b.iter(|| {
-        serde_json::from_str::<MemberChunk>(input).unwrap();
-    });
+    c.bench_function("member chunks", |b| b.iter(|| member_chunk(input)));
 }
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/model/benches/test_benches.rs
+++ b/model/benches/test_benches.rs
@@ -1,0 +1,108 @@
+#![feature(test)]
+
+extern crate test;
+
+use twilight_model::gateway::payload::MemberChunk;
+
+#[bench]
+fn bench_member_chunk(b: &mut test::Bencher) {
+    let input = r#"{
+        "chunk_count": 1,
+        "chunk_index": 0,
+        "guild_id": "1",
+        "members": [{
+            "deaf": false,
+            "hoisted_role": "6",
+            "joined_at": "2020-04-04T04:04:04.000000+00:00",
+            "mute": false,
+            "nick": "chunk",
+            "roles": ["6"],
+            "user": {
+                "avatar": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "discriminator": "0001",
+                "id": "5",
+                "public_flags": 131072,
+                "username": "test"
+            }
+        }, {
+            "deaf": false,
+            "hoisted_role": "6",
+            "joined_at": "2020-04-04T04:04:04.000000+00:00",
+            "mute": false,
+            "nick": "chunk",
+            "roles": ["6"],
+            "user": {
+                "avatar": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "discriminator": "0001",
+                "id": "6",
+                "username": "test"
+            }
+        }, {
+            "deaf": false,
+            "hoisted_role": "6",
+            "joined_at": "2020-04-04T04:04:04.000000+00:00",
+            "mute": false,
+            "nick": "chunk",
+            "roles": ["6"],
+            "user": {
+                "avatar": "cccccccccccccccccccccccccccccccc",
+                "bot": true,
+                "discriminator": "0001",
+                "id": "3",
+                "username": "test"
+            }
+        }, {
+            "deaf": false,
+            "hoisted_role": "6",
+            "joined_at": "2020-04-04T04:04:04.000000+00:00",
+            "mute": false,
+            "nick": "chunk",
+            "roles": [
+                "6",
+                "7"
+            ],
+            "user": {
+                "avatar": "dddddddddddddddddddddddddddddddd",
+                "bot": true,
+                "discriminator": "0001",
+                "id": "2",
+                "username": "test"
+            }
+        }],
+        "presences": [{
+            "activities": [],
+            "client_status": {
+                "web": "online"
+            },
+            "game": null,
+            "status": "online",
+            "user": {
+                "id": "2"
+            }
+        }, {
+            "activities": [],
+            "client_status": {
+                "web": "online"
+            },
+            "game": null,
+            "status": "online",
+            "user": {
+                "id": "3"
+            }
+        }, {
+            "activities": [],
+            "client_status": {
+                "desktop": "dnd"
+            },
+            "game": null,
+            "status": "dnd",
+            "user": {
+                "id": "5"
+            }
+        }]
+    }"#;
+
+    b.iter(|| {
+        serde_json::from_str::<MemberChunk>(input).unwrap();
+    });
+}

--- a/model/src/gateway/payload/member_chunk.rs
+++ b/model/src/gateway/payload/member_chunk.rs
@@ -118,6 +118,9 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
                         return Err(DeError::duplicate_field("presences"));
                     }
 
+                    // Since the guild ID may not be deserialised yet we'll use
+                    // a temporary placeholder value and update it with the real
+                    // guild ID after all the fields have been deserialised.
                     let deserializer = PresenceMapDeserializer::new(GuildId(0));
 
                     presences = Some(map.next_value_seed(deserializer)?);

--- a/model/src/gateway/payload/member_chunk.rs
+++ b/model/src/gateway/payload/member_chunk.rs
@@ -1,6 +1,6 @@
 use crate::{
-    gateway::presence::{Presence, UserOrId},
-    guild::member::{Member, MemberIntermediary},
+    gateway::presence::{Presence, PresenceMapDeserializer},
+    guild::member::{Member, MemberMapDeserializer},
     id::{GuildId, UserId},
 };
 use serde::Serialize;
@@ -8,7 +8,6 @@ use serde::{
     de::{Deserializer, Error as DeError, MapAccess, Visitor},
     Deserialize,
 };
-use serde_value::Value;
 use std::{
     collections::HashMap,
     fmt::{Formatter, Result as FmtResult},
@@ -54,10 +53,10 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
         let mut chunk_count = None;
         let mut chunk_index = None;
         let mut guild_id = None;
-        let mut members = None::<Value>;
+        let mut members = None;
         let mut nonce = None;
         let mut not_found = None;
-        let mut presences = None::<Value>;
+        let mut presences = None;
 
         loop {
             let key = match map.next_key() {
@@ -96,7 +95,9 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
                         return Err(DeError::duplicate_field("members"));
                     }
 
-                    members = Some(map.next_value()?);
+                    let deserializer = MemberMapDeserializer::new(GuildId(0));
+
+                    members = Some(map.next_value_seed(deserializer)?);
                 }
                 Field::Nonce => {
                     if nonce.is_some() {
@@ -117,7 +118,9 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
                         return Err(DeError::duplicate_field("presences"));
                     }
 
-                    presences = Some(map.next_value()?);
+                    let deserializer = PresenceMapDeserializer::new(GuildId(0));
+
+                    presences = Some(map.next_value_seed(deserializer)?);
                 }
             }
         }
@@ -125,47 +128,17 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
         let chunk_count = chunk_count.ok_or_else(|| DeError::missing_field("chunk_count"))?;
         let chunk_index = chunk_index.ok_or_else(|| DeError::missing_field("chunk_index"))?;
         let guild_id = guild_id.ok_or_else(|| DeError::missing_field("guild_id"))?;
-        let members = members.ok_or_else(|| DeError::missing_field("members"))?;
+        let mut members = members.ok_or_else(|| DeError::missing_field("members"))?;
         let not_found = not_found.unwrap_or_default();
+        let mut presences = presences.unwrap_or_default();
 
-        let members = members
-            .deserialize_into::<Vec<MemberIntermediary>>()
-            .map_err(DeError::custom)?
-            .into_iter()
-            .map(|member| {
-                (
-                    member.user.id,
-                    Member {
-                        deaf: member.deaf,
-                        guild_id,
-                        hoisted_role: member.hoisted_role,
-                        joined_at: member.joined_at,
-                        mute: member.mute,
-                        nick: member.nick,
-                        premium_since: member.premium_since,
-                        roles: member.roles,
-                        user: member.user,
-                    },
-                )
-            })
-            .collect::<HashMap<_, _>>();
+        for member in members.values_mut() {
+            member.guild_id = guild_id;
+        }
 
-        let presences = match presences {
-            Some(presences) => presences
-                .deserialize_into::<Vec<Presence>>()
-                .map_err(DeError::custom)?
-                .into_iter()
-                .map(|presence| {
-                    let user_id = match presence.user {
-                        UserOrId::User(ref u) => u.id,
-                        UserOrId::UserId { id } => id,
-                    };
-
-                    (user_id, presence)
-                })
-                .collect::<HashMap<_, _>>(),
-            None => HashMap::new(),
-        };
+        for presence in presences.values_mut() {
+            presence.guild_id.replace(guild_id);
+        }
 
         Ok(MemberChunk {
             chunk_count,
@@ -439,7 +412,7 @@ mod tests {
                             web: Some(Status::Online),
                         },
                         game: None,
-                        guild_id: None,
+                        guild_id: Some(GuildId(1)),
                         nick: None,
                         status: Status::Online,
                         user: UserOrId::UserId { id: UserId(2) },
@@ -455,7 +428,7 @@ mod tests {
                             web: Some(Status::Online),
                         },
                         game: None,
-                        guild_id: None,
+                        guild_id: Some(GuildId(1)),
                         nick: None,
                         status: Status::Online,
                         user: UserOrId::UserId { id: UserId(3) },
@@ -471,7 +444,7 @@ mod tests {
                             web: None,
                         },
                         game: None,
-                        guild_id: None,
+                        guild_id: Some(GuildId(1)),
                         nick: None,
                         status: Status::DoNotDisturb,
                         user: UserOrId::UserId { id: UserId(5) },
@@ -482,9 +455,19 @@ mod tests {
             },
         };
 
-        assert_eq!(
-            expected,
-            serde_json::from_value::<MemberChunk>(input).unwrap()
-        );
+        let actual = serde_json::from_value::<MemberChunk>(input).unwrap();
+        assert_eq!(expected.chunk_count, actual.chunk_count);
+        assert_eq!(expected.chunk_index, actual.chunk_index);
+        assert_eq!(expected.guild_id, actual.guild_id);
+        assert_eq!(expected.nonce, actual.nonce);
+        assert_eq!(expected.not_found, actual.not_found);
+
+        for member in actual.members.values() {
+            assert!(expected.members.values().any(|m| m == member));
+        }
+
+        for presences in actual.presences.values() {
+            assert!(expected.presences.values().any(|p| p == presences));
+        }
     }
 }

--- a/model/src/gateway/payload/member_chunk.rs
+++ b/model/src/gateway/payload/member_chunk.rs
@@ -95,6 +95,9 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
                         return Err(DeError::duplicate_field("members"));
                     }
 
+                    // Since the guild ID may not be deserialised yet we'll use
+                    // a temporary placeholder value and update it with the real
+                    // guild ID after all the fields have been deserialised.
                     let deserializer = MemberMapDeserializer::new(GuildId(0));
 
                     members = Some(map.next_value_seed(deserializer)?);
@@ -118,9 +121,6 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
                         return Err(DeError::duplicate_field("presences"));
                     }
 
-                    // Since the guild ID may not be deserialised yet we'll use
-                    // a temporary placeholder value and update it with the real
-                    // guild ID after all the fields have been deserialised.
                     let deserializer = PresenceMapDeserializer::new(GuildId(0));
 
                     presences = Some(map.next_value_seed(deserializer)?);

--- a/model/src/gateway/presence/mod.rs
+++ b/model/src/gateway/presence/mod.rs
@@ -78,7 +78,6 @@ impl<'de> Visitor<'de> for PresenceMapDeserializerVisitor {
         f.write_str("a sequence of presences")
     }
 
-    #[allow(unused)]
     fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
         let mut map = seq
             .size_hint()

--- a/model/src/guild/member.rs
+++ b/model/src/guild/member.rs
@@ -2,7 +2,18 @@ use crate::{
     id::{GuildId, RoleId, UserId},
     user::User,
 };
-use serde::{Deserialize, Serialize};
+
+use serde::{
+    de::{
+        value::MapAccessDeserializer, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor,
+    },
+    Deserialize, Serialize,
+};
+use serde_mappable_seq::Key;
+use std::{
+    collections::HashMap,
+    fmt::{Formatter, Result as FmtResult},
+};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Member {
@@ -16,10 +27,6 @@ pub struct Member {
     pub roles: Vec<RoleId>,
     pub user: User,
 }
-
-use serde::de::{value::MapAccessDeserializer, DeserializeSeed, Deserializer, MapAccess, Visitor};
-use serde_mappable_seq::Key;
-use std::fmt::{Formatter, Result as FmtResult};
 
 impl Key<'_, UserId> for Member {
     fn key(&self) -> UserId {
@@ -88,6 +95,48 @@ impl<'de> DeserializeSeed<'de> for MemberDeserializer {
         }
 
         deserializer.deserialize_map(MemberDeserializerVisitor(self.0))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MemberMapDeserializer(GuildId);
+
+impl MemberMapDeserializer {
+    /// Create a new deserializer for a map of members when you know the
+    /// Guild ID but the payload probably doesn't contain it.
+    pub fn new(guild_id: GuildId) -> Self {
+        Self(guild_id)
+    }
+}
+
+struct MemberMapDeserializerVisitor(GuildId);
+
+impl<'de> Visitor<'de> for MemberMapDeserializerVisitor {
+    type Value = HashMap<UserId, Member>;
+
+    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str("a sequence of members")
+    }
+
+    #[allow(unused)]
+    fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
+        let mut map = seq
+            .size_hint()
+            .map_or_else(HashMap::new, HashMap::with_capacity);
+
+        while let Some(member) = seq.next_element_seed(MemberDeserializer(self.0))? {
+            map.insert(member.user.id, member);
+        }
+
+        Ok(map)
+    }
+}
+
+impl<'de> DeserializeSeed<'de> for MemberMapDeserializer {
+    type Value = HashMap<UserId, Member>;
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_any(MemberMapDeserializerVisitor(self.0))
     }
 }
 

--- a/model/src/guild/member.rs
+++ b/model/src/guild/member.rs
@@ -118,7 +118,6 @@ impl<'de> Visitor<'de> for MemberMapDeserializerVisitor {
         f.write_str("a sequence of members")
     }
 
-    #[allow(unused)]
     fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
         let mut map = seq
             .size_hint()


### PR DESCRIPTION
Optimise the deserialisation of `twilight_model::gateway::payload::MemberChunk` by using seeded member and presence map deserialisers rather than `serde_value::Value` intermediary values.

This reduces the benchmark deserialising a 4 member chunk by 2.5x from:

```
test bench_member_chunk ... bench:      18,799 ns/iter (+/- 975)
```

to:

```
test bench_member_chunk ... bench:       7,644 ns/iter (+/- 383)
```

and a 1000 member chunk by 3.3x from:

```
test bench_member_chunk ... bench:   2,853,826 ns/iter (+/- 926,792)
```

to:

```
test bench_member_chunk ... bench:     873,607 ns/iter (+/- 317,657)
```