### PR TITLE
twilight/gateway: add features for rustls & native-tls

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.1.0"
 
 [dependencies]
 async-trait = { default-features = false, version = "0.1" }
+async-tungstenite = { default-features = false, features = ["tokio-runtime", "tokio-native-tls"], version = "0.7" }
 bitflags = { default-features = false, version = "1" }
 twilight-http = { path = "../http" }
 twilight-model = { default-features = false, path = "../model" }
@@ -25,7 +26,6 @@ serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, optional = true, version = "1" }
 simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.3" }
 tokio = { default-features = false, features = ["net", "rt-core", "sync"], version = "0.2" }
-tokio-tungstenite = { default-features = false, features = ["connect", "tls"], version = "0.10" }
 url = { default-features = false, version = "2" }
 # The default backend for flate2; miniz-oxide, works differently
 # from the C-backed backend zlib, When you give it the sync argument

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -14,9 +14,9 @@ version = "0.1.0"
 
 [dependencies]
 async-trait = { default-features = false, version = "0.1" }
-async-tungstenite = { default-features = false, features = ["tokio-runtime", "tokio-native-tls"], version = "0.7" }
+async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.7" }
 bitflags = { default-features = false, version = "1" }
-twilight-http = { path = "../http" }
+twilight-http = { default-features = false, features = ["serde_json"], path = "../http" }
 twilight-model = { default-features = false, path = "../model" }
 futures-channel = { default-features = false, features = ["sink"], version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
@@ -42,4 +42,6 @@ futures = { default-features = false, version = "0.3" }
 tokio = { default-features = false, features = ["rt-core", "macros"], version = "0.2" }
 
 [features]
-default = ["serde_json"]
+default = ["native", "serde_json"]
+native = ["twilight-http/native", "async-tungstenite/tokio-native-tls"]
+rustls = ["twilight-http/rustls", "async-tungstenite/async-tls"]

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -77,3 +77,6 @@ pub(crate) use simd_json::to_vec as json_to_vec;
 pub(crate) use serde_json::to_string as json_to_string;
 #[cfg(feature = "simd-json")]
 pub(crate) use simd_json::to_string as json_to_string;
+
+#[cfg(not(any(feature = "native", feature = "rustls")))]
+compile_error!("Either the `native` or `rustls` feature must be enabled");

--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -7,13 +7,13 @@ use serde_json::Error as JsonError;
 #[cfg(feature = "simd-json")]
 use simd_json::Error as JsonError;
 
+use async_tungstenite::tungstenite::{Error as TungsteniteError, Message as TungsteniteMessage};
 use std::{
     error::Error as StdError,
     fmt::{Display, Formatter, Result as FmtResult},
     result::Result as StdResult,
     str::Utf8Error,
 };
-use tokio_tungstenite::tungstenite::{Error as TungsteniteError, Message as TungsteniteMessage};
 use twilight_http::Error as HttpError;
 use twilight_model::gateway::GatewayIntents;
 use url::ParseError;

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -18,9 +18,9 @@ use std::sync::Arc;
 use tokio::sync::watch::Receiver as WatchReceiver;
 use tracing::debug;
 
+use async_tungstenite::tungstenite::protocol::{frame::coding::CloseCode, CloseFrame};
+use async_tungstenite::tungstenite::Message;
 use std::borrow::Cow;
-use tokio_tungstenite::tungstenite::protocol::{frame::coding::CloseCode, CloseFrame};
-use tokio_tungstenite::tungstenite::Message;
 use twilight_model::gateway::event::Event;
 
 /// Information about a shard, including its latency, current session sequence,

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -40,7 +40,7 @@ pub use self::{
     stage::Stage,
 };
 
-use tokio::net::TcpStream;
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+use async_tungstenite::tokio::ConnectStream;
+use async_tungstenite::WebSocketStream;
 
-type ShardStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+type ShardStream = WebSocketStream<ConnectStream>;

--- a/gateway/src/shard/processor/connect.rs
+++ b/gateway/src/shard/processor/connect.rs
@@ -1,21 +1,16 @@
 use super::super::error::{Error, Result};
-use std::str::FromStr;
-use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tracing::debug;
 use url::Url;
 
 use super::super::ShardStream;
 
 pub async fn connect(url: &str) -> Result<ShardStream> {
-    let url = Url::from_str(url).map_err(|source| Error::ParsingUrl {
+    let url = Url::parse(url).map_err(|source| Error::ParsingUrl {
         source,
         url: url.to_owned(),
     })?;
 
-    let request = url
-        .into_client_request()
-        .map_err(|source| Error::Connecting { source })?;
-    let (stream, _) = tokio_tungstenite::connect_async(request)
+    let (stream, _) = async_tungstenite::tokio::connect_async(url)
         .await
         .map_err(|source| Error::Connecting { source })?;
 

--- a/gateway/src/shard/processor/heartbeat.rs
+++ b/gateway/src/shard/processor/heartbeat.rs
@@ -1,4 +1,5 @@
 use super::super::error::{Error, Result};
+use async_tungstenite::tungstenite::Message as TungsteniteMessage;
 use futures_channel::mpsc::UnboundedSender;
 use futures_util::lock::Mutex;
 use std::{
@@ -10,7 +11,6 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
 use tracing::{debug, error, warn};
 use twilight_model::gateway::payload::Heartbeat;
 

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -22,16 +22,16 @@ use twilight_model::gateway::{
     },
 };
 
+use async_tungstenite::tungstenite::{
+    protocol::{frame::coding::CloseCode, CloseFrame},
+    Message,
+};
 use futures_channel::mpsc::UnboundedReceiver;
 use futures_util::stream::StreamExt;
 use serde::Serialize;
 use std::{env::consts::OS, ops::Deref, str, sync::Arc};
 use tokio::sync::watch::{
     channel as watch_channel, Receiver as WatchReceiver, Sender as WatchSender,
-};
-use tokio_tungstenite::tungstenite::{
-    protocol::{frame::coding::CloseCode, CloseFrame},
-    Message,
 };
 #[allow(unused_imports)]
 use tracing::{debug, info, trace, warn};

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -20,9 +20,9 @@ use std::{
 };
 use twilight_model::gateway::payload::Heartbeat;
 
+use async_tungstenite::tungstenite::{protocol::CloseFrame, Message as TungsteniteMessage};
 use std::time::Duration;
 use tokio::time::{interval, Interval};
-use tokio_tungstenite::tungstenite::{protocol::CloseFrame, Message as TungsteniteMessage};
 
 #[derive(Debug)]
 pub struct Session {

--- a/gateway/src/shard/processor/socket_forwarder.rs
+++ b/gateway/src/shard/processor/socket_forwarder.rs
@@ -1,4 +1,5 @@
 use super::super::ShardStream;
+use async_tungstenite::tungstenite::Message;
 use futures_channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use futures_util::{
     future::{self, Either},
@@ -6,7 +7,6 @@ use futures_util::{
     stream::StreamExt,
 };
 use tokio::time::timeout;
-use tokio_tungstenite::tungstenite::Message;
 #[allow(unused_imports)]
 use tracing::{debug, info, trace, warn};
 

--- a/gateway/src/shard/sink.rs
+++ b/gateway/src/shard/sink.rs
@@ -1,10 +1,10 @@
+use async_tungstenite::tungstenite::Message;
 use futures_channel::mpsc::{SendError, TrySendError, UnboundedSender};
 use futures_util::sink::Sink;
 use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio_tungstenite::tungstenite::Message;
 
 /// A sink which tungstenite messages can be sunk into. ⚓
 ///

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -120,3 +120,6 @@ pub(crate) fn json_from_slice<'a, T: serde::de::Deserialize<'a>>(s: &'a mut [u8]
 pub(crate) use serde_json::to_vec as json_to_vec;
 #[cfg(feature = "simd-json")]
 pub(crate) use simd_json::to_vec as json_to_vec;
+
+#[cfg(not(any(feature = "native", feature = "rustls")))]
+compile_error!("Either the `native` or `rustls` feature must be enabled.");

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.1.0"
 
 [dependencies]
-async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.5" }
+async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.7" }
 dashmap = { default-features = false, version = "3" }
 futures-channel = { default-features = false, features = ["std"], version = "0.3" }
 futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }

--- a/twilight/Cargo.toml
+++ b/twilight/Cargo.toml
@@ -16,8 +16,8 @@ version = "0.1.0"
 twilight-builders = { optional = true, path = "../builders" }
 twilight-cache = { optional = true, path = "../cache/base" }
 twilight-command-parser = { optional = true, path = "../command-parser" }
-twilight-gateway = { optional = true, path = "../gateway" }
-twilight-http = { optional = true, path = "../http" }
+twilight-gateway = { default-features = false, features = ["serde_json"], optional = true, path = "../gateway" }
+twilight-http = { default-features = false, features = ["serde_json"], optional = true, path = "../http" }
 twilight-model = { optional = true, path = "../model" }
 twilight-standby = { optional = true, path = "../standby" }
 
@@ -25,7 +25,7 @@ twilight-standby = { optional = true, path = "../standby" }
 tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }
 
 [features]
-default = ["all"]
+default = ["all", "native"]
 
 all = ["builders", "cache", "command-parser", "gateway", "http", "model", "standby"]
 builders = ["twilight-builders"]
@@ -36,6 +36,8 @@ http = ["twilight-http"]
 model = ["twilight-model"]
 standby = ["twilight-standby"]
 simd-json = ["twilight-gateway/simd-json", "twilight-http/simd-json"]
+native = ["twilight-gateway/native", "twilight-http/native"]
+rustls = ["twilight-gateway/rustls", "twilight-http/rustls"]
 
 metrics = ["gateway-metrics"]
 gateway-metrics = ["gateway", "twilight-gateway/metrics"]


### PR DESCRIPTION
This PR adds new features for `twilight` & `twilight-gateway` to switch between `rustls` and `native-tls`.

It also switches to `async-tungstenite`.
Closes: #309 
Closes: #124 