### PR TITLE
http/request/update_current_user: skip if empty

### DIFF
--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -26,7 +26,9 @@ impl Error for UpdateCurrentUserError {}
 
 #[derive(Default, Serialize)]
 struct UpdateCurrentUserFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     avatar: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     username: Option<String>,
 }
 


### PR DESCRIPTION
Skip serialising fields in the `UpdateCurrentUser` request if they're empty.