### PR TITLE
gateway/shard/processor/impl: fix typo in warn

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -168,7 +168,7 @@ impl ShardProcessor {
                     return;
                 }
                 Err(err) => {
-                    warn!("Error receiveing gateway event: {:?}", err.source());
+                    warn!("Error receiving gateway event: {:?}", err.source());
                     continue;
                 }
             };


### PR DESCRIPTION
Fix a typo in a warning from 'receiveing' to 'receiving'.