### PR TITLE
Do not wrap Reqwest client in Arc.

### DIFF
--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -45,11 +45,9 @@ impl ClientBuilder {
 
         Ok(Client {
             state: Arc::new(State {
-                http: Arc::new(
-                    builder
-                        .build()
-                        .map_err(|source| Error::BuildingClient { source })?,
-                ),
+                http: builder
+                    .build()
+                    .map_err(|source| Error::BuildingClient { source })?,
                 ratelimiter: Ratelimiter::new(),
                 skip_ratelimiter: self.skip_ratelimiter,
                 token: self.token,

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -34,7 +34,7 @@ use url::Url;
 use crate::json_from_slice;
 
 struct State {
-    http: Arc<ReqwestClient>,
+    http: ReqwestClient,
     ratelimiter: Ratelimiter,
     skip_ratelimiter: bool,
     token: Option<String>,
@@ -116,7 +116,7 @@ impl Client {
 
         Self {
             state: Arc::new(State {
-                http: Arc::new(ReqwestClient::new()),
+                http: ReqwestClient::new(),
                 ratelimiter: Ratelimiter::new(),
                 skip_ratelimiter: false,
                 token: Some(token),
@@ -1543,21 +1543,6 @@ impl Client {
 
 impl From<ReqwestClient> for Client {
     fn from(reqwest_client: ReqwestClient) -> Self {
-        Self {
-            state: Arc::new(State {
-                http: Arc::new(reqwest_client),
-                ratelimiter: Ratelimiter::new(),
-                skip_ratelimiter: false,
-                token: None,
-                use_http: false,
-                default_allowed_mentions: None,
-            }),
-        }
-    }
-}
-
-impl From<Arc<ReqwestClient>> for Client {
-    fn from(reqwest_client: Arc<ReqwestClient>) -> Self {
         Self {
             state: Arc::new(State {
                 http: reqwest_client,


### PR DESCRIPTION
Reqwest client does not needed to be wrapped in an arc as it is
internally handled in Reqwest. Furthermore this pr also removes a
implementation of From<Arc<ReqwestClient>> for HttpClient as it would
only be applicable if anyone else used the Reqwest unnecessarily
wrapped in an Arc.

Closes #275