### PR TITLE
project: add 'twilight-mention' utility crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ members = [
     "model",
     "standby",
     "twilight",
+    "utils/mention",
 ]

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ conveniently using players to send events and retrieve information for each
 guild, and an HTTP module for creating requests using the [`http`] crate and
 providing models to deserialize their responses.
 
+### `twilight-mention`
+
+`twilight-mention` is a utility crate for creating display formatters for
+various model types that format mentions. For example, it can create
+formatters for mentioning a channel or emoji, or pinging a role or user.
+
 ## Examples
 
 ```rust,no_run

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ users.
 
 ### `twilight-lavalink`
 
-`twilight-lavalink` is a client for [Lavalink] as part of the twilight
+[`twilight-lavalink`] is a client for [Lavalink] as part of the twilight
 ecosystem.
 
 It includes support for managing multiple nodes, a player manager for
@@ -97,7 +97,7 @@ providing models to deserialize their responses.
 
 ### `twilight-mention`
 
-`twilight-mention` is a utility crate for creating display formatters for
+[`twilight-mention`] is a utility crate for creating display formatters for
 various model types that format mentions. For example, it can create
 formatters for mentioning a channel or emoji, or pinging a role or user.
 
@@ -200,5 +200,7 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png
 [rust badge]: https://img.shields.io/badge/rust-1.40+%20(stable)-93450a.svg?style=flat-square
 [rust link]: https://github.com/rust-lang/rust/milestone/66
+[`twilight-lavalink`]: https://github.com/twilight-rs/twilight/tree/trunk/lavalink
+[`twilight-mention`]: https://github.com/twilight-rs/twilight/tree/trunk/utils/mention
 
 <!-- cargo-sync-readme end -->

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -85,13 +85,19 @@
 //!
 //! ### `twilight-lavalink`
 //!
-//! `twilight-lavalink` is a client for [Lavalink] as part of the twilight
+//! [`twilight-lavalink`] is a client for [Lavalink] as part of the twilight
 //! ecosystem.
 //!
 //! It includes support for managing multiple nodes, a player manager for
 //! conveniently using players to send events and retrieve information for each
 //! guild, and an HTTP module for creating requests using the [`http`] crate and
 //! providing models to deserialize their responses.
+//!
+//! ### `twilight-mention`
+//!
+//! [`twilight-mention`] is a utility crate for creating display formatters for
+//! various model types that format mentions. For example, it can create
+//! formatters for mentioning a channel or emoji, or pinging a role or user.
 //!
 //! ## Examples
 //!
@@ -192,6 +198,8 @@
 //! [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png
 //! [rust badge]: https://img.shields.io/badge/rust-1.40+%20(stable)-93450a.svg?style=flat-square
 //! [rust link]: https://github.com/rust-lang/rust/milestone/66
+//! [`twilight-lavalink`]: https://github.com/twilight-rs/twilight/tree/trunk/lavalink
+//! [`twilight-mention`]: https://github.com/twilight-rs/twilight/tree/trunk/utils/mention
 
 #[cfg(feature = "builders")]
 pub extern crate twilight_builders as builders;

--- a/utils/mention/Cargo.toml
+++ b/utils/mention/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+authors = ["Vivian Hellyer <vivian@hellyer.dev>"]
+description = "Utility crate for twilight-model to create mentions for resources."
+documentation = "https://twilight.cascadia.cafe/twilight_mention/index.html"
+edition = "2018"
+homepage = "https://github.com/twilight-rs/twilight"
+include = ["src/*.rs", "Cargo.toml", "README.md"]
+keywords = ["twilight"]
+license = "ISC"
+name = "twilight-mention"
+publish = false
+repository = "https://github.com/twilight-rs/twilight.git"
+readme = "README.md"
+version = "0.1.0"
+
+[dependencies]
+twilight-model = { default-features = false, path = "../../model" }

--- a/utils/mention/README.md
+++ b/utils/mention/README.md
@@ -1,0 +1,34 @@
+<!-- cargo-sync-readme start -->
+
+# twilight-mention
+
+`twilight-mention` is a utility crate for the Discord [`twilight-rs`]
+ecosystem to mention its model types.
+
+With this library, you can create mentions for various types, such as users,
+emojis, roles, members, or channels.
+
+## Installation
+
+Add the following to your `Cargo.toml`:
+
+```toml
+[dependencies]
+twilight-mention = { branch = "trunk", git = "https://github.com/twilight-rs/twilight" }
+```
+
+## Examples
+
+Create a mention formatter a user ID, and then format it in a message:
+
+```rust
+use twilight_mention::Mention;
+use twilight_model::id::UserId;
+
+let user_id = UserId(123);
+let message = format!("Hey there, {}!", user_id.mention());
+```
+
+[`twilight-rs`]: https://github.com/twilight-rs/twilight
+
+<!-- cargo-sync-readme end -->

--- a/utils/mention/src/lib.rs
+++ b/utils/mention/src/lib.rs
@@ -1,0 +1,378 @@
+//! # twilight-mention
+//!
+//! `twilight-mention` is a utility crate for the Discord [`twilight-rs`]
+//! ecosystem to mention its model types.
+//!
+//! With this library, you can create mentions for various types, such as users,
+//! emojis, roles, members, or channels.
+//!
+//! ## Installation
+//!
+//! Add the following to your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! twilight-mention = { branch = "main", git = "https://github.com/twilight-rs/twilight" }
+//! ```
+//!
+//! ## Examples
+//!
+//! Create a mention formatter a user ID, and then format it in a message:
+//!
+//! ```rust
+//! use twilight_mention::Mention;
+//! use twilight_model::id::UserId;
+//!
+//! let user_id = UserId(123);
+//! let message = format!("Hey there, {}!", user_id.mention());
+//! ```
+//!
+//! [`twilight-rs`]: https://github.com/twilight-rs/twilight
+
+#![deny(
+    clippy::all,
+    clippy::pedantic,
+    future_incompatible,
+    missing_docs,
+    nonstandard_style,
+    rust_2018_idioms,
+    unsafe_code,
+    unused,
+    warnings
+)]
+
+use std::fmt::{Display, Formatter, Result as FmtResult};
+use twilight_model::{
+    channel::{
+        CategoryChannel, Channel, Group, GuildChannel, PrivateChannel, TextChannel, VoiceChannel,
+    },
+    guild::{Emoji, Member, Role},
+    id::{ChannelId, EmojiId, RoleId, UserId},
+    user::{CurrentUser, User},
+};
+
+/// Formatter to mention a resource that implements `std::fmt::Display`.
+///
+/// # Examples
+///
+/// Mention a `UserId`:
+///
+/// ```rust
+/// use twilight_mention::Mention;
+/// use twilight_model::id::UserId;
+///
+/// assert_eq!("<@123>", UserId(123).mention().to_string());
+/// ```
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MentionFormat<T>(T);
+
+/// Mention a channel. This will format as `<#ID>`.
+impl Display for MentionFormat<ChannelId> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_fmt(format_args!("<#{}>", self.0))
+    }
+}
+
+/// Mention an emoji. This will format as `<:emoji:ID>`.
+impl Display for MentionFormat<EmojiId> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_fmt(format_args!("<:emoji:{}>", self.0))
+    }
+}
+
+/// Mention a role. This will format as `<@&ID>`.
+impl Display for MentionFormat<RoleId> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_fmt(format_args!("<@&{}>", self.0))
+    }
+}
+
+/// Mention a user. This will format as `<@ID>`.
+impl Display for MentionFormat<UserId> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_fmt(format_args!("<@{}>", self.0))
+    }
+}
+
+/// Mention a resource, such as an emoji or user.
+///
+/// This will create a mention that will link to a user if it exists.
+///
+/// Look at the implementations list to see what you can mention.
+///
+/// # Examples
+///
+/// Mention a `ChannelId`:
+///
+/// ```rust
+/// use twilight_mention::Mention;
+/// use twilight_model::id::ChannelId;
+///
+/// assert_eq!("<#123>", ChannelId(123).mention().to_string());
+/// ```
+pub trait Mention<T> {
+    /// Mention a resource by using its ID.
+    fn mention(&self) -> MentionFormat<T>;
+}
+
+/// Mention a channel ID. This will format as `<#ID>`.
+impl Mention<ChannelId> for ChannelId {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        MentionFormat(*self)
+    }
+}
+
+/// Mention a channel ID. This will format as `<#ID>`.
+impl Mention<ChannelId> for &'_ ChannelId {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        (*self).mention()
+    }
+}
+
+/// Mention a guild category channel. This will format as `<#ID>`.
+impl Mention<ChannelId> for CategoryChannel {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        MentionFormat(self.id)
+    }
+}
+
+/// Mention a guild category channel. This will format as `<#ID>`.
+impl Mention<ChannelId> for &'_ CategoryChannel {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        (*self).mention()
+    }
+}
+
+/// Mention a channel. This will format as `<#ID>`.
+impl Mention<ChannelId> for Channel {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        MentionFormat(match self {
+            Self::Group(group) => group.id,
+            Self::Guild(guild) => guild_channel_id(guild),
+            Self::Private(private) => private.id,
+        })
+    }
+}
+
+/// Mention a channel. This will format as `<#ID>`.
+impl Mention<ChannelId> for &'_ Channel {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        (*self).mention()
+    }
+}
+
+/// Mention the current user. This will format as `<@ID>`.
+impl Mention<UserId> for CurrentUser {
+    fn mention(&self) -> MentionFormat<UserId> {
+        MentionFormat(self.id)
+    }
+}
+
+/// Mention the current user. This will format as `<@ID>`.
+impl Mention<UserId> for &'_ CurrentUser {
+    fn mention(&self) -> MentionFormat<UserId> {
+        (*self).mention()
+    }
+}
+
+/// Mention an emoji. This will format as `<:emoji:ID>`.
+impl Mention<EmojiId> for EmojiId {
+    fn mention(&self) -> MentionFormat<EmojiId> {
+        MentionFormat(*self)
+    }
+}
+
+/// Mention an emoji. This will format as `<:emoji:ID>`.
+impl Mention<EmojiId> for &'_ EmojiId {
+    fn mention(&self) -> MentionFormat<EmojiId> {
+        (*self).mention()
+    }
+}
+
+/// Mention an emoji. This will format as `<:emoji:ID>`.
+impl Mention<EmojiId> for Emoji {
+    fn mention(&self) -> MentionFormat<EmojiId> {
+        MentionFormat(self.id)
+    }
+}
+
+/// Mention an emoji. This will format as `<:emoji:ID>`.
+impl Mention<EmojiId> for &'_ Emoji {
+    fn mention(&self) -> MentionFormat<EmojiId> {
+        (*self).mention()
+    }
+}
+
+/// Mention a group. This will format as `<#ID>`.
+impl Mention<ChannelId> for Group {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        MentionFormat(self.id)
+    }
+}
+
+/// Mention a group. This will format as `<#ID>`.
+impl Mention<ChannelId> for &'_ Group {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        (*self).mention()
+    }
+}
+
+/// Mention a guild channel. This will format as `<#ID>`.
+impl Mention<ChannelId> for GuildChannel {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        MentionFormat(guild_channel_id(self))
+    }
+}
+
+/// Mention a guild channel. This will format as `<#ID>`.
+impl Mention<ChannelId> for &'_ GuildChannel {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        (*self).mention()
+    }
+}
+
+/// Mention a member's user. This will format as `<@ID>`.
+impl Mention<UserId> for Member {
+    fn mention(&self) -> MentionFormat<UserId> {
+        MentionFormat(self.user.id)
+    }
+}
+
+/// Mention a member's user. This will format as `<@ID>`.
+impl Mention<UserId> for &'_ Member {
+    fn mention(&self) -> MentionFormat<UserId> {
+        (*self).mention()
+    }
+}
+
+/// Mention a private channel. This will format as `<#ID>`.
+impl Mention<ChannelId> for PrivateChannel {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        MentionFormat(self.id)
+    }
+}
+
+/// Mention a private channel. This will format as `<#ID>`.
+impl Mention<ChannelId> for &'_ PrivateChannel {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        (*self).mention()
+    }
+}
+
+/// Mention a role ID. This will format as `<@&ID>`.
+impl Mention<RoleId> for RoleId {
+    fn mention(&self) -> MentionFormat<RoleId> {
+        MentionFormat(*self)
+    }
+}
+
+/// Mention a role ID. This will format as `<@&ID>`.
+impl Mention<RoleId> for &'_ RoleId {
+    fn mention(&self) -> MentionFormat<RoleId> {
+        (*self).mention()
+    }
+}
+
+/// Mention a role ID. This will format as `<@&ID>`.
+impl Mention<RoleId> for Role {
+    fn mention(&self) -> MentionFormat<RoleId> {
+        MentionFormat(self.id)
+    }
+}
+
+/// Mention a role ID. This will format as `<@&ID>`.
+impl Mention<RoleId> for &'_ Role {
+    fn mention(&self) -> MentionFormat<RoleId> {
+        (*self).mention()
+    }
+}
+
+/// Mention a guild text channel. This will format as `<#ID>`.
+impl Mention<ChannelId> for TextChannel {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        MentionFormat(self.id)
+    }
+}
+
+/// Mention a guild text channel. This will format as `<#ID>`.
+impl Mention<ChannelId> for &'_ TextChannel {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        (*self).mention()
+    }
+}
+
+/// Mention a user ID. This will format as `<&ID>`.
+impl Mention<UserId> for UserId {
+    fn mention(&self) -> MentionFormat<UserId> {
+        MentionFormat(*self)
+    }
+}
+
+/// Mention a user ID. This will format as `<&ID>`.
+impl Mention<UserId> for &'_ UserId {
+    fn mention(&self) -> MentionFormat<UserId> {
+        (*self).mention()
+    }
+}
+
+/// Mention a user. This will format as `<&ID>`.
+impl Mention<UserId> for User {
+    fn mention(&self) -> MentionFormat<UserId> {
+        MentionFormat(self.id)
+    }
+}
+
+/// Mention a user. This will format as `<&ID>`.
+impl Mention<UserId> for &'_ User {
+    fn mention(&self) -> MentionFormat<UserId> {
+        (*self).mention()
+    }
+}
+
+/// Mention a guild voice channel. This will format as `<#ID>`.
+impl Mention<ChannelId> for VoiceChannel {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        MentionFormat(self.id)
+    }
+}
+
+/// Mention a guild voice channel. This will format as `<#ID>`.
+impl Mention<ChannelId> for &'_ VoiceChannel {
+    fn mention(&self) -> MentionFormat<ChannelId> {
+        (*self).mention()
+    }
+}
+
+fn guild_channel_id(channel: &GuildChannel) -> ChannelId {
+    match channel {
+        GuildChannel::Category(c) => c.id,
+        GuildChannel::Text(c) => c.id,
+        GuildChannel::Voice(c) => c.id,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Mention;
+    use twilight_model::id::{ChannelId, EmojiId, RoleId, UserId};
+
+    #[test]
+    fn test_mention_format_channel_id() {
+        assert_eq!("<#123>", ChannelId(123).mention().to_string());
+    }
+
+    #[test]
+    fn test_mention_format_emoji_id() {
+        assert_eq!("<:emoji:123>", EmojiId(123).mention().to_string());
+    }
+
+    #[test]
+    fn test_mention_format_role_id() {
+        assert_eq!("<@&123>", RoleId(123).mention().to_string());
+    }
+
+    #[test]
+    fn test_mention_format_user_id() {
+        assert_eq!("<@123>", UserId(123).mention().to_string());
+    }
+}

--- a/utils/mention/src/lib.rs
+++ b/utils/mention/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-mention = { branch = "main", git = "https://github.com/twilight-rs/twilight" }
+//! twilight-mention = { branch = "trunk", git = "https://github.com/twilight-rs/twilight" }
 //! ```
 //!
 //! ## Examples


### PR DESCRIPTION
Add a small utility crate named 'twilight-mention'. twilight-mention is a crate for creating display formatters that mention various `twilight-model` types.

It includes two types: a `Mention` trait and a `MentionFormat` struct. The Mention trait includes a `mention` method that will create a `MentionFormat` struct. The `MentionFormat` struct implements `std::fmt::Display` and will format a mention for the given resource.

Supported resources include things like channel IDs, guild channels, the current user, emojis and emoji IDs, roles, users.

Here's an example:

```rust
use twilight_mention::Mention;
use twilight_model::id::UserId;

let user_id = UserId(123);
let message = format!("Hey there, {}!", user_id.mention());
```

This crate isn't included as part of the main `twilight` crate and is listed in the readme as an additional, non-core crate. Instead of putting the crate at the project root, I put it in a new `utils` folder. This folder can be used for smaller utilities like these and makes them appear less important, since that was one of the concerns.

Project is being transferred from <https://github.com/rarity-rs/mention> because I consider it to be complete.