### PR TITLE
Fix doc links and add build job to check the documentation

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,13 +1,22 @@
-name: Sync Documentation
+name: Check Documentation
 
-on:
-  push:
-  pull_request:
-    paths:
-      - '**/lib.rs'
-      - '**/README.md'
+on: [push, pull_request]
 
 jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        profile: minimal
+        override: true
+    - name: Build docs
+      env:
+        RUSTDOCFLAGS: -D intra_doc_link_resolution_failure
+      run: cargo doc --no-deps
+
   sync-readme:
     runs-on: ubuntu-latest
     steps:

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -38,5 +38,6 @@ twilight-gateway = { branch = "trunk", default-features = false, features = ["si
 ```
 
 [simd-json]: https://github.com/simd-lite/simd-json
+[docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 
 <!-- cargo-sync-readme end -->

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -36,6 +36,7 @@
 //! ```
 //!
 //! [simd-json]: https://github.com/simd-lite/simd-json
+//! [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 
 #![deny(
     clippy::all,

--- a/gateway/src/shard/event.rs
+++ b/gateway/src/shard/event.rs
@@ -11,6 +11,7 @@
 //! [`Shard::some_events`].
 //!
 //! [`Event`]: enum.Event.html
+//! [`EventType`]: ../struct.EventType.html
 //! [`Shard::some_events`]: ../struct.Shard.html#method.some_events
 
 use crate::EventTypeFlags;

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -6,9 +6,10 @@
 //! the active audio.
 //!
 //! [`PlayerManager`]: struct.PlayerManager.html
-/// [players]: struct.Player.html
-/// [send events]: struct.Player.html#method.send
-/// [read the position]: struct.Player.html#method.position
+//! [players]: struct.Player.html
+//! [send events]: struct.Player.html#method.send
+//! [read the position]: struct.Player.html#method.position
+
 use crate::{model::*, node::Node};
 use dashmap::{
     mapref::one::{Ref, RefMut},


### PR DESCRIPTION
The PR fixes unresolved doc links and adds a build job to check the documentation on rust nightly with denied
`intra_doc_link_resolution_failure` warnings.

Related: #202 

What about the use of [intra-doc links][intra-rustdoc-links] instead of urls to the rendered files?

[intra-rustdoc-links]: https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md