### PR TITLE
 model/guild: optimise deserialisation 

### DIFF
--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -28,7 +28,10 @@ use serde::{
     Deserialize, Serialize,
 };
 use serde_mappable_seq::Key;
-use std::{collections::HashMap, fmt::{Formatter, Result as FmtResult}};
+use std::{
+    collections::HashMap,
+    fmt::{Formatter, Result as FmtResult},
+};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(untagged)]
@@ -301,7 +304,9 @@ impl<'de> Visitor<'de> for GuildChannelMapVisitor {
     }
 
     fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
-        let mut map = seq.size_hint().map_or_else(HashMap::new, HashMap::with_capacity);
+        let mut map = seq
+            .size_hint()
+            .map_or_else(HashMap::new, HashMap::with_capacity);
 
         while let Some(channel) = seq.next_element()? {
             let id = match channel {
@@ -320,10 +325,7 @@ impl<'de> Visitor<'de> for GuildChannelMapVisitor {
 impl<'de> DeserializeSeed<'de> for GuildChannelMapDeserializer {
     type Value = HashMap<ChannelId, GuildChannel>;
 
-    fn deserialize<D: Deserializer<'de>>(
-        self,
-        deserializer: D,
-    ) -> Result<Self::Value, D::Error> {
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
         deserializer.deserialize_seq(GuildChannelMapVisitor)
     }
 }

--- a/model/src/guild/emoji.rs
+++ b/model/src/guild/emoji.rs
@@ -2,9 +2,15 @@ use crate::{
     id::{EmojiId, RoleId},
     user::User,
 };
-use serde::{de::{DeserializeSeed, Deserializer, SeqAccess, Visitor}, Deserialize, Serialize};
+use serde::{
+    de::{DeserializeSeed, Deserializer, SeqAccess, Visitor},
+    Deserialize, Serialize,
+};
 use serde_mappable_seq::Key;
-use std::{collections::HashMap, fmt::{Formatter, Result as FmtResult}};
+use std::{
+    collections::HashMap,
+    fmt::{Formatter, Result as FmtResult},
+};
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -46,7 +52,9 @@ impl<'de> Visitor<'de> for EmojiMapVisitor {
     }
 
     fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
-        let mut map = seq.size_hint().map_or_else(HashMap::new, HashMap::with_capacity);
+        let mut map = seq
+            .size_hint()
+            .map_or_else(HashMap::new, HashMap::with_capacity);
 
         while let Some(emoji) = seq.next_element::<Emoji>()? {
             map.insert(emoji.id, emoji);
@@ -59,10 +67,7 @@ impl<'de> Visitor<'de> for EmojiMapVisitor {
 impl<'de> DeserializeSeed<'de> for EmojiMapDeserializer {
     type Value = HashMap<EmojiId, Emoji>;
 
-    fn deserialize<D: Deserializer<'de>>(
-        self,
-        deserializer: D,
-    ) -> Result<Self::Value, D::Error> {
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
         deserializer.deserialize_seq(EmojiMapVisitor)
     }
 }

--- a/model/src/guild/emoji.rs
+++ b/model/src/guild/emoji.rs
@@ -2,8 +2,9 @@ use crate::{
     id::{EmojiId, RoleId},
     user::User,
 };
-use serde::{Deserialize, Serialize};
+use serde::{de::{DeserializeSeed, Deserializer, SeqAccess, Visitor}, Deserialize, Serialize};
 use serde_mappable_seq::Key;
+use std::{collections::HashMap, fmt::{Formatter, Result as FmtResult}};
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -29,5 +30,39 @@ pub struct Emoji {
 impl Key<'_, EmojiId> for Emoji {
     fn key(&self) -> EmojiId {
         self.id
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EmojiMapDeserializer;
+
+struct EmojiMapVisitor;
+
+impl<'de> Visitor<'de> for EmojiMapVisitor {
+    type Value = HashMap<EmojiId, Emoji>;
+
+    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str("a sequence of emojis")
+    }
+
+    fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
+        let mut map = seq.size_hint().map_or_else(HashMap::new, HashMap::with_capacity);
+
+        while let Some(emoji) = seq.next_element::<Emoji>()? {
+            map.insert(emoji.id, emoji);
+        }
+
+        Ok(map)
+    }
+}
+
+impl<'de> DeserializeSeed<'de> for EmojiMapDeserializer {
+    type Value = HashMap<EmojiId, Emoji>;
+
+    fn deserialize<D: Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_seq(EmojiMapVisitor)
     }
 }

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -35,11 +35,11 @@ pub use self::{
 
 use self::{member::MemberMapDeserializer, role::RoleMapDeserializer};
 use crate::{
-    channel::{GuildChannelMapDeserializer, GuildChannel},
+    channel::{GuildChannel, GuildChannelMapDeserializer},
+    gateway::presence::{Presence, PresenceMapDeserializer},
     guild::emoji::EmojiMapDeserializer,
-    gateway::presence::{PresenceMapDeserializer, Presence},
     id::{ApplicationId, ChannelId, EmojiId, GuildId, RoleId, UserId},
-    voice::voice_state::{VoiceStateMapDeserializer, VoiceState},
+    voice::voice_state::{VoiceState, VoiceStateMapDeserializer},
 };
 use serde::{
     de::{Deserializer, Error as DeError, MapAccess, Visitor},
@@ -622,13 +622,13 @@ impl<'de> Deserialize<'de> for Guild {
                     match channel {
                         GuildChannel::Category(c) => {
                             c.guild_id.replace(id);
-                        },
+                        }
                         GuildChannel::Text(c) => {
                             c.guild_id.replace(id);
-                        },
+                        }
                         GuildChannel::Voice(c) => {
                             c.guild_id.replace(id);
-                        },
+                        }
                     }
                 }
 

--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -1,7 +1,13 @@
 use crate::{guild::Permissions, id::RoleId};
-use serde::{de::{DeserializeSeed, Deserializer, SeqAccess, Visitor}, Deserialize, Serialize};
+use serde::{
+    de::{DeserializeSeed, Deserializer, SeqAccess, Visitor},
+    Deserialize, Serialize,
+};
 use serde_mappable_seq::Key;
-use std::{collections::HashMap, fmt::{Formatter, Result as FmtResult}};
+use std::{
+    collections::HashMap,
+    fmt::{Formatter, Result as FmtResult},
+};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Role {
@@ -34,7 +40,9 @@ impl<'de> Visitor<'de> for RoleMapDeserializerVisitor {
     }
 
     fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
-        let mut map = seq.size_hint().map_or_else(HashMap::new, HashMap::with_capacity);
+        let mut map = seq
+            .size_hint()
+            .map_or_else(HashMap::new, HashMap::with_capacity);
 
         while let Some(role) = seq.next_element::<Role>()? {
             map.insert(role.id, role);
@@ -47,10 +55,7 @@ impl<'de> Visitor<'de> for RoleMapDeserializerVisitor {
 impl<'de> DeserializeSeed<'de> for RoleMapDeserializer {
     type Value = HashMap<RoleId, Role>;
 
-    fn deserialize<D: Deserializer<'de>>(
-        self,
-        deserializer: D,
-    ) -> Result<Self::Value, D::Error> {
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
         deserializer.deserialize_seq(RoleMapDeserializerVisitor)
     }
 }

--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -1,6 +1,7 @@
 use crate::{guild::Permissions, id::RoleId};
-use serde::{Deserialize, Serialize};
+use serde::{de::{DeserializeSeed, Deserializer, SeqAccess, Visitor}, Deserialize, Serialize};
 use serde_mappable_seq::Key;
+use std::{collections::HashMap, fmt::{Formatter, Result as FmtResult}};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Role {
@@ -17,5 +18,39 @@ pub struct Role {
 impl Key<'_, RoleId> for Role {
     fn key(&self) -> RoleId {
         self.id
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoleMapDeserializer;
+
+struct RoleMapDeserializerVisitor;
+
+impl<'de> Visitor<'de> for RoleMapDeserializerVisitor {
+    type Value = HashMap<RoleId, Role>;
+
+    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str("a sequence of roles")
+    }
+
+    fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
+        let mut map = seq.size_hint().map_or_else(HashMap::new, HashMap::with_capacity);
+
+        while let Some(role) = seq.next_element::<Role>()? {
+            map.insert(role.id, role);
+        }
+
+        Ok(map)
+    }
+}
+
+impl<'de> DeserializeSeed<'de> for RoleMapDeserializer {
+    type Value = HashMap<RoleId, Role>;
+
+    fn deserialize<D: Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_seq(RoleMapDeserializerVisitor)
     }
 }

--- a/model/src/voice/mod.rs
+++ b/model/src/voice/mod.rs
@@ -1,4 +1,5 @@
+pub(crate) mod voice_state;
+
 mod voice_region;
-mod voice_state;
 
 pub use self::{voice_region::VoiceRegion, voice_state::VoiceState};

--- a/model/src/voice/voice_state.rs
+++ b/model/src/voice/voice_state.rs
@@ -7,7 +7,10 @@ use serde::{
     Deserialize, Serialize,
 };
 use serde_mappable_seq::Key;
-use std::{collections::HashMap, fmt::{Formatter, Result as FmtResult}};
+use std::{
+    collections::HashMap,
+    fmt::{Formatter, Result as FmtResult},
+};
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
@@ -240,7 +243,9 @@ impl<'de> Visitor<'de> for VoiceStateMapVisitor {
     }
 
     fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
-        let mut map = seq.size_hint().map_or_else(HashMap::new, HashMap::with_capacity);
+        let mut map = seq
+            .size_hint()
+            .map_or_else(HashMap::new, HashMap::with_capacity);
 
         while let Some(voice_state) = seq.next_element::<VoiceState>()? {
             map.insert(voice_state.user_id, voice_state);
@@ -253,10 +258,7 @@ impl<'de> Visitor<'de> for VoiceStateMapVisitor {
 impl<'de> DeserializeSeed<'de> for VoiceStateMapDeserializer {
     type Value = HashMap<UserId, VoiceState>;
 
-    fn deserialize<D: Deserializer<'de>>(
-        self,
-        deserializer: D,
-    ) -> Result<Self::Value, D::Error> {
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
         deserializer.deserialize_seq(VoiceStateMapVisitor)
     }
 }

--- a/model/src/voice/voice_state.rs
+++ b/model/src/voice/voice_state.rs
@@ -3,11 +3,11 @@ use crate::{
     id::{ChannelId, GuildId, UserId},
 };
 use serde::{
-    de::{Deserializer, Error as DeError, MapAccess, Visitor},
+    de::{DeserializeSeed, Deserializer, Error as DeError, MapAccess, SeqAccess, Visitor},
     Deserialize, Serialize,
 };
 use serde_mappable_seq::Key;
-use std::fmt::{Formatter, Result as FmtResult};
+use std::{collections::HashMap, fmt::{Formatter, Result as FmtResult}};
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
@@ -224,5 +224,39 @@ impl<'de> Deserialize<'de> for VoiceState {
         ];
 
         deserializer.deserialize_struct("VoiceState", FIELDS, VoiceStateVisitor)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct VoiceStateMapDeserializer;
+
+struct VoiceStateMapVisitor;
+
+impl<'de> Visitor<'de> for VoiceStateMapVisitor {
+    type Value = HashMap<UserId, VoiceState>;
+
+    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str("a sequence of voice states")
+    }
+
+    fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
+        let mut map = seq.size_hint().map_or_else(HashMap::new, HashMap::with_capacity);
+
+        while let Some(voice_state) = seq.next_element::<VoiceState>()? {
+            map.insert(voice_state.user_id, voice_state);
+        }
+
+        Ok(map)
+    }
+}
+
+impl<'de> DeserializeSeed<'de> for VoiceStateMapDeserializer {
+    type Value = HashMap<UserId, VoiceState>;
+
+    fn deserialize<D: Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_seq(VoiceStateMapVisitor)
     }
 }


### PR DESCRIPTION
Optimise the deserialisation of `twilight_model::guild::Guild` by
avoiding the use of `serde_value::Value` and instead using custom
deserialisers to directly deserialise into maps for guild channels,
emojis, roles, and voice states.

This reduces the time to deserialise a relatively large (1000 member)
guild create event by 33%:

```
guild                   time:   [5.5180 ms 5.5768 ms 5.6433 ms]
                        change: [-34.867% -33.259% -31.819%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
```