### PR TITLE
model/guild_delete: use serde_test for tests

### DIFF
--- a/model/src/gateway/payload/guild_delete.rs
+++ b/model/src/gateway/payload/guild_delete.rs
@@ -17,7 +17,6 @@ fn nullable_unavailable<'de, D: Deserializer<'de>>(deserializer: D) -> Result<bo
 mod tests {
     use super::super::GuildDelete;
     use crate::id::GuildId;
-    use serde_json::json;
     use serde_test::Token;
 
     #[test]
@@ -105,13 +104,14 @@ mod tests {
             unavailable: false,
         };
 
-        assert_eq!(
-            expected,
-            serde_json::from_value(json!({
-                "id": "123",
-                "unavailable": null,
-            }))
-            .unwrap()
-        );
+        serde_test::assert_de_tokens(&expected, &[
+            Token::Struct { name: "GuildDelete", len: 2 },
+            Token::Str("id"),
+            Token::NewtypeStruct { name: "GuildId" },
+            Token::Str("123"),
+            Token::Str("unavailable"),
+            Token::None,
+            Token::StructEnd,
+        ]);
     }
 }

--- a/model/src/gateway/payload/guild_delete.rs
+++ b/model/src/gateway/payload/guild_delete.rs
@@ -104,14 +104,20 @@ mod tests {
             unavailable: false,
         };
 
-        serde_test::assert_de_tokens(&expected, &[
-            Token::Struct { name: "GuildDelete", len: 2 },
-            Token::Str("id"),
-            Token::NewtypeStruct { name: "GuildId" },
-            Token::Str("123"),
-            Token::Str("unavailable"),
-            Token::None,
-            Token::StructEnd,
-        ]);
+        serde_test::assert_de_tokens(
+            &expected,
+            &[
+                Token::Struct {
+                    name: "GuildDelete",
+                    len: 2,
+                },
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "GuildId" },
+                Token::Str("123"),
+                Token::Str("unavailable"),
+                Token::None,
+                Token::StructEnd,
+            ],
+        );
     }
 }


### PR DESCRIPTION
For the `gateway::payload::GuildDelete` test suite, use `serde_test` for all of the tests instead of `serde_json` for one of them.