### PR TITLE
standby: add more documentation

### DIFF
--- a/standby/Cargo.toml
+++ b/standby/Cargo.toml
@@ -20,4 +20,5 @@ log = { default-features = false, version = "0.4" }
 twilight-model = { default-features = false, path = "../model" }
 
 [dev-dependencies]
+twilight-gateway = { path = "../gateway" }
 tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }

--- a/standby/README.md
+++ b/standby/README.md
@@ -41,7 +41,6 @@ A full sample bot connecting to the gateway, processing events, and
 including a handler to wait for reactions:
 
 ```rust,no_run
-#[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 use futures_util::StreamExt;
 use std::{env, error::Error};
 use twilight_gateway::{Event, Shard};
@@ -52,24 +51,29 @@ use twilight_model::{
 };
 use twilight_standby::Standby;
 
-// Start a shard connected to the gateway to receive events.
-let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
-let mut events = shard.events().await;
-shard.start().await?;
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // Start a shard connected to the gateway to receive events.
+    let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
+    let mut events = shard.events().await;
+    shard.start().await?;
 
-let standby = Standby::new();
+    let standby = Standby::new();
 
-while let Some(event) = events.next().await {
-    // Have standby process the event, which will fulfill any futures that
-    // are waiting for an event.
-    standby.process(&event);
+    while let Some(event) = events.next().await {
+        // Have standby process the event, which will fulfill any futures that
+        // are waiting for an event.
+        standby.process(&event);
 
-    match event {
-        Event::MessageCreate(msg) if msg.content == "!react" => {
-            tokio::spawn(react(msg.0, standby.clone()));
-        },
-        _ => {},
+        match event {
+            Event::MessageCreate(msg) if msg.content == "!react" => {
+                tokio::spawn(react(msg.0, standby.clone()));
+            },
+            _ => {},
+        }
     }
+
+    Ok(())
 }
 
 // Wait for a reaction from the user who sent the message, and then print it

--- a/standby/README.md
+++ b/standby/README.md
@@ -20,10 +20,11 @@ Check out the [`Standby::process`] method.
 
 # Examples
 
+## At a glance
+
 Wait for a message in channel 123 by user 456 with the content "test":
 
-```no_run
-use futures_util::future;
+```rust,no_run
 use twilight_model::{gateway::payload::MessageCreate, id::{ChannelId, UserId}};
 use twilight_standby::Standby;
 
@@ -34,8 +35,61 @@ let message = standby.wait_for_message(ChannelId(123), |event: &MessageCreate| {
 }).await?;
 ```
 
-For more examples, check out each method.
+## A full example
 
+A full sample bot connecting to the gateway, processing events, and
+including a handler to wait for reactions:
+
+```rust,no_run
+#[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+use futures_util::StreamExt;
+use std::{env, error::Error};
+use twilight_gateway::{Event, Shard};
+use twilight_model::{
+    channel::Message,
+    gateway::payload::ReactionAdd,
+    id::{ChannelId, UserId},
+};
+use twilight_standby::Standby;
+
+// Start a shard connected to the gateway to receive events.
+let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
+let mut events = shard.events().await;
+shard.start().await?;
+
+let standby = Standby::new();
+
+while let Some(event) = events.next().await {
+    // Have standby process the event, which will fulfill any futures that
+    // are waiting for an event.
+    standby.process(&event);
+
+    match event {
+        Event::MessageCreate(msg) if msg.content == "!react" => {
+            tokio::spawn(react(msg.0, standby.clone()));
+        },
+        _ => {},
+    }
+}
+
+// Wait for a reaction from the user who sent the message, and then print it
+// once they react.
+async fn react(msg: Message, standby: Standby) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let author_id = msg.author.id;
+
+    let reaction = standby.wait_for_reaction(msg.id, move |event: &ReactionAdd| {
+        event.user_id == author_id
+    }).await?;
+
+    println!("user reacted with {:?}", reaction.emoji);
+
+    Ok(())
+}
+```
+
+For more examples, check out each of the methods on [`Standby`].
+
+[`Standby`]: struct.Standby.html
 [`Standby::process`]: struct.Standby.html#method.process
 [`Standby::wait_for`]: struct.Standby.html#method.wait_for
 [`Standby::wait_for_event`]: struct.Standby.html#method.wait_for_event

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -18,11 +18,12 @@
 //!
 //! # Examples
 //!
+//! ## At a glance
+//!
 //! Wait for a message in channel 123 by user 456 with the content "test":
 //!
-//! ```no_run
+//! ```rust,no_run
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! use futures_util::future;
 //! use twilight_model::{gateway::payload::MessageCreate, id::{ChannelId, UserId}};
 //! use twilight_standby::Standby;
 //!
