### PR TITLE
Decrease some log levels in `socket_forwarder`

### DIFF
--- a/gateway/src/shard/processor/socket_forwarder.rs
+++ b/gateway/src/shard/processor/socket_forwarder.rs
@@ -47,7 +47,7 @@ impl SocketForwarder {
                     }
                 }
                 Either::Left((None, _)) => {
-                    info!("[SocketForwarder] Got None, closing stream");
+                    debug!("[SocketForwarder] Got None, closing stream");
                     let _ = self.stream.close(None).await;
 
                     break;
@@ -63,7 +63,7 @@ impl SocketForwarder {
                     break;
                 }
                 Either::Right((Ok(None), _)) => {
-                    info!("[SocketForwarder] Got None, closing tx");
+                    debug!("[SocketForwarder] Got None, closing tx");
                     self.tx.close_channel();
                     break;
                 }

--- a/gateway/src/shard/processor/socket_forwarder.rs
+++ b/gateway/src/shard/processor/socket_forwarder.rs
@@ -47,7 +47,7 @@ impl SocketForwarder {
                     }
                 }
                 Either::Left((None, _)) => {
-                    warn!("[SocketForwarder] Got None, closing stream");
+                    info!("[SocketForwarder] Got None, closing stream");
                     let _ = self.stream.close(None).await;
 
                     break;
@@ -63,7 +63,7 @@ impl SocketForwarder {
                     break;
                 }
                 Either::Right((Ok(None), _)) => {
-                    warn!("[SocketForwarder] Got None, closing tx");
+                    info!("[SocketForwarder] Got None, closing tx");
                     self.tx.close_channel();
                     break;
                 }
@@ -74,6 +74,6 @@ impl SocketForwarder {
                 }
             }
         }
-        warn!("[SocketForwarder] Leaving loop");
+        debug!("[SocketForwarder] Leaving loop");
     }
 }


### PR DESCRIPTION
These logs don't belong at the `warn` level since they are encountered during normal operation.

I changed the two inside the match to `info`, maybe they should also be `debug`? :thinking: