### PR TITLE
actions: publish docs to gh-pages branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Deploy documentation
+
+on:
+  push:
+    branches:
+      - trunk
+
+jobs:
+  deploy-docs:
+    name: Deploy docs to gh-pages
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        profile: minimal
+        override: true
+
+    - name: Build docs
+      env:
+        RUSTDOCFLAGS: -D intra_doc_link_resolution_failure
+      run: |
+        exclude_examples=($(grep -h '^name' **/examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
+        cargo doc --workspace --no-deps "${exclude_examples[@]}"
+
+    - name: Prepare docs
+      run: |
+        echo '<meta http-equiv="refresh" content="0;url=twilight/index.html">' > target/doc/index.html
+
+    - name: Deploy docs
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_branch: gh-pages
+        publish_dir: target/doc
+        allow_empty_commit: true


### PR DESCRIPTION
Adds a new workflow to publish the `trunk` docs to the `gh-pages` branch.
See the [build job] and the [deployed docs].

But it needs some additional work for the first deployment when using `GITHUB_TOKEN`.

There two ways to go:
1. Merge PR and the workflow creates the `gh-pages` branch with the docs.
2. Go to Settings and select the `gh-pages` branch again to enable the GitHub Pages.
3. Re-run the workflow build job / Wait for the next commit

Or

1. Create the `gh-pages` branch with a `.nojekyll` file.
2. Go to Settings and select the `gh-pages` branch to enable the GitHub Pages.
3. Merge PR and the workflow creates the docs.

[build job]: https://github.com/nickelc/twilight/runs/883542757?check_suite_focus=true
[deployed docs]: https://nickelc.github.io/twilight/