### PR TITLE
cache/in-memory: use dashmap where possible

### DIFF
--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 [dependencies]
 async-trait = { default-features = false, version = "0.1" }
 bitflags = { default-features = false, version = "1" }
+dashmap = { default-features = false, version = "3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 twilight-cache-trait = { default-features = false, path = "../trait" }
 twilight-model = { default-features = false, path = "../../model" }

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -452,41 +452,12 @@ impl InMemoryCache {
     pub async fn cache_guild(&self, guild: Guild) {
         // The map and set creation needs to occur first, so caching states and objects
         // always has a place to put them.
-        self.0
-            .guild_channels
-            .lock()
-            .await
-            .insert(guild.id, HashSet::new());
-
-        self.0
-            .guild_emojis
-            .lock()
-            .await
-            .insert(guild.id, HashSet::new());
-
-        self.0
-            .guild_members
-            .lock()
-            .await
-            .insert(guild.id, HashSet::new());
-
-        self.0
-            .guild_presences
-            .lock()
-            .await
-            .insert(guild.id, HashSet::new());
-
-        self.0
-            .guild_roles
-            .lock()
-            .await
-            .insert(guild.id, HashSet::new());
-
-        self.0
-            .guild_voice_states
-            .lock()
-            .await
-            .insert(guild.id, HashMap::new());
+        self.0.guild_channels.insert(guild.id, HashSet::new());
+        self.0.guild_emojis.insert(guild.id, HashSet::new());
+        self.0.guild_members.insert(guild.id, HashSet::new());
+        self.0.guild_presences.insert(guild.id, HashSet::new());
+        self.0.guild_roles.insert(guild.id, HashSet::new());
+        self.0.guild_voice_states.insert(guild.id, HashMap::new());
 
         self.cache_guild_channels(guild.id, guild.channels.into_iter().map(|(_, v)| v))
             .await;


### PR DESCRIPTION
Use DashMap instead of mutexed hashmaps. This means that most operations will no longer be locking. The current user is still behind a mutex since it's a single object, but this isn't too bad since it's so infrequently accessed.
