### PR TITLE
model/reaction: optimise deserialisation

### DIFF
--- a/model/benches/deserialization.rs
+++ b/model/benches/deserialization.rs
@@ -1,6 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use twilight_model::gateway::payload::{MemberChunk, TypingStart};
+use twilight_model::{
+    channel::Reaction,
+    gateway::payload::{MemberChunk, TypingStart},
+};
 
 fn member_chunk() {
     let input = r#"{
@@ -102,6 +105,35 @@ fn member_chunk() {
     serde_json::from_str::<MemberChunk>(input).unwrap();
 }
 
+fn reaction() {
+    let input = r#"{
+        "channel_id": "2",
+        "emoji": {
+            "id": null,
+            "name": "🙂"
+        },
+        "guild_id": "1",
+        "member": {
+            "deaf": false,
+            "hoisted_role": "5",
+            "joined_at": "2020-01-01T00:00:00.000000+00:00",
+            "mute": false,
+            "nick": "typing",
+            "roles": ["5"],
+            "user": {
+                "username": "test",
+                "id": "4",
+                "discriminator": "0001",
+                "avatar": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+        },
+        "message_id": "3",
+        "user_id": "4",
+    }"#;
+
+    serde_json::from_str::<Reaction>(input).unwrap();
+}
+
 fn typing_start() {
     let input = r#"{
         "channel_id": "2",
@@ -129,6 +161,7 @@ fn typing_start() {
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("member chunk", |b| b.iter(|| member_chunk()));
+    c.bench_function("reaction", |b| b.iter(|| reaction()));
     c.bench_function("typing start", |b| b.iter(|| typing_start()));
 }
 

--- a/model/src/channel/reaction.rs
+++ b/model/src/channel/reaction.rs
@@ -1,13 +1,12 @@
 use crate::{
     channel::ReactionType,
-    guild::member::{Member, MemberDeserializer},
+    guild::member::{Member, OptionalMemberDeserializer},
     id::{ChannelId, GuildId, MessageId, UserId},
 };
 use serde::{
-    de::{DeserializeSeed, Deserializer, Error as DeError, MapAccess, Visitor},
+    de::{Deserializer, Error as DeError, MapAccess, Visitor},
     Deserialize, Serialize,
 };
-use serde_value::Value;
 use std::fmt::{Formatter, Result as FmtResult};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
@@ -43,8 +42,8 @@ impl<'de> Visitor<'de> for ReactionVisitor {
     fn visit_map<V: MapAccess<'de>>(self, mut map: V) -> Result<Self::Value, V::Error> {
         let mut channel_id = None;
         let mut emoji = None;
-        let mut guild_id = None::<Option<_>>;
-        let mut member = None::<Option<Value>>;
+        let mut guild_id = None;
+        let mut member = None;
         let mut message_id = None;
         let mut user_id = None;
 
@@ -78,14 +77,16 @@ impl<'de> Visitor<'de> for ReactionVisitor {
                         return Err(DeError::duplicate_field("guild_id"));
                     }
 
-                    guild_id = Some(map.next_value()?);
+                    guild_id = map.next_value()?;
                 }
                 Field::Member => {
                     if member.is_some() {
                         return Err(DeError::duplicate_field("member"));
                     }
 
-                    member = Some(map.next_value()?);
+                    let deserializer = OptionalMemberDeserializer::new(GuildId(0));
+
+                    member = map.next_value_seed(deserializer)?;
                 }
                 Field::MessageId => {
                     if message_id.is_some() {
@@ -109,17 +110,9 @@ impl<'de> Visitor<'de> for ReactionVisitor {
         let message_id = message_id.ok_or_else(|| DeError::missing_field("message_id"))?;
         let user_id = user_id.ok_or_else(|| DeError::missing_field("user_id"))?;
 
-        let guild_id = guild_id.unwrap_or_default();
-        let member = member.unwrap_or_default();
-
-        let member = match (member, guild_id) {
-            (Some(value), Some(guild_id)) => {
-                let deserializer = MemberDeserializer::new(guild_id);
-
-                Some(deserializer.deserialize(value).map_err(DeError::custom)?)
-            }
-            _ => None,
-        };
+        if let (Some(guild_id), Some(member)) = (guild_id, member.as_mut()) {
+            member.guild_id = guild_id;
+        }
 
         Ok(Reaction {
             channel_id,


### PR DESCRIPTION
Optimise the deserialisation of `channel::Reaction` by using an `OptionalMemberDeserializer` instead of an intermediary `serde_value::Value`.

This optimises the deserialisation of a reaction with a member by 47.2%:

```
reaction                time:   [1.8670 us 1.8758 us 1.8859 us]
                        change: [-48.078% -47.175% -46.456%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
5 (5.00%) high mild
```

Blocks on #264.