### PR TITLE
model/voice/region: fix 'optimal' field name

### DIFF
--- a/model/src/voice/voice_region.rs
+++ b/model/src/voice/voice_region.rs
@@ -7,6 +7,47 @@ pub struct VoiceRegion {
     pub deprecated: bool,
     pub id: String,
     pub name: String,
-    pub optional: bool,
+    pub optimal: bool,
     pub vip: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VoiceRegion;
+    use serde_test::Token;
+
+    #[test]
+    fn test_voice_region() {
+        let region = VoiceRegion {
+            custom: false,
+            deprecated: false,
+            id: "region".to_owned(),
+            name: "Region".to_owned(),
+            optimal: false,
+            vip: false,
+        };
+
+        serde_test::assert_tokens(
+            &region,
+            &[
+                Token::Struct {
+                    name: "VoiceRegion",
+                    len: 6,
+                },
+                Token::Str("custom"),
+                Token::Bool(false),
+                Token::Str("deprecated"),
+                Token::Bool(false),
+                Token::Str("id"),
+                Token::Str("region"),
+                Token::Str("name"),
+                Token::Str("Region"),
+                Token::Str("optimal"),
+                Token::Bool(false),
+                Token::Str("vip"),
+                Token::Bool(false),
+                Token::StructEnd,
+            ],
+        );
+    }
 }


### PR DESCRIPTION
Fix the field name of the `twilight_model::voice::VoiceRegion` model's incorrect `optional` field to `optimal`.

Additionally, add a (de)serialization test using a payload from the HTTP API.