### PR TITLE
model/gateway/event/shard: derive (de)serialize

### DIFF
--- a/model/src/gateway/event/shard.rs
+++ b/model/src/gateway/event/shard.rs
@@ -1,5 +1,7 @@
+use serde::{Deserialize, Serialize};
+
 /// Indicator that a shard is now fully connected.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Connected {
     /// The interval that heartbeats are being sent to the gateway.
     pub heartbeat_interval: u64,
@@ -8,7 +10,7 @@ pub struct Connected {
 }
 
 /// Indicator that a shard is now connecting.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Connecting {
     /// The URL used to connect to the gateway.
     pub gateway: String,
@@ -18,7 +20,7 @@ pub struct Connecting {
 
 /// Indicator that a shard is now disconnected and may soon be reconnecting if
 /// not explicitly shutdown.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Disconnected {
     /// The code for the disconnect if not initiated by the host, if any.
     pub code: Option<u16>,
@@ -30,7 +32,7 @@ pub struct Disconnected {
 
 /// Indicator that a shard is now identifying with the gateway to create a new
 /// session.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Identifying {
     /// The ID of the shard that identified with the gateway.
     pub shard_id: u64,
@@ -39,21 +41,21 @@ pub struct Identifying {
 }
 
 /// A payload of bytes came in through the gateway.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Payload {
     /// The bytes that came in.
     pub bytes: Vec<u8>,
 }
 
 /// Indicator that a shard is now reconnecting.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Reconnecting {
     /// The ID of the shard that began reconnecting.
     pub shard_id: u64,
 }
 
 /// Indicator that a shard is now resuming a session after a disconnect.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Resuming {
     /// The event sequence sent when resuming was initiated.
     pub seq: u64,
@@ -62,7 +64,8 @@ pub struct Resuming {
 }
 
 /// "Meta" events about a shard's status, not from the gateway.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(untagged)]
 pub enum ShardEvent {
     /// A shard is now in a Connected stage after being fully connected to the
     /// gateway.


### PR DESCRIPTION
Derive `Deserialize` and `Serialize` on all of the shard events, marking the `ShardEvent` enum as untagged.