### PR TITLE
http: take cows for requests 🐮

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -18,6 +18,7 @@ use bytes::Bytes;
 use reqwest::{header::HeaderValue, Body, Client as ReqwestClient, Response, StatusCode};
 use serde::de::DeserializeOwned;
 use std::{
+    borrow::Cow,
     convert::TryFrom,
     fmt::{Debug, Formatter, Result as FmtResult},
     result::Result as StdResult,
@@ -489,11 +490,11 @@ impl Client {
     }
 
     /// Changes the user's nickname in a guild.
-    pub fn update_current_user_nick(
-        &self,
+    pub fn update_current_user_nick<'a>(
+        &'a self,
         guild_id: GuildId,
-        nick: impl Into<String>,
-    ) -> UpdateCurrentUserNick<'_> {
+        nick: impl Into<Cow<'a, str>>,
+    ) -> UpdateCurrentUserNick<'a> {
         UpdateCurrentUserNick::new(self, guild_id, nick)
     }
 
@@ -556,12 +557,12 @@ impl Client {
     /// discord docs] for more information about image data.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn create_emoji(
-        &self,
+    pub fn create_emoji<'a>(
+        &'a self,
         guild_id: GuildId,
-        name: impl Into<String>,
-        image: impl Into<String>,
-    ) -> CreateEmoji<'_> {
+        name: impl Into<Cow<'a, str>>,
+        image: impl Into<Cow<'a, str>>,
+    ) -> CreateEmoji<'a> {
         CreateEmoji::new(self, guild_id, name, image)
     }
 
@@ -628,10 +629,10 @@ impl Client {
     /// Returns [`CreateGuildError::NameInvalid`] if the name length is too short or too long.
     ///
     /// [`CreateGuildError::NameInvalid`]: ../request/guild/enum.CreateGuildError.html#variant.NameInvalid
-    pub fn create_guild(
-        &self,
-        name: impl Into<String>,
-    ) -> StdResult<CreateGuild<'_>, CreateGuildError> {
+    pub fn create_guild<'a>(
+        &'a self,
+        name: impl Into<Cow<'a, str>>,
+    ) -> StdResult<CreateGuild<'a>, CreateGuildError> {
         CreateGuild::new(self, name)
     }
 
@@ -679,11 +680,11 @@ impl Client {
     /// [`CreateGuildChannelError::NameInvalid`]: ../request/guild/create_guild_channel/enum.CreateGuildChannelError.html#variant.NameInvalid
     /// [`CreateGuildChannelError::RateLimitPerUserInvalid`]: ../request/guild/create_guild_channel/enum.CreateGuildChannelError.html#variant.RateLimitPerUserInvalid
     /// [`CreateGuildChannelError::TopicInvalid`]: ../request/guild/create_guild_channel/enum.CreateGuildChannelError.html#variant.TopicInvalid
-    pub fn create_guild_channel(
-        &self,
+    pub fn create_guild_channel<'a>(
+        &'a self,
         guild_id: GuildId,
-        name: impl Into<String>,
-    ) -> StdResult<CreateGuildChannel<'_>, CreateGuildChannelError> {
+        name: impl Into<Cow<'a, str>>,
+    ) -> StdResult<CreateGuildChannel<'a>, CreateGuildChannelError> {
         CreateGuildChannel::new(self, guild_id, name)
     }
 
@@ -722,12 +723,12 @@ impl Client {
     /// Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#create-guild-integration
-    pub fn create_guild_integration(
-        &self,
+    pub fn create_guild_integration<'a>(
+        &'a self,
         guild_id: GuildId,
         integration_id: IntegrationId,
-        kind: impl Into<String>,
-    ) -> CreateGuildIntegration<'_> {
+        kind: impl Into<Cow<'a, str>>,
+    ) -> CreateGuildIntegration<'a> {
         CreateGuildIntegration::new(self, guild_id, integration_id, kind)
     }
 
@@ -903,7 +904,7 @@ impl Client {
     /// ```
     ///
     /// [`with_counts`]: ../request/channel/invite/struct.GetInvite.html#method.with_counts
-    pub fn invite(&self, code: impl Into<String>) -> GetInvite<'_> {
+    pub fn invite<'a>(&'a self, code: impl Into<Cow<'a, str>>) -> GetInvite<'a> {
         GetInvite::new(self, code)
     }
 
@@ -931,7 +932,7 @@ impl Client {
     }
 
     /// Delete an invite by its code.
-    pub fn delete_invite(&self, code: impl Into<String>) -> DeleteInvite<'_> {
+    pub fn delete_invite<'a>(&'a self, code: impl Into<Cow<'a, str>>) -> DeleteInvite<'a> {
         DeleteInvite::new(self, code)
     }
 
@@ -1004,11 +1005,11 @@ impl Client {
     /// [`ChannelId`]: ../../twilight_model/id/struct.ChannelId.html
     /// [`MessageId`]: ../../twilight_model/id/struct.MessageId.html
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#bulk-delete-messages
-    pub fn delete_messages(
-        &self,
+    pub fn delete_messages<'a>(
+        &'a self,
         channel_id: ChannelId,
-        message_ids: impl Into<Vec<MessageId>>,
-    ) -> DeleteMessages<'_> {
+        message_ids: impl Into<Cow<'a, [MessageId]>>,
+    ) -> DeleteMessages<'a> {
         DeleteMessages::new(self, channel_id, message_ids)
     }
 
@@ -1030,7 +1031,7 @@ impl Client {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     /// let client = Client::new("my token");
     /// client.update_message(ChannelId(1), MessageId(2))
-    ///     .content("test update".to_owned())?
+    ///     .content(Some("test update".into()))?
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -1080,12 +1081,12 @@ impl Client {
     ///
     /// This endpoint is limited to 100 users maximum, so if a message has more than 100 reactions,
     /// requests must be chained until all reactions are retireved.
-    pub fn reactions(
-        &self,
+    pub fn reactions<'a>(
+        &'a self,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: impl Into<String>,
-    ) -> GetReactions<'_> {
+        emoji: impl Into<Cow<'a, str>>,
+    ) -> GetReactions<'a> {
         GetReactions::new(self, channel_id, message_id, emoji)
     }
 
@@ -1220,11 +1221,11 @@ impl Client {
     /// Modify the position of the roles.
     ///
     /// The minimum amount of roles to modify, is a swap between two roles.
-    pub fn update_role_positions(
-        &self,
+    pub fn update_role_positions<'a>(
+        &'a self,
         guild_id: GuildId,
-        roles: impl Iterator<Item = (RoleId, u64)>,
-    ) -> UpdateRolePositions<'_> {
+        roles: impl Into<Cow<'a, [(RoleId, u64)]>>,
+    ) -> UpdateRolePositions<'a> {
         UpdateRolePositions::new(self, guild_id, roles)
     }
 
