### PR TITLE
model/typing_start: optimise deserialization

### DIFF
--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -26,5 +26,5 @@ serde_json = { default-features = false, features = ["alloc"], version = "1" }
 serde_test = { default-features = false, version = "1" }
 
 [[bench]]
-name = "member_chunk"
+name = "deserialization"
 harness = false

--- a/model/benches/deserialization.rs
+++ b/model/benches/deserialization.rs
@@ -1,12 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use twilight_model::gateway::payload::MemberChunk;
+use twilight_model::gateway::payload::{MemberChunk, TypingStart};
 
-fn member_chunk(input: &str) {
-    serde_json::from_str::<MemberChunk>(input).unwrap();
-}
-
-fn criterion_benchmark(c: &mut Criterion) {
+fn member_chunk() {
     let input = r#"{
         "chunk_count": 1,
         "chunk_index": 0,
@@ -103,7 +99,37 @@ fn criterion_benchmark(c: &mut Criterion) {
         }]
     }"#;
 
-    c.bench_function("member chunk", |b| b.iter(|| member_chunk(input)));
+    serde_json::from_str::<MemberChunk>(input).unwrap();
+}
+
+fn typing_start() {
+    let input = r#"{
+        "channel_id": "2",
+        "guild_id": "1",
+        "member": {
+            "deaf": false,
+            "hoisted_role": "4",
+            "joined_at": "2020-01-01T00:00:00.000000+00:00",
+            "mute": false,
+            "nick": "typing",
+            "roles": ["4"],
+            "user": {
+                "username": "test",
+                "id": "3",
+                "discriminator": "0001",
+                "avatar": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+        },
+        "timestamp": 1500000000,
+        "user_id": "3"
+    }"#;
+
+    serde_json::from_str::<TypingStart>(input).unwrap();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("member chunk", |b| b.iter(|| member_chunk()));
+    c.bench_function("typing start", |b| b.iter(|| typing_start()));
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
Optimise the deserialisation of the `gateway::payload::TypingStart` model by avoiding deserialising the intermediary member into a `serde_value::Value` and instead deserializing via a custom `OptionalMemberDeserializer` instead.

This increases deserialization performance of typing start events by ~55.5%:

```
typing start            time:   [1.1537 us 1.1571 us 1.1613 us]
                        change: [-55.731% -55.318% -54.923%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
```