### PR TITLE
model/event/gateway: optimise deserialiser

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -23,7 +23,7 @@ log = { default-features = false, version = "0.4" }
 once_cell = { default-features = false, features = ["std"], version = "1" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, optional = true, version = "1" }
-simd-json = { default-features = false, optional = true, version = "0.3" }
+simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.3" }
 tokio = { default-features = false, features = ["net", "rt-core", "sync"], version = "0.2" }
 tokio-tungstenite = { default-features = false, features = ["connect", "tls"], version = "0.10" }
 url = { default-features = false, version = "2" }

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -69,24 +69,6 @@ pub use self::{
 pub use twilight_model::gateway::event::{Event, EventType};
 
 #[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
-use serde_json::Result as JsonResult;
-#[cfg(feature = "simd-json")]
-use simd_json::Result as JsonResult;
-
-pub(crate) fn json_from_slice<'a, T: serde::de::Deserialize<'a>>(s: &'a mut [u8]) -> JsonResult<T> {
-    #[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
-    return serde_json::from_slice(s);
-    #[cfg(feature = "simd-json")]
-    return simd_json::from_slice(s);
-}
-pub(crate) fn json_from_str<'a, T: serde::de::Deserialize<'a>>(s: &'a mut str) -> JsonResult<T> {
-    #[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
-    return serde_json::from_str(s);
-    #[cfg(feature = "simd-json")]
-    return simd_json::from_str(s);
-}
-
-#[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
 pub(crate) use serde_json::to_vec as json_to_vec;
 #[cfg(feature = "simd-json")]
 pub(crate) use simd_json::to_vec as json_to_vec;

--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -81,10 +81,7 @@ pub enum Error {
     ///
     /// The payload was either invalid JSON or did not contain the necessary
     /// "op" key in the object.
-    PayloadInvalid {
-        /// The payload received over the connection.
-        payload: String,
-    },
+    PayloadInvalid,
     /// The binary payload received from Discord wasn't validly encoded as
     /// UTF-8.
     PayloadNotUtf8 {

--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -136,7 +136,10 @@ impl Display for Error {
                 value
             ),
             Self::ParsingUrl { url, .. } => write!(f, "The gateway URL {:?} is invalid", url),
-            Self::PayloadInvalid { .. } => write!(f, "The binary payload received from Discord wasn't UTF-8 valid"),
+            Self::PayloadInvalid { .. } => write!(
+                f,
+                "The binary payload received from Discord wasn't UTF-8 valid"
+            ),
             Self::PayloadNotUtf8 { .. } => write!(f, "The payload from Discord wasn't UTF-8 valid"),
             Self::PayloadSerialization { .. } => {
                 f.write_str("Deserializing or serializing a payload failed")

--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -85,7 +85,8 @@ pub enum Error {
         /// The payload received over the connection.
         payload: String,
     },
-    /// The binary payload received from Discord wasn't UTF-8 valid.
+    /// The binary payload received from Discord wasn't validly encoded as
+    /// UTF-8.
     PayloadNotUtf8 {
         /// Source error when converting to a UTF-8 valid string.
         source: Utf8Error,
@@ -138,7 +139,7 @@ impl Display for Error {
             Self::ParsingUrl { url, .. } => write!(f, "The gateway URL {:?} is invalid", url),
             Self::PayloadInvalid { .. } => write!(
                 f,
-                "The binary payload received from Discord wasn't UTF-8 valid"
+                "The payload received from Discord contained an invalid data structure"
             ),
             Self::PayloadNotUtf8 { .. } => write!(f, "The payload from Discord wasn't UTF-8 valid"),
             Self::PayloadSerialization { .. } => {

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -487,11 +487,8 @@ impl ShardProcessor {
                         Some(json) => {
                             emit::bytes(self.listeners.clone(), json).await;
 
-                            let mut text = str::from_utf8_mut(json).map_err(|source| {
-                                Error::PayloadNotUtf8 {
-                                    source,
-                                }
-                            })?;
+                            let mut text = str::from_utf8_mut(json)
+                                .map_err(|source| Error::PayloadNotUtf8 { source })?;
 
                             Self::parse_gateway_event(&mut text)
                         }
@@ -560,9 +557,9 @@ impl ShardProcessor {
         let gateway_deserializer = GatewayEventDeserializer::from_json(json).unwrap();
         let mut json_deserializer = Deserializer::from_str(json);
 
-        gateway_deserializer.deserialize(&mut json_deserializer).map_err(|source| Error::PayloadSerialization {
-            source
-        })
+        gateway_deserializer
+            .deserialize(&mut json_deserializer)
+            .map_err(|source| Error::PayloadSerialization { source })
     }
 
     #[allow(unsafe_code)]
@@ -573,10 +570,11 @@ impl ShardProcessor {
         use twilight_model::gateway::event::gateway::GatewayEventDeserializerOwned;
 
         let gateway_deserializer = GatewayEventDeserializerOwned::from_json(json).unwrap();
-        let mut json_deserializer = Deserializer::from_slice(unsafe { json.as_bytes_mut() }).unwrap();
+        let mut json_deserializer =
+            Deserializer::from_slice(unsafe { json.as_bytes_mut() }).unwrap();
 
-        gateway_deserializer.deserialize(&mut json_deserializer).map_err(|source| Error::PayloadSerialization {
-            source
-        })
+        gateway_deserializer
+            .deserialize(&mut json_deserializer)
+            .map_err(|source| Error::PayloadSerialization { source })
     }
 }

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -575,7 +575,7 @@ impl ShardProcessor {
         use serde_json::Deserializer;
         use twilight_model::gateway::event::GatewayEventDeserializer;
 
-        let gateway_deserializer = GatewayEventDeserializer::from_json(json).unwrap();
+        let gateway_deserializer = GatewayEventDeserializer::from_json(json).ok_or_else(|| Error::PayloadInvalid)?;
         let mut json_deserializer = Deserializer::from_str(json);
 
         gateway_deserializer

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -575,7 +575,8 @@ impl ShardProcessor {
         use serde_json::Deserializer;
         use twilight_model::gateway::event::GatewayEventDeserializer;
 
-        let gateway_deserializer = GatewayEventDeserializer::from_json(json).ok_or_else(|| Error::PayloadInvalid)?;
+        let gateway_deserializer =
+            GatewayEventDeserializer::from_json(json).ok_or_else(|| Error::PayloadInvalid)?;
         let mut json_deserializer = Deserializer::from_str(json);
 
         gateway_deserializer

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -581,7 +581,11 @@ impl ShardProcessor {
 
         gateway_deserializer
             .deserialize(&mut json_deserializer)
-            .map_err(|source| Error::PayloadSerialization { source })
+            .map_err(|source| {
+                log::debug!("Broken JSON: {}", json);
+
+                Error::PayloadSerialization { source }
+            })
     }
 
     /// Parse a gateway event from a string using `simd-json`.
@@ -616,6 +620,10 @@ impl ShardProcessor {
 
         gateway_deserializer
             .deserialize(&mut json_deserializer)
-            .map_err(|source| Error::PayloadSerialization { source })
+            .map_err(|source| {
+                log::debug!("Broken JSON: {}", json);
+
+                Error::PayloadSerialization { source }
+            })
     }
 }

--- a/model/benches/deserialization.rs
+++ b/model/benches/deserialization.rs
@@ -1,9 +1,32 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
+use serde::de::DeserializeSeed;
+use serde_json::Deserializer;
 use twilight_model::{
     channel::Reaction,
-    gateway::payload::{MemberChunk, TypingStart},
+    gateway::{
+        event::GatewayEventDeserializer,
+        payload::{MemberChunk, TypingStart},
+    },
 };
+
+fn gateway_event_role_delete() {
+    let input = r##"{
+        "op": 0,
+        "s": 2,
+        "d": {
+            "guild_id": "1",
+            "role_id": "2"
+        },
+        "t": "GUILD_ROLE_DELETE"
+    }"##;
+
+    let mut json_deserializer = Deserializer::from_str(input);
+    let gateway_deserializer = GatewayEventDeserializer::new(input).unwrap();
+    gateway_deserializer
+        .deserialize(&mut json_deserializer)
+        .unwrap();
+}
 
 fn member_chunk() {
     let input = r#"{
@@ -160,6 +183,9 @@ fn typing_start() {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("gateway event role delete", |b| {
+        b.iter(|| gateway_event_role_delete())
+    });
     c.bench_function("member chunk", |b| b.iter(|| member_chunk()));
     c.bench_function("reaction", |b| b.iter(|| reaction()));
     c.bench_function("typing start", |b| b.iter(|| typing_start()));

--- a/model/benches/deserialization.rs
+++ b/model/benches/deserialization.rs
@@ -22,7 +22,7 @@ fn gateway_event_role_delete() {
     }"##;
 
     let mut json_deserializer = Deserializer::from_str(input);
-    let gateway_deserializer = GatewayEventDeserializer::new(input).unwrap();
+    let gateway_deserializer = GatewayEventDeserializer::from_json(input).unwrap();
     gateway_deserializer
         .deserialize(&mut json_deserializer)
         .unwrap();

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -92,7 +92,11 @@ impl GatewayEventVisitor<'_> {
         loop {
             match map.next_key::<Field>() {
                 Ok(Some(key)) if key == field => return map.next_value(),
-                Ok(Some(_)) | Err(_) => continue,
+                Ok(Some(_)) | Err(_) => {
+                    map.next_value::<IgnoredAny>()?;
+
+                    continue;
+                },
                 Ok(None) => {
                     return Err(DeError::missing_field(match field {
                         Field::D => "d",

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -30,7 +30,7 @@ enum Field {
     T,
 }
 
-/// A deserializer that deserializes into a GatewayEvent by cloning some bits
+/// A deserializer that deserializes into a `GatewayEvent` by cloning some bits
 /// of scanned information before the actual deserialisation.
 ///
 /// This is the owned version of [`GatewayEventDeserializer`].
@@ -56,7 +56,7 @@ impl GatewayEventDeserializerOwned {
     }
 }
 
-/// A deserializer that deserializes into a GatewayEvent by borrowing some bits
+/// A deserializer that deserializes into a `GatewayEvent` by borrowing some bits
 /// of scanned information before the actual deserialisation.
 ///
 /// This is the borrowed version of [`GatewayEventDeserializerOwned`].

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -131,7 +131,7 @@ impl GatewayEventVisitor<'_> {
                     map.next_value::<IgnoredAny>()?;
 
                     continue;
-                },
+                }
                 Ok(None) => {
                     return Err(DeError::missing_field(match field {
                         Field::D => "d",

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -482,4 +482,22 @@ mod tests {
 
         assert!(matches!(event, GatewayEvent::Hello(41250)));
     }
+
+    /// Test that the deserializer won't mess up on a nested "t" in user input
+    /// while searching for the event type.
+    #[test]
+    fn test_deserializer_from_json_nested_quotes() {
+        let input = r#"{
+            "t": "DOESNT_MATTER",
+            "s": 5144,
+            "op": 0,
+            "d": {
+                "name": "a \"t\"role"
+            }
+        }"#;
+
+        let deserializer = GatewayEventDeserializer::from_json(input).unwrap();
+        assert_eq!(deserializer.event_type, Some("DOESNT_MATTER"));
+        assert_eq!(deserializer.op, 0);
+    }
 }

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -1,10 +1,12 @@
 use super::super::OpCode;
 use super::{DispatchEvent, DispatchEventWithTypeDeserializer};
 use serde::{
-    de::{Deserialize, DeserializeSeed, Deserializer, Error as DeError, MapAccess, Visitor},
-    Deserialize as DeserializeMacro,
+    de::{
+        value::U8Deserializer, DeserializeSeed, Deserializer, Error as DeError, IgnoredAny,
+        IntoDeserializer, MapAccess, Unexpected, Visitor,
+    },
+    Deserialize,
 };
-use serde_value::Value;
 use std::fmt::{Formatter, Result as FmtResult};
 
 /// An event from the gateway, which can either be a dispatch event with
@@ -19,7 +21,7 @@ pub enum GatewayEvent {
     Reconnect,
 }
 
-#[derive(DeserializeMacro)]
+#[derive(Clone, Copy, Deserialize, PartialEq)]
 #[serde(field_identifier, rename_all = "lowercase")]
 enum Field {
     D,
@@ -28,9 +30,83 @@ enum Field {
     T,
 }
 
-struct GatewayEventVisitor;
+pub struct GatewayEventDeserializer<'a> {
+    event_type: Option<&'a str>,
+    op: u8,
+}
 
-impl<'de> Visitor<'de> for GatewayEventVisitor {
+impl<'a> GatewayEventDeserializer<'a> {
+    // Create a gateway event deserializer with some information found by
+    // scanning the JSON payload to deserialise.
+    //
+    // This will scan the payload for the opcode and, optionally, event type if
+    // provided. The opcode key ("op"), must be in the payload while the event
+    // type key ("t") is optional and only required for event ops.
+    pub fn new(input: &'a str) -> Option<Self> {
+        let op = Self::find_opcode(input)?;
+        let event_type = Self::find_event_type(input);
+
+        Some(Self { event_type, op })
+    }
+
+    fn find_event_type(input: &'a str) -> Option<&'a str> {
+        // Discord seems to usually (always?) provide the type at the end of the
+        // payload, so let's search from the right...
+        let from = input.rfind(r#""t":"#)? + 4;
+
+        // Now let's find where the value starts. There may or may not be any
+        // amount of whitespace after the "t" key.
+        let start = input.get(from..)?.find('"')? + from + 1;
+        let to = input.get(start..)?.find('"')?;
+
+        input.get(start..start + to)
+    }
+
+    fn find_opcode(input: &'a str) -> Option<u8> {
+        // Find the op key's position and then search for where the first
+        // character that's not base 10 is. This'll give us the bytes with the
+        // op which can be parsed.
+        //
+        // Add on 5 at the end since that's the length of what we're finding.
+        let from = input.find(r#""op":"#)? + 5;
+
+        // Look for the first thing that isn't a base 10 digit or whitespace,
+        // i.e. a comma (denoting another JSON field), curly brace (end of the
+        // object), etc. This'll give us the op number, maybe with a little
+        // whitespace.
+        let to = input.get(from..)?.find(|c: char| c == ',' || c == '}')?;
+        // We might have some whitespace, so let's trim this.
+        let clean = input.get(from..from + to)?.trim();
+
+        clean.parse::<u8>().ok()
+    }
+}
+
+struct GatewayEventVisitor<'a>(u8, Option<&'a str>);
+
+impl GatewayEventVisitor<'_> {
+    fn field<'de, T: Deserialize<'de>, V: MapAccess<'de>>(
+        map: &mut V,
+        field: Field,
+    ) -> Result<T, V::Error> {
+        loop {
+            match map.next_key::<Field>() {
+                Ok(Some(key)) if key == field => return map.next_value(),
+                Ok(Some(_)) | Err(_) => continue,
+                Ok(None) => {
+                    return Err(DeError::missing_field(match field {
+                        Field::D => "d",
+                        Field::Op => "op",
+                        Field::S => "s",
+                        Field::T => "t",
+                    }));
+                }
+            }
+        }
+    }
+}
+
+impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
     type Value = GatewayEvent;
 
     fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
@@ -51,80 +127,82 @@ impl<'de> Visitor<'de> for GatewayEventVisitor {
             "RECONNECT",
         ];
 
-        // Have to use a serde_json::Value here because serde has no
-        // abstract container type.
-        let mut d = None::<Value>;
-        let mut op = None::<OpCode>;
-        let mut s = None::<u64>;
-        let mut t = None::<String>;
+        let op_deser: U8Deserializer<V::Error> = self.0.into_deserializer();
 
-        while let Some(key) = map.next_key()? {
-            match key {
-                Field::D => {
-                    if d.is_some() {
-                        return Err(DeError::duplicate_field("d"));
-                    }
+        let op = OpCode::deserialize(op_deser).ok().ok_or_else(|| {
+            let unexpected = Unexpected::Unsigned(u64::from(self.0));
 
-                    d = Some(map.next_value()?);
-                }
-                Field::Op => {
-                    if op.is_some() {
-                        return Err(DeError::duplicate_field("op"));
-                    }
-
-                    op = Some(map.next_value()?);
-                }
-                Field::S => {
-                    if s.is_some() {
-                        return Err(DeError::duplicate_field("s"));
-                    }
-
-                    s = map.next_value::<Option<_>>()?;
-                }
-                Field::T => {
-                    if t.is_some() {
-                        return Err(DeError::duplicate_field("t"));
-                    }
-
-                    t = map.next_value::<Option<_>>()?;
-                }
-            }
-        }
-
-        let op = op.ok_or_else(|| DeError::missing_field("op"))?;
+            DeError::invalid_value(unexpected, &"an opcode")
+        })?;
 
         Ok(match op {
             OpCode::Event => {
+                let t = self
+                    .1
+                    .ok_or_else(|| DeError::custom("event type not provided beforehand"))?;
+
+                let mut d = None;
+                let mut s = None;
+
+                loop {
+                    let key = match map.next_key() {
+                        Ok(Some(key)) => key,
+                        Ok(None) => break,
+                        Err(_) => {
+                            map.next_value::<IgnoredAny>()?;
+
+                            continue;
+                        }
+                    };
+
+                    match key {
+                        Field::D => {
+                            if d.is_some() {
+                                return Err(DeError::duplicate_field("d"));
+                            }
+
+                            let deserializer = DispatchEventWithTypeDeserializer::new(t);
+
+                            d = Some(map.next_value_seed(deserializer)?);
+                        }
+                        Field::S => {
+                            if s.is_some() {
+                                return Err(DeError::duplicate_field("s"));
+                            }
+
+                            s = Some(map.next_value()?);
+                        }
+                        Field::Op | Field::T => {
+                            map.next_value::<IgnoredAny>()?;
+                        }
+                    }
+                }
+
                 let d = d.ok_or_else(|| DeError::missing_field("d"))?;
                 let s = s.ok_or_else(|| DeError::missing_field("s"))?;
-                let t = t.ok_or_else(|| DeError::missing_field("t"))?;
-                let event_deserialize = DispatchEventWithTypeDeserializer::new(t.as_ref());
-                let dispatch = event_deserialize.deserialize(d).map_err(DeError::custom)?;
 
-                GatewayEvent::Dispatch(s, Box::new(dispatch))
+                GatewayEvent::Dispatch(s, Box::new(d))
             }
             OpCode::Heartbeat => {
-                let s = s.ok_or_else(|| DeError::missing_field("s"))?;
+                let seq = Self::field(&mut map, Field::S)?;
 
-                GatewayEvent::Heartbeat(s)
+                GatewayEvent::Heartbeat(seq)
             }
             OpCode::HeartbeatAck => GatewayEvent::HeartbeatAck,
             OpCode::Hello => {
-                #[derive(DeserializeMacro)]
+                #[derive(Deserialize)]
                 struct Hello {
                     heartbeat_interval: u64,
                 }
 
-                let d = d.ok_or_else(|| DeError::missing_field("d"))?;
-                let hello = Hello::deserialize(d).map_err(DeError::custom)?;
+                let hello = Self::field::<Hello, _>(&mut map, Field::D)?;
 
                 GatewayEvent::Hello(hello.heartbeat_interval)
             }
             OpCode::InvalidSession => {
-                let d = d.ok_or_else(|| DeError::missing_field("d"))?;
-                let resumeable = bool::deserialize(d).map_err(DeError::custom)?;
+                let invalidate = Self::field::<bool, _>(&mut map, Field::D)?;
 
-                GatewayEvent::InvalidateSession(resumeable)
+                GatewayEvent::InvalidateSession(invalidate)
             }
             OpCode::Identify => return Err(DeError::unknown_variant("Identify", VALID_OPCODES)),
             OpCode::Reconnect => GatewayEvent::Reconnect,
@@ -148,21 +226,47 @@ impl<'de> Visitor<'de> for GatewayEventVisitor {
     }
 }
 
-impl<'de> Deserialize<'de> for GatewayEvent {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        const FIELDS: &[&str] = &["d", "op", "s", "t"];
+impl<'de> DeserializeSeed<'de> for GatewayEventDeserializer<'_> {
+    type Value = GatewayEvent;
 
-        deserializer.deserialize_struct("GatewayEvent", FIELDS, GatewayEventVisitor)
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        const FIELDS: &[&str] = &["d", "s"];
+
+        deserializer.deserialize_struct(
+            "GatewayEvent",
+            FIELDS,
+            GatewayEventVisitor(self.op, self.event_type),
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{GatewayEvent, GatewayEventDeserializer};
+    use serde::de::DeserializeSeed;
+    use serde_json::de::Deserializer;
+
+    #[test]
+    fn test_deserializer_constructor() {
+        let input = r#"{
+            "d": {
+                "guild_id": "1",
+                "role_id": "2"
+            },
+            "op": 0,
+            "s": 7,
+            "t": "GUILD_ROLE_DELETE"
+        }"#;
+
+        let deserializer = GatewayEventDeserializer::new(input).unwrap();
+        let mut json_deserializer = Deserializer::from_str(input);
+        let event = deserializer.deserialize(&mut json_deserializer).unwrap();
+        assert!(matches!(event, GatewayEvent::Dispatch(7, _)));
+    }
 
     #[test]
     fn test_guild() {
-        let broken_guild = r#"{
+        let input = r#"{
   "d": {
     "afk_channel_id": "1337",
     "afk_timeout": 300,
@@ -227,12 +331,16 @@ mod tests {
   "t": "GUILD_UPDATE"
 }"#;
 
-        serde_json::from_str::<GatewayEvent>(broken_guild).unwrap();
+        let deserializer = GatewayEventDeserializer::new(input).unwrap();
+        let mut json_deserializer = Deserializer::from_str(input);
+        let event = deserializer.deserialize(&mut json_deserializer).unwrap();
+
+        assert!(matches!(event, GatewayEvent::Dispatch(42, _)));
     }
 
     #[test]
     fn test_guild_2() {
-        let broken_guild = r#"{
+        let input = r#"{
   "d": {
     "afk_channel_id": null,
     "afk_timeout": 300,
@@ -293,6 +401,11 @@ mod tests {
   "s": 1190911,
   "t": "GUILD_UPDATE"
 }"#;
-        serde_json::from_str::<GatewayEvent>(broken_guild).unwrap();
+
+        let deserializer = GatewayEventDeserializer::new(input).unwrap();
+        let mut json_deserializer = Deserializer::from_str(input);
+        let event = deserializer.deserialize(&mut json_deserializer).unwrap();
+
+        assert!(matches!(event, GatewayEvent::Dispatch(1190911, _)));
     }
 }

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -108,7 +108,6 @@ impl<'a> GatewayEventDeserializer<'a> {
     }
 
     // Search for the index of the event type key from the end.
-    #[allow(unused)]
     fn find_event_type_end(input: &'a str) -> Option<usize> {
         let search_idx = input.len().saturating_sub(100);
 

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -89,7 +89,8 @@ impl<'a> GatewayEventDeserializer<'a> {
         // in the first several bytes, start searching from the start. There
         // doesn't appear to be any particular chance it's on either side by the
         // looks of it.
-        let from = Self::find_event_type_end(input).or_else(|| Self::find_event_type_start(input))?;
+        let from =
+            Self::find_event_type_end(input).or_else(|| Self::find_event_type_start(input))?;
 
         // Now let's find where the value starts. There may or may not be any
         // amount of whitespace after the "t" key.
@@ -113,9 +114,10 @@ impl<'a> GatewayEventDeserializer<'a> {
 
         // If we find it, add 4, since that's the length of what we're searching
         // for.
-        let x = input.get(search_idx..)?.find(r#""t":"#).map(|idx| search_idx + idx + 4);
-
-        x
+        input
+            .get(search_idx..)?
+            .find(r#""t":"#)
+            .map(|idx| search_idx + idx + 4)
     }
 
     fn find_opcode(input: &'a str) -> Option<u8> {

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -455,10 +455,31 @@ mod tests {
   "t": "GUILD_UPDATE"
 }"#;
 
-        let deserializer = GatewayEventDeserializer::new(input).unwrap();
+        let deserializer = GatewayEventDeserializer::from_json(input).unwrap();
         let mut json_deserializer = Deserializer::from_str(input);
         let event = deserializer.deserialize(&mut json_deserializer).unwrap();
 
         assert!(matches!(event, GatewayEvent::Dispatch(1190911, _)));
+    }
+
+    #[test]
+    fn hello() {
+        let input = r#"{
+            "t": null,
+            "s": null,
+            "op": 10,
+            "d": {
+                "heartbeat_interval": 41250,
+                "_trace": [
+                    "[\"gateway-prd-main-mjmw\",{\"micros\":0.0}]"
+                ]
+            }
+        }"#;
+
+        let deserializer = GatewayEventDeserializer::from_json(input).unwrap();
+        let mut json_deserializer = Deserializer::from_str(input);
+        let event = deserializer.deserialize(&mut json_deserializer).unwrap();
+
+        assert!(matches!(event, GatewayEvent::Hello(41250)));
     }
 }

--- a/model/src/gateway/event/mod.rs
+++ b/model/src/gateway/event/mod.rs
@@ -1,12 +1,16 @@
 #![allow(clippy::wildcard_imports)]
 
+pub mod gateway;
 pub mod shard;
 
 mod dispatch;
-mod gateway;
 mod kind;
 
-pub use self::{dispatch::DispatchEvent, gateway::GatewayEvent, kind::EventType};
+pub use self::{
+    dispatch::DispatchEvent,
+    gateway::{GatewayEvent, GatewayEventDeserializer},
+    kind::EventType,
+};
 
 pub use self::dispatch::DispatchEventWithTypeDeserializer;
 

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -42,7 +42,7 @@ use crate::{
     voice::voice_state::{VoiceState, VoiceStateMapDeserializer},
 };
 use serde::{
-    de::{Deserializer, Error as DeError, MapAccess, Visitor},
+    de::{Deserializer, Error as DeError, IgnoredAny, MapAccess, Visitor},
     Deserialize, Serialize,
 };
 use std::{
@@ -228,6 +228,8 @@ impl<'de> Deserialize<'de> for Guild {
                         Ok(None) => break,
                         Err(_) => {
                             // Encountered when we run into an unknown key.
+                            map.next_value::<IgnoredAny>()?;
+
                             continue;
                         }
                     };


### PR DESCRIPTION
Optimise the deserialisation of
`twilight_model::gateway::event::GatewayEvent` by scanning the input JSON payload to deserialise prior to actually deserialising it.

Instead of implementing `serde::Deserialize` directly on `GatewayEvent`, make a `GatewayEventDeserializer` that implements `serde::de::DeserializeSeed` and outputs a `GatewayEvent` on success.

When making a `GatewayEventDeserializer`, it will scan the payload for an "op" and parse out the opcode value, and optionally a "t", which denotes the event type in the case that the gateway event is a Dispatch event (op 0).

When deserialising the gateway event itself, the op can be matched on and logic can be applied based on the opcode. For example, for the event op the sequence will be parsed and the dispatch payload will be parsed due to the event type already being known. For a heartbeat opcode, only the sequence will be parsed, and other fields can be ignored.

This removes the use of an intermediary `serde_value::Value` that the dispatch payload (such as an entire guild create's payload, or a role create payload, etc.) was being deserialised into before later being deserialised into the destination type.

This improves the performance of a simple `GUILD_ROLE_DELETE` dispatch event's deserialisation by 30%:

```
gateway event role delete
                        time:   [460.83 ns 463.49 ns 467.09 ns]
                        change: [-30.530% -30.153% -29.713%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```

An approximately 1000 member guild now sees a 62.3% improvement in performance:

```
gateway event guild create
                        time:   [1.9464 ms 1.9503 ms 1.9544 ms]
                        change: [-62.539% -62.301% -62.080%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```