### PR TITLE
gateway,http,lavalink: use rustls for default

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -42,6 +42,6 @@ futures = { default-features = false, version = "0.3" }
 tokio = { default-features = false, features = ["rt-core", "macros"], version = "0.2" }
 
 [features]
-default = ["native"]
+default = ["rustls"]
 native = ["twilight-http/native", "async-tungstenite/tokio-native-tls"]
 rustls = ["twilight-http/rustls", "async-tungstenite/async-tls"]

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -60,7 +60,7 @@ To enable `native`, do something like this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-twilight-gateway = { branch = "trunk", default-features = false, features = ["native", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
+twilight-gateway = { branch = "trunk", default-features = false, features = ["native"], git = "https://github.com/twilight-rs/twilight" }
 ```
 
 #### `rustls`

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -26,8 +26,8 @@ deserializing and serializing events.
 
 #### `simd-json`
 
-The `simd-json` feature enables [`simd-json`] support to use simd features of
-the modern cpus to deserialize responses faster. It is not enabled by
+The `simd-json` feature enables [`simd-json`] support to use simd features
+of modern cpus to deserialize responses faster. It is not enabled by
 default.
 
 To use this feature you need to also add these lines to

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -41,7 +41,7 @@ you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`.
 
 ```toml
 [dependencies]
-twilight-gateway = { branch = "trunk", default-features = false, features = ["native", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
+twilight-gateway = { branch = "trunk", default-features = false, features = ["rustls", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
 ```
 
 ### TLS

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -19,11 +19,20 @@ useful to use if you have a large bot in over 1000 or 2000 guilds.
 
 ## Features
 
-`twilight-gateway` includes only a feature: `simd-json`.
+### Deserialization
 
-`simd` feature enables [simd-json] support to use simd features of the modern cpus
-to deserialize json data faster. It is not enabled by default since not every cpu has those features.
-To use this feature you need to also add these lines to a file in `<project root>/.cargo/config`
+`twilight-gateway` supports [`serde_json`] and [`simd-json`] for
+deserializing and serializing events.
+
+#### `simd-json`
+
+The `simd-json` feature enables [`simd-json`] support to use simd features of
+the modern cpus to deserialize responses faster. It is not enabled by
+default.
+
+To use this feature you need to also add these lines to
+`<project root>/.cargo/config`:
+
 ```toml
 [build]
 rustflags = ["-C", "target-cpu=native"]
@@ -32,10 +41,41 @@ you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`.
 
 ```toml
 [dependencies]
-twilight-gateway = { branch = "trunk", default-features = false, features = ["simd-json"], git = "https://github.com/twilight-rs/twilight" }
+twilight-gateway = { branch = "trunk", default-features = false, features = ["native", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
 ```
 
-[simd-json]: https://github.com/simd-lite/simd-json
+### TLS
+
+`twilight-gateway` has features to enable [`async-tungstenite`] and
+[`twilight-http`]'s TLS features. These features are mutually exclusive.
+`rustls` is enabled by default.
+
+#### `native`
+
+The `native` feature enables [`async-tungstenite`]'s `tokio-native-tls`
+feature as well as [`twilight-http`]'s `native` feature which is mostly
+equivalent to using [`native-tls`].
+
+To enable `native`, do something like this in your `Cargo.toml`:
+
+```toml
+[dependencies]
+twilight-gateway = { branch = "trunk", default-features = false, features = ["native", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
+```
+
+#### `rustls`
+
+The `rustls` feature enables [`async-tungstenite`]'s `async-tls` feature and
+[`twilight-http`]'s `rustls` feature, which use [`rustls`] as the TLS backend.
+
+This is enabled by default.
+
+[`async-tungstenite`]: https://crates.io/crates/async-tungstenite
+[`native-tls`]: https://crates.io/crates/native-tls
+[`rustls`]: https://crates.io/crates/rustls
+[`serde_json`]: https://crates.io/crates/serde_json
+[`simd-json`]: https://crates.io/crates/simd-json
+[`twilight-http`]: https://twilight-rs.github.io/twilight/twilight_http/index.html
 [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 
 <!-- cargo-sync-readme end -->

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-gateway = { branch = "trunk", default-features = false, features = ["native", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
+//! twilight-gateway = { branch = "trunk", default-features = false, features = ["rustls", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
 //! ```
 //!
 //! ### TLS

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -17,11 +17,20 @@
 //!
 //! ## Features
 //!
-//! `twilight-gateway` includes only a feature: `simd-json`.
+//! ### Deserialization
 //!
-//! `simd` feature enables [simd-json] support to use simd features of the modern cpus
-//! to deserialize json data faster. It is not enabled by default since not every cpu has those features.
-//! To use this feature you need to also add these lines to a file in `<project root>/.cargo/config`
+//! `twilight-gateway` supports [`serde_json`] and [`simd-json`] for
+//! deserializing and serializing events.
+//!
+//! #### `simd-json`
+//!
+//! The `simd-json` feature enables [`simd-json`] support to use simd features of
+//! the modern cpus to deserialize responses faster. It is not enabled by
+//! default.
+//!
+//! To use this feature you need to also add these lines to
+//! `<project root>/.cargo/config`:
+//!
 //! ```toml
 //! [build]
 //! rustflags = ["-C", "target-cpu=native"]
@@ -30,10 +39,41 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-gateway = { branch = "trunk", default-features = false, features = ["simd-json"], git = "https://github.com/twilight-rs/twilight" }
+//! twilight-gateway = { branch = "trunk", default-features = false, features = ["native", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
 //! ```
 //!
-//! [simd-json]: https://github.com/simd-lite/simd-json
+//! ### TLS
+//!
+//! `twilight-gateway` has features to enable [`async-tungstenite`] and
+//! [`twilight-http`]'s TLS features. These features are mutually exclusive.
+//! `rustls` is enabled by default.
+//!
+//! #### `native`
+//!
+//! The `native` feature enables [`async-tungstenite`]'s `tokio-native-tls`
+//! feature as well as [`twilight-http`]'s `native` feature which is mostly
+//! equivalent to using [`native-tls`].
+//!
+//! To enable `native`, do something like this in your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! twilight-gateway = { branch = "trunk", default-features = false, features = ["native", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
+//! ```
+//!
+//! #### `rustls`
+//!
+//! The `rustls` feature enables [`async-tungstenite`]'s `async-tls` feature and
+//! [`twilight-http`]'s `rustls` feature, which use [`rustls`] as the TLS backend.
+//!
+//! This is enabled by default.
+//!
+//! [`async-tungstenite`]: https://crates.io/crates/async-tungstenite
+//! [`native-tls`]: https://crates.io/crates/native-tls
+//! [`rustls`]: https://crates.io/crates/rustls
+//! [`serde_json`]: https://crates.io/crates/serde_json
+//! [`simd-json`]: https://crates.io/crates/simd-json
+//! [`twilight-http`]: https://twilight-rs.github.io/twilight/twilight_http/index.html
 //! [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 
 #![deny(

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -58,7 +58,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-gateway = { branch = "trunk", default-features = false, features = ["native", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
+//! twilight-gateway = { branch = "trunk", default-features = false, features = ["native"], git = "https://github.com/twilight-rs/twilight" }
 //! ```
 //!
 //! #### `rustls`

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -24,8 +24,8 @@
 //!
 //! #### `simd-json`
 //!
-//! The `simd-json` feature enables [`simd-json`] support to use simd features of
-//! the modern cpus to deserialize responses faster. It is not enabled by
+//! The `simd-json` feature enables [`simd-json`] support to use simd features
+//! of modern cpus to deserialize responses faster. It is not enabled by
 //! default.
 //!
 //! To use this feature you need to also add these lines to

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -30,7 +30,7 @@ url = { default-features = false, version = "2" }
 simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.3" }
 
 [features]
-default = ["native"]
+default = ["rustls"]
 native = ["reqwest/default-tls"]
 rustls = ["reqwest/rustls-tls"]
 

--- a/http/README.md
+++ b/http/README.md
@@ -8,7 +8,8 @@ HTTP support for the twilight ecosystem.
 
 ### Deserialization
 
-`twilight-http` supports [`serde_json`] and [`simd-json`] for deserializing responses.
+`twilight-http` supports [`serde_json`] and [`simd-json`] for deserializing
+responses.
 
 #### `simd-json`
 
@@ -32,32 +33,32 @@ To enable `simd-json`, do something like this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-twilight-http = { branch = "trunk", default-features = false, features = ["native", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
+twilight-http = { branch = "trunk", default-features = false, features = ["rustls", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
 ```
 
 ### TLS
 
 `twilight-http` has features to enable [`reqwest`]'s TLS features. These
-features are mutually exclusive. `native` is enabled by default.
+features are mutually exclusive. `rustls` is enabled by default.
 
 #### `native`
 
 The `native` feature enables [`reqwest`]'s `default-tls`
 feature, which is mostly equivalent to using [`native-tls`].
 
-This is enabled by default.
+To enable `native`, do something like this in your `Cargo.toml`:
+
+```toml
+[dependencies]
+twilight-http = { branch = "trunk", default-features = false, features = ["native", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
+```
 
 #### `rustls`
 
 The `rustls` feature enables [`reqwest`]'s `rustls` feature, which uses
 [`rustls`] as the TLS backend.
 
-To enable `rustls`, do something like this in your `Cargo.toml`:
-
-```toml
-[dependencies]
-twilight-http = { branch = "trunk", default-features = false, features = ["rustls"], git = "https://github.com/twilight-rs/twilight" }
-```
+This is enabled by default.
 
 [`native-tls`]: https://crates.io/crates/native-tls
 [`reqwest`]: https://crates.io/crates/reqwest

--- a/http/README.md
+++ b/http/README.md
@@ -50,7 +50,7 @@ To enable `native`, do something like this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-twilight-http = { branch = "trunk", default-features = false, features = ["native", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
+twilight-http = { branch = "trunk", default-features = false, features = ["native"], git = "https://github.com/twilight-rs/twilight" }
 ```
 
 #### `rustls`

--- a/http/README.md
+++ b/http/README.md
@@ -13,8 +13,8 @@ responses.
 
 #### `simd-json`
 
-The `simd-json` feature enables [`simd-json`] support to use simd features of
-the modern cpus to deserialize responses faster. It is not enabled by
+The `simd-json` feature enables [`simd-json`] support to use simd features
+of modern cpus to deserialize responses faster. It is not enabled by
 default.
 
 To use this feature you need to also add these lines to

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-http = { branch = "trunk", default-features = false, features = ["native", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
+//! twilight-http = { branch = "trunk", default-features = false, features = ["native"], git = "https://github.com/twilight-rs/twilight" }
 //! ```
 //!
 //! #### `rustls`

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -6,7 +6,8 @@
 //!
 //! ### Deserialization
 //!
-//! `twilight-http` supports [`serde_json`] and [`simd-json`] for deserializing responses.
+//! `twilight-http` supports [`serde_json`] and [`simd-json`] for deserializing
+//! responses.
 //!
 //! #### `simd-json`
 //!
@@ -30,32 +31,32 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-http = { branch = "trunk", default-features = false, features = ["native", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
+//! twilight-http = { branch = "trunk", default-features = false, features = ["rustls", "simd-json"], git = "https://github.com/twilight-rs/twilight" }
 //! ```
 //!
 //! ### TLS
 //!
 //! `twilight-http` has features to enable [`reqwest`]'s TLS features. These
-//! features are mutually exclusive. `native` is enabled by default.
+//! features are mutually exclusive. `rustls` is enabled by default.
 //!
 //! #### `native`
 //!
 //! The `native` feature enables [`reqwest`]'s `default-tls`
 //! feature, which is mostly equivalent to using [`native-tls`].
 //!
-//! This is enabled by default.
+//! To enable `native`, do something like this in your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! twilight-http = { branch = "trunk", default-features = false, features = ["native", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
+//! ```
 //!
 //! #### `rustls`
 //!
 //! The `rustls` feature enables [`reqwest`]'s `rustls` feature, which uses
 //! [`rustls`] as the TLS backend.
 //!
-//! To enable `rustls`, do something like this in your `Cargo.toml`:
-//!
-//! ```toml
-//! [dependencies]
-//! twilight-http = { branch = "trunk", default-features = false, features = ["rustls"], git = "https://github.com/twilight-rs/twilight" }
-//! ```
+//! This is enabled by default.
 //!
 //! [`native-tls`]: https://crates.io/crates/native-tls
 //! [`reqwest`]: https://crates.io/crates/reqwest

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -11,8 +11,8 @@
 //!
 //! #### `simd-json`
 //!
-//! The `simd-json` feature enables [`simd-json`] support to use simd features of
-//! the modern cpus to deserialize responses faster. It is not enabled by
+//! The `simd-json` feature enables [`simd-json`] support to use simd features
+//! of modern cpus to deserialize responses faster. It is not enabled by
 //! default.
 //!
 //! To use this feature you need to also add these lines to

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -33,5 +33,7 @@ twilight-gateway = { path = "../gateway" }
 twilight-http = { path = "../http" }
 
 [features]
-default = ["http-support"]
+default = ["http-support", "rustls"]
 http-support = ["http", "percent-encoding"]
+native = ["async-tungstenite/tokio-native-tls"]
+rustls = ["async-tungstenite/async-tls"]

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -15,10 +15,35 @@ with every Voice State Update and Voice Server Update you receive.
 
 ## Features
 
-Included is the `http-support` feature.
+### `http-support`
 
 The `http-support` feature adds support for the `http` module to return
 request types from the [`http`] crate. This is enabled by default.
+
+### TLS
+
+`twilight-lavalink` has features to enable [`async-tungstenite`]'s TLS
+features. These features are mutually exclusive. `rustls` is enabled by
+default.
+
+#### `native`
+
+The `native` feature enables [`async-tungstenite`]'s `tokio-native-tls`
+feature.
+
+To enable `native`, do something like this in your `Cargo.toml`:
+
+```toml
+[dependencies]
+twilight-lavalink = { branch = "trunk", default-features = false, features = ["native"], git = "https://github.com/twilight-rs/twilight" }
+```
+
+#### `rustls`
+
+The `rustls` feature enables [`async-tungstenite`]'s `async-tls` feature, which
+use [`rustls`] as the TLS backend.
+
+This is enabled by default.
 
 ## Examples
 
@@ -69,11 +94,13 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 }
 ```
 
-[Lavalink]: https://github.com/Frederikam/Lavalink
 [`Lavalink::process`]: client/struct.Lavalink.html#method.process
+[Lavalink]: https://github.com/Frederikam/Lavalink
+[`async-tungstenite`]: https://crates.io/crates/async-tungstenite
+[`http`]: https://crates.io/crates/http
+[`rustls`]: https://crates.io/crates/rustls
 [client]: client/struct.Lavalink.html
 [node]: node/struct.Node.html
 [process]: client/struct.Lavalink.html#method.process
-[`http`]: https://crates.io/crates/http
 
 <!-- cargo-sync-readme end -->

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -13,10 +13,35 @@
 //!
 //! ## Features
 //!
-//! Included is the `http-support` feature.
+//! ### `http-support`
 //!
 //! The `http-support` feature adds support for the `http` module to return
 //! request types from the [`http`] crate. This is enabled by default.
+//!
+//! ### TLS
+//!
+//! `twilight-lavalink` has features to enable [`async-tungstenite`]'s TLS
+//! features. These features are mutually exclusive. `rustls` is enabled by
+//! default.
+//!
+//! #### `native`
+//!
+//! The `native` feature enables [`async-tungstenite`]'s `tokio-native-tls`
+//! feature.
+//!
+//! To enable `native`, do something like this in your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! twilight-lavalink = { branch = "trunk", default-features = false, features = ["native"], git = "https://github.com/twilight-rs/twilight" }
+//! ```
+//!
+//! #### `rustls`
+//!
+//! The `rustls` feature enables [`async-tungstenite`]'s `async-tls` feature, which
+//! use [`rustls`] as the TLS backend.
+//!
+//! This is enabled by default.
 //!
 //! ## Examples
 //!
@@ -67,12 +92,14 @@
 //! }
 //! ```
 //!
-//! [Lavalink]: https://github.com/Frederikam/Lavalink
 //! [`Lavalink::process`]: client/struct.Lavalink.html#method.process
+//! [Lavalink]: https://github.com/Frederikam/Lavalink
+//! [`async-tungstenite`]: https://crates.io/crates/async-tungstenite
+//! [`http`]: https://crates.io/crates/http
+//! [`rustls`]: https://crates.io/crates/rustls
 //! [client]: client/struct.Lavalink.html
 //! [node]: node/struct.Node.html
 //! [process]: client/struct.Lavalink.html#method.process
-//! [`http`]: https://crates.io/crates/http
 
 #![deny(
     clippy::all,


### PR DESCRIPTION
Switch out the `gateway`, `http`, and `lavalink` crates' default TLS feature from being `native` to `rustls`.

See #124 for justification.

Closes #313.