### PR TITLE
Revert "http: take cows for requests (#321)"

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -18,7 +18,6 @@ use bytes::Bytes;
 use reqwest::{header::HeaderValue, Body, Client as ReqwestClient, Response, StatusCode};
 use serde::de::DeserializeOwned;
 use std::{
-    borrow::Cow,
     convert::TryFrom,
     fmt::{Debug, Formatter, Result as FmtResult},
     result::Result as StdResult,
@@ -487,11 +486,11 @@ impl Client {
     }
 
     /// Changes the user's nickname in a guild.
-    pub fn update_current_user_nick<'a>(
-        &'a self,
+    pub fn update_current_user_nick(
+        &self,
         guild_id: GuildId,
-        nick: impl Into<Cow<'a, str>>,
-    ) -> UpdateCurrentUserNick<'a> {
+        nick: impl Into<String>,
+    ) -> UpdateCurrentUserNick<'_> {
         UpdateCurrentUserNick::new(self, guild_id, nick)
     }
 
@@ -554,12 +553,12 @@ impl Client {
     /// discord docs] for more information about image data.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn create_emoji<'a>(
-        &'a self,
+    pub fn create_emoji(
+        &self,
         guild_id: GuildId,
-        name: impl Into<Cow<'a, str>>,
-        image: impl Into<Cow<'a, str>>,
-    ) -> CreateEmoji<'a> {
+        name: impl Into<String>,
+        image: impl Into<String>,
+    ) -> CreateEmoji<'_> {
         CreateEmoji::new(self, guild_id, name, image)
     }
 
@@ -626,10 +625,10 @@ impl Client {
     /// Returns [`CreateGuildError::NameInvalid`] if the name length is too short or too long.
     ///
     /// [`CreateGuildError::NameInvalid`]: ../request/guild/enum.CreateGuildError.html#variant.NameInvalid
-    pub fn create_guild<'a>(
-        &'a self,
-        name: impl Into<Cow<'a, str>>,
-    ) -> StdResult<CreateGuild<'a>, CreateGuildError> {
+    pub fn create_guild(
+        &self,
+        name: impl Into<String>,
+    ) -> StdResult<CreateGuild<'_>, CreateGuildError> {
         CreateGuild::new(self, name)
     }
 
@@ -677,11 +676,11 @@ impl Client {
     /// [`CreateGuildChannelError::NameInvalid`]: ../request/guild/create_guild_channel/enum.CreateGuildChannelError.html#variant.NameInvalid
     /// [`CreateGuildChannelError::RateLimitPerUserInvalid`]: ../request/guild/create_guild_channel/enum.CreateGuildChannelError.html#variant.RateLimitPerUserInvalid
     /// [`CreateGuildChannelError::TopicInvalid`]: ../request/guild/create_guild_channel/enum.CreateGuildChannelError.html#variant.TopicInvalid
-    pub fn create_guild_channel<'a>(
-        &'a self,
+    pub fn create_guild_channel(
+        &self,
         guild_id: GuildId,
-        name: impl Into<Cow<'a, str>>,
-    ) -> StdResult<CreateGuildChannel<'a>, CreateGuildChannelError> {
+        name: impl Into<String>,
+    ) -> StdResult<CreateGuildChannel<'_>, CreateGuildChannelError> {
         CreateGuildChannel::new(self, guild_id, name)
     }
 
@@ -720,12 +719,12 @@ impl Client {
     /// Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#create-guild-integration
-    pub fn create_guild_integration<'a>(
-        &'a self,
+    pub fn create_guild_integration(
+        &self,
         guild_id: GuildId,
         integration_id: IntegrationId,
-        kind: impl Into<Cow<'a, str>>,
-    ) -> CreateGuildIntegration<'a> {
+        kind: impl Into<String>,
+    ) -> CreateGuildIntegration<'_> {
         CreateGuildIntegration::new(self, guild_id, integration_id, kind)
     }
 
@@ -901,7 +900,7 @@ impl Client {
     /// ```
     ///
     /// [`with_counts`]: ../request/channel/invite/struct.GetInvite.html#method.with_counts
-    pub fn invite<'a>(&'a self, code: impl Into<Cow<'a, str>>) -> GetInvite<'a> {
+    pub fn invite(&self, code: impl Into<String>) -> GetInvite<'_> {
         GetInvite::new(self, code)
     }
 
@@ -929,7 +928,7 @@ impl Client {
     }
 
     /// Delete an invite by its code.
-    pub fn delete_invite<'a>(&'a self, code: impl Into<Cow<'a, str>>) -> DeleteInvite<'a> {
+    pub fn delete_invite(&self, code: impl Into<String>) -> DeleteInvite<'_> {
         DeleteInvite::new(self, code)
     }
 
@@ -1002,11 +1001,11 @@ impl Client {
     /// [`ChannelId`]: ../../twilight_model/id/struct.ChannelId.html
     /// [`MessageId`]: ../../twilight_model/id/struct.MessageId.html
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#bulk-delete-messages
-    pub fn delete_messages<'a>(
-        &'a self,
+    pub fn delete_messages(
+        &self,
         channel_id: ChannelId,
-        message_ids: impl Into<Cow<'a, [MessageId]>>,
-    ) -> DeleteMessages<'a> {
+        message_ids: impl Into<Vec<MessageId>>,
+    ) -> DeleteMessages<'_> {
         DeleteMessages::new(self, channel_id, message_ids)
     }
 
@@ -1028,7 +1027,7 @@ impl Client {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     /// let client = Client::new("my token");
     /// client.update_message(ChannelId(1), MessageId(2))
-    ///     .content(Some("test update".into()))?
+    ///     .content("test update".to_owned())?
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -1078,12 +1077,12 @@ impl Client {
     ///
     /// This endpoint is limited to 100 users maximum, so if a message has more than 100 reactions,
     /// requests must be chained until all reactions are retireved.
-    pub fn reactions<'a>(
-        &'a self,
+    pub fn reactions(
+        &self,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: impl Into<Cow<'a, str>>,
-    ) -> GetReactions<'a> {
+        emoji: impl Into<String>,
+    ) -> GetReactions<'_> {
         GetReactions::new(self, channel_id, message_id, emoji)
     }
 
@@ -1218,11 +1217,11 @@ impl Client {
     /// Modify the position of the roles.
     ///
     /// The minimum amount of roles to modify, is a swap between two roles.
-    pub fn update_role_positions<'a>(
-        &'a self,
+    pub fn update_role_positions(
+        &self,
         guild_id: GuildId,
-        roles: impl Into<Cow<'a, [(RoleId, u64)]>>,
-    ) -> UpdateRolePositions<'a> {
+        roles: impl Iterator<Item = (RoleId, u64)>,
+    ) -> UpdateRolePositions<'_> {
         UpdateRolePositions::new(self, guild_id, roles)
     }
 
@@ -1259,11 +1258,11 @@ impl Client {
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn create_webhook<'a>(
-        &'a self,
+    pub fn create_webhook(
+        &self,
         channel_id: ChannelId,
-        name: impl Into<Cow<'a, str>>,
-    ) -> CreateWebhook<'a> {
+        name: impl Into<String>,
+    ) -> CreateWebhook<'_> {
         CreateWebhook::new(self, channel_id, name)
     }
 
@@ -1279,7 +1278,7 @@ impl Client {
     /// Returns [`UrlError::SegmentMissing`] if the URL can not be parsed.
     ///
     /// [`UrlError::SegmentMissing`]: ../error/enum.UrlError.html#variant.SegmentMissing
-    pub fn delete_webhook_from_url<'a>(&'a self, url: &str) -> Result<DeleteWebhook<'a>> {
+    pub fn delete_webhook_from_url(&self, url: impl AsRef<str>) -> Result<DeleteWebhook<'_>> {
         let (id, _) = parse_webhook_url(url)?;
         Ok(self.delete_webhook(id))
     }
@@ -1296,17 +1295,17 @@ impl Client {
     /// Returns [`UrlError::SegmentMissing`] if the URL can not be parsed.
     ///
     /// [`UrlError::SegmentMissing`]: ../error/enum.UrlError.html#variant.SegmentMissing
-    pub fn update_webhook_from_url(&self, url: &str) -> Result<UpdateWebhook<'_>> {
+    pub fn update_webhook_from_url(&self, url: impl AsRef<str>) -> Result<UpdateWebhook<'_>> {
         let (id, _) = parse_webhook_url(url)?;
         Ok(self.update_webhook(id))
     }
 
     /// Update a webhook, with a token, by ID.
-    pub fn update_webhook_with_token<'a>(
-        &'a self,
+    pub fn update_webhook_with_token(
+        &self,
         webhook_id: WebhookId,
-        token: impl Into<Cow<'a, str>>,
-    ) -> UpdateWebhookWithToken<'a> {
+        token: impl Into<String>,
+    ) -> UpdateWebhookWithToken<'_> {
         UpdateWebhookWithToken::new(self, webhook_id, token)
     }
 
