### PR TITLE
allow bearer tokens in Client and ClientBuilder

### DIFF
--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -119,8 +119,12 @@ impl ClientBuilder {
     pub fn token(&mut self, token: impl Into<String>) -> &mut Self {
         let mut token = token.into();
 
-        // Make sure it is a bot token.
-        if !token.starts_with("Bot ") {
+        let is_bot = token.starts_with("Bot ");
+        let is_bearer = token.starts_with("Bearer ");
+
+        // Make sure it is either a bot or bearer token, and assume it's a bot
+        // token if no prefix is given
+        if !is_bot && !is_bearer {
             token.insert_str(0, "Bot ");
         }
 

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -105,8 +105,12 @@ impl Client {
     pub fn new(token: impl Into<String>) -> Self {
         let mut token = token.into();
 
-        // Make sure it is a bot token.
-        if !token.starts_with("Bot ") {
+        let is_bot = token.starts_with("Bot ");
+        let is_bearer = token.starts_with("Bearer ");
+
+        // Make sure it is either a bot or bearer token, and assume it's a bot
+        // token if no prefix is given
+        if !is_bot && !is_bearer {
             token.insert_str(0, "Bot ");
         }
 


### PR DESCRIPTION
Possible bikesheds:

1. Define an enum `TokenType`
2. Define an enum `Token` like `enum Token {Bot(String), Bearer(String)}`
3. Split `ClientBuilder::token` into `bearer_token` and `bot_token`
4. Just do check the string for the prefix and default to "Bot " -- which is what this PR is

Possible issues I may encounter as I attempt to use this branch on a web server I'm writing:

1. Different rate limits?
2. Different error handling?
3. Limitations on what oauth2 bearer token clients can actually do?