### PR TITLE
gateway: separate shard processor errors

### DIFF
--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -1,6 +1,5 @@
 //! The error type of why errors occur in the shard module.
 
-use flate2::DecompressError;
 use futures_channel::mpsc::TrySendError;
 #[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
 use serde_json::Error as JsonError;
@@ -12,11 +11,10 @@ use std::{
     error::Error as StdError,
     fmt::{Display, Formatter, Result as FmtResult},
     result::Result as StdResult,
-    str::Utf8Error,
 };
 use twilight_http::Error as HttpError;
-use twilight_model::gateway::GatewayIntents;
-use url::ParseError;
+
+use super::processor::Error as ProcessorError;
 
 /// A result enum with the error type being the shard's [`Error`] type.
 ///
@@ -27,8 +25,11 @@ pub type Result<T, E = Error> = StdResult<T, E>;
 /// shard.
 #[derive(Debug)]
 pub enum Error {
-    /// The provided authorization token is invalid.
-    AuthorizationInvalid { shard_id: u64, token: String },
+    /// An error happened while creating a shard processor.
+    Processor {
+        /// The error from the shard processor.
+        source: ProcessorError,
+    },
     /// An error happened while trying to connect to the gateway.
     Connecting {
         /// The error from the WebSocket client.
@@ -46,47 +47,10 @@ pub enum Error {
         /// The total number of shards in use.
         total: u64,
     },
-    /// The current user isn't allowed to use at least one of the configured
-    /// intents.
-    ///
-    /// The intents are provided.
-    IntentsDisallowed {
-        /// The configured intents for the shard.
-        intents: Option<GatewayIntents>,
-        /// The ID of the shard.
-        shard_id: u64,
-    },
-    /// The configured intents aren't supported by Discord's gateway.
-    ///
-    /// The intents are provided.
-    IntentsInvalid {
-        /// The configured intents for the shard.
-        intents: Option<GatewayIntents>,
-        /// The ID of the shard.
-        shard_id: u64,
-    },
     /// The "large threshold" value was too large or too small.
     LargeThresholdInvalid {
         /// The value that is invalid.
         value: u64,
-    },
-    /// Parsing the URL to connect to the gateway failed due to an invalid URL.
-    ParsingUrl {
-        /// The reason for the parse failing.
-        source: ParseError,
-        /// The URL that couldn't be parsed.
-        url: String,
-    },
-    /// The payload received from Discord was an invalid structure.
-    ///
-    /// The payload was either invalid JSON or did not contain the necessary
-    /// "op" key in the object.
-    PayloadInvalid,
-    /// The binary payload received from Discord wasn't validly encoded as
-    /// UTF-8.
-    PayloadNotUtf8 {
-        /// Source error when converting to a UTF-8 valid string.
-        source: Utf8Error,
     },
     /// There was an error serializing or deserializing a payload.
     PayloadSerialization {
@@ -101,44 +65,22 @@ pub enum Error {
     },
     /// The shard hasn't been started, so there is no active session.
     Stopped,
-    /// There was a error decompressing a frame from discord.
-    Decompressing { source: DecompressError },
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::AuthorizationInvalid { shard_id, .. } => write!(
-                f,
-                "The authorization token for shard {} is invalid",
-                shard_id
-            ),
+            Self::Processor { .. } => f.write_str("An issue occured creating a shard processor"),
             Self::Connecting { .. } => f.write_str("An issue occurred connecting to the gateway"),
             Self::GettingGatewayUrl { .. } => f.write_str("Getting the gateway URL failed"),
             Self::IdTooLarge { id, total } => {
                 write!(f, "The shard ID {} is larger than the total, {}", id, total)
             }
-            Self::IntentsDisallowed { intents, shard_id } => write!(
-                f,
-                "At least one of the intents ({:?}) for shard {} are disallowed",
-                intents, shard_id
-            ),
-            Self::IntentsInvalid { intents, shard_id } => write!(
-                f,
-                "At least one of the intents ({:?}) for shard {} are invalid",
-                intents, shard_id
-            ),
             Self::LargeThresholdInvalid { value } => write!(
                 f,
                 "The large threshold given, {}, is not in the accepted range",
                 value
             ),
-            Self::ParsingUrl { url, .. } => write!(f, "The gateway URL {:?} is invalid", url),
-            Self::PayloadInvalid { .. } => write!(
-                f,
-                "The payload received from Discord contained an invalid data structure"
-            ),
-            Self::PayloadNotUtf8 { .. } => write!(f, "The payload from Discord wasn't UTF-8 valid"),
             Self::PayloadSerialization { .. } => {
                 f.write_str("Deserializing or serializing a payload failed")
             }
@@ -146,7 +88,6 @@ impl Display for Error {
                 f.write_str("The message couldn't be sent because the receiver half dropped")
             }
             Self::Stopped { .. } => f.write_str("the shard hasn't been started yet"),
-            Self::Decompressing { .. } => f.write_str("A frame could not be decompressed"),
         }
     }
 }
