### PR TITLE
gateway: remove guild subscriptions

### DIFF
--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -202,18 +202,6 @@ impl ClusterConfigBuilder {
         self.0
     }
 
-    /// Whether to subscribe shards to "guild subscriptions", which are the
-    /// presence update and typing start events.
-    ///
-    /// Refer to the shard's [`ShardConfigBuilder::guild_subscriptions`] for more
-    /// information.
-    ///
-    /// [`ShardConfigBuilder::guild_subscriptions`]: ../../shard/config/struct.ShardConfigBuilder.html#method.guild_subscriptions
-    pub fn guild_subscriptions(mut self, guild_subscriptions: bool) -> Self {
-        self.1 = self.1.guild_subscriptions(guild_subscriptions);
-        self
-    }
-
     /// Sets the `twilight_http` Client used by the cluster and the shards it
     /// manages.
     ///

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -12,7 +12,6 @@ use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, GatewayI
 /// [`ShardConfig::builder`]: #method.builder
 #[derive(Clone, Debug)]
 pub struct ShardConfig {
-    guild_subscriptions: bool,
     http_client: HttpClient,
     intents: Option<GatewayIntents>,
     large_threshold: u64,
@@ -32,12 +31,6 @@ impl ShardConfig {
     /// [`ShardConfigBuilder::new`]: struct.ShardConfigBuilder.html#method.new
     pub fn builder(token: impl Into<String>) -> ShardConfigBuilder {
         ShardConfigBuilder::new(token)
-    }
-
-    /// Returns whether to subscribe to guilds' presence updates and typing
-    /// events.
-    pub fn guild_subscriptions(&self) -> bool {
-        self.guild_subscriptions
     }
 
     /// Returns the `twilight_http` client to be used by the shard.
@@ -107,7 +100,6 @@ impl ShardConfigBuilder {
         }
 
         Self(ShardConfig {
-            guild_subscriptions: true,
             http_client: HttpClient::new(token.clone()),
             intents: None,
             large_threshold: 250,
@@ -123,18 +115,6 @@ impl ShardConfigBuilder {
     /// Consumes the builder and returns the final configuration.
     pub fn build(self) -> ShardConfig {
         self.0
-    }
-
-    /// Whether to subscribe to guilds' presence updates and typing events.
-    ///
-    /// Many bots don't need these, so it would be beneficial to turn this off.
-    /// Presence updates alone account for about 85% of all event traffic.
-    ///
-    /// The default value is `true`.
-    pub fn guild_subscriptions(mut self, guild_subscriptions: bool) -> Self {
-        self.0.guild_subscriptions = guild_subscriptions;
-
-        self
     }
 
     /// The HTTP client to be used by the shard for getting gateway information.

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -196,7 +196,6 @@ impl ShardProcessor {
 
         let identify = Identify::new(IdentifyInfo {
             compression: false,
-            guild_subscriptions: true,
             intents,
             large_threshold: 250,
             properties: self.properties.clone(),

--- a/model/src/gateway/payload/identify.rs
+++ b/model/src/gateway/payload/identify.rs
@@ -20,7 +20,6 @@ impl Identify {
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct IdentifyInfo {
     pub compression: bool,
-    pub guild_subscriptions: bool,
     pub intents: Option<GatewayIntents>,
     pub large_threshold: u64,
     pub presence: Option<UpdateStatusInfo>,


### PR DESCRIPTION
Remove guild subscriptions from the gateway since it has been soft-deprecated-but-not-really in the API and in general superseded by intents:

<https://discord.com/developers/docs/topics/gateway#guild-subscriptions>

Closes #302.