### PR TITLE
gateway, http, twilight: fix the `simd-json` feature / serde_json is no longer optional

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -16,15 +16,14 @@ version = "0.1.0"
 async-trait = { default-features = false, version = "0.1" }
 async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.7" }
 bitflags = { default-features = false, version = "1" }
-twilight-http = { default-features = false, features = ["serde_json"], path = "../http" }
+twilight-http = { default-features = false, path = "../http" }
 twilight-model = { default-features = false, path = "../model" }
 futures-channel = { default-features = false, features = ["sink"], version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 once_cell = { default-features = false, features = ["std"], version = "1" }
 serde = { default-features = false, features = ["derive"], version = "1" }
-serde_json = { default-features = false, optional = true, version = "1" }
-simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.3" }
+serde_json = { default-features = false, version = "1" }
 tokio = { default-features = false, features = ["net", "rt-core", "sync"], version = "0.2" }
 url = { default-features = false, version = "2" }
 # The default backend for flate2; miniz-oxide, works differently
@@ -34,14 +33,15 @@ url = { default-features = false, version = "2" }
 flate2 = { default-features = false, features = ["zlib"], version = "1.0" }
 dashmap = { default-features = false, version = "3" }
 
-#optional
+# optional
 metrics = { default-features = false, optional = true, version = "0.12.1" }
+simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.3" }
 
 [dev-dependencies]
 futures = { default-features = false, version = "0.3" }
 tokio = { default-features = false, features = ["rt-core", "macros"], version = "0.2" }
 
 [features]
-default = ["native", "serde_json"]
+default = ["native"]
 native = ["twilight-http/native", "async-tungstenite/tokio-native-tls"]
 rustls = ["twilight-http/rustls", "async-tungstenite/async-tls"]

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -28,9 +28,7 @@ To use this feature you need to also add these lines to a file in `<project root
 [build]
 rustflags = ["-C", "target-cpu=native"]
 ```
-you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`. If you enable both
-`serde_json` and `simd-json` at the same time; this crate uses `simd-json`. But it is recommended to
-disable `serde_json` if you are going to use `simd-json`. It is easy to switch to out:
+you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`.
 
 ```toml
 [dependencies]

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -26,9 +26,7 @@
 //! [build]
 //! rustflags = ["-C", "target-cpu=native"]
 //! ```
-//! you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`. If you enable both
-//! `serde_json` and `simd-json` at the same time; this crate uses `simd-json`. But it is recommended to
-//! disable `serde_json` if you are going to use `simd-json`. It is easy to switch to out:
+//! you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`.
 //!
 //! ```toml
 //! [dependencies]

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -62,12 +62,12 @@ pub use self::{
 };
 pub use twilight_model::gateway::event::{Event, EventType};
 
-#[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
+#[cfg(not(feature = "simd-json"))]
 pub(crate) use serde_json::to_vec as json_to_vec;
 #[cfg(feature = "simd-json")]
 pub(crate) use simd_json::to_vec as json_to_vec;
 
-#[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
+#[cfg(not(feature = "simd-json"))]
 pub(crate) use serde_json::to_string as json_to_string;
 #[cfg(feature = "simd-json")]
 pub(crate) use simd_json::to_string as json_to_string;

--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -1,7 +1,7 @@
 //! The error type of why errors occur in the shard module.
 
 use futures_channel::mpsc::TrySendError;
-#[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
+#[cfg(not(feature = "simd-json"))]
 use serde_json::Error as JsonError;
 #[cfg(feature = "simd-json")]
 use simd_json::Error as JsonError;

--- a/gateway/src/shard/processor/error.rs
+++ b/gateway/src/shard/processor/error.rs
@@ -5,7 +5,7 @@ use std::str::Utf8Error;
 
 use flate2::DecompressError;
 use futures_channel::mpsc::TrySendError;
-#[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
+#[cfg(not(feature = "simd-json"))]
 use serde_json::Error as JsonError;
 #[cfg(feature = "simd-json")]
 use simd_json::Error as JsonError;

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -565,7 +565,7 @@ impl ShardProcessor {
     /// [`Error::PayloadInvalid`]: ../enum.Error.html#variant.PayloadInvalid
     /// [`Error::PayloadSerialization`]: ../enum.Error.html#variant.PayloadSerialization
     #[allow(unsafe_code)]
-    #[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
+    #[cfg(not(feature = "simd-json"))]
     unsafe fn parse_gateway_event(json: &mut str) -> Result<GatewayEvent> {
         use serde::de::DeserializeSeed;
         use serde_json::Deserializer;
@@ -610,9 +610,9 @@ impl ShardProcessor {
         use twilight_model::gateway::event::gateway::GatewayEventDeserializerOwned;
 
         let gateway_deserializer =
-            GatewayEventDeserializerOwned::from_json(json).map_err(|_| Error::PayloadInvalid)?;
-        let mut json_deserializer = Deserializer::from_slice(unsafe { json.as_bytes_mut() })
-            .map_err(|_| Error::PayloadInvalid)?;
+            GatewayEventDeserializerOwned::from_json(json).ok_or_else(|| Error::PayloadInvalid)?;
+        let mut json_deserializer =
+            Deserializer::from_slice(json.as_bytes_mut()).map_err(|_| Error::PayloadInvalid)?;
 
         gateway_deserializer
             .deserialize(&mut json_deserializer)

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -20,15 +20,17 @@ twilight-model = { default-features = false, path = "../model" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 reqwest = { default-features = false, version = "0.10" }
 serde = { default-features = false, features = ["derive"], version = "1" }
-serde_json = { default-features = false, optional = true, version = "1" }
+serde_json = { default-features = false, version = "1" }
 serde_repr = { default-features = false, version = "0.1" }
-simd-json = { default-features = false, optional = true, version = "0.3" }
 tokio = { default-features = false, version = "0.2" }
 percent-encoding = { default-features = false, version = "2" }
 url = { default-features = false, version = "2" }
 
+# optional
+simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.3" }
+
 [features]
-default = ["native", "serde_json"]
+default = ["native"]
 native = ["reqwest/default-tls"]
 rustls = ["reqwest/rustls-tls"]
 

--- a/http/README.md
+++ b/http/README.md
@@ -8,16 +8,7 @@ HTTP support for the twilight ecosystem.
 
 ### Deserialization
 
-`twilight-http` supports [`serde_json`] and [`simd-json`] for deserializing
-responses. These features are mutually exclusive. `serde_json` is enabled by
-default.
-
-#### `serde_json`
-
-[`serde_json`] is the inverse of `simd-json` and will use the `serde_json`
-crate to deserialize responses.
-
-This is enabled by default.
+`twilight-http` supports [`serde_json`] and [`simd-json`] for deserializing responses.
 
 #### `simd-json`
 
@@ -65,7 +56,7 @@ To enable `rustls`, do something like this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-twilight-http = { branch = "trunk", default-features = false, features = ["rustls", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
+twilight-http = { branch = "trunk", default-features = false, features = ["rustls"], git = "https://github.com/twilight-rs/twilight" }
 ```
 
 [`native-tls`]: https://crates.io/crates/native-tls

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -1,7 +1,7 @@
 use crate::{api_error::ApiError, ratelimiting::RatelimitError};
 use futures_channel::oneshot::Canceled;
 use reqwest::{header::InvalidHeaderValue, Error as ReqwestError, StatusCode};
-#[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
+#[cfg(not(feature = "simd-json"))]
 use serde_json::Error as JsonError;
 #[cfg(feature = "simd-json")]
 use simd_json::Error as JsonError;

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -6,16 +6,7 @@
 //!
 //! ### Deserialization
 //!
-//! `twilight-http` supports [`serde_json`] and [`simd-json`] for deserializing
-//! responses. These features are mutually exclusive. `serde_json` is enabled by
-//! default.
-//!
-//! #### `serde_json`
-//!
-//! [`serde_json`] is the inverse of `simd-json` and will use the `serde_json`
-//! crate to deserialize responses.
-//!
-//! This is enabled by default.
+//! `twilight-http` supports [`serde_json`] and [`simd-json`] for deserializing responses.
 //!
 //! #### `simd-json`
 //!
@@ -63,7 +54,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-http = { branch = "trunk", default-features = false, features = ["rustls", "serde_json"], git = "https://github.com/twilight-rs/twilight" }
+//! twilight-http = { branch = "trunk", default-features = false, features = ["rustls"], git = "https://github.com/twilight-rs/twilight" }
 //! ```
 //!
 //! [`native-tls`]: https://crates.io/crates/native-tls

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -100,19 +100,19 @@ pub use crate::{
     error::{Error, Result},
 };
 
-#[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
+#[cfg(not(feature = "simd-json"))]
 use serde_json::Result as JsonResult;
 #[cfg(feature = "simd-json")]
 use simd_json::Result as JsonResult;
 
 pub(crate) fn json_from_slice<'a, T: serde::de::Deserialize<'a>>(s: &'a mut [u8]) -> JsonResult<T> {
-    #[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
+    #[cfg(not(feature = "simd-json"))]
     return serde_json::from_slice(s);
     #[cfg(feature = "simd-json")]
     return simd_json::from_slice(s);
 }
 
-#[cfg(all(feature = "serde_json", not(feature = "simd-json")))]
+#[cfg(not(feature = "simd-json"))]
 pub(crate) use serde_json::to_vec as json_to_vec;
 #[cfg(feature = "simd-json")]
 pub(crate) use simd_json::to_vec as json_to_vec;

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -57,12 +57,14 @@ impl Future for GetGuildVanityUrl<'_> {
                     Poll::Pending => return Poll::Pending,
                 };
 
-                let vanity_url = serde_json::from_slice::<VanityUrl>(&bytes).map_err(|source| {
-                    Error::Parsing {
-                        body: bytes.to_vec(),
-                        source,
-                    }
-                })?;
+                let mut bytes = bytes.as_ref().to_vec();
+                let vanity_url =
+                    crate::json_from_slice::<VanityUrl>(&mut bytes).map_err(|source| {
+                        Error::Parsing {
+                            body: bytes.to_vec(),
+                            source,
+                        }
+                    })?;
 
                 return Poll::Ready(Ok(Some(vanity_url.code)));
             }

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -28,6 +28,7 @@ macro_rules! poll_req {
                 mut self: std::pin::Pin<&mut Self>,
                 cx: &mut std::task::Context<'_>,
             ) -> ::std::task::Poll<Self::Output> {
+                use crate::json_from_slice;
                 use std::task::Poll;
 
                 loop {
@@ -43,7 +44,8 @@ macro_rules! poll_req {
                             Poll::Pending => return Poll::Pending,
                         };
 
-                        return Poll::Ready(serde_json::from_slice(&bytes).map(Some).map_err(
+                        let mut bytes = bytes.as_ref().to_vec();
+                        return Poll::Ready(json_from_slice(&mut bytes).map(Some).map_err(
                             |source| crate::Error::Parsing {
                                 body: bytes.to_vec(),
                                 source,

--- a/twilight/Cargo.toml
+++ b/twilight/Cargo.toml
@@ -16,8 +16,8 @@ version = "0.1.0"
 twilight-builders = { optional = true, path = "../builders" }
 twilight-cache = { optional = true, path = "../cache/base" }
 twilight-command-parser = { optional = true, path = "../command-parser" }
-twilight-gateway = { default-features = false, features = ["serde_json"], optional = true, path = "../gateway" }
-twilight-http = { default-features = false, features = ["serde_json"], optional = true, path = "../http" }
+twilight-gateway = { default-features = false, optional = true, path = "../gateway" }
+twilight-http = { default-features = false, optional = true, path = "../http" }
 twilight-model = { optional = true, path = "../model" }
 twilight-standby = { optional = true, path = "../standby" }
 


### PR DESCRIPTION
`serde_json` is no longer optional

http:
- enable `serde-impl` & `sway-number-parsing` features for `simd-json`
- use `crate::json_from_slice`
- use of `simd_json::value::OwnedValue`

gateway:
- fix the error mapping of `GatewayEventDeserializerOwned::from_json(json)`

Fixes the simd-json builds for #332 