@@ -154,20 +95,14 @@ impl Display for Error {
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
+            Self::Processor { source } => Some(source),
             Self::Connecting { source } => Some(source),
             Self::GettingGatewayUrl { source } => Some(source),
-            Self::ParsingUrl { source, .. } => Some(source),
-            Self::PayloadNotUtf8 { source } => Some(source),
             Self::PayloadSerialization { source } => Some(source),
             Self::SendingMessage { source } => Some(source),
-            Self::Decompressing { source } => Some(source),
-            Self::AuthorizationInvalid { .. }
-            | Self::IdTooLarge { .. }
-            | Self::IntentsDisallowed { .. }
-            | Self::IntentsInvalid { .. }
-            | Self::LargeThresholdInvalid { .. }
-            | Self::PayloadInvalid { .. }
-            | Self::Stopped { .. } => None,
+            Self::IdTooLarge { .. } | Self::LargeThresholdInvalid { .. } | Self::Stopped { .. } => {
+                None
+            }
         }
     }
 }

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -147,9 +147,11 @@ impl Shard {
             .map_err(|source| Error::GettingGatewayUrl { source })?
             .url;
 
+        let config = Arc::clone(&self.0.config);
         let listeners = self.0.listeners.clone();
-        let (processor, wrx) =
-            ShardProcessor::new(Arc::clone(&self.0.config), url, listeners).await?;
+        let (processor, wrx) = ShardProcessor::new(config, url, listeners)
+            .await
+            .map_err(|source| Error::Processor { source })?;
         let (fut, handle) = future::abortable(processor.run());
 
         tokio::spawn(async move {

--- a/gateway/src/shard/processor/connect.rs
+++ b/gateway/src/shard/processor/connect.rs
@@ -1,4 +1,4 @@
-use super::super::error::{Error, Result};
+use super::error::{Error, Result};
 use tracing::debug;
 use url::Url;
 

--- a/gateway/src/shard/processor/error.rs
+++ b/gateway/src/shard/processor/error.rs
@@ -1,0 +1,136 @@
+//! The error type of why errors occur in the shard processor module.
+
+use std::fmt;
+use std::str::Utf8Error;
+
+use flate2::DecompressError;
+use futures_channel::mpsc::TrySendError;
+#[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
+use serde_json::Error as JsonError;
+#[cfg(feature = "simd-json")]
+use simd_json::Error as JsonError;
+use url::ParseError;
+
+use async_tungstenite::tungstenite::{Error as TungsteniteError, Message as TungsteniteMessage};
+use twilight_model::gateway::GatewayIntents;
+
+/// A result enum with the error type being the shard processor's [`Error`] type.
+///
+/// [`Error`]: enum.Error.html
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Error type representing the possible reasons for errors to occur in the
+/// shard processor.
+#[derive(Debug)]
+pub enum Error {
+    /// The provided authorization token is invalid.
+    AuthorizationInvalid { shard_id: u64, token: String },
+    /// An error happened while trying to connect to the gateway.
+    Connecting {
+        /// The error from the WebSocket client.
+        source: TungsteniteError,
+    },
+    /// The current user isn't allowed to use at least one of the configured
+    /// intents.
+    ///
+    /// The intents are provided.
+    IntentsDisallowed {
+        /// The configured intents for the shard.
+        intents: Option<GatewayIntents>,
+        /// The ID of the shard.
+        shard_id: u64,
+    },
+    /// The configured intents aren't supported by Discord's gateway.
+    ///
+    /// The intents are provided.
+    IntentsInvalid {
+        /// The configured intents for the shard.
+        intents: Option<GatewayIntents>,
+        /// The ID of the shard.
+        shard_id: u64,
+    },
+    /// Parsing the URL to connect to the gateway failed due to an invalid URL.
+    ParsingUrl {
+        /// The reason for the parse failing.
+        source: ParseError,
+        /// The URL that couldn't be parsed.
+        url: String,
+    },
+    /// The payload received from Discord was an invalid structure.
+    ///
+    /// The payload was either invalid JSON or did not contain the necessary
+    /// "op" key in the object.
+    PayloadInvalid,
+    /// The binary payload received from Discord wasn't validly encoded as
+    /// UTF-8.
+    PayloadNotUtf8 {
+        /// Source error when converting to a UTF-8 valid string.
+        source: Utf8Error,
+    },
+    /// There was an error serializing or deserializing a payload.
+    PayloadSerialization {
+        /// The serialization error.
+        source: JsonError,
+    },
+    /// A message tried to be sent but the receiving half was dropped. This
+    /// typically means that the shard is shutdown.
+    SendingMessage {
+        /// The reason for the error.
+        source: TrySendError<TungsteniteMessage>,
+    },
+    /// There was a error decompressing a frame from discord.
+    Decompressing { source: DecompressError },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AuthorizationInvalid { shard_id, .. } => write!(
+                f,
+                "The authorization token for shard {} is invalid",
+                shard_id
+            ),
+            Self::Connecting { .. } => f.write_str("An issue occurred connecting to the gateway"),
+            Self::IntentsDisallowed { intents, shard_id } => write!(
+                f,
+                "At least one of the intents ({:?}) for shard {} are disallowed",
+                intents, shard_id
+            ),
+            Self::IntentsInvalid { intents, shard_id } => write!(
+                f,
+                "At least one of the intents ({:?}) for shard {} are invalid",
+                intents, shard_id
+            ),
+            Self::ParsingUrl { url, .. } => write!(f, "The gateway URL {:?} is invalid", url),
+            Self::PayloadInvalid { .. } => write!(
+                f,
+                "The payload received from Discord contained an invalid data structure"
+            ),
+            Self::PayloadNotUtf8 { .. } => write!(f, "The payload from Discord wasn't UTF-8 valid"),
+            Self::PayloadSerialization { .. } => {
+                f.write_str("Deserializing or serializing a payload failed")
+            }
+            Self::SendingMessage { .. } => {
+                f.write_str("The message couldn't be sent because the receiver half dropped")
+            }
+            Self::Decompressing { .. } => f.write_str("A frame could not be decompressed"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Connecting { source } => Some(source),
+            Self::ParsingUrl { source, .. } => Some(source),
+            Self::PayloadNotUtf8 { source } => Some(source),
+            Self::PayloadSerialization { source } => Some(source),
+            Self::SendingMessage { source } => Some(source),
+            Self::Decompressing { source } => Some(source),
+            Self::AuthorizationInvalid { .. }
+            | Self::IntentsDisallowed { .. }
+            | Self::IntentsInvalid { .. }
+            | Self::PayloadInvalid { .. } => None,
+        }
+    }
+}

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -1,10 +1,7 @@
 use super::{
-    super::{
-        config::ShardConfig,
-        error::{Error, Result},
-        stage::Stage,
-    },
+    super::{config::ShardConfig, stage::Stage},
     connect, emit,
+    error::{Error, Result},
     inflater::Inflater,
     session::Session,
     socket_forwarder::SocketForwarder,

--- a/gateway/src/shard/processor/mod.rs
+++ b/gateway/src/shard/processor/mod.rs
@@ -2,9 +2,11 @@ pub mod heartbeat;
 
 mod connect;
 mod emit;
+mod error;
 mod r#impl;
 mod inflater;
 mod session;
 mod socket_forwarder;
 
 pub use self::{heartbeat::Latency, r#impl::ShardProcessor, session::Session};
+pub use error::{Error, Result};

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -1,8 +1,6 @@
 use super::{
-    super::{
-        error::{Error, Result},
-        stage::Stage,
-    },
+    super::stage::Stage,
+    error::{Error, Result},
     heartbeat::{Heartbeater, Heartbeats},
 };
 use futures_channel::mpsc::UnboundedSender;


### PR DESCRIPTION
I moved/copied the error variants used by the `processor` module to its own error type and created a `Error::Processor` variant in the shard error.
