### PR TITLE
Fix queue ignoring ratelimit when send fails

### DIFF
--- a/gateway/src/queue.rs
+++ b/gateway/src/queue.rs
@@ -75,7 +75,6 @@ async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
     while let Some(req) = rx.next().await {
         if let Err(err) = req.send(()) {
             warn!("[LocalQueue/waiter] send failed with: {:?}, skipping", err);
-            continue;
         }
         delay_for(DUR).await;
     }

--- a/gateway/src/queue/large_bot_queue.rs
+++ b/gateway/src/queue/large_bot_queue.rs
@@ -62,7 +62,6 @@ async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
                 "[LargeBotQueue/waiter] send failed with: {:?}, skipping",
                 err
             );
-            continue;
         }
         delay_for(DUR).await;
     }


### PR DESCRIPTION
Before this change, the shard queue would send the next request right away if a send fails.