### PR TITLE
model: impl serialize for dispatch, gateway models

### DIFF
--- a/model/src/gateway/event/dispatch.rs
+++ b/model/src/gateway/event/dispatch.rs
@@ -1,6 +1,9 @@
 use super::super::payload::*;
 use super::EventType;
-use serde::{de::{Deserialize, DeserializeSeed, Deserializer, Error as DeError, IgnoredAny}, Serialize};
+use serde::{
+    de::{Deserialize, DeserializeSeed, Deserializer, Error as DeError, IgnoredAny},
+    Serialize,
+};
 
 /// A dispatch event, containing information about a created guild, a member
 /// added, etc.

--- a/model/src/gateway/event/dispatch.rs
+++ b/model/src/gateway/event/dispatch.rs
@@ -1,6 +1,6 @@
 use super::super::payload::*;
 use super::EventType;
-use serde::de::{Deserialize, DeserializeSeed, Deserializer, Error as DeError, IgnoredAny};
+use serde::{de::{Deserialize, DeserializeSeed, Deserializer, Error as DeError, IgnoredAny}, Serialize};
 
 /// A dispatch event, containing information about a created guild, a member
 /// added, etc.
@@ -9,7 +9,7 @@ use serde::de::{Deserialize, DeserializeSeed, Deserializer, Error as DeError, Ig
 /// [`DispatchEventWithTypeDeserializer`].
 ///
 /// [`DispatchEventWithTypeDeserializer`]: struct.DispatchEventWithTypeDeserializer.html
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum DispatchEvent {
     BanAdd(BanAdd),
     BanRemove(BanRemove),

--- a/model/src/gateway/event/kind.rs
+++ b/model/src/gateway/event/kind.rs
@@ -1,7 +1,12 @@
+use serde::{Deserialize, Serialize};
+
 /// The type of an event.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum EventType {
+    #[serde(rename = "GUILD_BAN_ADD")]
     BanAdd,
+    #[serde(rename = "GUILD_BAN_REMOVE")]
     BanRemove,
     ChannelCreate,
     ChannelDelete,
@@ -20,9 +25,13 @@ pub enum EventType {
     GuildUpdate,
     InviteCreate,
     InviteDelete,
+    #[serde(rename = "GUILD_MEMBER_ADD")]
     MemberAdd,
+    #[serde(rename = "GUILD_MEMBER_REMOVE")]
     MemberRemove,
+    #[serde(rename = "GUILD_MEMBER_UPDATE")]
     MemberUpdate,
+    #[serde(rename = "GUILD_MEMBERS_CHUNK")]
     MemberChunk,
     MessageCreate,
     MessageDelete,
@@ -30,14 +39,21 @@ pub enum EventType {
     MessageUpdate,
     PresenceUpdate,
     PresencesReplace,
+    #[serde(rename = "MESSAGE_REACTION_ADD")]
     ReactionAdd,
+    #[serde(rename = "REACTION_REMOVE")]
     ReactionRemove,
+    #[serde(rename = "REACTION_REMOVE_ALL")]
     ReactionRemoveAll,
+    #[serde(rename = "REACTION_REMOVE_EMOJI")]
     ReactionRemoveEmoji,
     Ready,
     Resumed,
+    #[serde(rename = "GUILD_ROLE_CREATE")]
     RoleCreate,
+    #[serde(rename = "GUILD_ROLE_DELETE")]
     RoleDelete,
+    #[serde(rename = "GUILD_ROLE_UPDATE")]
     RoleUpdate,
     ShardConnected,
     ShardConnecting,


### PR DESCRIPTION
Implement `serde::Serialize` for the `DispatchEvent` and `GatewayEvent` models. The `DispatchEvent` enum is just a simple derive, but `GatewayEvent` is a custom serializer. For Dispatch variants it will serialize the T, S, Op, and D keys. For other variants, it will serialize T and S as null and then serialize the Op and, possibly nullably, serialize the D key.

Tests for all GatewayEvent variants (dispatch, heartbeat, heartbeat ack, hello, invalidate session, reconnect) have been added.

Additionally, this makes the `EventType` enum derive `Deserialize` and `Serialize`.

Closes #102.