### PR TITLE
gateway/shard: send normal close on shutdown

### DIFF
--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -317,7 +317,10 @@ impl Shard {
 
         if let Ok(session) = self.session() {
             // Since we're shutting down now, we don't care if it sends or not.
-            let _ = session.tx.unbounded_send(Message::Close(None));
+            let _ = session.tx.unbounded_send(Message::Close(Some(CloseFrame {
+                code: CloseCode::Normal,
+                reason: "".into(),
+            })));
             session.stop_heartbeater().await;
         }
     }


### PR DESCRIPTION
When `Shard::shutdown` is called, send a close message with a frame with a normal close code. This will make the bot immediately appear offline.

I have tested this a few times and it worked each time.