@@ -1261,11 +1262,11 @@ impl Client {
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn create_webhook(
-        &self,
+    pub fn create_webhook<'a>(
+        &'a self,
         channel_id: ChannelId,
-        name: impl Into<String>,
-    ) -> CreateWebhook<'_> {
+        name: impl Into<Cow<'a, str>>,
+    ) -> CreateWebhook<'a> {
         CreateWebhook::new(self, channel_id, name)
     }
 
@@ -1281,7 +1282,7 @@ impl Client {
     /// Returns [`UrlError::SegmentMissing`] if the URL can not be parsed.
     ///
     /// [`UrlError::SegmentMissing`]: ../error/enum.UrlError.html#variant.SegmentMissing
-    pub fn delete_webhook_from_url(&self, url: impl AsRef<str>) -> Result<DeleteWebhook<'_>> {
+    pub fn delete_webhook_from_url<'a>(&'a self, url: &str) -> Result<DeleteWebhook<'a>> {
         let (id, _) = parse_webhook_url(url)?;
         Ok(self.delete_webhook(id))
     }
@@ -1298,17 +1299,17 @@ impl Client {
     /// Returns [`UrlError::SegmentMissing`] if the URL can not be parsed.
     ///
     /// [`UrlError::SegmentMissing`]: ../error/enum.UrlError.html#variant.SegmentMissing
-    pub fn update_webhook_from_url(&self, url: impl AsRef<str>) -> Result<UpdateWebhook<'_>> {
+    pub fn update_webhook_from_url(&self, url: &str) -> Result<UpdateWebhook<'_>> {
         let (id, _) = parse_webhook_url(url)?;
         Ok(self.update_webhook(id))
     }
 
     /// Update a webhook, with a token, by ID.
-    pub fn update_webhook_with_token(
-        &self,
+    pub fn update_webhook_with_token<'a>(
+        &'a self,
         webhook_id: WebhookId,
-        token: impl Into<String>,
-    ) -> UpdateWebhookWithToken<'_> {
+        token: impl Into<Cow<'a, str>>,
+    ) -> UpdateWebhookWithToken<'a> {
         UpdateWebhookWithToken::new(self, webhook_id, token)
     }
 
@@ -1319,10 +1320,10 @@ impl Client {
     /// Returns [`UrlError::SegmentMissing`] if the URL can not be parsed.
     ///
     /// [`UrlError::SegmentMissing`]: ../error/enum.UrlError.html#variant.SegmentMissing
-    pub fn update_webhook_with_token_from_url(
-        &self,
-        url: impl AsRef<str>,
-    ) -> Result<UpdateWebhookWithToken<'_>> {
+    pub fn update_webhook_with_token_from_url<'a>(
+        &'a self,
+        url: &'a str,
+    ) -> Result<UpdateWebhookWithToken<'a>> {
         let (id, token) = parse_webhook_url(url)?;
         Ok(self.update_webhook_with_token(id, token.ok_or(UrlError::SegmentMissing)?))
     }
@@ -1352,11 +1353,11 @@ impl Client {
     /// [`content`]: ../request/channel/webhook/struct.ExecuteWebhook.html#method.content
     /// [`embeds`]: ../request/channel/webhook/struct.ExecuteWebhook.html#method.embeds
     /// [`file`]: ../request/channel/webhook/struct.ExecuteWebhook.html#method.file
-    pub fn execute_webhook(
-        &self,
+    pub fn execute_webhook<'a>(
+        &'a self,
         webhook_id: WebhookId,
-        token: impl Into<String>,
-    ) -> ExecuteWebhook<'_> {
+        token: impl Into<Cow<'a, str>>,
+    ) -> ExecuteWebhook<'a> {
         ExecuteWebhook::new(self, webhook_id, token)
     }
 
