### PR TITLE
gateway,http: remove allow used_underscore_binding

### DIFF
--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -49,10 +49,6 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    // This issue made it into a stable clippy:
-    //
-    // <https://github.com/rust-lang/rust-clippy/issues/5360>
-    clippy::used_underscore_binding
 )]
 
 pub mod cluster;

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -46,10 +46,7 @@
     rust_2018_idioms,
     unsafe_code
 )]
-#![allow(
-    clippy::module_name_repetitions,
-    clippy::must_use_candidate,
-)]
+#![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
 
 pub mod cluster;
 pub mod queue;

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -85,7 +85,7 @@
     clippy::module_name_repetitions,
     clippy::pub_enum_variant_names,
     clippy::must_use_candidate,
-    clippy::missing_errors_doc,
+    clippy::missing_errors_doc
 )]
 
 pub mod api_error;

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -86,10 +86,6 @@
     clippy::pub_enum_variant_names,
     clippy::must_use_candidate,
     clippy::missing_errors_doc,
-    // This issue made it into a stable clippy:
-    //
-    // <https://github.com/rust-lang/rust-clippy/issues/5360>
-    clippy::used_underscore_binding
 )]
 
 pub mod api_error;


### PR DESCRIPTION
In the gateway and http crates, remove the lint allows for the `clippy::used_underscore_binding` lint.

See #189 for why this was originally added, but basically it was because Clippy would error on code generated from awaits.