@@ -1317,10 +1316,10 @@ impl Client {
     /// Returns [`UrlError::SegmentMissing`] if the URL can not be parsed.
     ///
     /// [`UrlError::SegmentMissing`]: ../error/enum.UrlError.html#variant.SegmentMissing
-    pub fn update_webhook_with_token_from_url<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> Result<UpdateWebhookWithToken<'a>> {
+    pub fn update_webhook_with_token_from_url(
+        &self,
+        url: impl AsRef<str>,
+    ) -> Result<UpdateWebhookWithToken<'_>> {
         let (id, token) = parse_webhook_url(url)?;
         Ok(self.update_webhook_with_token(id, token.ok_or(UrlError::SegmentMissing)?))
     }
@@ -1350,11 +1349,11 @@ impl Client {
     /// [`content`]: ../request/channel/webhook/struct.ExecuteWebhook.html#method.content
     /// [`embeds`]: ../request/channel/webhook/struct.ExecuteWebhook.html#method.embeds
     /// [`file`]: ../request/channel/webhook/struct.ExecuteWebhook.html#method.file
-    pub fn execute_webhook<'a>(
-        &'a self,
+    pub fn execute_webhook(
+        &self,
         webhook_id: WebhookId,
-        token: impl Into<Cow<'a, str>>,
-    ) -> ExecuteWebhook<'a> {
+        token: impl Into<String>,
+    ) -> ExecuteWebhook<'_> {
         ExecuteWebhook::new(self, webhook_id, token)
     }
 