@@ -1367,7 +1368,7 @@ impl Client {
     /// Returns [`UrlError::SegmentMissing`] if the URL can not be parsed.
     ///
     /// [`UrlError::SegmentMissing`]: ../error/enum.UrlError.html#variant.SegmentMissing
-    pub fn execute_webhook_from_url(&self, url: impl AsRef<str>) -> Result<ExecuteWebhook<'_>> {
+    pub fn execute_webhook_from_url<'a>(&'a self, url: &'a str) -> Result<ExecuteWebhook<'a>> {
         let (id, token) = parse_webhook_url(url)?;
         Ok(self.execute_webhook(id, token.ok_or(UrlError::SegmentMissing)?))
     }
@@ -1558,9 +1559,9 @@ impl From<ReqwestClient> for Client {
 
 // parse the webhook id and token, if it exists in the string
 fn parse_webhook_url(
-    url: impl AsRef<str>,
-) -> std::result::Result<(WebhookId, Option<String>), UrlError> {
-    let url = Url::parse(url.as_ref())?;
+    webhook_uri: &str,
+) -> std::result::Result<(WebhookId, Option<&str>), UrlError> {
+    let url = Url::parse(webhook_uri)?;
     let mut segments = url.path_segments().ok_or(UrlError::SegmentMissing)?;
 
     segments
@@ -1572,9 +1573,14 @@ fn parse_webhook_url(
         .filter(|s| s == &"webhooks")
         .ok_or(UrlError::SegmentMissing)?;
     let id = segments.next().ok_or(UrlError::SegmentMissing)?;
-    let token = segments.next();
 
-    Ok((WebhookId(id.parse()?), token.map(String::from)))
+    let token = segments.next().and_then(|_| {
+        let half = webhook_uri.split("api/webhooks/").nth(1)?;
+
+        half.split('/').nth(1)
+    });
+
+    Ok((WebhookId(id.parse()?), token))
 }
 
 #[cfg(test)]

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Create a new pin in a channel.
@@ -7,7 +8,7 @@ pub struct CreatePin<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> CreatePin<'a> {
@@ -22,7 +23,7 @@ impl<'a> CreatePin<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{channel::Channel, id::ChannelId};
 
 /// Delete a channel by ID.
@@ -6,7 +7,7 @@ pub struct DeleteChannel<'a> {
     channel_id: ChannelId,
     fut: Option<Pending<'a, Channel>>,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> DeleteChannel<'a> {
@@ -20,7 +21,7 @@ impl<'a> DeleteChannel<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/delete_channel_permission.rs
+++ b/http/src/request/channel/delete_channel_permission.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::ChannelId;
 
 /// Clear the permissions for a target ID in a channel.
@@ -9,7 +10,7 @@ pub struct DeleteChannelPermission<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     target_id: u64,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> DeleteChannelPermission<'a> {
@@ -24,7 +25,7 @@ impl<'a> DeleteChannelPermission<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Delete a pin in a channel, by ID.
@@ -7,7 +8,7 @@ pub struct DeletePin<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> DeletePin<'a> {
@@ -22,7 +23,7 @@ impl<'a> DeletePin<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -39,7 +39,7 @@ pub struct CreateInvite<'a> {
     fields: CreateInviteFields,
     fut: Option<Pending<'a, Invite>>,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> CreateInvite<'a> {
@@ -106,8 +106,8 @@ impl<'a> CreateInvite<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
+    pub fn reason(mut self, reason: &'a str) -> Self {
+        self.reason.replace(reason);
 
         self
     }

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -1,15 +1,16 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 
 /// Delete an invite by its code.
 pub struct DeleteInvite<'a> {
-    code: String,
+    code: Cow<'a, str>,
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> DeleteInvite<'a> {
-    pub(crate) fn new(http: &'a Client, code: impl Into<String>) -> Self {
+    pub(crate) fn new(http: &'a Client, code: impl Into<Cow<'a, str>>) -> Self {
         Self {
             code: code.into(),
             fut: None,
@@ -19,25 +20,20 @@ impl<'a> DeleteInvite<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
+        let reason = self.reason.take();
+
+        let request = if let Some(reason) = reason.as_deref() {
             let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::DeleteInvite {
-                    code: self.code.clone(),
-                },
-            ))
+            Request::from((headers, Route::DeleteInvite { code: &self.code }))
         } else {
-            Request::from(Route::DeleteInvite {
-                code: self.code.clone(),
-            })
+            Request::from(Route::DeleteInvite { code: &self.code })
         };
 
         self.fut.replace(Box::pin(self.http.verify(request)));

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::invite::Invite;
 
 #[derive(Default)]
@@ -28,14 +29,14 @@ struct GetInviteFields {
 ///
 /// [`with_counts`]: #method.with_counts
 pub struct GetInvite<'a> {
-    code: String,
+    code: Cow<'a, str>,
     fields: GetInviteFields,
     fut: Option<PendingOption<'a>>,
     http: &'a Client,
 }
 
 impl<'a> GetInvite<'a> {
-    pub(crate) fn new(http: &'a Client, code: impl Into<String>) -> Self {
+    pub(crate) fn new(http: &'a Client, code: impl Into<Cow<'a, str>>) -> Self {
         Self {
             code: code.into(),
             fields: GetInviteFields::default(),
@@ -55,7 +56,7 @@ impl<'a> GetInvite<'a> {
         self.fut
             .replace(Box::pin(self.http.request_bytes(Request::from(
                 Route::GetInvite {
-                    code: self.code.clone(),
+                    code: &self.code,
                     with_counts: self.fields.with_counts,
                 },
             ))));

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Delete a message by [`ChannelId`] and [`MessageId`].
@@ -10,7 +11,7 @@ pub struct DeleteMessage<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> DeleteMessage<'a> {
@@ -25,14 +26,14 @@ impl<'a> DeleteMessage<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
+        let request = if let Some(reason) = self.reason.as_ref() {
             let headers = audit_header(&reason)?;
             Request::from((
                 headers,

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -1,10 +1,11 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::{ChannelId, MessageId};
 
 #[derive(Serialize)]
-struct DeleteMessagesFields {
-    messages: Vec<MessageId>,
+struct DeleteMessagesFields<'a> {
+    messages: Cow<'a, [MessageId]>,
 }
 
 /// Delete messgaes by [`ChannelId`] and Vec<[`MessageId`]>.
@@ -18,17 +19,17 @@ struct DeleteMessagesFields {
 /// [the discord docs]: https://discord.com/developers/docs/resources/channel#bulk-delete-messages
 pub struct DeleteMessages<'a> {
     channel_id: ChannelId,
-    fields: DeleteMessagesFields,
+    fields: DeleteMessagesFields<'a>,
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> DeleteMessages<'a> {
     pub(crate) fn new(
         http: &'a Client,
         channel_id: ChannelId,
-        message_ids: impl Into<Vec<MessageId>>,
+        message_ids: impl Into<Cow<'a, [MessageId]>>,
     ) -> Self {
         Self {
             channel_id,
@@ -42,7 +43,7 @@ impl<'a> DeleteMessages<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{
     channel::ReactionType,
     id::{ChannelId, MessageId},
@@ -61,7 +62,7 @@ impl<'a> CreateReaction<'a> {
         self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::CreateReaction {
                 channel_id: self.channel_id.0,
-                emoji: self.emoji.clone(),
+                emoji: Cow::Owned(self.emoji.clone()),
                 message_id: self.message_id.0,
             },
         ))));

--- a/http/src/request/channel/reaction/delete_all_reaction.rs
+++ b/http/src/request/channel/reaction/delete_all_reaction.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{
     channel::ReactionType,
     id::{ChannelId, MessageId},
@@ -34,7 +35,7 @@ impl<'a> DeleteAllReaction<'a> {
             Route::DeleteMessageSpecficReaction {
                 channel_id: self.channel_id.0,
                 message_id: self.message_id.0,
-                emoji: self.emoji.clone(),
+                emoji: Cow::Owned(self.emoji.clone()),
             },
         ))));
 

--- a/http/src/request/channel/reaction/delete_reaction.rs
+++ b/http/src/request/channel/reaction/delete_reaction.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{
     channel::ReactionType,
     id::{ChannelId, MessageId},
@@ -11,7 +12,7 @@ pub struct DeleteReaction<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
-    target_user: String,
+    target_user: Cow<'a, str>,
 }
 
 impl<'a> DeleteReaction<'a> {
@@ -20,7 +21,7 @@ impl<'a> DeleteReaction<'a> {
         channel_id: ChannelId,
         message_id: MessageId,
         emoji: ReactionType,
-        target_user: impl Into<String>,
+        target_user: impl Into<Cow<'a, str>>,
     ) -> Self {
         Self {
             channel_id,
@@ -36,7 +37,7 @@ impl<'a> DeleteReaction<'a> {
         self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::DeleteReaction {
                 channel_id: self.channel_id.0,
-                emoji: self.emoji.clone(),
+                emoji: Cow::Owned(self.emoji.clone()),
                 message_id: self.message_id.0,
                 user: self.target_user.clone(),
             },

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -1,5 +1,6 @@
 use crate::request::prelude::*;
 use std::{
+    borrow::Cow,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
@@ -38,7 +39,7 @@ struct GetReactionsFields {
 /// requests must be chained until all reactions are retireved.
 pub struct GetReactions<'a> {
     channel_id: ChannelId,
-    emoji: String,
+    emoji: Cow<'a, str>,
     fields: GetReactionsFields,
     fut: Option<Pending<'a, Vec<User>>>,
     http: &'a Client,
@@ -50,7 +51,7 @@ impl<'a> GetReactions<'a> {
         http: &'a Client,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: impl Into<String>,
+        emoji: impl Into<Cow<'a, str>>,
     ) -> Self {
         Self {
             channel_id,
@@ -102,7 +103,7 @@ impl<'a> GetReactions<'a> {
                 after: self.fields.after.map(|x| x.0),
                 before: self.fields.before.map(|x| x.0),
                 channel_id: self.channel_id.0,
-                emoji: self.emoji.to_owned(),
+                emoji: &self.emoji,
                 limit: self.fields.limit,
                 message_id: self.message_id.0,
             },

--- a/http/src/request/channel/reaction/mod.rs
+++ b/http/src/request/channel/reaction/mod.rs
@@ -19,7 +19,7 @@ fn format_emoji(emoji: ReactionType) -> String {
         ReactionType::Custom { id, name, .. } => {
             let mut emoji = String::new();
             match name {
-                Some(name) => emoji.push_str(name.as_ref()),
+                Some(name) => emoji.push_str(&name),
                 None => emoji.push_str("e"),
             }
             let _ = write!(emoji, ":{}", id);

--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -62,11 +62,7 @@ impl<'a> UpdateChannelPermission<'a> {
         self.configure("role", role_id.into().0)
     }
 
-    fn configure(
-        self,
-        kind: impl Into<String>,
-        target_id: u64,
-    ) -> UpdateChannelPermissionConfigured<'a> {
+    fn configure(self, kind: &'a str, target_id: u64) -> UpdateChannelPermissionConfigured<'a> {
         UpdateChannelPermissionConfigured::new(
             self.http,
             self.channel_id,

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -1,22 +1,23 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{guild::Permissions, id::ChannelId};
 
 #[derive(Serialize)]
-struct UpdateChannelPermissionConfiguredFields {
+struct UpdateChannelPermissionConfiguredFields<'a> {
     allow: Permissions,
     deny: Permissions,
-    kind: String,
+    kind: Cow<'a, str>,
 }
 
 /// Created when either `member` or `role` is called on a `DeleteChannelPermission` struct.
 pub struct UpdateChannelPermissionConfigured<'a> {
     channel_id: ChannelId,
-    fields: UpdateChannelPermissionConfiguredFields,
+    fields: UpdateChannelPermissionConfiguredFields<'a>,
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     target_id: u64,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> UpdateChannelPermissionConfigured<'a> {
@@ -25,7 +26,7 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
         channel_id: ChannelId,
         allow: Permissions,
         deny: Permissions,
-        kind: impl Into<String>,
+        kind: impl Into<Cow<'a, str>>,
         target_id: u64,
     ) -> Self {
         Self {
@@ -43,7 +44,7 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -1,11 +1,12 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{channel::Webhook, id::ChannelId};
 
 #[derive(Serialize)]
-struct CreateWebhookFields {
-    avatar: Option<String>,
-    name: String,
+struct CreateWebhookFields<'a> {
+    avatar: Option<Cow<'a, str>>,
+    name: Cow<'a, str>,
 }
 
 /// Create a webhook in a channel.
@@ -28,14 +29,18 @@ struct CreateWebhookFields {
 /// ```
 pub struct CreateWebhook<'a> {
     channel_id: ChannelId,
-    fields: CreateWebhookFields,
+    fields: CreateWebhookFields<'a>,
     fut: Option<Pending<'a, Webhook>>,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> CreateWebhook<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId, name: impl Into<String>) -> Self {
+    pub(crate) fn new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        name: impl Into<Cow<'a, str>>,
+    ) -> Self {
         Self {
             channel_id,
             fields: CreateWebhookFields {
@@ -55,14 +60,14 @@ impl<'a> CreateWebhook<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<String>) -> Self {
+    pub fn avatar(mut self, avatar: impl Into<Cow<'a, str>>) -> Self {
         self.fields.avatar.replace(avatar.into());
 
         self
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/webhook/delete_webhook.rs
+++ b/http/src/request/channel/webhook/delete_webhook.rs
@@ -1,17 +1,18 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::WebhookId;
 
-struct DeleteWebhookParams {
-    token: Option<String>,
+struct DeleteWebhookParams<'a> {
+    token: Option<Cow<'a, str>>,
 }
 
 /// Delete a webhook by its ID.
 pub struct DeleteWebhook<'a> {
-    fields: DeleteWebhookParams,
+    fields: DeleteWebhookParams<'a>,
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     id: WebhookId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> DeleteWebhook<'a> {
@@ -26,14 +27,14 @@ impl<'a> DeleteWebhook<'a> {
     }
 
     /// Specify the token for auth, if not already authenticated with a Bot token.
-    pub fn token(mut self, token: impl Into<String>) -> Self {
+    pub fn token(mut self, token: impl Into<Cow<'a, str>>) -> Self {
         self.fields.token.replace(token.into());
 
         self
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self
@@ -46,13 +47,13 @@ impl<'a> DeleteWebhook<'a> {
                 headers,
                 Route::DeleteWebhook {
                     webhook_id: self.id.0,
-                    token: self.fields.token.clone(),
+                    token: self.fields.token.as_deref(),
                 },
             ))
         } else {
             Request::from(Route::DeleteWebhook {
                 webhook_id: self.id.0,
-                token: self.fields.token.clone(),
+                token: self.fields.token.as_deref(),
             })
         };
 

--- a/http/src/request/channel/webhook/get_webhook.rs
+++ b/http/src/request/channel/webhook/get_webhook.rs
@@ -1,14 +1,15 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{channel::Webhook, id::WebhookId};
 
 #[derive(Default)]
-struct GetWebhookFields {
-    token: Option<String>,
+struct GetWebhookFields<'a> {
+    token: Option<Cow<'a, str>>,
 }
 
 /// Get a webhook by ID.
 pub struct GetWebhook<'a> {
-    fields: GetWebhookFields,
+    fields: GetWebhookFields<'a>,
     fut: Option<PendingOption<'a>>,
     http: &'a Client,
     id: WebhookId,
@@ -25,7 +26,7 @@ impl<'a> GetWebhook<'a> {
     }
 
     /// Specify the token for auth, if not already authenticated with a Bot token.
-    pub fn token(mut self, token: impl Into<String>) -> Self {
+    pub fn token(mut self, token: impl Into<Cow<'a, str>>) -> Self {
         self.fields.token.replace(token.into());
 
         self
@@ -35,7 +36,7 @@ impl<'a> GetWebhook<'a> {
         self.fut
             .replace(Box::pin(self.http.request_bytes(Request::from(
                 Route::GetWebhook {
-                    token: self.fields.token.clone(),
+                    token: self.fields.token.as_deref(),
                     webhook_id: self.id.0,
                 },
             ))));

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -1,24 +1,25 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{
     channel::Webhook,
     id::{ChannelId, WebhookId},
 };
 
 #[derive(Default, Serialize)]
-struct UpdateWebhookFields {
-    avatar: Option<String>,
+struct UpdateWebhookFields<'a> {
+    avatar: Option<Cow<'a, str>>,
     channel_id: Option<ChannelId>,
-    name: Option<String>,
+    name: Option<Cow<'a, str>>,
 }
 
 /// Update a webhook by ID.
 pub struct UpdateWebhook<'a> {
-    fields: UpdateWebhookFields,
+    fields: UpdateWebhookFields<'a>,
     fut: Option<Pending<'a, Webhook>>,
     http: &'a Client,
     webhook_id: WebhookId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 /// Update a webhook by its ID.
@@ -40,7 +41,7 @@ impl<'a> UpdateWebhook<'a> {
     /// base64-encoded image.
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<String>) -> Self {
+    pub fn avatar(mut self, avatar: impl Into<Cow<'a, str>>) -> Self {
         self.fields.avatar.replace(avatar.into());
 
         self
@@ -54,14 +55,14 @@ impl<'a> UpdateWebhook<'a> {
     }
 
     /// Change the name of the webhook.
-    pub fn name(mut self, name: impl Into<String>) -> Self {
+    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Self {
         self.fields.name.replace(name.into());
 
         self
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -1,5 +1,6 @@
 use crate::request::prelude::*;
 use std::{
+    borrow::Cow,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
@@ -25,9 +26,9 @@ impl Display for CreateBanError {
 impl Error for CreateBanError {}
 
 #[derive(Default)]
-struct CreateBanFields {
+struct CreateBanFields<'a> {
     delete_message_days: Option<u64>,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 /// Bans a user from a guild, optionally with the number of days' worth of
@@ -55,7 +56,7 @@ struct CreateBanFields {
 /// # Ok(()) }
 /// ```
 pub struct CreateBan<'a> {
-    fields: CreateBanFields,
+    fields: CreateBanFields<'a>,
     fut: Option<Pending<'a, ()>>,
     guild_id: GuildId,
     http: &'a Client,
@@ -94,7 +95,7 @@ impl<'a> CreateBan<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.fields.reason.replace(reason.into());
 
         self
@@ -105,7 +106,7 @@ impl<'a> CreateBan<'a> {
             Route::CreateBan {
                 delete_message_days: self.fields.delete_message_days,
                 guild_id: self.guild_id.0,
-                reason: self.fields.reason.clone(),
+                reason: self.fields.reason.as_deref(),
                 user_id: self.user_id.0,
             },
         ))));

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::{GuildId, UserId};
 
 /// Remove a ban from a user in a guild.
@@ -26,7 +27,7 @@ pub struct DeleteBan<'a> {
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> DeleteBan<'a> {
@@ -41,7 +42,7 @@ impl<'a> DeleteBan<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -1,15 +1,16 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{
     guild::Emoji,
     id::{GuildId, RoleId},
 };
 
 #[derive(Serialize)]
-struct CreateEmojiFields {
-    image: String,
-    name: String,
-    roles: Option<Vec<RoleId>>,
+struct CreateEmojiFields<'a> {
+    image: Cow<'a, str>,
+    name: Cow<'a, str>,
+    roles: Option<Cow<'a, [RoleId]>>,
 }
 
 /// Create an emoji in a guild.
@@ -21,18 +22,18 @@ struct CreateEmojiFields {
 /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
 pub struct CreateEmoji<'a> {
     fut: Option<Pending<'a, Emoji>>,
-    fields: CreateEmojiFields,
+    fields: CreateEmojiFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> CreateEmoji<'a> {
     pub(crate) fn new(
         http: &'a Client,
         guild_id: GuildId,
-        name: impl Into<String>,
-        image: impl Into<String>,
+        name: impl Into<Cow<'a, str>>,
+        image: impl Into<Cow<'a, str>>,
     ) -> Self {
         Self {
             fields: CreateEmojiFields {
@@ -52,14 +53,14 @@ impl<'a> CreateEmoji<'a> {
     /// Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/emoji
-    pub fn roles(mut self, roles: Vec<RoleId>) -> Self {
-        self.fields.roles.replace(roles);
+    pub fn roles(mut self, roles: impl Into<Cow<'a, [RoleId]>>) -> Self {
+        self.fields.roles.replace(roles.into());
 
         self
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -7,7 +7,7 @@ pub struct DeleteEmoji<'a> {
     fut: Option<Pending<'a, ()>>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> DeleteEmoji<'a> {
@@ -22,8 +22,8 @@ impl<'a> DeleteEmoji<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
+    pub fn reason(mut self, reason: &'a str) -> Self {
+        self.reason.replace(reason);
 
         self
     }

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -1,24 +1,25 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{
     guild::Emoji,
     id::{EmojiId, GuildId, RoleId},
 };
 
 #[derive(Default, Serialize)]
-struct UpdateEmojiFields {
-    name: Option<String>,
-    roles: Option<Vec<RoleId>>,
+struct UpdateEmojiFields<'a> {
+    name: Option<Cow<'a, str>>,
+    roles: Option<Cow<'a, [RoleId]>>,
 }
 
 /// Update an emoji in a guild, by id.
 pub struct UpdateEmoji<'a> {
     emoji_id: EmojiId,
-    fields: UpdateEmojiFields,
+    fields: UpdateEmojiFields<'a>,
     fut: Option<Pending<'a, Emoji>>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> UpdateEmoji<'a> {
@@ -34,21 +35,21 @@ impl<'a> UpdateEmoji<'a> {
     }
 
     /// Change the name of the emoji.
-    pub fn name(mut self, name: impl Into<String>) -> Self {
+    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Self {
         self.fields.name.replace(name.into());
 
         self
     }
 
     /// Change the roles that the emoji is whitelisted to.
-    pub fn roles(mut self, roles: Vec<RoleId>) -> Self {
-        self.fields.roles.replace(roles);
+    pub fn roles(mut self, roles: impl Into<Cow<'a, [RoleId]>>) -> Self {
+        self.fields.roles.replace(roles.into());
 
         self
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/integration/create_guild_integration.rs
+++ b/http/src/request/guild/integration/create_guild_integration.rs
@@ -1,12 +1,13 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::{GuildId, IntegrationId};
 
 #[derive(Serialize)]
-struct CreateGuildIntegrationFields {
+struct CreateGuildIntegrationFields<'a> {
     id: IntegrationId,
     #[serde(rename = "type")]
-    kind: String,
+    kind: Cow<'a, str>,
 }
 
 /// Create a guild integration from the current user to the guild.
@@ -15,11 +16,11 @@ struct CreateGuildIntegrationFields {
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#create-guild-integration
 pub struct CreateGuildIntegration<'a> {
-    fields: CreateGuildIntegrationFields,
+    fields: CreateGuildIntegrationFields<'a>,
     fut: Option<Pending<'a, ()>>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> CreateGuildIntegration<'a> {
@@ -27,7 +28,7 @@ impl<'a> CreateGuildIntegration<'a> {
         http: &'a Client,
         guild_id: GuildId,
         integration_id: IntegrationId,
-        kind: impl Into<String>,
+        kind: impl Into<Cow<'a, str>>,
     ) -> Self {
         Self {
             fields: CreateGuildIntegrationFields {
@@ -42,7 +43,7 @@ impl<'a> CreateGuildIntegration<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::{GuildId, IntegrationId};
 
 /// Delete an integration for a guild, by the integration's id.
@@ -7,7 +8,7 @@ pub struct DeleteGuildIntegration<'a> {
     guild_id: GuildId,
     http: &'a Client,
     integration_id: IntegrationId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> DeleteGuildIntegration<'a> {
@@ -22,7 +23,7 @@ impl<'a> DeleteGuildIntegration<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/integration/update_guild_integration.rs
+++ b/http/src/request/guild/integration/update_guild_integration.rs
@@ -1,5 +1,6 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::{GuildId, IntegrationId};
 
 #[derive(Default, Serialize)]
@@ -23,7 +24,7 @@ pub struct UpdateGuildIntegration<'a> {
     guild_id: GuildId,
     http: &'a Client,
     integration_id: IntegrationId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> UpdateGuildIntegration<'a> {
@@ -66,7 +67,7 @@ impl<'a> UpdateGuildIntegration<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::{GuildId, RoleId, UserId};
 
 /// Add a role to a member in a guild.
@@ -28,7 +29,7 @@ pub struct AddRoleToMember<'a> {
     http: &'a Client,
     role_id: RoleId,
     user_id: UserId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> AddRoleToMember<'a> {
@@ -49,7 +50,7 @@ impl<'a> AddRoleToMember<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::{GuildId, UserId};
 
 /// Kick a member from a guild, by their id.
@@ -7,7 +8,7 @@ pub struct RemoveMember<'a> {
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> RemoveMember<'a> {
@@ -22,7 +23,7 @@ impl<'a> RemoveMember<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/member/remove_role_from_member.rs
+++ b/http/src/request/guild/member/remove_role_from_member.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::{GuildId, RoleId, UserId};
 
 /// Remove a role from a member in a guild, by id.
@@ -8,7 +9,7 @@ pub struct RemoveRoleFromMember<'a> {
     http: &'a Client,
     role_id: RoleId,
     user_id: UserId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> RemoveRoleFromMember<'a> {
@@ -29,7 +30,7 @@ impl<'a> RemoveRoleFromMember<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -1,16 +1,17 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{
     guild::{Permissions, Role},
     id::GuildId,
 };
 
 #[derive(Default, Serialize)]
-struct CreateRoleFields {
+struct CreateRoleFields<'a> {
     color: Option<u64>,
     hoist: Option<bool>,
     mentionable: Option<bool>,
-    name: Option<String>,
+    name: Option<Cow<'a, str>>,
     permissions: Option<Permissions>,
 }
 
@@ -34,11 +35,11 @@ struct CreateRoleFields {
 /// # Ok(()) }
 /// ```
 pub struct CreateRole<'a> {
-    fields: CreateRoleFields,
+    fields: CreateRoleFields<'a>,
     fut: Option<Pending<'a, Role>>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> CreateRole<'a> {
@@ -76,7 +77,7 @@ impl<'a> CreateRole<'a> {
     /// Set the name of the role.
     ///
     /// If none is specified, Discord sets this to `New Role`.
-    pub fn name(mut self, name: impl Into<String>) -> Self {
+    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Self {
         self.fields.name.replace(name.into());
 
         self
@@ -90,7 +91,7 @@ impl<'a> CreateRole<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::{GuildId, RoleId};
 
 /// Delete a role in a guild, by id.
@@ -7,7 +8,7 @@ pub struct DeleteRole<'a> {
     guild_id: GuildId,
     http: &'a Client,
     role_id: RoleId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> DeleteRole<'a> {
@@ -22,7 +23,7 @@ impl<'a> DeleteRole<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -1,27 +1,28 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{
     guild::{Permissions, Role},
     id::{GuildId, RoleId},
 };
 
 #[derive(Default, Serialize)]
-struct UpdateRoleFields {
+struct UpdateRoleFields<'a> {
     color: Option<u64>,
     hoist: Option<bool>,
     mentionable: Option<bool>,
-    name: Option<String>,
+    name: Option<Cow<'a, str>>,
     permissions: Option<Permissions>,
 }
 
 /// Update a role by guild id and its id.
 pub struct UpdateRole<'a> {
-    fields: UpdateRoleFields,
+    fields: UpdateRoleFields<'a>,
     fut: Option<Pending<'a, Role>>,
     guild_id: GuildId,
     http: &'a Client,
     role_id: RoleId,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> UpdateRole<'a> {
@@ -58,7 +59,7 @@ impl<'a> UpdateRole<'a> {
     }
 
     /// Set the name of the role.
-    pub fn name(mut self, name: impl Into<String>) -> Self {
+    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Self {
         self.fields.name.replace(name.into());
 
         self
@@ -72,7 +73,7 @@ impl<'a> UpdateRole<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/role/update_role_positions.rs
+++ b/http/src/request/guild/role/update_role_positions.rs
@@ -1,5 +1,6 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::{
     guild::Role,
     id::{GuildId, RoleId},
@@ -12,20 +13,20 @@ pub struct UpdateRolePositions<'a> {
     fut: Option<Pending<'a, Vec<Role>>>,
     guild_id: GuildId,
     http: &'a Client,
-    roles: Vec<(RoleId, u64)>,
+    roles: Cow<'a, [(RoleId, u64)]>,
 }
 
 impl<'a> UpdateRolePositions<'a> {
     pub(crate) fn new(
         http: &'a Client,
         guild_id: GuildId,
-        roles: impl Iterator<Item = (RoleId, u64)>,
+        roles: impl Into<Cow<'a, [(RoleId, u64)]>>,
     ) -> Self {
         Self {
             fut: None,
             guild_id,
             http,
-            roles: roles.collect(),
+            roles: roles.into(),
         }
     }
 

--- a/http/src/request/guild/update_current_user_nick.rs
+++ b/http/src/request/guild/update_current_user_nick.rs
@@ -1,22 +1,23 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::id::GuildId;
 
 #[derive(Serialize)]
-struct UpdateCurrentUserNickFields {
-    nick: String,
+struct UpdateCurrentUserNickFields<'a> {
+    nick: Cow<'a, str>,
 }
 
 /// Changes the user's nickname in a guild.
 pub struct UpdateCurrentUserNick<'a> {
-    fields: UpdateCurrentUserNickFields,
+    fields: UpdateCurrentUserNickFields<'a>,
     fut: Option<Pending<'a, ()>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> UpdateCurrentUserNick<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId, nick: impl Into<String>) -> Self {
+    pub(crate) fn new(http: &'a Client, guild_id: GuildId, nick: impl Into<Cow<'a, str>>) -> Self {
         Self {
             fields: UpdateCurrentUserNickFields { nick: nick.into() },
             fut: None,

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -1,6 +1,7 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
 use std::{
+    borrow::Cow,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
@@ -30,21 +31,21 @@ impl Display for UpdateGuildError {
 impl Error for UpdateGuildError {}
 
 #[derive(Default, Serialize)]
-struct UpdateGuildFields {
+struct UpdateGuildFields<'a> {
     afk_channel_id: Option<ChannelId>,
     afk_timeout: Option<u64>,
     default_message_notifications: Option<DefaultMessageNotificationLevel>,
     explicit_content_filter: Option<ExplicitContentFilter>,
-    icon: Option<String>,
-    name: Option<String>,
+    icon: Option<Cow<'a, str>>,
+    name: Option<Cow<'a, str>>,
     owner_id: Option<UserId>,
-    region: Option<String>,
-    splash: Option<String>,
+    region: Option<Cow<'a, str>>,
+    splash: Option<Cow<'a, str>>,
     system_channel_id: Option<ChannelId>,
     verification_level: Option<VerificationLevel>,
     rules_channel_id: Option<ChannelId>,
     public_updates_channel_id: Option<ChannelId>,
-    preferred_locale: Option<String>,
+    preferred_locale: Option<Cow<'a, str>>,
 }
 
 /// Update a guild.
@@ -53,11 +54,11 @@ struct UpdateGuildFields {
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild
 pub struct UpdateGuild<'a> {
-    fields: UpdateGuildFields,
+    fields: UpdateGuildFields<'a>,
     fut: Option<Pending<'a, PartialGuild>>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<Cow<'a, str>>,
 }
 
 impl<'a> UpdateGuild<'a> {
@@ -119,7 +120,7 @@ impl<'a> UpdateGuild<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn icon(mut self, icon: impl Into<String>) -> Self {
+    pub fn icon(mut self, icon: impl Into<Cow<'a, str>>) -> Self {
         self.fields.icon.replace(icon.into());
 
         self
@@ -136,11 +137,9 @@ impl<'a> UpdateGuild<'a> {
     /// short or too long.
     ///
     /// [`UpdateGuildError::NameInvalid`]: enum.UpdateGuildError.html#variant.NameInvalid
-    pub fn name(self, name: impl Into<String>) -> Result<Self, UpdateGuildError> {
-        self._name(name.into())
-    }
+    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Result<Self, UpdateGuildError> {
+        let name = name.into();
 
-    fn _name(mut self, name: String) -> Result<Self, UpdateGuildError> {
         if !validate::guild_name(&name) {
             return Err(UpdateGuildError::NameInvalid);
         }
@@ -163,7 +162,7 @@ impl<'a> UpdateGuild<'a> {
     /// information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/voice#voice-region-object
-    pub fn region(mut self, region: impl Into<String>) -> Self {
+    pub fn region(mut self, region: impl Into<Cow<'a, str>>) -> Self {
         self.fields.region.replace(region.into());
 
         self
@@ -172,7 +171,7 @@ impl<'a> UpdateGuild<'a> {
     /// Set the guild's splash image.
     ///
     /// Requires the guild to have the `INVITE_SPLASH` feature enabled.
-    pub fn splash(mut self, splash: impl Into<String>) -> Self {
+    pub fn splash(mut self, splash: impl Into<Cow<'a, str>>) -> Self {
         self.fields.splash.replace(splash.into());
 
         self
@@ -217,7 +216,7 @@ impl<'a> UpdateGuild<'a> {
     /// Set the preferred locale for the guild.
     ///
     /// Defaults to `en-US`. Requires the guild to be `PUBLIC`.
-    pub fn preferred_locale(mut self, preferred_locale: impl Into<String>) -> Self {
+    pub fn preferred_locale(mut self, preferred_locale: impl Into<Cow<'a, str>>) -> Self {
         self.fields
             .preferred_locale
             .replace(preferred_locale.into());
@@ -235,7 +234,7 @@ impl<'a> UpdateGuild<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -87,14 +87,14 @@ use reqwest::{
     Method,
 };
 
-use std::{borrow::Cow, future::Future, pin::Pin};
+use std::{future::Future, pin::Pin};
 
 type Pending<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
 type PendingOption<'a> = Pin<Box<dyn Future<Output = Result<Bytes>> + Send + 'a>>;
 
+/// The body of the request, if any.
 #[derive(Debug)]
 pub struct Request {
-    /// The body of the request, if any.
     pub body: Option<Vec<u8>>,
     /// The multipart form of the request, if any.
     pub form: Option<Form>,
@@ -105,7 +105,7 @@ pub struct Request {
     /// The ratelimiting bucket path.
     pub path: Path,
     /// The URI path to request.
-    pub path_str: Cow<'static, str>,
+    pub path_str: String,
 }
 
 pub(crate) fn audit_header(reason: &str) -> Result<HeaderMap<HeaderValue>> {
@@ -131,7 +131,7 @@ impl Request {
     pub fn new(
         body: Option<Vec<u8>>,
         headers: Option<HeaderMap<HeaderValue>>,
-        route: Route,
+        route: Route<'_>,
     ) -> Self {
         let (method, path, path_str) = route.into_parts();
 
@@ -146,8 +146,8 @@ impl Request {
     }
 }
 
-impl From<Route> for Request {
-    fn from(route: Route) -> Self {
+impl<'a> From<Route<'a>> for Request {
+    fn from(route: Route<'a>) -> Self {
         let (method, path, path_str) = route.into_parts();
 
         Self {
@@ -161,8 +161,8 @@ impl From<Route> for Request {
     }
 }
 
-impl From<(Vec<u8>, Route)> for Request {
-    fn from((body, route): (Vec<u8>, Route)) -> Self {
+impl<'a> From<(Vec<u8>, Route<'a>)> for Request {
+    fn from((body, route): (Vec<u8>, Route<'a>)) -> Self {
         let (method, path, path_str) = route.into_parts();
 
         Self {
@@ -176,8 +176,8 @@ impl From<(Vec<u8>, Route)> for Request {
     }
 }
 
-impl From<(Vec<u8>, Form, Route)> for Request {
-    fn from((body, form, route): (Vec<u8>, Form, Route)) -> Self {
+impl<'a> From<(Vec<u8>, Form, Route<'a>)> for Request {
+    fn from((body, form, route): (Vec<u8>, Form, Route<'a>)) -> Self {
         let (method, path, path_str) = route.into_parts();
 
         Self {
@@ -191,8 +191,8 @@ impl From<(Vec<u8>, Form, Route)> for Request {
     }
 }
 
-impl From<(HeaderMap<HeaderValue>, Route)> for Request {
-    fn from((headers, route): (HeaderMap<HeaderValue>, Route)) -> Self {
+impl<'a> From<(HeaderMap<HeaderValue>, Route<'a>)> for Request {
+    fn from((headers, route): (HeaderMap<HeaderValue>, Route<'a>)) -> Self {
         let (method, path, path_str) = route.into_parts();
 
         Self {
@@ -206,8 +206,8 @@ impl From<(HeaderMap<HeaderValue>, Route)> for Request {
     }
 }
 
-impl From<(Vec<u8>, HeaderMap<HeaderValue>, Route)> for Request {
-    fn from((body, headers, route): (Vec<u8>, HeaderMap<HeaderValue>, Route)) -> Self {
+impl<'a> From<(Vec<u8>, HeaderMap<HeaderValue>, Route<'a>)> for Request {
+    fn from((body, headers, route): (Vec<u8>, HeaderMap<HeaderValue>, Route<'a>)) -> Self {
         let (method, path, path_str) = route.into_parts();
 
         Self {

--- a/http/src/request/user/get_current_user.rs
+++ b/http/src/request/user/get_current_user.rs
@@ -13,10 +13,10 @@ impl<'a> GetCurrentUser<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request(Request::from(Route::GetUser {
-                target_user: "@me".to_owned(),
-            }))));
+        self.fut.replace(Box::pin(
+            self.http
+                .request(Request::from(Route::GetUser { target_user: "@me" })),
+        ));
 
         Ok(())
     }

--- a/http/src/request/user/get_user.rs
+++ b/http/src/request/user/get_user.rs
@@ -1,15 +1,16 @@
 use crate::request::prelude::*;
+use std::borrow::Cow;
 use twilight_model::user::User;
 
 /// Get a user's information by id.
 pub struct GetUser<'a> {
     fut: Option<PendingOption<'a>>,
     http: &'a Client,
-    target_user: String,
+    target_user: Cow<'a, str>,
 }
 
 impl<'a> GetUser<'a> {
-    pub(crate) fn new(http: &'a Client, target_user: impl Into<String>) -> Self {
+    pub(crate) fn new(http: &'a Client, target_user: impl Into<Cow<'a, str>>) -> Self {
         Self {
             fut: None,
             http,
@@ -21,7 +22,7 @@ impl<'a> GetUser<'a> {
         self.fut
             .replace(Box::pin(self.http.request_bytes(Request::from(
                 Route::GetUser {
-                    target_user: self.target_user.clone(),
+                    target_user: &self.target_user,
                 },
             ))));
 

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -1,6 +1,7 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
 use std::{
+    borrow::Cow,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
@@ -25,11 +26,11 @@ impl Display for UpdateCurrentUserError {
 impl Error for UpdateCurrentUserError {}
 
 #[derive(Default, Serialize)]
-struct UpdateCurrentUserFields {
+struct UpdateCurrentUserFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<String>,
+    avatar: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    username: Option<String>,
+    username: Option<Cow<'a, str>>,
 }
 
 /// Update the current user.
@@ -37,7 +38,7 @@ struct UpdateCurrentUserFields {
 /// All paramaters are optional. If the username is changed, it may cause the discriminator to be
 /// rnadomized.
 pub struct UpdateCurrentUser<'a> {
-    fields: UpdateCurrentUserFields,
+    fields: UpdateCurrentUserFields<'a>,
     fut: Option<Pending<'a, User>>,
     http: &'a Client,
 }
@@ -58,7 +59,7 @@ impl<'a> UpdateCurrentUser<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<String>) -> Self {
+    pub fn avatar(mut self, avatar: impl Into<Cow<'a, str>>) -> Self {
         self.fields.avatar.replace(avatar.into());
 
         self
@@ -74,11 +75,14 @@ impl<'a> UpdateCurrentUser<'a> {
     /// too long.
     ///
     /// [`UpdateCurrentUserError::UsernameInvalid`]: enum.UpdateCurrentUserError.html#variant.UsernameInvalid
-    pub fn username(self, username: impl Into<String>) -> Result<Self, UpdateCurrentUserError> {
+    pub fn username(
+        self,
+        username: impl Into<Cow<'a, str>>,
+    ) -> Result<Self, UpdateCurrentUserError> {
         self._username(username.into())
     }
 
-    fn _username(mut self, username: String) -> Result<Self, UpdateCurrentUserError> {
+    fn _username(mut self, username: Cow<'a, str>) -> Result<Self, UpdateCurrentUserError> {
         if !validate::username(&username) {
             return Err(UpdateCurrentUserError::UsernameInvalid);
         }


### PR DESCRIPTION
Instead of taking `Into<T>` where T is an owned value for all values that aren't primitives in requests, take `Into<Cow<'_, T>>`. This allows users to pass in references or owned values.

The reason simply references aren't accepted is because it would make code like `client.create_message(channel).content(format!("foo {}", x)).await` not possible.

The one exception that doesn't accept `Into<Cow<'_, T>>` is the UpdateMessage request due to trait implementations with the cow.

The only breaking change as part of this PR is that you will have to specify `None` or `Some` for the content field of the `UpdateMessage` request.

Closes #216.