### PR TITLE
make event listeners non async

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -33,6 +33,7 @@ url = { default-features = false, version = "2" }
 # it does not seem to update the total_in of the function to have an offset
 # https://github.com/alexcrichton/flate2-rs/issues/217
 flate2 = { default-features = false, features = ["zlib"], version = "1.0" }
+dashmap = { default-features = false, version = "3" }
 
 #optional
 metrics = { default-features = false, optional = true, version = "0.12.1" }

--- a/gateway/src/listener.rs
+++ b/gateway/src/listener.rs
@@ -1,14 +1,12 @@
 use crate::EventTypeFlags;
+use dashmap::DashMap;
 use futures_channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use futures_util::lock::Mutex;
-use std::{
-    collections::HashMap,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
 };
 
+#[derive(Debug)]
 pub struct Listener<T> {
     pub events: EventTypeFlags,
     pub tx: UnboundedSender<T>,
@@ -17,14 +15,14 @@ pub struct Listener<T> {
 #[derive(Debug)]
 struct ListenersRef<T> {
     id: AtomicU64,
-    listeners: Mutex<HashMap<u64, Listener<T>>>,
+    listeners: DashMap<u64, Listener<T>>,
 }
 
 impl<T> Default for ListenersRef<T> {
     fn default() -> Self {
         Self {
             id: AtomicU64::new(0),
-            listeners: Mutex::new(HashMap::default()),
+            listeners: DashMap::new(),
         }
     }
 }
@@ -33,25 +31,21 @@ impl<T> Default for ListenersRef<T> {
 pub struct Listeners<T>(Arc<ListenersRef<T>>);
 
 impl<T> Listeners<T> {
-    pub async fn add(&self, events: EventTypeFlags) -> UnboundedReceiver<T> {
+    pub fn add(&self, events: EventTypeFlags) -> UnboundedReceiver<T> {
         let id = self.0.id.fetch_add(1, Ordering::Release) + 1;
         let (tx, rx) = mpsc::unbounded();
 
-        self.0
-            .listeners
-            .lock()
-            .await
-            .insert(id, Listener { events, tx });
+        self.0.listeners.insert(id, Listener { events, tx });
 
         rx
     }
 
-    pub fn all(&self) -> &Mutex<HashMap<u64, Listener<T>>> {
+    pub fn all(&self) -> &DashMap<u64, Listener<T>> {
         &self.0.listeners
     }
 
-    pub async fn remove_all(&self) {
-        self.0.listeners.lock().await.clear();
+    pub fn remove_all(&self) {
+        self.0.listeners.clear();
     }
 }
 

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -176,7 +176,7 @@ impl Shard {
     /// [`EventType::SHARD_PAYLOAD`]: events/struct.EventType.html#const.SHARD_PAYLOAD
     /// [`some_events`]: #method.some_events
     pub async fn events(&self) -> impl Stream<Item = Event> {
-        let rx = self.0.listeners.add(EventTypeFlags::default()).await;
+        let rx = self.0.listeners.add(EventTypeFlags::default());
 
         Events::new(EventTypeFlags::default(), rx)
     }
@@ -214,7 +214,7 @@ impl Shard {
     /// # Ok(()) }
     /// ```
     pub async fn some_events(&self, event_types: EventTypeFlags) -> impl Stream<Item = Event> {
-        let rx = self.0.listeners.add(event_types).await;
+        let rx = self.0.listeners.add(event_types);
 
         Events::new(event_types, rx)
     }
@@ -307,7 +307,7 @@ impl Shard {
     ///
     /// This will cleanly close the connection, causing discord to end the session and show the bot offline
     pub async fn shutdown(&self) {
-        self.0.listeners.remove_all().await;
+        self.0.listeners.remove_all();
 
         if let Some(processor_handle) = self.0.processor_handle.get() {
             processor_handle.abort();
@@ -322,7 +322,7 @@ impl Shard {
 
     /// This will shut down the shard in a resumable way and return shard id and optional session info to resume with later if this shard is resumable
     pub async fn shutdown_resumable(&self) -> (u64, Option<ResumeSession>) {
-        self.0.listeners.remove_all().await;
+        self.0.listeners.remove_all();
 
         if let Some(processor_handle) = self.0.processor_handle.get() {
             processor_handle.abort();

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -80,7 +80,7 @@ impl ShardProcessor {
         url.push_str("?v=6&compress=zlib-stream");
 
         emit::event(
-            listeners.clone(),
+            &listeners,
             Event::ShardConnecting(Connecting {
                 gateway: url.clone(),
                 shard_id: config.shard()[0],
@@ -136,7 +136,7 @@ impl ShardProcessor {
                         "The authorization for shard {} is invalid, quitting",
                         shard_id
                     );
-                    self.listeners.remove_all().await;
+                    self.listeners.remove_all();
 
                     return;
                 }
@@ -156,7 +156,7 @@ impl ShardProcessor {
                         "At least one of the provided intents for shard {} are disallowed",
                         shard_id
                     );
-                    self.listeners.remove_all().await;
+                    self.listeners.remove_all();
                     return;
                 }
                 Err(Error::IntentsInvalid { shard_id, .. }) => {
@@ -164,7 +164,7 @@ impl ShardProcessor {
                         "At least one of the provided intents for shard {} are invalid",
                         shard_id
                     );
-                    self.listeners.remove_all().await;
+                    self.listeners.remove_all();
                     return;
                 }
                 Err(err) => {
@@ -184,7 +184,7 @@ impl ShardProcessor {
                 continue;
             }
 
-            emit::event(self.listeners.clone(), Event::from(gateway_event));
+            emit::event(&self.listeners, Event::from(gateway_event));
         }
     }
 
@@ -206,7 +206,7 @@ impl ShardProcessor {
             v: 6,
         });
         emit::event(
-            self.listeners.clone(),
+            &self.listeners,
             Event::ShardIdentifying(Identifying {
                 shard_id: self.config.shard()[0],
                 shard_total: self.config.shard()[1],
@@ -235,7 +235,7 @@ impl ShardProcessor {
                         self.session.set_id(&ready.session_id).await;
 
                         emit::event(
-                            self.listeners.clone(),
+                            &self.listeners,
                             Event::ShardConnected(Connected {
                                 heartbeat_interval: self.session.heartbeat_interval(),
                                 shard_id: self.config.shard()[0],
@@ -245,7 +245,7 @@ impl ShardProcessor {
                     DispatchEvent::Resumed => {
                         self.session.set_stage(Stage::Connected);
                         emit::event(
-                            self.listeners.clone(),
+                            &self.listeners,
                             Event::ShardConnected(Connected {
                                 heartbeat_interval: self.session.heartbeat_interval(),
                                 shard_id: self.config.shard()[0],
@@ -345,14 +345,14 @@ impl ShardProcessor {
 
             if full_reconnect {
                 emit::event(
-                    self.listeners.clone(),
+                    &self.listeners,
                     Event::ShardReconnecting(Reconnecting {
                         shard_id: self.config.shard()[0],
                     }),
                 );
             } else {
                 emit::event(
-                    self.listeners.clone(),
+                    &self.listeners,
                     Event::ShardResuming(Resuming {
                         seq: self.session.seq(),
                         shard_id: self.config.shard()[0],
@@ -401,7 +401,7 @@ impl ShardProcessor {
         }
 
         emit::event(
-            self.listeners.clone(),
+            &self.listeners,
             Event::ShardConnecting(Connecting {
                 gateway: self.url.clone(),
                 shard_id: self.config.shard()[0],
@@ -505,7 +505,7 @@ impl ShardProcessor {
                 Message::Close(close_frame) => {
                     log::warn!("Got close code: {:?}.", close_frame);
                     emit::event(
-                        self.listeners.clone(),
+                        &self.listeners,
                         Event::ShardDisconnected(Disconnected {
                             code: close_frame.as_ref().map(|frame| frame.code.into()),
                             reason: close_frame


### PR DESCRIPTION
this makes sure they always get handled in the same order, doesn't require pinning them anymore and solves events sometimes getting out of order