### PR TITLE
gateway, http: emit compile error if no json feature is enabled

### DIFF
--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -72,5 +72,8 @@ pub(crate) use serde_json::to_string as json_to_string;
 #[cfg(feature = "simd-json")]
 pub(crate) use simd_json::to_string as json_to_string;
 
+#[cfg(not(any(feature = "serde_json", feature = "simd-json")))]
+compile_error!("Either the `serde_json` or `simd-json` feature must be enabled.");
+
 #[cfg(not(any(feature = "native", feature = "rustls")))]
-compile_error!("Either the `native` or `rustls` feature must be enabled");
+compile_error!("Either the `native` or `rustls` feature must be enabled.");

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -117,5 +117,8 @@ pub(crate) use serde_json::to_vec as json_to_vec;
 #[cfg(feature = "simd-json")]
 pub(crate) use simd_json::to_vec as json_to_vec;
 
+#[cfg(not(any(feature = "serde_json", feature = "simd-json")))]
+compile_error!("Either the `serde_json` or `simd-json` feature must be enabled.");
+
 #[cfg(not(any(feature = "native", feature = "rustls")))]
 compile_error!("Either the `native` or `rustls` feature must be enabled.");


### PR DESCRIPTION
Emit a compile error if neither `serde_json` nor `simd-json` is enabled.