### PR TITLE
project: add rusty-hook

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,0 +1,5 @@
+[hooks]
+pre-commit = "cargo fmt -- --check && cargo clippy --all && cargo test"
+
+[logging]
+verbose = true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,11 @@
+# Development
+
+## Making a commit
+
+Before working on the project, be sure to run `cargo test` at least once from
+the workspace root. This will install [`rusty-hook`], which will add some git
+hooks. One of these will be a pre-commit hook, which will run tests, clippy, and
+rustfmt before allowing you to commit. This will help make sure pull requests
+usually build successfully the first time around.
+
+[`rusty-hook`]: https://github.com/swellaby/rusty-hook

--- a/twilight/Cargo.toml
+++ b/twilight/Cargo.toml
@@ -22,6 +22,7 @@ twilight-model = { optional = true, path = "../model" }
 twilight-standby = { optional = true, path = "../standby" }
 
 [dev-dependencies]
+rusty-hook = { default-features = false, version = "0.11" }
 tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }
 
 [features]


### PR DESCRIPTION
Add [`rusty-hook`] to the development dependencies of the main `twilight` crate. When `cargo test` is first run, it will automatically add a pre-commit hook. This patch configures the pre-commit hook to run cargo fmt, cargo clippy, and then cargo test.

This will help ensure that (probably) properly building PRs are pushed the on every PR commit and reduce iteration.

[`rusty-hook`]: https://crates.io/crates/rusty-hook