### PR TITLE
 model/gateway/event: fix reconnect deserialization 

### DIFF
--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -284,7 +284,7 @@ impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
                 Self::ignore_all(&mut map)?;
 
                 GatewayEvent::Reconnect
-            },
+            }
             OpCode::RequestGuildMembers => {
                 return Err(DeError::unknown_variant(
                     "RequestGuildMembers",


### PR DESCRIPTION
Fix the deserialization of the Reconnect variant by deserializing and ignoring the rest of the fields.

Tests for all variants have been added.