@@ -1365,7 +1364,7 @@ impl Client {
     /// Returns [`UrlError::SegmentMissing`] if the URL can not be parsed.
     ///
     /// [`UrlError::SegmentMissing`]: ../error/enum.UrlError.html#variant.SegmentMissing
-    pub fn execute_webhook_from_url<'a>(&'a self, url: &'a str) -> Result<ExecuteWebhook<'a>> {
+    pub fn execute_webhook_from_url(&self, url: impl AsRef<str>) -> Result<ExecuteWebhook<'_>> {
         let (id, token) = parse_webhook_url(url)?;
         Ok(self.execute_webhook(id, token.ok_or(UrlError::SegmentMissing)?))
     }
@@ -1558,9 +1557,9 @@ impl From<ReqwestClient> for Client {
 
 // parse the webhook id and token, if it exists in the string
 fn parse_webhook_url(
-    webhook_uri: &str,
-) -> std::result::Result<(WebhookId, Option<&str>), UrlError> {
-    let url = Url::parse(webhook_uri)?;
+    url: impl AsRef<str>,
+) -> std::result::Result<(WebhookId, Option<String>), UrlError> {
+    let url = Url::parse(url.as_ref())?;
     let mut segments = url.path_segments().ok_or(UrlError::SegmentMissing)?;
 
     segments
@@ -1572,14 +1571,9 @@ fn parse_webhook_url(
         .filter(|s| s == &"webhooks")
         .ok_or(UrlError::SegmentMissing)?;
     let id = segments.next().ok_or(UrlError::SegmentMissing)?;
+    let token = segments.next();
 
-    let token = segments.next().and_then(|_| {
-        let half = webhook_uri.split("api/webhooks/").nth(1)?;
-
-        half.split('/').nth(1)
-    });
-
-    Ok((WebhookId(id.parse()?), token))
+    Ok((WebhookId(id.parse()?), token.map(String::from)))
 }
 
 #[cfg(test)]

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Create a new pin in a channel.
@@ -8,7 +7,7 @@ pub struct CreatePin<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> CreatePin<'a> {
@@ -23,7 +22,7 @@ impl<'a> CreatePin<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{channel::Channel, id::ChannelId};
 
 /// Delete a channel by ID.
@@ -7,7 +6,7 @@ pub struct DeleteChannel<'a> {
     channel_id: ChannelId,
     fut: Option<Pending<'a, Channel>>,
     http: &'a Client,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteChannel<'a> {
@@ -21,7 +20,7 @@ impl<'a> DeleteChannel<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/delete_channel_permission.rs
+++ b/http/src/request/channel/delete_channel_permission.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::ChannelId;
 
 /// Clear the permissions for a target ID in a channel.
@@ -10,7 +9,7 @@ pub struct DeleteChannelPermission<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     target_id: u64,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteChannelPermission<'a> {
@@ -25,7 +24,7 @@ impl<'a> DeleteChannelPermission<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Delete a pin in a channel, by ID.
@@ -8,7 +7,7 @@ pub struct DeletePin<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> DeletePin<'a> {
@@ -23,7 +22,7 @@ impl<'a> DeletePin<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -39,7 +39,7 @@ pub struct CreateInvite<'a> {
     fields: CreateInviteFields,
     fut: Option<Pending<'a, Invite>>,
     http: &'a Client,
-    reason: Option<&'a str>,
+    reason: Option<String>,
 }
 
 impl<'a> CreateInvite<'a> {
@@ -106,8 +106,8 @@ impl<'a> CreateInvite<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: &'a str) -> Self {
-        self.reason.replace(reason);
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
 
         self
     }

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::invite::Invite;
 
 #[derive(Default)]
@@ -29,14 +28,14 @@ struct GetInviteFields {
 ///
 /// [`with_counts`]: #method.with_counts
 pub struct GetInvite<'a> {
-    code: Cow<'a, str>,
+    code: String,
     fields: GetInviteFields,
     fut: Option<PendingOption<'a>>,
     http: &'a Client,
 }
 
 impl<'a> GetInvite<'a> {
-    pub(crate) fn new(http: &'a Client, code: impl Into<Cow<'a, str>>) -> Self {
+    pub(crate) fn new(http: &'a Client, code: impl Into<String>) -> Self {
         Self {
             code: code.into(),
             fields: GetInviteFields::default(),
@@ -56,7 +55,7 @@ impl<'a> GetInvite<'a> {
         self.fut
             .replace(Box::pin(self.http.request_bytes(Request::from(
                 Route::GetInvite {
-                    code: &self.code,
+                    code: self.code.clone(),
                     with_counts: self.fields.with_counts,
                 },
             ))));

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -6,7 +6,6 @@ use reqwest::{
     Body,
 };
 use std::{
-    borrow::Cow,
     collections::HashMap,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -47,11 +46,11 @@ impl Error for CreateMessageError {
 }
 
 #[derive(Default, Serialize)]
-pub(crate) struct CreateMessageFields<'a> {
-    content: Option<Cow<'a, str>>,
-    embed: Option<&'a Embed>,
+pub(crate) struct CreateMessageFields {
+    content: Option<String>,
+    embed: Option<Embed>,
     nonce: Option<u64>,
-    payload_json: Option<Cow<'a, [u8]>>,
+    payload_json: Option<Vec<u8>>,
     tts: Option<bool>,
     pub(crate) allowed_mentions: Option<AllowedMentions>,
 }
@@ -79,7 +78,7 @@ pub(crate) struct CreateMessageFields<'a> {
 pub struct CreateMessage<'a> {
     attachments: HashMap<String, Body>,
     channel_id: ChannelId,
-    pub(crate) fields: CreateMessageFields<'a>,
+    pub(crate) fields: CreateMessageFields,
     fut: Option<Pending<'a, Message>>,
     http: &'a Client,
 }
@@ -108,11 +107,11 @@ impl<'a> CreateMessage<'a> {
     /// too long.
     ///
     /// [`CreateMessageError::ContentInvalid`]: enum.CreateMessageError.html#variant.ContentInvalid
-    pub fn content(self, content: impl Into<Cow<'a, str>>) -> Result<Self, CreateMessageError> {
+    pub fn content(self, content: impl Into<String>) -> Result<Self, CreateMessageError> {
         self._content(content.into())
     }
 
-    fn _content(mut self, content: Cow<'a, str>) -> Result<Self, CreateMessageError> {
+    fn _content(mut self, content: String) -> Result<Self, CreateMessageError> {
         if !validate::content_limit(&content) {
             return Err(CreateMessageError::ContentInvalid);
         }
@@ -138,8 +137,8 @@ impl<'a> CreateMessage<'a> {
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#embed-limits
     /// [`EmbedBuilder`]: ../../../../../twilight_builders/embed/struct.EmbedBuilder.html
     /// [`CreateMessageError::EmbedTooLarge`]: enum.CreateMessageError.html#variant.EmbedTooLarge
-    pub fn embed(mut self, embed: &'a Embed) -> Result<Self, CreateMessageError> {
-        validate::embed(embed).map_err(|source| CreateMessageError::EmbedTooLarge { source })?;
+    pub fn embed(mut self, embed: Embed) -> Result<Self, CreateMessageError> {
+        validate::embed(&embed).map_err(|source| CreateMessageError::EmbedTooLarge { source })?;
 
         self.fields.embed.replace(embed);
 
@@ -186,7 +185,7 @@ impl<'a> CreateMessage<'a> {
     /// JSON encoded body of any additional request fields.  See [Discord Docs/Create Message]
     ///
     /// [Discord Docs/Create Message]: https://discord.com/developers/docs/resources/channel#create-message-params
-    pub fn payload_json(mut self, payload_json: impl Into<Cow<'a, [u8]>>) -> Self {
+    pub fn payload_json(mut self, payload_json: impl Into<Vec<u8>>) -> Self {
         self.fields.payload_json.replace(payload_json.into());
 
         self

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Delete a message by [`ChannelId`] and [`MessageId`].
@@ -11,7 +10,7 @@ pub struct DeleteMessage<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteMessage<'a> {
@@ -26,14 +25,14 @@ impl<'a> DeleteMessage<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = self.reason.as_ref() {
+        let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
                 headers,

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -1,11 +1,10 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::{ChannelId, MessageId};
 
 #[derive(Serialize)]
-struct DeleteMessagesFields<'a> {
-    messages: Cow<'a, [MessageId]>,
+struct DeleteMessagesFields {
+    messages: Vec<MessageId>,
 }
 
 /// Delete messgaes by [`ChannelId`] and Vec<[`MessageId`]>.
@@ -19,17 +18,17 @@ struct DeleteMessagesFields<'a> {
 /// [the discord docs]: https://discord.com/developers/docs/resources/channel#bulk-delete-messages
 pub struct DeleteMessages<'a> {
     channel_id: ChannelId,
-    fields: DeleteMessagesFields<'a>,
+    fields: DeleteMessagesFields,
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteMessages<'a> {
     pub(crate) fn new(
         http: &'a Client,
         channel_id: ChannelId,
-        message_ids: impl Into<Cow<'a, [MessageId]>>,
+        message_ids: impl Into<Vec<MessageId>>,
     ) -> Self {
         Self {
             channel_id,
@@ -43,7 +42,7 @@ impl<'a> DeleteMessages<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{
     channel::ReactionType,
     id::{ChannelId, MessageId},
@@ -62,7 +61,7 @@ impl<'a> CreateReaction<'a> {
         self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::CreateReaction {
                 channel_id: self.channel_id.0,
-                emoji: Cow::Owned(self.emoji.clone()),
+                emoji: self.emoji.clone(),
                 message_id: self.message_id.0,
             },
         ))));

--- a/http/src/request/channel/reaction/delete_all_reaction.rs
+++ b/http/src/request/channel/reaction/delete_all_reaction.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{
     channel::ReactionType,
     id::{ChannelId, MessageId},
@@ -35,7 +34,7 @@ impl<'a> DeleteAllReaction<'a> {
             Route::DeleteMessageSpecficReaction {
                 channel_id: self.channel_id.0,
                 message_id: self.message_id.0,
-                emoji: Cow::Owned(self.emoji.clone()),
+                emoji: self.emoji.clone(),
             },
         ))));
 

--- a/http/src/request/channel/reaction/delete_reaction.rs
+++ b/http/src/request/channel/reaction/delete_reaction.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{
     channel::ReactionType,
     id::{ChannelId, MessageId},
@@ -12,7 +11,7 @@ pub struct DeleteReaction<'a> {
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
-    target_user: Cow<'a, str>,
+    target_user: String,
 }
 
 impl<'a> DeleteReaction<'a> {
@@ -21,7 +20,7 @@ impl<'a> DeleteReaction<'a> {
         channel_id: ChannelId,
         message_id: MessageId,
         emoji: ReactionType,
-        target_user: impl Into<Cow<'a, str>>,
+        target_user: impl Into<String>,
     ) -> Self {
         Self {
             channel_id,
@@ -37,7 +36,7 @@ impl<'a> DeleteReaction<'a> {
         self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::DeleteReaction {
                 channel_id: self.channel_id.0,
-                emoji: Cow::Owned(self.emoji.clone()),
+                emoji: self.emoji.clone(),
                 message_id: self.message_id.0,
                 user: self.target_user.clone(),
             },

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -1,6 +1,5 @@
 use crate::request::prelude::*;
 use std::{
-    borrow::Cow,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
@@ -39,7 +38,7 @@ struct GetReactionsFields {
 /// requests must be chained until all reactions are retireved.
 pub struct GetReactions<'a> {
     channel_id: ChannelId,
-    emoji: Cow<'a, str>,
+    emoji: String,
     fields: GetReactionsFields,
     fut: Option<Pending<'a, Vec<User>>>,
     http: &'a Client,
@@ -51,7 +50,7 @@ impl<'a> GetReactions<'a> {
         http: &'a Client,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: impl Into<Cow<'a, str>>,
+        emoji: impl Into<String>,
     ) -> Self {
         Self {
             channel_id,
@@ -103,7 +102,7 @@ impl<'a> GetReactions<'a> {
                 after: self.fields.after.map(|x| x.0),
                 before: self.fields.before.map(|x| x.0),
                 channel_id: self.channel_id.0,
-                emoji: &self.emoji,
+                emoji: self.emoji.to_owned(),
                 limit: self.fields.limit,
                 message_id: self.message_id.0,
             },

--- a/http/src/request/channel/reaction/mod.rs
+++ b/http/src/request/channel/reaction/mod.rs
@@ -19,7 +19,7 @@ fn format_emoji(emoji: ReactionType) -> String {
         ReactionType::Custom { id, name, .. } => {
             let mut emoji = String::new();
             match name {
-                Some(name) => emoji.push_str(&name),
+                Some(name) => emoji.push_str(name.as_ref()),
                 None => emoji.push_str("e"),
             }
             let _ = write!(emoji, ":{}", id);

--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -62,7 +62,11 @@ impl<'a> UpdateChannelPermission<'a> {
         self.configure("role", role_id.into().0)
     }
 
-    fn configure(self, kind: &'a str, target_id: u64) -> UpdateChannelPermissionConfigured<'a> {
+    fn configure(
+        self,
+        kind: impl Into<String>,
+        target_id: u64,
+    ) -> UpdateChannelPermissionConfigured<'a> {
         UpdateChannelPermissionConfigured::new(
             self.http,
             self.channel_id,

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -1,23 +1,22 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{guild::Permissions, id::ChannelId};
 
 #[derive(Serialize)]
-struct UpdateChannelPermissionConfiguredFields<'a> {
+struct UpdateChannelPermissionConfiguredFields {
     allow: Permissions,
     deny: Permissions,
-    kind: Cow<'a, str>,
+    kind: String,
 }
 
 /// Created when either `member` or `role` is called on a `DeleteChannelPermission` struct.
 pub struct UpdateChannelPermissionConfigured<'a> {
     channel_id: ChannelId,
-    fields: UpdateChannelPermissionConfiguredFields<'a>,
+    fields: UpdateChannelPermissionConfiguredFields,
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     target_id: u64,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> UpdateChannelPermissionConfigured<'a> {
@@ -26,7 +25,7 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
         channel_id: ChannelId,
         allow: Permissions,
         deny: Permissions,
-        kind: impl Into<Cow<'a, str>>,
+        kind: impl Into<String>,
         target_id: u64,
     ) -> Self {
         Self {
@@ -44,7 +43,7 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -1,12 +1,11 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{channel::Webhook, id::ChannelId};
 
 #[derive(Serialize)]
-struct CreateWebhookFields<'a> {
-    avatar: Option<Cow<'a, str>>,
-    name: Cow<'a, str>,
+struct CreateWebhookFields {
+    avatar: Option<String>,
+    name: String,
 }
 
 /// Create a webhook in a channel.
@@ -29,18 +28,14 @@ struct CreateWebhookFields<'a> {
 /// ```
 pub struct CreateWebhook<'a> {
     channel_id: ChannelId,
-    fields: CreateWebhookFields<'a>,
+    fields: CreateWebhookFields,
     fut: Option<Pending<'a, Webhook>>,
     http: &'a Client,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> CreateWebhook<'a> {
-    pub(crate) fn new(
-        http: &'a Client,
-        channel_id: ChannelId,
-        name: impl Into<Cow<'a, str>>,
-    ) -> Self {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId, name: impl Into<String>) -> Self {
         Self {
             channel_id,
             fields: CreateWebhookFields {
@@ -60,14 +55,14 @@ impl<'a> CreateWebhook<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<Cow<'a, str>>) -> Self {
+    pub fn avatar(mut self, avatar: impl Into<String>) -> Self {
         self.fields.avatar.replace(avatar.into());
 
         self
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/webhook/delete_webhook.rs
+++ b/http/src/request/channel/webhook/delete_webhook.rs
@@ -1,18 +1,17 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::WebhookId;
 
-struct DeleteWebhookParams<'a> {
-    token: Option<Cow<'a, str>>,
+struct DeleteWebhookParams {
+    token: Option<String>,
 }
 
 /// Delete a webhook by its ID.
 pub struct DeleteWebhook<'a> {
-    fields: DeleteWebhookParams<'a>,
+    fields: DeleteWebhookParams,
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     id: WebhookId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteWebhook<'a> {
@@ -27,14 +26,14 @@ impl<'a> DeleteWebhook<'a> {
     }
 
     /// Specify the token for auth, if not already authenticated with a Bot token.
-    pub fn token(mut self, token: impl Into<Cow<'a, str>>) -> Self {
+    pub fn token(mut self, token: impl Into<String>) -> Self {
         self.fields.token.replace(token.into());
 
         self
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self
@@ -47,13 +46,13 @@ impl<'a> DeleteWebhook<'a> {
                 headers,
                 Route::DeleteWebhook {
                     webhook_id: self.id.0,
-                    token: self.fields.token.as_deref(),
+                    token: self.fields.token.clone(),
                 },
             ))
         } else {
             Request::from(Route::DeleteWebhook {
                 webhook_id: self.id.0,
-                token: self.fields.token.as_deref(),
+                token: self.fields.token.clone(),
             })
         };
 

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -1,20 +1,19 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{
     channel::{embed::Embed, Message},
     id::WebhookId,
 };
 
 #[derive(Default, Serialize)]
-struct ExecuteWebhookFields<'a> {
-    avatar_url: Option<Cow<'a, str>>,
-    content: Option<Cow<'a, str>>,
-    embeds: Option<Cow<'a, [Embed]>>,
-    file: Option<Cow<'a, [u8]>>,
-    payload_json: Option<Cow<'a, [u8]>>,
+struct ExecuteWebhookFields {
+    avatar_url: Option<String>,
+    content: Option<String>,
+    embeds: Option<Vec<Embed>>,
+    file: Option<Vec<u8>>,
+    payload_json: Option<Vec<u8>>,
     tts: Option<bool>,
-    username: Option<Cow<'a, str>>,
+    username: Option<String>,
     wait: Option<bool>,
 }
 
@@ -44,19 +43,15 @@ struct ExecuteWebhookFields<'a> {
 /// [`embeds`]: #method.embeds
 /// [`file`]: #method.file
 pub struct ExecuteWebhook<'a> {
-    fields: ExecuteWebhookFields<'a>,
+    fields: ExecuteWebhookFields,
     fut: Option<Pending<'a, Option<Message>>>,
     http: &'a Client,
-    token: Cow<'a, str>,
+    token: String,
     webhook_id: WebhookId,
 }
 
 impl<'a> ExecuteWebhook<'a> {
-    pub(crate) fn new(
-        http: &'a Client,
-        webhook_id: WebhookId,
-        token: impl Into<Cow<'a, str>>,
-    ) -> Self {
+    pub(crate) fn new(http: &'a Client, webhook_id: WebhookId, token: impl Into<String>) -> Self {
         Self {
             fields: ExecuteWebhookFields::default(),
             fut: None,
@@ -67,7 +62,7 @@ impl<'a> ExecuteWebhook<'a> {
     }
 
     /// The URL of the avatar of the webhook.
-    pub fn avatar_url(mut self, avatar_url: impl Into<Cow<'a, str>>) -> Self {
+    pub fn avatar_url(mut self, avatar_url: impl Into<String>) -> Self {
         self.fields.avatar_url.replace(avatar_url.into());
 
         self
@@ -76,21 +71,21 @@ impl<'a> ExecuteWebhook<'a> {
     /// The content of the webook's message.
     ///
     /// Up to 2000 UTF-16 codepoints, same as a message.
-    pub fn content(mut self, content: impl Into<Cow<'a, str>>) -> Self {
+    pub fn content(mut self, content: impl Into<String>) -> Self {
         self.fields.content.replace(content.into());
 
         self
     }
 
     /// Set the list of embeds of the webhook's message.
-    pub fn embeds(mut self, embeds: impl Into<Cow<'a, [Embed]>>) -> Self {
-        self.fields.embeds.replace(embeds.into());
+    pub fn embeds(mut self, embeds: Vec<Embed>) -> Self {
+        self.fields.embeds.replace(embeds);
 
         self
     }
 
     /// Attach a file to the webhook.
-    pub fn file(mut self, file: impl Into<Cow<'a, [u8]>>) -> Self {
+    pub fn file(mut self, file: impl Into<Vec<u8>>) -> Self {
         self.fields.file.replace(file.into());
 
         self
@@ -99,7 +94,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// JSON encoded body of any additional request fields. See [Discord Docs/Create Message]
     ///
     /// [Discord Docs/Create Message]: https://discord.com/developers/docs/resources/channel#create-message-params
-    pub fn payload_json(mut self, payload_json: impl Into<Cow<'a, [u8]>>) -> Self {
+    pub fn payload_json(mut self, payload_json: impl Into<Vec<u8>>) -> Self {
         self.fields.payload_json.replace(payload_json.into());
 
         self
@@ -113,7 +108,7 @@ impl<'a> ExecuteWebhook<'a> {
     }
 
     /// Specify the username of the webhook's message.
-    pub fn username(mut self, username: impl Into<Cow<'a, str>>) -> Self {
+    pub fn username(mut self, username: impl Into<String>) -> Self {
         self.fields.username.replace(username.into());
 
         self
@@ -133,7 +128,7 @@ impl<'a> ExecuteWebhook<'a> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
             json_to_vec(&self.fields)?,
             Route::ExecuteWebhook {
-                token: &self.token,
+                token: self.token.to_owned(),
                 wait: self.fields.wait,
                 webhook_id: self.webhook_id.0,
             },

--- a/http/src/request/channel/webhook/get_webhook.rs
+++ b/http/src/request/channel/webhook/get_webhook.rs
@@ -1,15 +1,14 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{channel::Webhook, id::WebhookId};
 
 #[derive(Default)]
-struct GetWebhookFields<'a> {
-    token: Option<Cow<'a, str>>,
+struct GetWebhookFields {
+    token: Option<String>,
 }
 
 /// Get a webhook by ID.
 pub struct GetWebhook<'a> {
-    fields: GetWebhookFields<'a>,
+    fields: GetWebhookFields,
     fut: Option<PendingOption<'a>>,
     http: &'a Client,
     id: WebhookId,
@@ -26,7 +25,7 @@ impl<'a> GetWebhook<'a> {
     }
 
     /// Specify the token for auth, if not already authenticated with a Bot token.
-    pub fn token(mut self, token: impl Into<Cow<'a, str>>) -> Self {
+    pub fn token(mut self, token: impl Into<String>) -> Self {
         self.fields.token.replace(token.into());
 
         self
@@ -36,7 +35,7 @@ impl<'a> GetWebhook<'a> {
         self.fut
             .replace(Box::pin(self.http.request_bytes(Request::from(
                 Route::GetWebhook {
-                    token: self.fields.token.as_deref(),
+                    token: self.fields.token.clone(),
                     webhook_id: self.id.0,
                 },
             ))));

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -1,25 +1,24 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{
     channel::Webhook,
     id::{ChannelId, WebhookId},
 };
 
 #[derive(Default, Serialize)]
-struct UpdateWebhookFields<'a> {
-    avatar: Option<Cow<'a, str>>,
+struct UpdateWebhookFields {
+    avatar: Option<String>,
     channel_id: Option<ChannelId>,
-    name: Option<Cow<'a, str>>,
+    name: Option<String>,
 }
 
 /// Update a webhook by ID.
 pub struct UpdateWebhook<'a> {
-    fields: UpdateWebhookFields<'a>,
+    fields: UpdateWebhookFields,
     fut: Option<Pending<'a, Webhook>>,
     http: &'a Client,
     webhook_id: WebhookId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 /// Update a webhook by its ID.
@@ -41,7 +40,7 @@ impl<'a> UpdateWebhook<'a> {
     /// base64-encoded image.
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<Cow<'a, str>>) -> Self {
+    pub fn avatar(mut self, avatar: impl Into<String>) -> Self {
         self.fields.avatar.replace(avatar.into());
 
         self
@@ -55,14 +54,14 @@ impl<'a> UpdateWebhook<'a> {
     }
 
     /// Change the name of the webhook.
-    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Self {
+    pub fn name(mut self, name: impl Into<String>) -> Self {
         self.fields.name.replace(name.into());
 
         self
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -1,29 +1,24 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{channel::Webhook, id::WebhookId};
 
 #[derive(Default, Serialize)]
-struct UpdateWebhookWithTokenFields<'a> {
-    avatar: Option<Cow<'a, str>>,
-    name: Option<Cow<'a, str>>,
+struct UpdateWebhookWithTokenFields {
+    avatar: Option<String>,
+    name: Option<String>,
 }
 
 /// Update a webhook, with a token, by ID.
 pub struct UpdateWebhookWithToken<'a> {
-    fields: UpdateWebhookWithTokenFields<'a>,
+    fields: UpdateWebhookWithTokenFields,
     fut: Option<Pending<'a, Webhook>>,
     http: &'a Client,
-    token: Cow<'a, str>,
+    token: String,
     webhook_id: WebhookId,
 }
 
 impl<'a> UpdateWebhookWithToken<'a> {
-    pub(crate) fn new(
-        http: &'a Client,
-        webhook_id: WebhookId,
-        token: impl Into<Cow<'a, str>>,
-    ) -> Self {
+    pub(crate) fn new(http: &'a Client, webhook_id: WebhookId, token: impl Into<String>) -> Self {
         Self {
             fields: UpdateWebhookWithTokenFields::default(),
             fut: None,
@@ -40,14 +35,14 @@ impl<'a> UpdateWebhookWithToken<'a> {
     /// base64-encoded image.
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<Cow<'a, str>>) -> Self {
+    pub fn avatar(mut self, avatar: impl Into<String>) -> Self {
         self.fields.avatar.replace(avatar.into());
 
         self
     }
 
     /// Change the name of the webhook.
-    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Self {
+    pub fn name(mut self, name: impl Into<String>) -> Self {
         self.fields.name.replace(name.into());
 
         self
@@ -57,7 +52,7 @@ impl<'a> UpdateWebhookWithToken<'a> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
             json_to_vec(&self.fields)?,
             Route::UpdateWebhook {
-                token: Some(&self.token),
+                token: Some(self.token.clone()),
                 webhook_id: self.webhook_id.0,
             },
         )))));

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -1,6 +1,5 @@
 use crate::request::prelude::*;
 use std::{
-    borrow::Cow,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
@@ -26,9 +25,9 @@ impl Display for CreateBanError {
 impl Error for CreateBanError {}
 
 #[derive(Default)]
-struct CreateBanFields<'a> {
+struct CreateBanFields {
     delete_message_days: Option<u64>,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 /// Bans a user from a guild, optionally with the number of days' worth of
@@ -56,7 +55,7 @@ struct CreateBanFields<'a> {
 /// # Ok(()) }
 /// ```
 pub struct CreateBan<'a> {
-    fields: CreateBanFields<'a>,
+    fields: CreateBanFields,
     fut: Option<Pending<'a, ()>>,
     guild_id: GuildId,
     http: &'a Client,
@@ -95,7 +94,7 @@ impl<'a> CreateBan<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.fields.reason.replace(reason.into());
 
         self
@@ -106,7 +105,7 @@ impl<'a> CreateBan<'a> {
             Route::CreateBan {
                 delete_message_days: self.fields.delete_message_days,
                 guild_id: self.guild_id.0,
-                reason: self.fields.reason.as_deref(),
+                reason: self.fields.reason.clone(),
                 user_id: self.user_id.0,
             },
         ))));

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::{GuildId, UserId};
 
 /// Remove a ban from a user in a guild.
@@ -27,7 +26,7 @@ pub struct DeleteBan<'a> {
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteBan<'a> {
@@ -42,7 +41,7 @@ impl<'a> DeleteBan<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/create_guild.rs
+++ b/http/src/request/guild/create_guild.rs
@@ -1,7 +1,6 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
 use std::{
-    borrow::Cow,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
@@ -42,14 +41,14 @@ impl Display for CreateGuildError {
 impl Error for CreateGuildError {}
 
 #[derive(Serialize)]
-struct CreateGuildFields<'a> {
-    channels: Option<Cow<'a, [Cow<'a, GuildChannel>]>>,
+struct CreateGuildFields {
+    channels: Option<Vec<GuildChannel>>,
     default_message_notifications: Option<DefaultMessageNotificationLevel>,
     explicit_content_filter: Option<ExplicitContentFilter>,
-    icon: Option<Cow<'a, str>>,
-    name: Cow<'a, str>,
-    region: Option<Cow<'a, str>>,
-    roles: Option<Cow<'a, [Role]>>,
+    icon: Option<String>,
+    name: String,
+    region: Option<String>,
+    roles: Option<Vec<Role>>,
     verification_level: Option<VerificationLevel>,
 }
 
@@ -64,18 +63,17 @@ struct CreateGuildFields<'a> {
 ///
 /// [`CreateGuildError::NameInvalid`]: ../request/guild/enum.CreateGuildError.html#variant.NameInvalid
 pub struct CreateGuild<'a> {
-    fields: CreateGuildFields<'a>,
+    fields: CreateGuildFields,
     fut: Option<Pending<'a, PartialGuild>>,
     http: &'a Client,
 }
 
 impl<'a> CreateGuild<'a> {
-    pub(crate) fn new(
-        http: &'a Client,
-        name: impl Into<Cow<'a, str>>,
-    ) -> Result<Self, CreateGuildError> {
-        let name = name.into();
+    pub(crate) fn new(http: &'a Client, name: impl Into<String>) -> Result<Self, CreateGuildError> {
+        Self::_new(http, name.into())
+    }
 
+    fn _new(http: &'a Client, name: String) -> Result<Self, CreateGuildError> {
         if !validate::guild_name(&name) {
             return Err(CreateGuildError::NameInvalid);
         }
@@ -105,12 +103,7 @@ impl<'a> CreateGuild<'a> {
     /// Returns [`CreateGuildError::TooManyChannels`] if the number of channels is over 500.
     ///
     /// [`CreateGuildError::TooManyChannels`]: enum.CreateGuildError.html#variant.TooManyChannels
-    pub fn channels(
-        mut self,
-        channels: impl Into<Cow<'a, [Cow<'a, GuildChannel>]>>,
-    ) -> Result<Self, CreateGuildError> {
-        let channels = channels.into();
-
+    pub fn channels(mut self, channels: Vec<GuildChannel>) -> Result<Self, CreateGuildError> {
         // Error 30013
         // <https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#json>
         if channels.len() > 500 {
@@ -156,7 +149,7 @@ impl<'a> CreateGuild<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn icon(mut self, icon: impl Into<Cow<'a, str>>) -> Self {
+    pub fn icon(mut self, icon: impl Into<String>) -> Self {
         self.fields.icon.replace(icon.into());
 
         self
@@ -166,7 +159,7 @@ impl<'a> CreateGuild<'a> {
     /// information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/voice#voice-region-object
-    pub fn region(mut self, region: impl Into<Cow<'a, str>>) -> Self {
+    pub fn region(mut self, region: impl Into<String>) -> Self {
         self.fields.region.replace(region.into());
 
         self
@@ -182,9 +175,7 @@ impl<'a> CreateGuild<'a> {
     /// over 250.
     ///
     /// [`CreateGuildError::TooManyRoles`]: enum.CreateGuildError.html#variant.TooManyRoles
-    pub fn roles(mut self, roles: impl Into<Cow<'a, [Role]>>) -> Result<Self, CreateGuildError> {
-        let roles = roles.into();
-
+    pub fn roles(mut self, roles: Vec<Role>) -> Result<Self, CreateGuildError> {
         if roles.len() > 250 {
             return Err(CreateGuildError::TooManyRoles);
         }

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -1,6 +1,5 @@
 use crate::request::prelude::*;
 use std::{
-    borrow::{Borrow, Cow},
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
@@ -27,10 +26,10 @@ impl Display for CreateGuildPruneError {
 impl Error for CreateGuildPruneError {}
 
 #[derive(Default)]
-struct CreateGuildPruneFields<'a> {
+struct CreateGuildPruneFields {
     compute_prune_count: Option<bool>,
     days: Option<u64>,
-    include_roles: Option<Cow<'a, [RoleId]>>,
+    include_roles: Vec<u64>,
 }
 
 /// Begin a guild prune.
@@ -39,11 +38,11 @@ struct CreateGuildPruneFields<'a> {
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#begin-guild-prune
 pub struct CreateGuildPrune<'a> {
-    fields: CreateGuildPruneFields<'a>,
+    fields: CreateGuildPruneFields,
     guild_id: GuildId,
     fut: Option<Pending<'a, Option<GuildPrune>>>,
     http: &'a Client,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> CreateGuildPrune<'a> {
@@ -58,8 +57,10 @@ impl<'a> CreateGuildPrune<'a> {
     }
 
     /// List of roles to include when pruning.
-    pub fn include_roles(mut self, roles: impl Into<Cow<'a, [RoleId]>>) -> Self {
-        self.fields.include_roles.replace(roles.into());
+    pub fn include_roles(mut self, roles: impl Iterator<Item = RoleId>) -> Self {
+        let roles = roles.map(|e| e.0).collect::<Vec<_>>();
+
+        self.fields.include_roles = roles;
 
         self
     }
@@ -91,26 +92,22 @@ impl<'a> CreateGuildPrune<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self
     }
 
     fn start(&mut self) -> Result<()> {
-        let include_roles = self.fields.include_roles.take();
-        let include_roles = include_roles.as_deref();
-
-        let request = if let Some(reason) = self.reason.take() {
-            let headers = audit_header(reason.borrow())?;
-
+        let request = if let Some(reason) = &self.reason {
+            let headers = audit_header(&reason)?;
             Request::from((
                 headers,
                 Route::CreateGuildPrune {
                     compute_prune_count: self.fields.compute_prune_count,
                     days: self.fields.days,
                     guild_id: self.guild_id.0,
-                    include_roles,
+                    include_roles: self.fields.include_roles.clone(),
                 },
             ))
         } else {
@@ -118,7 +115,7 @@ impl<'a> CreateGuildPrune<'a> {
                 compute_prune_count: self.fields.compute_prune_count,
                 days: self.fields.days,
                 guild_id: self.guild_id.0,
-                include_roles,
+                include_roles: self.fields.include_roles.clone(),
             })
         };
 

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -1,16 +1,15 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{
     guild::Emoji,
     id::{GuildId, RoleId},
 };
 
 #[derive(Serialize)]
-struct CreateEmojiFields<'a> {
-    image: Cow<'a, str>,
-    name: Cow<'a, str>,
-    roles: Option<Cow<'a, [RoleId]>>,
+struct CreateEmojiFields {
+    image: String,
+    name: String,
+    roles: Option<Vec<RoleId>>,
 }
 
 /// Create an emoji in a guild.
@@ -22,18 +21,18 @@ struct CreateEmojiFields<'a> {
 /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
 pub struct CreateEmoji<'a> {
     fut: Option<Pending<'a, Emoji>>,
-    fields: CreateEmojiFields<'a>,
+    fields: CreateEmojiFields,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> CreateEmoji<'a> {
     pub(crate) fn new(
         http: &'a Client,
         guild_id: GuildId,
-        name: impl Into<Cow<'a, str>>,
-        image: impl Into<Cow<'a, str>>,
+        name: impl Into<String>,
+        image: impl Into<String>,
     ) -> Self {
         Self {
             fields: CreateEmojiFields {
@@ -53,14 +52,14 @@ impl<'a> CreateEmoji<'a> {
     /// Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/emoji
-    pub fn roles(mut self, roles: impl Into<Cow<'a, [RoleId]>>) -> Self {
-        self.fields.roles.replace(roles.into());
+    pub fn roles(mut self, roles: Vec<RoleId>) -> Self {
+        self.fields.roles.replace(roles);
 
         self
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -7,7 +7,7 @@ pub struct DeleteEmoji<'a> {
     fut: Option<Pending<'a, ()>>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<&'a str>,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteEmoji<'a> {
@@ -22,8 +22,8 @@ impl<'a> DeleteEmoji<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: &'a str) -> Self {
-        self.reason.replace(reason);
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason.replace(reason.into());
 
         self
     }

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -1,25 +1,24 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{
     guild::Emoji,
     id::{EmojiId, GuildId, RoleId},
 };
 
 #[derive(Default, Serialize)]
-struct UpdateEmojiFields<'a> {
-    name: Option<Cow<'a, str>>,
-    roles: Option<Cow<'a, [RoleId]>>,
+struct UpdateEmojiFields {
+    name: Option<String>,
+    roles: Option<Vec<RoleId>>,
 }
 
 /// Update an emoji in a guild, by id.
 pub struct UpdateEmoji<'a> {
     emoji_id: EmojiId,
-    fields: UpdateEmojiFields<'a>,
+    fields: UpdateEmojiFields,
     fut: Option<Pending<'a, Emoji>>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> UpdateEmoji<'a> {
@@ -35,21 +34,21 @@ impl<'a> UpdateEmoji<'a> {
     }
 
     /// Change the name of the emoji.
-    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Self {
+    pub fn name(mut self, name: impl Into<String>) -> Self {
         self.fields.name.replace(name.into());
 
         self
     }
 
     /// Change the roles that the emoji is whitelisted to.
-    pub fn roles(mut self, roles: impl Into<Cow<'a, [RoleId]>>) -> Self {
-        self.fields.roles.replace(roles.into());
+    pub fn roles(mut self, roles: Vec<RoleId>) -> Self {
+        self.fields.roles.replace(roles);
 
         self
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -1,6 +1,5 @@
 use crate::request::prelude::*;
 use std::{
-    borrow::Cow,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
@@ -27,14 +26,14 @@ impl Display for GetGuildPruneCountError {
 impl Error for GetGuildPruneCountError {}
 
 #[derive(Default)]
-struct GetGuildPruneCountFields<'a> {
+struct GetGuildPruneCountFields {
     days: Option<u64>,
-    include_roles: Option<Cow<'a, [RoleId]>>,
+    include_roles: Vec<u64>,
 }
 
 /// Get the counts of guild members to be pruned.
 pub struct GetGuildPruneCount<'a> {
-    fields: GetGuildPruneCountFields<'a>,
+    fields: GetGuildPruneCountFields,
     fut: Option<Pending<'a, GuildPrune>>,
     guild_id: GuildId,
     http: &'a Client,
@@ -72,8 +71,10 @@ impl<'a> GetGuildPruneCount<'a> {
     }
 
     /// List of roles to include when calculating prune count
-    pub fn include_roles(mut self, roles: Cow<'a, [RoleId]>) -> Self {
-        self.fields.include_roles.replace(roles);
+    pub fn include_roles(mut self, roles: impl Iterator<Item = RoleId>) -> Self {
+        let roles = roles.map(|e| e.0).collect::<Vec<_>>();
+
+        self.fields.include_roles = roles;
 
         self
     }
@@ -83,7 +84,7 @@ impl<'a> GetGuildPruneCount<'a> {
             Route::GetGuildPruneCount {
                 days: self.fields.days,
                 guild_id: self.guild_id.0,
-                include_roles: self.fields.include_roles.take().as_deref(),
+                include_roles: self.fields.include_roles.clone(),
             },
         ))));
 

--- a/http/src/request/guild/integration/create_guild_integration.rs
+++ b/http/src/request/guild/integration/create_guild_integration.rs
@@ -1,13 +1,12 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::{GuildId, IntegrationId};
 
 #[derive(Serialize)]
-struct CreateGuildIntegrationFields<'a> {
+struct CreateGuildIntegrationFields {
     id: IntegrationId,
     #[serde(rename = "type")]
-    kind: Cow<'a, str>,
+    kind: String,
 }
 
 /// Create a guild integration from the current user to the guild.
@@ -16,11 +15,11 @@ struct CreateGuildIntegrationFields<'a> {
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#create-guild-integration
 pub struct CreateGuildIntegration<'a> {
-    fields: CreateGuildIntegrationFields<'a>,
+    fields: CreateGuildIntegrationFields,
     fut: Option<Pending<'a, ()>>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> CreateGuildIntegration<'a> {
@@ -28,7 +27,7 @@ impl<'a> CreateGuildIntegration<'a> {
         http: &'a Client,
         guild_id: GuildId,
         integration_id: IntegrationId,
-        kind: impl Into<Cow<'a, str>>,
+        kind: impl Into<String>,
     ) -> Self {
         Self {
             fields: CreateGuildIntegrationFields {
@@ -43,7 +42,7 @@ impl<'a> CreateGuildIntegration<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::{GuildId, IntegrationId};
 
 /// Delete an integration for a guild, by the integration's id.
@@ -8,7 +7,7 @@ pub struct DeleteGuildIntegration<'a> {
     guild_id: GuildId,
     http: &'a Client,
     integration_id: IntegrationId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteGuildIntegration<'a> {
@@ -23,7 +22,7 @@ impl<'a> DeleteGuildIntegration<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/integration/update_guild_integration.rs
+++ b/http/src/request/guild/integration/update_guild_integration.rs
@@ -1,6 +1,5 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::{GuildId, IntegrationId};
 
 #[derive(Default, Serialize)]
@@ -24,7 +23,7 @@ pub struct UpdateGuildIntegration<'a> {
     guild_id: GuildId,
     http: &'a Client,
     integration_id: IntegrationId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> UpdateGuildIntegration<'a> {
@@ -67,7 +66,7 @@ impl<'a> UpdateGuildIntegration<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::{GuildId, RoleId, UserId};
 
 /// Add a role to a member in a guild.
@@ -29,7 +28,7 @@ pub struct AddRoleToMember<'a> {
     http: &'a Client,
     role_id: RoleId,
     user_id: UserId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> AddRoleToMember<'a> {
@@ -50,7 +49,7 @@ impl<'a> AddRoleToMember<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::{GuildId, UserId};
 
 /// Kick a member from a guild, by their id.
@@ -8,7 +7,7 @@ pub struct RemoveMember<'a> {
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> RemoveMember<'a> {
@@ -23,7 +22,7 @@ impl<'a> RemoveMember<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/member/remove_role_from_member.rs
+++ b/http/src/request/guild/member/remove_role_from_member.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::{GuildId, RoleId, UserId};
 
 /// Remove a role from a member in a guild, by id.
@@ -9,7 +8,7 @@ pub struct RemoveRoleFromMember<'a> {
     http: &'a Client,
     role_id: RoleId,
     user_id: UserId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> RemoveRoleFromMember<'a> {
@@ -30,7 +29,7 @@ impl<'a> RemoveRoleFromMember<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -1,17 +1,16 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{
     guild::{Permissions, Role},
     id::GuildId,
 };
 
 #[derive(Default, Serialize)]
-struct CreateRoleFields<'a> {
+struct CreateRoleFields {
     color: Option<u64>,
     hoist: Option<bool>,
     mentionable: Option<bool>,
-    name: Option<Cow<'a, str>>,
+    name: Option<String>,
     permissions: Option<Permissions>,
 }
 
@@ -35,11 +34,11 @@ struct CreateRoleFields<'a> {
 /// # Ok(()) }
 /// ```
 pub struct CreateRole<'a> {
-    fields: CreateRoleFields<'a>,
+    fields: CreateRoleFields,
     fut: Option<Pending<'a, Role>>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> CreateRole<'a> {
@@ -77,7 +76,7 @@ impl<'a> CreateRole<'a> {
     /// Set the name of the role.
     ///
     /// If none is specified, Discord sets this to `New Role`.
-    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Self {
+    pub fn name(mut self, name: impl Into<String>) -> Self {
         self.fields.name.replace(name.into());
 
         self
@@ -91,7 +90,7 @@ impl<'a> CreateRole<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::{GuildId, RoleId};
 
 /// Delete a role in a guild, by id.
@@ -8,7 +7,7 @@ pub struct DeleteRole<'a> {
     guild_id: GuildId,
     http: &'a Client,
     role_id: RoleId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> DeleteRole<'a> {
@@ -23,7 +22,7 @@ impl<'a> DeleteRole<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -1,28 +1,27 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{
     guild::{Permissions, Role},
     id::{GuildId, RoleId},
 };
 
 #[derive(Default, Serialize)]
-struct UpdateRoleFields<'a> {
+struct UpdateRoleFields {
     color: Option<u64>,
     hoist: Option<bool>,
     mentionable: Option<bool>,
-    name: Option<Cow<'a, str>>,
+    name: Option<String>,
     permissions: Option<Permissions>,
 }
 
 /// Update a role by guild id and its id.
 pub struct UpdateRole<'a> {
-    fields: UpdateRoleFields<'a>,
+    fields: UpdateRoleFields,
     fut: Option<Pending<'a, Role>>,
     guild_id: GuildId,
     http: &'a Client,
     role_id: RoleId,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> UpdateRole<'a> {
@@ -59,7 +58,7 @@ impl<'a> UpdateRole<'a> {
     }
 
     /// Set the name of the role.
-    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Self {
+    pub fn name(mut self, name: impl Into<String>) -> Self {
         self.fields.name.replace(name.into());
 
         self
@@ -73,7 +72,7 @@ impl<'a> UpdateRole<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/guild/role/update_role_positions.rs
+++ b/http/src/request/guild/role/update_role_positions.rs
@@ -1,6 +1,5 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::{
     guild::Role,
     id::{GuildId, RoleId},
@@ -13,20 +12,20 @@ pub struct UpdateRolePositions<'a> {
     fut: Option<Pending<'a, Vec<Role>>>,
     guild_id: GuildId,
     http: &'a Client,
-    roles: Cow<'a, [(RoleId, u64)]>,
+    roles: Vec<(RoleId, u64)>,
 }
 
 impl<'a> UpdateRolePositions<'a> {
     pub(crate) fn new(
         http: &'a Client,
         guild_id: GuildId,
-        roles: impl Into<Cow<'a, [(RoleId, u64)]>>,
+        roles: impl Iterator<Item = (RoleId, u64)>,
     ) -> Self {
         Self {
             fut: None,
             guild_id,
             http,
-            roles: roles.into(),
+            roles: roles.collect(),
         }
     }
 

--- a/http/src/request/guild/update_current_user_nick.rs
+++ b/http/src/request/guild/update_current_user_nick.rs
@@ -1,23 +1,22 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::id::GuildId;
 
 #[derive(Serialize)]
-struct UpdateCurrentUserNickFields<'a> {
-    nick: Cow<'a, str>,
+struct UpdateCurrentUserNickFields {
+    nick: String,
 }
 
 /// Changes the user's nickname in a guild.
 pub struct UpdateCurrentUserNick<'a> {
-    fields: UpdateCurrentUserNickFields<'a>,
+    fields: UpdateCurrentUserNickFields,
     fut: Option<Pending<'a, ()>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> UpdateCurrentUserNick<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId, nick: impl Into<Cow<'a, str>>) -> Self {
+    pub(crate) fn new(http: &'a Client, guild_id: GuildId, nick: impl Into<String>) -> Self {
         Self {
             fields: UpdateCurrentUserNickFields { nick: nick.into() },
             fut: None,

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -1,7 +1,6 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
 use std::{
-    borrow::Cow,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
@@ -31,23 +30,23 @@ impl Display for UpdateGuildError {
 impl Error for UpdateGuildError {}
 
 #[derive(Default, Serialize)]
-struct UpdateGuildFields<'a> {
+struct UpdateGuildFields {
     afk_channel_id: Option<ChannelId>,
     afk_timeout: Option<u64>,
     default_message_notifications: Option<DefaultMessageNotificationLevel>,
     explicit_content_filter: Option<ExplicitContentFilter>,
-    icon: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<Cow<'a, str>>,
+    icon: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
     owner_id: Option<UserId>,
-    region: Option<Cow<'a, str>>,
-    splash: Option<Cow<'a, str>>,
+    region: Option<String>,
+    splash: Option<String>,
     system_channel_id: Option<ChannelId>,
     verification_level: Option<VerificationLevel>,
     rules_channel_id: Option<ChannelId>,
     public_updates_channel_id: Option<ChannelId>,
-    preferred_locale: Option<Cow<'a, str>>,
+    preferred_locale: Option<String>,
 }
 
 /// Update a guild.
@@ -56,11 +55,11 @@ struct UpdateGuildFields<'a> {
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild
 pub struct UpdateGuild<'a> {
-    fields: UpdateGuildFields<'a>,
+    fields: UpdateGuildFields,
     fut: Option<Pending<'a, PartialGuild>>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<Cow<'a, str>>,
+    reason: Option<String>,
 }
 
 impl<'a> UpdateGuild<'a> {
@@ -122,7 +121,7 @@ impl<'a> UpdateGuild<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn icon(mut self, icon: impl Into<Cow<'a, str>>) -> Self {
+    pub fn icon(mut self, icon: impl Into<String>) -> Self {
         self.fields.icon.replace(icon.into());
 
         self
@@ -139,9 +138,11 @@ impl<'a> UpdateGuild<'a> {
     /// short or too long.
     ///
     /// [`UpdateGuildError::NameInvalid`]: enum.UpdateGuildError.html#variant.NameInvalid
-    pub fn name(mut self, name: impl Into<Cow<'a, str>>) -> Result<Self, UpdateGuildError> {
-        let name = name.into();
+    pub fn name(self, name: impl Into<String>) -> Result<Self, UpdateGuildError> {
+        self._name(name.into())
+    }
 
+    fn _name(mut self, name: String) -> Result<Self, UpdateGuildError> {
         if !validate::guild_name(&name) {
             return Err(UpdateGuildError::NameInvalid);
         }
@@ -164,7 +165,7 @@ impl<'a> UpdateGuild<'a> {
     /// information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/voice#voice-region-object
-    pub fn region(mut self, region: impl Into<Cow<'a, str>>) -> Self {
+    pub fn region(mut self, region: impl Into<String>) -> Self {
         self.fields.region.replace(region.into());
 
         self
@@ -173,7 +174,7 @@ impl<'a> UpdateGuild<'a> {
     /// Set the guild's splash image.
     ///
     /// Requires the guild to have the `INVITE_SPLASH` feature enabled.
-    pub fn splash(mut self, splash: impl Into<Cow<'a, str>>) -> Self {
+    pub fn splash(mut self, splash: impl Into<String>) -> Self {
         self.fields.splash.replace(splash.into());
 
         self
@@ -218,7 +219,7 @@ impl<'a> UpdateGuild<'a> {
     /// Set the preferred locale for the guild.
     ///
     /// Defaults to `en-US`. Requires the guild to be `PUBLIC`.
-    pub fn preferred_locale(mut self, preferred_locale: impl Into<Cow<'a, str>>) -> Self {
+    pub fn preferred_locale(mut self, preferred_locale: impl Into<String>) -> Self {
         self.fields
             .preferred_locale
             .replace(preferred_locale.into());
@@ -236,7 +237,7 @@ impl<'a> UpdateGuild<'a> {
     }
 
     /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<Cow<'a, str>>) -> Self {
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
 
         self

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -87,14 +87,14 @@ use reqwest::{
     Method,
 };
 
-use std::{future::Future, pin::Pin};
+use std::{borrow::Cow, future::Future, pin::Pin};
 
 type Pending<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
 type PendingOption<'a> = Pin<Box<dyn Future<Output = Result<Bytes>> + Send + 'a>>;
 
-/// The body of the request, if any.
 #[derive(Debug)]
 pub struct Request {
+    /// The body of the request, if any.
     pub body: Option<Vec<u8>>,
     /// The multipart form of the request, if any.
     pub form: Option<Form>,
@@ -105,7 +105,7 @@ pub struct Request {
     /// The ratelimiting bucket path.
     pub path: Path,
     /// The URI path to request.
-    pub path_str: String,
+    pub path_str: Cow<'static, str>,
 }
 
 pub(crate) fn audit_header(reason: &str) -> Result<HeaderMap<HeaderValue>> {
@@ -131,7 +131,7 @@ impl Request {
     pub fn new(
         body: Option<Vec<u8>>,
         headers: Option<HeaderMap<HeaderValue>>,
-        route: Route<'_>,
+        route: Route,
     ) -> Self {
         let (method, path, path_str) = route.into_parts();
 
@@ -146,8 +146,8 @@ impl Request {
     }
 }
 
-impl<'a> From<Route<'a>> for Request {
-    fn from(route: Route<'a>) -> Self {
+impl From<Route> for Request {
+    fn from(route: Route) -> Self {
         let (method, path, path_str) = route.into_parts();
 
         Self {
@@ -161,8 +161,8 @@ impl<'a> From<Route<'a>> for Request {
     }
 }
 
-impl<'a> From<(Vec<u8>, Route<'a>)> for Request {
-    fn from((body, route): (Vec<u8>, Route<'a>)) -> Self {
+impl From<(Vec<u8>, Route)> for Request {
+    fn from((body, route): (Vec<u8>, Route)) -> Self {
         let (method, path, path_str) = route.into_parts();
 
         Self {
@@ -176,8 +176,8 @@ impl<'a> From<(Vec<u8>, Route<'a>)> for Request {
     }
 }
 
-impl<'a> From<(Vec<u8>, Form, Route<'a>)> for Request {
-    fn from((body, form, route): (Vec<u8>, Form, Route<'a>)) -> Self {
+impl From<(Vec<u8>, Form, Route)> for Request {
+    fn from((body, form, route): (Vec<u8>, Form, Route)) -> Self {
         let (method, path, path_str) = route.into_parts();
 
         Self {
@@ -191,8 +191,8 @@ impl<'a> From<(Vec<u8>, Form, Route<'a>)> for Request {
     }
 }
 
-impl<'a> From<(HeaderMap<HeaderValue>, Route<'a>)> for Request {
-    fn from((headers, route): (HeaderMap<HeaderValue>, Route<'a>)) -> Self {
+impl From<(HeaderMap<HeaderValue>, Route)> for Request {
+    fn from((headers, route): (HeaderMap<HeaderValue>, Route)) -> Self {
         let (method, path, path_str) = route.into_parts();
 
         Self {
@@ -206,8 +206,8 @@ impl<'a> From<(HeaderMap<HeaderValue>, Route<'a>)> for Request {
     }
 }
 
-impl<'a> From<(Vec<u8>, HeaderMap<HeaderValue>, Route<'a>)> for Request {
-    fn from((body, headers, route): (Vec<u8>, HeaderMap<HeaderValue>, Route<'a>)) -> Self {
+impl From<(Vec<u8>, HeaderMap<HeaderValue>, Route)> for Request {
+    fn from((body, headers, route): (Vec<u8>, HeaderMap<HeaderValue>, Route)) -> Self {
         let (method, path, path_str) = route.into_parts();
 
         Self {

--- a/http/src/request/user/get_current_user.rs
+++ b/http/src/request/user/get_current_user.rs
@@ -13,10 +13,10 @@ impl<'a> GetCurrentUser<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(
-            self.http
-                .request(Request::from(Route::GetUser { target_user: "@me" })),
-        ));
+        self.fut
+            .replace(Box::pin(self.http.request(Request::from(Route::GetUser {
+                target_user: "@me".to_owned(),
+            }))));
 
         Ok(())
     }

--- a/http/src/request/user/get_user.rs
+++ b/http/src/request/user/get_user.rs
@@ -1,16 +1,15 @@
 use crate::request::prelude::*;
-use std::borrow::Cow;
 use twilight_model::user::User;
 
 /// Get a user's information by id.
 pub struct GetUser<'a> {
     fut: Option<PendingOption<'a>>,
     http: &'a Client,
-    target_user: Cow<'a, str>,
+    target_user: String,
 }
 
 impl<'a> GetUser<'a> {
-    pub(crate) fn new(http: &'a Client, target_user: impl Into<Cow<'a, str>>) -> Self {
+    pub(crate) fn new(http: &'a Client, target_user: impl Into<String>) -> Self {
         Self {
             fut: None,
             http,
@@ -22,7 +21,7 @@ impl<'a> GetUser<'a> {
         self.fut
             .replace(Box::pin(self.http.request_bytes(Request::from(
                 Route::GetUser {
-                    target_user: &self.target_user,
+                    target_user: self.target_user.clone(),
                 },
             ))));
 

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -1,7 +1,6 @@
 use crate::json_to_vec;
 use crate::request::prelude::*;
 use std::{
-    borrow::Cow,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
@@ -26,11 +25,11 @@ impl Display for UpdateCurrentUserError {
 impl Error for UpdateCurrentUserError {}
 
 #[derive(Default, Serialize)]
-struct UpdateCurrentUserFields<'a> {
+struct UpdateCurrentUserFields {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<Cow<'a, str>>,
+    avatar: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    username: Option<Cow<'a, str>>,
+    username: Option<String>,
 }
 
 /// Update the current user.
@@ -38,7 +37,7 @@ struct UpdateCurrentUserFields<'a> {
 /// All paramaters are optional. If the username is changed, it may cause the discriminator to be
 /// rnadomized.
 pub struct UpdateCurrentUser<'a> {
-    fields: UpdateCurrentUserFields<'a>,
+    fields: UpdateCurrentUserFields,
     fut: Option<Pending<'a, User>>,
     http: &'a Client,
 }
@@ -59,7 +58,7 @@ impl<'a> UpdateCurrentUser<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<Cow<'a, str>>) -> Self {
+    pub fn avatar(mut self, avatar: impl Into<String>) -> Self {
         self.fields.avatar.replace(avatar.into());
 
         self
@@ -75,14 +74,11 @@ impl<'a> UpdateCurrentUser<'a> {
     /// too long.
     ///
     /// [`UpdateCurrentUserError::UsernameInvalid`]: enum.UpdateCurrentUserError.html#variant.UsernameInvalid
-    pub fn username(
-        self,
-        username: impl Into<Cow<'a, str>>,
-    ) -> Result<Self, UpdateCurrentUserError> {
+    pub fn username(self, username: impl Into<String>) -> Result<Self, UpdateCurrentUserError> {
         self._username(username.into())
     }
 
-    fn _username(mut self, username: Cow<'a, str>) -> Result<Self, UpdateCurrentUserError> {
+    fn _username(mut self, username: String) -> Result<Self, UpdateCurrentUserError> {
         if !validate::username(&username) {
             return Err(UpdateCurrentUserError::UsernameInvalid);
         }


### PR DESCRIPTION
This reverts commit 700dc923e6f3c04ca3bddc3acdd8fb4958ea3d82.

This was a bad commit that, due to testing only with cows containing
strings, ended up being nearly unusable for methods taking other types.
For example, types taking an Embed could not simply have the owned value
passed in, since Cow does not implement `From<T>`.