### PR TITLE
model/request_guild_members: add an untagged

### DIFF
--- a/model/src/gateway/payload/request_guild_members.rs
+++ b/model/src/gateway/payload/request_guild_members.rs
@@ -93,6 +93,7 @@ impl RequestGuildMembers {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(untagged)]
 pub enum RequestGuildMembersInfo {
     Query {
         guild_id: GuildId,


### PR DESCRIPTION
Add a `#[serde(untagged)]` to the `twilight_model::gateway::payload::RequestGuildMembersInfo` enum.