### PR TITLE
model: properly handle unknown map keys

### DIFF
--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -24,7 +24,9 @@ pub use self::{
 
 use crate::id::{ChannelId, MessageId};
 use serde::{
-    de::{DeserializeSeed, Deserializer, Error as DeError, MapAccess, SeqAccess, Visitor},
+    de::{
+        DeserializeSeed, Deserializer, Error as DeError, IgnoredAny, MapAccess, SeqAccess, Visitor,
+    },
     Deserialize, Serialize,
 };
 use serde_mappable_seq::Key;
@@ -116,7 +118,12 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
             let key = match map.next_key() {
                 Ok(Some(key)) => key,
                 Ok(None) => break,
-                Err(_) => continue,
+                Err(_) => {
+                    // Encountered when we run into an unknown key.
+                    map.next_value::<IgnoredAny>()?;
+
+                    continue;
+                }
             };
 
             match key {

--- a/model/src/channel/reaction.rs
+++ b/model/src/channel/reaction.rs
@@ -4,7 +4,7 @@ use crate::{
     id::{ChannelId, GuildId, MessageId, UserId},
 };
 use serde::{
-    de::{Deserializer, Error as DeError, MapAccess, Visitor},
+    de::{Deserializer, Error as DeError, IgnoredAny, MapAccess, Visitor},
     Deserialize, Serialize,
 };
 use std::fmt::{Formatter, Result as FmtResult};
@@ -53,6 +53,8 @@ impl<'de> Visitor<'de> for ReactionVisitor {
                 Ok(None) => break,
                 Err(_) => {
                     // Encountered when we run into an unknown key.
+                    map.next_value::<IgnoredAny>()?;
+
                     continue;
                 }
             };

--- a/model/src/gateway/payload/member_chunk.rs
+++ b/model/src/gateway/payload/member_chunk.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use serde::Serialize;
 use serde::{
-    de::{Deserializer, Error as DeError, MapAccess, Visitor},
+    de::{Deserializer, Error as DeError, IgnoredAny, MapAccess, Visitor},
     Deserialize,
 };
 use std::{
@@ -64,6 +64,8 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
                 Ok(None) => break,
                 Err(_) => {
                     // Encountered when we run into an unknown key.
+                    map.next_value::<IgnoredAny>()?;
+
                     continue;
                 }
             };

--- a/model/src/gateway/payload/typing_start.rs
+++ b/model/src/gateway/payload/typing_start.rs
@@ -3,7 +3,7 @@ use crate::{
     id::{ChannelId, GuildId, UserId},
 };
 use serde::{
-    de::{Deserializer, Error as DeError, MapAccess, Visitor},
+    de::{Deserializer, Error as DeError, IgnoredAny, MapAccess, Visitor},
     Deserialize, Serialize,
 };
 use std::fmt::{Formatter, Result as FmtResult};
@@ -49,6 +49,8 @@ impl<'de> Visitor<'de> for TypingStartVisitor {
                 Ok(None) => break,
                 Err(_) => {
                     // Encountered when we run into an unknown key.
+                    map.next_value::<IgnoredAny>()?;
+
                     continue;
                 }
             };

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -42,7 +42,7 @@ use crate::{
     voice::voice_state::{VoiceState, VoiceStateMapDeserializer},
 };
 use serde::{
-    de::{Deserializer, Error as DeError, MapAccess, Visitor},
+    de::{Deserializer, Error as DeError, IgnoredAny, MapAccess, Visitor},
     Deserialize, Serialize,
 };
 use std::{
@@ -228,6 +228,8 @@ impl<'de> Deserialize<'de> for Guild {
                         Ok(None) => break,
                         Err(_) => {
                             // Encountered when we run into an unknown key.
+                            map.next_value::<IgnoredAny>()?;
+
                             continue;
                         }
                     };

--- a/model/src/voice/voice_state.rs
+++ b/model/src/voice/voice_state.rs
@@ -3,7 +3,9 @@ use crate::{
     id::{ChannelId, GuildId, UserId},
 };
 use serde::{
-    de::{DeserializeSeed, Deserializer, Error as DeError, MapAccess, SeqAccess, Visitor},
+    de::{
+        DeserializeSeed, Deserializer, Error as DeError, IgnoredAny, MapAccess, SeqAccess, Visitor,
+    },
     Deserialize, Serialize,
 };
 use serde_mappable_seq::Key;
@@ -84,6 +86,8 @@ impl<'de> Visitor<'de> for VoiceStateVisitor {
                 Ok(None) => break,
                 Err(_) => {
                     // Encountered when we run into an unknown key.
+                    map.next_value::<IgnoredAny>()?;
+
                     continue;
                 }
             };


### PR DESCRIPTION
Properly handle unknown map keys by also deserializing the associated value via `serde::de::IgnoredAny`.