@@ -34,8 +35,62 @@
 //! # Ok(()) }
 //! ```
 //!
-//! For more examples, check out each method.
+//! ## A full example
 //!
+//! A full sample bot connecting to the gateway, processing events, and
+//! including a handler to wait for reactions:
+//!
+//! ```rust,no_run
+//! #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use futures_util::StreamExt;
+//! use std::{env, error::Error};
+//! use twilight_gateway::{Event, Shard};
+//! use twilight_model::{
+//!     channel::Message,
+//!     gateway::payload::ReactionAdd,
+//!     id::{ChannelId, UserId},
+//! };
+//! use twilight_standby::Standby;
+//!
+//! // Start a shard connected to the gateway to receive events.
+//! let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
+//! let mut events = shard.events().await;
+//! shard.start().await?;
+//!
+//! let standby = Standby::new();
+//!
+//! while let Some(event) = events.next().await {
+//!     // Have standby process the event, which will fulfill any futures that
+//!     // are waiting for an event.
+//!     standby.process(&event);
+//!
+//!     match event {
+//!         Event::MessageCreate(msg) if msg.content == "!react" => {
+//!             tokio::spawn(react(msg.0, standby.clone()));
+//!         },
+//!         _ => {},
+//!     }
+//! }
+//!
+//! // Wait for a reaction from the user who sent the message, and then print it
+//! // once they react.
+//! async fn react(msg: Message, standby: Standby) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+//!     let author_id = msg.author.id;
+//!
+//!     let reaction = standby.wait_for_reaction(msg.id, move |event: &ReactionAdd| {
+//!         event.user_id == author_id
+//!     }).await?;
+//!
+//!     println!("user reacted with {:?}", reaction.emoji);
+//!
+//!     Ok(())
+//! }
+//! # Ok(()) }
+//! ```
+//!
+//! For more examples, check out each of the methods on [`Standby`].
+//!
+//! [`Standby`]: struct.Standby.html
 //! [`Standby::process`]: struct.Standby.html#method.process
 //! [`Standby::wait_for`]: struct.Standby.html#method.wait_for
 //! [`Standby::wait_for_event`]: struct.Standby.html#method.wait_for_event
@@ -102,6 +157,9 @@ impl Standby {
     ///
     /// When a bystander checks to see if an event is what it's waiting for, it
     /// will receive the event by cloning it.
+    ///
+    /// This function must be called when events are received in order for
+    /// futures returned by methods to fulfill.
     pub fn process(&self, event: &Event) {
         log::trace!("Processing event: {:?}", event);
 

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -41,7 +41,6 @@
 //! including a handler to wait for reactions:
 //!
 //! ```rust,no_run
-//! #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use futures_util::StreamExt;
 //! use std::{env, error::Error};
 //! use twilight_gateway::{Event, Shard};
@@ -52,24 +51,29 @@
 //! };
 //! use twilight_standby::Standby;
 //!
-//! // Start a shard connected to the gateway to receive events.
-//! let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
-//! let mut events = shard.events().await;
-//! shard.start().await?;
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn Error>> {
+//!     // Start a shard connected to the gateway to receive events.
+//!     let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
+//!     let mut events = shard.events().await;
+//!     shard.start().await?;
 //!
-//! let standby = Standby::new();
+//!     let standby = Standby::new();
 //!
-//! while let Some(event) = events.next().await {
-//!     // Have standby process the event, which will fulfill any futures that
-//!     // are waiting for an event.
-//!     standby.process(&event);
+//!     while let Some(event) = events.next().await {
+//!         // Have standby process the event, which will fulfill any futures that
+//!         // are waiting for an event.
+//!         standby.process(&event);
 //!
-//!     match event {
-//!         Event::MessageCreate(msg) if msg.content == "!react" => {
-//!             tokio::spawn(react(msg.0, standby.clone()));
-//!         },
-//!         _ => {},
+//!         match event {
+//!             Event::MessageCreate(msg) if msg.content == "!react" => {
+//!                 tokio::spawn(react(msg.0, standby.clone()));
+//!             },
+//!             _ => {},
+//!         }
 //!     }
+//!
+//!     Ok(())
 //! }
 //!
 //! // Wait for a reaction from the user who sent the message, and then print it
@@ -85,7 +89,6 @@
 //!
 //!     Ok(())
 //! }
-//! # Ok(()) }
 //! ```
 //!
 //! For more examples, check out each of the methods on [`Standby`].


### PR DESCRIPTION
Add additional documentation to the crate docs which includes a full sample bot and slightly clearer small example.

Additionally, clarify in `Standby::process` that it must be called with events for returned futures to be fulfilled.