### PR TITLE
http: skip serializing name/owner in request/guild/update_guild

### DIFF
--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -36,7 +36,9 @@ struct UpdateGuildFields {
     default_message_notifications: Option<DefaultMessageNotificationLevel>,
     explicit_content_filter: Option<ExplicitContentFilter>,
     icon: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     owner_id: Option<UserId>,
     region: Option<String>,
     splash: Option<String>,


### PR DESCRIPTION
Don't send `name` or `owner_id` if they aren't set. Related issue: #281 