### PR TITLE
Allow specifying a Ratelimiter in ClientBuilder

### DIFF
--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -15,10 +15,17 @@ pub struct ClientBuilder {
     pub(crate) proxy: Option<Proxy>,
     pub(crate) proxy_http: bool,
     pub(crate) reqwest_client: Option<ReqwestClient>,
-    pub(crate) skip_ratelimiter: bool,
+    pub(crate) ratelimiter: RatelimiterBuilder,
     pub(crate) timeout: Duration,
     pub(crate) token: Option<String>,
     pub(crate) default_allowed_mentions: Option<AllowedMentions>,
+}
+
+#[derive(Clone, Debug)]
+pub enum RatelimiterBuilder {
+    Skip,
+    New,
+    Use(Ratelimiter),
 }
 
 impl ClientBuilder {
@@ -43,6 +50,12 @@ impl ClientBuilder {
             builder = builder.proxy(proxy)
         }
 
+        let (skip_ratelimiter, ratelimiter) = match self.ratelimiter {
+            RatelimiterBuilder::New => (false, Ratelimiter::new()),
+            RatelimiterBuilder::Skip => (true, Ratelimiter::new()),
+            RatelimiterBuilder::Use(rl) => (false, rl),
+        };
+
         Ok(Client {
             state: Arc::new(State {
                 http: Arc::new(
@@ -50,8 +63,8 @@ impl ClientBuilder {
                         .build()
                         .map_err(|source| Error::BuildingClient { source })?,
                 ),
-                ratelimiter: Ratelimiter::new(),
-                skip_ratelimiter: self.skip_ratelimiter,
+                ratelimiter,
+                skip_ratelimiter,
                 token: self.token,
                 use_http: self.proxy_http,
                 default_allowed_mentions: self.default_allowed_mentions,
@@ -101,7 +114,20 @@ impl ClientBuilder {
     ///
     /// The default is `false`.
     pub fn skip_ratelimiter(&mut self, skip_ratelimiter: bool) -> &mut Self {
-        self.skip_ratelimiter = skip_ratelimiter;
+        self.ratelimiter = if skip_ratelimiter {
+            RatelimiterBuilder::Skip
+        } else {
+            RatelimiterBuilder::New
+        };
+
+        self
+    }
+
+    /// Set whether to skip the client's ratelimiter before making the request.
+    ///
+    /// The default is `false`.
+    pub fn ratelimiter(&mut self, ratelimiter: Ratelimiter) -> &mut Self {
+        self.ratelimiter = RatelimiterBuilder::Use(ratelimiter);
 
         self
     }
@@ -141,7 +167,7 @@ impl Default for ClientBuilder {
             proxy: None,
             proxy_http: false,
             reqwest_client: None,
-            skip_ratelimiter: false,
+            ratelimiter: RatelimiterBuilder::New,
             timeout: Duration::from_secs(10),
             token: None,
         }

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -119,8 +119,12 @@ impl ClientBuilder {
     pub fn token(&mut self, token: impl Into<String>) -> &mut Self {
         let mut token = token.into();
 
-        // Make sure it is a bot token.
-        if !token.starts_with("Bot ") {
+        let is_bot = token.starts_with("Bot ");
+        let is_bearer = token.starts_with("Bearer ");
+
+        // Make sure it is either a bot or bearer token, and assume it's a bot
+        // token if no prefix is given
+        if !is_bot && !is_bearer {
             token.insert_str(0, "Bot ");
         }
 

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -105,8 +105,12 @@ impl Client {
     pub fn new(token: impl Into<String>) -> Self {
         let mut token = token.into();
 
-        // Make sure it is a bot token.
-        if !token.starts_with("Bot ") {
+        let is_bot = token.starts_with("Bot ");
+        let is_bearer = token.starts_with("Bearer ");
+
+        // Make sure it is either a bot or bearer token, and assume it's a bot
+        // token if no prefix is given
+        if !is_bot && !is_bearer {
             token.insert_str(0, "Bot ");
         }
 

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1391,7 +1391,7 @@ impl Client {
 
         if let Some(ref token) = self.state.token {
             let value = HeaderValue::from_str(&token).map_err(|source| Error::CreatingHeader {
-                name: "Authroization".to_owned(),
+                name: "Authorization".to_owned(),
                 source,
             })?;
 

--- a/http/src/ratelimiting/mod.rs
+++ b/http/src/ratelimiting/mod.rs
@@ -42,7 +42,7 @@ impl GlobalLockPair {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Ratelimiter {
     buckets: Arc<Mutex<HashMap<Path, Arc<Bucket>>>>,
     global: Arc<GlobalLockPair>,


### PR DESCRIPTION
Allows sharing of `Ratelimiter`s between clients, without having to carry around the full `Client`.