### PR TITLE
Reorder guild caching to uphold voice state invariant

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -469,19 +469,8 @@ impl InMemoryCache {
     }
 
     pub async fn cache_guild(&self, guild: Guild) {
-        self.cache_guild_channels(guild.id, guild.channels.into_iter().map(|(_, v)| v))
-            .await;
-        self.cache_emojis(guild.id, guild.emojis.into_iter().map(|(_, v)| v))
-            .await;
-        self.cache_members(guild.id, guild.members.into_iter().map(|(_, v)| v))
-            .await;
-        self.cache_presences(Some(guild.id), guild.presences.into_iter().map(|(_, v)| v))
-            .await;
-        self.cache_roles(guild.id, guild.roles.into_iter().map(|(_, v)| v))
-            .await;
-        self.cache_voice_states(guild.voice_states.into_iter().map(|(_, v)| v))
-            .await;
-
+        // The map and set creation needs to occur first, so caching states and objects
+        // always has a place to put them.
         self.0
             .guild_channels
             .lock()
@@ -517,6 +506,19 @@ impl InMemoryCache {
             .lock()
             .await
             .insert(guild.id, HashMap::new());
+
+        self.cache_guild_channels(guild.id, guild.channels.into_iter().map(|(_, v)| v))
+            .await;
+        self.cache_emojis(guild.id, guild.emojis.into_iter().map(|(_, v)| v))
+            .await;
+        self.cache_members(guild.id, guild.members.into_iter().map(|(_, v)| v))
+            .await;
+        self.cache_presences(Some(guild.id), guild.presences.into_iter().map(|(_, v)| v))
+            .await;
+        self.cache_roles(guild.id, guild.roles.into_iter().map(|(_, v)| v))
+            .await;
+        self.cache_voice_states(guild.voice_states.into_iter().map(|(_, v)| v))
+            .await;
 
         let guild = CachedGuild {
             id: guild.id,


### PR DESCRIPTION
With #292, the issue ended up being I made a wrong assumption about the way the cache was designed. This PR changes that to A. Fix the current issue, and B. Make a bit more sense. It doesn't make a whole lot of sense to "cache" anything until the maps and the like are in place to do so.

Closes #292 