### PR TITLE
model/partial_emoji: make fields public

### DIFF
--- a/model/src/gateway/payload/reaction_remove_emoji.rs
+++ b/model/src/gateway/payload/reaction_remove_emoji.rs
@@ -11,6 +11,6 @@ pub struct ReactionRemoveEmoji {
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct PartialEmoji {
-    id: Option<EmojiId>,
-    name: String,
+    pub id: Option<EmojiId>,
+    pub name: String,
 }


### PR DESCRIPTION
Make the fields of `gateway::payload::reaction_remove_emoji::PartialEmoji` public. These were all private.