### PR TITLE
model/channel: add a few convenience methods

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -387,7 +387,7 @@ impl InMemoryCache {
         guild_channels: impl IntoIterator<Item = GuildChannel>,
     ) -> HashSet<ChannelId> {
         let pairs = future::join_all(guild_channels.into_iter().map(|channel| async {
-            let id = *guild_channel_id(&channel);
+            let id = channel.id();
             self.cache_guild_channel(guild_id, channel).await;
 
             id
@@ -414,7 +414,7 @@ impl InMemoryCache {
             }
         }
 
-        let id = *guild_channel_id(&channel);
+        let id = channel.id();
 
         upsert_guild_item(&self.0.channels_guild, guild_id, id, channel).await
     }
@@ -795,22 +795,6 @@ impl<T: Into<InMemoryConfig>> From<T> for InMemoryCache {
 
 impl Cache for InMemoryCache {}
 impl Cache for &'_ InMemoryCache {}
-
-fn guild_channel_guild_id(channel: &GuildChannel) -> Option<&GuildId> {
-    match channel {
-        GuildChannel::Category(c) => c.guild_id.as_ref(),
-        GuildChannel::Text(c) => c.guild_id.as_ref(),
-        GuildChannel::Voice(c) => c.guild_id.as_ref(),
-    }
-}
-
-fn guild_channel_id(channel: &GuildChannel) -> &ChannelId {
-    match channel {
-        GuildChannel::Category(c) => &c.id,
-        GuildChannel::Text(c) => &c.id,
-        GuildChannel::Voice(c) => &c.id,
-    }
-}
 
 fn presence_user_id(presence: &Presence) -> UserId {
     match presence.user {

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -109,8 +109,8 @@ impl UpdateCache<InMemoryCache, InMemoryCacheError> for ChannelCreate {
                 super::upsert_item(&cache.0.groups, c.id, c).await;
             }
             Channel::Guild(c) => {
-                if let Some(gid) = super::guild_channel_guild_id(&c) {
-                    cache.cache_guild_channel(*gid, c.clone()).await;
+                if let Some(gid) = c.guild_id() {
+                    cache.cache_guild_channel(gid, c.clone()).await;
                 }
             }
             Channel::Private(c) => {
@@ -134,9 +134,7 @@ impl UpdateCache<InMemoryCache, InMemoryCacheError> for ChannelDelete {
                 cache.delete_group(c.id).await;
             }
             Channel::Guild(ref c) => {
-                let id = *super::guild_channel_id(&c);
-
-                cache.delete_guild_channel(id).await;
+                cache.delete_guild_channel(c.id()).await;
             }
             Channel::Private(ref c) => {
                 cache.0.channels_private.lock().await.remove(&c.id);
@@ -202,8 +200,8 @@ impl UpdateCache<InMemoryCache, InMemoryCacheError> for ChannelUpdate {
                 cache.cache_group(c.clone()).await;
             }
             Channel::Guild(c) => {
-                if let Some(gid) = super::guild_channel_guild_id(&c) {
-                    cache.cache_guild_channel(*gid, c.clone()).await;
+                if let Some(gid) = c.guild_id() {
+                    cache.cache_guild_channel(gid, c.clone()).await;
                 }
             }
             Channel::Private(c) => {

--- a/model/README.md
+++ b/model/README.md
@@ -6,8 +6,8 @@
 
 See the [`twilight`] documentation for more information.
 
-`twilight-model` is a crate of only serde models defining the Discord APIs with
-no implementations on top of them or functions to work with them.
+`twilight-model` is a crate of serde models defining the Discord APIs with
+few convenience methods on top of them.
 
 These are in a single crate for ease of use, a single point of definition,
 and a sort of versioning of the Discord API. Similar to how a database

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -22,7 +22,7 @@ pub use self::{
     voice_channel::VoiceChannel, webhook::Webhook, webhook_type::WebhookType,
 };
 
-use crate::id::{ChannelId, MessageId};
+use crate::id::{ChannelId, GuildId, MessageId};
 use serde::{
     de::{DeserializeSeed, Deserializer, Error as DeError, MapAccess, SeqAccess, Visitor},
     Deserialize, Serialize,
@@ -41,12 +41,65 @@ pub enum Channel {
     Private(PrivateChannel),
 }
 
+impl Channel {
+    /// Return the ID of the inner channel.
+    pub fn id(&self) -> ChannelId {
+        match self {
+            Self::Group(group) => group.id,
+            Self::Guild(guild_channel) => guild_channel.id(),
+            Self::Private(private) => private.id,
+        }
+    }
+
+    /// Return an immutable reference to the name of the inner channel.
+    ///
+    /// The group variant might not always have a name, since they are optional
+    /// for groups. The guild variant will always have a name. The private
+    /// variant doesn't have a name.
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Self::Group(group) => group.name.as_deref(),
+            Self::Guild(guild_channel) => Some(guild_channel.name()),
+            Self::Private(_) => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum GuildChannel {
     Category(CategoryChannel),
     Text(TextChannel),
     Voice(VoiceChannel),
+}
+
+impl GuildChannel {
+    /// Return the guild ID of the inner guild channel.
+    pub fn guild_id(&self) -> Option<GuildId> {
+        match self {
+            Self::Category(category) => category.guild_id,
+            Self::Text(text) => text.guild_id,
+            Self::Voice(voice) => voice.guild_id,
+        }
+    }
+
+    /// Return the ID of the inner guild channel.
+    pub fn id(&self) -> ChannelId {
+        match self {
+            Self::Category(category) => category.id,
+            Self::Text(text) => text.id,
+            Self::Voice(voice) => voice.id,
+        }
+    }
+
+    /// Return an immutable reference to the name of the inner guild channel.
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Category(category) => category.name.as_ref(),
+            Self::Text(text) => text.name.as_ref(),
+            Self::Voice(voice) => voice.name.as_ref(),
+        }
+    }
 }
 
 impl Key<'_, ChannelId> for GuildChannel {
@@ -308,14 +361,8 @@ impl<'de> Visitor<'de> for GuildChannelMapVisitor {
             .size_hint()
             .map_or_else(HashMap::new, HashMap::with_capacity);
 
-        while let Some(channel) = seq.next_element()? {
-            let id = match channel {
-                GuildChannel::Category(ref c) => c.id,
-                GuildChannel::Text(ref t) => t.id,
-                GuildChannel::Voice(ref v) => v.id,
-            };
-
-            map.insert(id, channel);
+        while let Some(channel) = seq.next_element::<GuildChannel>()? {
+            map.insert(channel.id(), channel);
         }
 
         Ok(map)
@@ -332,11 +379,154 @@ impl<'de> DeserializeSeed<'de> for GuildChannelMapDeserializer {
 
 #[cfg(test)]
 mod tests {
-    use super::{CategoryChannel, ChannelType, GuildChannel, TextChannel, VoiceChannel};
+    use super::{
+        CategoryChannel, Channel, ChannelType, Group, GuildChannel, PrivateChannel, TextChannel,
+        VoiceChannel,
+    };
     use crate::{
         channel::permission_overwrite::PermissionOverwrite,
-        id::{ChannelId, GuildId, MessageId},
+        id::{ChannelId, GuildId, MessageId, UserId},
     };
+
+    fn group() -> Group {
+        Group {
+            application_id: None,
+            icon: None,
+            id: ChannelId(123),
+            kind: ChannelType::Group,
+            last_message_id: None,
+            last_pin_timestamp: None,
+            name: Some("a group".to_owned()),
+            owner_id: UserId(456),
+            recipients: Vec::new(),
+        }
+    }
+
+    fn guild_category() -> CategoryChannel {
+        CategoryChannel {
+            guild_id: Some(GuildId(321)),
+            id: ChannelId(123),
+            kind: ChannelType::GuildCategory,
+            name: "category".to_owned(),
+            nsfw: false,
+            parent_id: None,
+            permission_overwrites: Vec::new(),
+            position: 0,
+        }
+    }
+
+    fn guild_text() -> TextChannel {
+        TextChannel {
+            guild_id: Some(GuildId(321)),
+            id: ChannelId(456),
+            kind: ChannelType::GuildText,
+            last_message_id: None,
+            last_pin_timestamp: None,
+            name: "text".to_owned(),
+            nsfw: false,
+            permission_overwrites: Vec::new(),
+            parent_id: None,
+            position: 1,
+            rate_limit_per_user: None,
+            topic: None,
+        }
+    }
+
+    fn guild_voice() -> VoiceChannel {
+        VoiceChannel {
+            bitrate: 1000,
+            guild_id: Some(GuildId(321)),
+            id: ChannelId(789),
+            kind: ChannelType::GuildVoice,
+            name: "voice".to_owned(),
+            permission_overwrites: Vec::new(),
+            parent_id: None,
+            position: 2,
+            user_limit: None,
+        }
+    }
+
+    fn private() -> PrivateChannel {
+        PrivateChannel {
+            id: ChannelId(234),
+            last_message_id: None,
+            last_pin_timestamp: None,
+            kind: ChannelType::Private,
+            recipients: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_channel_helpers() {
+        assert_eq!(Channel::Group(group()).id(), ChannelId(123));
+        assert_eq!(
+            Channel::Guild(GuildChannel::Category(guild_category())).id(),
+            ChannelId(123)
+        );
+        assert_eq!(
+            Channel::Guild(GuildChannel::Text(guild_text())).id(),
+            ChannelId(456)
+        );
+        assert_eq!(
+            Channel::Guild(GuildChannel::Voice(guild_voice())).id(),
+            ChannelId(789)
+        );
+        assert_eq!(Channel::Private(private()).id(), ChannelId(234));
+    }
+
+    #[test]
+    fn test_channel_name() {
+        assert_eq!(Channel::Group(group()).name(), Some("a group"));
+        let mut group_no_name = group();
+        group_no_name.name = None;
+        assert!(Channel::Group(group_no_name).name().is_none());
+        assert_eq!(
+            Channel::Guild(GuildChannel::Category(guild_category())).name(),
+            Some("category")
+        );
+        assert_eq!(
+            Channel::Guild(GuildChannel::Text(guild_text())).name(),
+            Some("text")
+        );
+        assert_eq!(
+            Channel::Guild(GuildChannel::Voice(guild_voice())).name(),
+            Some("voice")
+        );
+        assert!(Channel::Private(private()).name().is_none());
+    }
+
+    #[test]
+    fn test_guild_channel_guild_id() {
+        assert_eq!(
+            GuildChannel::Category(guild_category()).guild_id(),
+            Some(GuildId(321))
+        );
+        assert_eq!(
+            GuildChannel::Text(guild_text()).guild_id(),
+            Some(GuildId(321))
+        );
+        assert_eq!(
+            GuildChannel::Voice(guild_voice()).guild_id(),
+            Some(GuildId(321))
+        );
+    }
+
+    #[test]
+    fn test_guild_channel_id() {
+        assert_eq!(
+            GuildChannel::Category(guild_category()).id(),
+            ChannelId(123)
+        );
+        assert_eq!(GuildChannel::Text(guild_text()).id(), ChannelId(456));
+        assert_eq!(GuildChannel::Voice(guild_voice()).id(), ChannelId(789));
+    }
+
+    #[test]
+    fn test_guild_channel_name() {
+        assert_eq!(GuildChannel::Category(guild_category()).name(), "category");
+        assert_eq!(GuildChannel::Text(guild_text()).name(), "text");
+        assert_eq!(GuildChannel::Voice(guild_voice()).name(), "voice");
+    }
 
     // The deserializer for GuildChannel should skip over fields names that
     // it couldn't deserialize.

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -4,8 +4,8 @@
 //!
 //! See the [`twilight`] documentation for more information.
 //!
-//! `twilight-model` is a crate of only serde models defining the Discord APIs with
-//! no implementations on top of them or functions to work with them.
+//! `twilight-model` is a crate of serde models defining the Discord APIs with
+//! few convenience methods on top of them.
 //!
 //! These are in a single crate for ease of use, a single point of definition,
 //! and a sort of versioning of the Discord API. Similar to how a database

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -113,7 +113,7 @@ use std::{
     sync::Arc,
 };
 use twilight_model::{
-    channel::{Channel, GuildChannel},
+    channel::Channel,
     gateway::{
         event::{Event, EventType},
         payload::{MessageCreate, ReactionAdd},
@@ -541,11 +541,7 @@ fn event_guild_id(event: &Event) -> Option<GuildId> {
 
 fn channel_guild_id(channel: &Channel) -> Option<GuildId> {
     match channel {
-        Channel::Guild(c) => match c {
-            GuildChannel::Category(c) => c.guild_id,
-            GuildChannel::Text(c) => c.guild_id,
-            GuildChannel::Voice(c) => c.guild_id,
-        },
+        Channel::Guild(c) => c.guild_id(),
         _ => None,
     }
 }


### PR DESCRIPTION
Add a few convenience methods to `twilight_model::channel::{Channel, GuildChannel}`:

- `Channel::id`
- `Channel::name`
- `GuildChannel::guild_id`
- `GuildChannel::id`
- `GuildChannel::name`

These are a few operations that are done a lot, probably by most users. All channels and guild channels have an ID and can have a name, so both have matching methods for retrieving both from the inner variants. `GuildChannel` is the only one with a `guild_id` method since it only applies to guild channels, and not other types of channels.

Since this is a first for the model crate, we should probably all approve it before merging. If anyone has any concerns about doing this (see #217 for my opinion) please comment them.

Closes #217.