### PR TITLE
cache,gateway,http: remove tracing imports

### DIFF
--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -2,8 +2,6 @@ use super::{config::EventType, InMemoryCache, InMemoryCacheError};
 use async_trait::async_trait;
 use dashmap::DashMap;
 use std::{collections::HashSet, hash::Hash, ops::Deref, sync::Arc};
-#[allow(unused_imports)]
-use tracing::debug;
 use twilight_cache_trait::UpdateCache;
 use twilight_model::{
     channel::{message::MessageReaction, Channel, GuildChannel},

--- a/gateway/src/queue/day_limiter.rs
+++ b/gateway/src/queue/day_limiter.rs
@@ -4,7 +4,6 @@ use tokio::{
     sync::Mutex,
     time::{self, Instant},
 };
-use tracing::warn;
 
 #[derive(Debug)]
 pub(crate) struct DayLimiter(pub(crate) Mutex<DayLimiterInner>);
@@ -62,7 +61,9 @@ impl DayLimiter {
                 lock.total = total;
                 lock.current = current + 1;
             } else {
-                warn!("unable to get new session limits, skipping (this may cause bad things)")
+                tracing::warn!(
+                    "unable to get new session limits, skipping (this may cause bad things)"
+                )
             }
         }
     }

--- a/gateway/src/queue/large_bot_queue.rs
+++ b/gateway/src/queue/large_bot_queue.rs
@@ -7,7 +7,6 @@ use futures_channel::{
 use futures_util::{sink::SinkExt, stream::StreamExt};
 use std::{fmt::Debug, time::Duration};
 use tokio::time::delay_for;
-use tracing::{info, warn};
 
 /// Large bot queue is for bots that are marked as very large by Discord.
 ///
@@ -60,7 +59,7 @@ async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
     const DUR: Duration = Duration::from_secs(6);
     while let Some(req) = rx.next().await {
         if let Err(err) = req.send(()) {
-            warn!("skipping, send failed with: {:?}", err);
+            tracing::warn!("skipping, send failed with: {:?}", err);
         }
         delay_for(DUR).await;
     }
@@ -78,11 +77,11 @@ impl Queue for LargeBotQueue {
 
         self.limiter.get().await;
         if let Err(err) = self.buckets[bucket].clone().send(tx).await {
-            warn!("skipping, send failed with: {:?}", err);
+            tracing::warn!("skipping, send failed with: {:?}", err);
             return;
         }
 
-        info!("waiting for allowance on shard {}", shard_id[0]);
+        tracing::info!("waiting for allowance on shard {}", shard_id[0]);
 
         let _ = rx.await;
     }

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -18,7 +18,6 @@ use std::{
     sync::{atomic::Ordering, Arc},
 };
 use tokio::sync::watch::Receiver as WatchReceiver;
-use tracing::debug;
 use twilight_model::gateway::event::Event;
 
 /// Information about a shard, including its latency, current session sequence,
@@ -155,7 +154,7 @@ impl Shard {
         tokio::spawn(async move {
             let _ = fut.await;
 
-            debug!("shard processor future ended");
+            tracing::debug!("shard processor future ended");
         });
 
         // We know that these haven't been set, so we can ignore this.

--- a/gateway/src/shard/processor/connect.rs
+++ b/gateway/src/shard/processor/connect.rs
@@ -1,0 +1,19 @@
+use super::error::{Error, Result};
+use url::Url;
+
+use super::super::ShardStream;
+
+pub async fn connect(url: &str) -> Result<ShardStream> {
+    let url = Url::parse(url).map_err(|source| Error::ParsingUrl {
+        source,
+        url: url.to_owned(),
+    })?;
+
+    let (stream, _) = async_tungstenite::tokio::connect_async(url)
+        .await
+        .map_err(|source| Error::Connecting { source })?;
+
+    tracing::debug!("Shook hands with remote");
+
+    Ok(stream)
+}

--- a/gateway/src/shard/processor/emit.rs
+++ b/gateway/src/shard/processor/emit.rs
@@ -2,8 +2,6 @@ use crate::{
     listener::{Listener, Listeners},
     EventTypeFlags,
 };
-#[allow(unused_imports)]
-use tracing::{debug, info, trace, warn};
 use twilight_model::gateway::event::{shard::Payload, Event};
 
 pub async fn bytes(listeners: Listeners<Event>, bytes: &[u8]) {
@@ -44,7 +42,7 @@ pub fn event(listeners: &Listeners<Event>, event: Event) {
         let event_type = EventTypeFlags::from(event.kind());
 
         if !listener.events.contains(event_type) {
-            trace!("listener {} doesn't want event type {:?}", id, event_type,);
+            tracing::trace!("listener {} doesn't want event type {:?}", id, event_type,);
 
             continue;
         }
@@ -63,7 +61,7 @@ pub fn event(listeners: &Listeners<Event>, event: Event) {
     }
 
     for id in &remove_listeners {
-        debug!("removing listener {}", id);
+        tracing::debug!("removing listener {}", id);
 
         listeners.remove(id);
     }
@@ -77,7 +75,7 @@ fn _emit_to_listener(id: u64, listener: &Listener<Event>, event: Event) -> bool 
     let event_type = EventTypeFlags::from(event.kind());
 
     if !listener.events.contains(event_type) {
-        trace!("listener {} doesn't want event type {:?}", id, event_type,);
+        tracing::trace!("listener {} doesn't want event type {:?}", id, event_type,);
 
         return true;
     }

--- a/gateway/src/shard/processor/heartbeat.rs
+++ b/gateway/src/shard/processor/heartbeat.rs
@@ -11,7 +11,6 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use tracing::{debug, error, warn};
 use twilight_model::gateway::payload::Heartbeat;
 
 /// Information about the latency of a [`Shard`]'s websocket connection.
@@ -112,7 +111,7 @@ impl Heartbeats {
             let millis = if let Ok(millis) = dur.as_millis().try_into() {
                 millis
             } else {
-                error!("duration millis is more than u64: {:?}", dur);
+                tracing::error!("duration millis is more than u64: {:?}", dur);
 
                 return;
             };
@@ -179,7 +178,7 @@ impl Heartbeater {
 
     pub async fn run(self) {
         if let Err(why) = self.run_inner().await {
-            warn!("Error sending heartbeat: {:?}", why);
+            tracing::warn!("Error sending heartbeat: {:?}", why);
         }
     }
 
@@ -215,11 +214,11 @@ impl Heartbeater {
             let bytes = crate::json_to_vec(&heartbeat)
                 .map_err(|source| Error::PayloadSerialization { source })?;
 
-            debug!("sending heartbeat with seq: {}", seq);
+            tracing::debug!("sending heartbeat with seq: {}", seq);
             self.tx
                 .unbounded_send(TungsteniteMessage::Binary(bytes))
                 .map_err(|source| Error::SendingMessage { source })?;
-            debug!("sent heartbeat with seq: {}", seq);
+            tracing::debug!("sent heartbeat with seq: {}", seq);
             self.heartbeats.send().await;
         }
     }

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -58,7 +58,7 @@ impl ShardProcessor {
         mut url: String,
         listeners: Listeners<Event>,
     ) -> Result<(Self, WatchReceiver<Arc<Session>>)> {
-        //if we got resume tracing::info we don't need to wait
+        //if we got resume info we don't need to wait
         let shard_id = config.shard();
         let resumable = config.sequence.is_some() && config.session_id.is_some();
         if !resumable {

--- a/gateway/src/shard/processor/inflater.rs
+++ b/gateway/src/shard/processor/inflater.rs
@@ -1,6 +1,5 @@
 use flate2::{Decompress, DecompressError, FlushDecompress};
 use std::convert::TryInto;
-use tracing::trace;
 
 const ZLIB_SUFFIX: [u8; 4] = [0x00, 0x00, 0xff, 0xff];
 const INTERNAL_BUFFER_SIZE: usize = 32 * 1024;
@@ -57,14 +56,14 @@ impl Inflater {
                 }
             }
 
-            trace!("in: {}, out: {}", self.compressed.len(), self.buffer.len());
+            tracing::trace!("in: {}, out: {}", self.compressed.len(), self.buffer.len());
             self.compressed.clear();
 
             #[allow(clippy::cast_precision_loss)]
             {
                 // To get around the u64 → f64 precision loss lint
                 // it does really not matter that it happens here
-                trace!(
+                tracing::trace!(
                     "data saved: {}KiB ({:.2}%)",
                     ((self.decompress.total_out() - self.decompress.total_in()) / 1024),
                     ((self.decompress.total_in() as f64) / (self.decompress.total_out() as f64)
@@ -86,7 +85,7 @@ impl Inflater {
                     self.decompress.total_out().try_into().unwrap_or(-1)
                 );
             }
-            trace!("capacity: {}", self.buffer.capacity());
+            tracing::trace!("capacity: {}", self.buffer.capacity());
             Ok(Some(&mut self.buffer))
         } else {
             // Received a partial payload.
@@ -108,8 +107,8 @@ impl Inflater {
             // https://github.com/rust-lang/rust/issues/56431
             self.compressed.shrink_to_fit();
             self.buffer.shrink_to_fit();
-            trace!("compressed: {}", self.compressed.capacity());
-            trace!("buffer: {}", self.buffer.capacity());
+            tracing::trace!("compressed: {}", self.compressed.capacity());
+            tracing::trace!("buffer: {}", self.buffer.capacity());
             self.countdown_to_resize = u8::max_value();
         }
         self.compressed.clear();

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -23,7 +23,6 @@ use std::{
     result::Result as StdResult,
     sync::Arc,
 };
-use tracing::{debug, warn};
 use twilight_model::{
     channel::ReactionType,
     guild::Permissions,
@@ -1379,7 +1378,7 @@ impl Client {
         let protocol = if self.state.use_http { "http" } else { "https" };
         let url = format!("{}://discord.com/api/v6/{}", protocol, path);
 
-        debug!("URL: {:?}", url);
+        tracing::debug!("URL: {:?}", url);
 
         let mut builder = self.state.http.request(method.clone(), &url);
 
@@ -1448,7 +1447,7 @@ impl Client {
                 let _ = tx.send(Some(v));
             }
             Err(why) => {
-                warn!("header parsing failed: {:?}; {:?}", why, resp);
+                tracing::warn!("header parsing failed: {:?}; {:?}", why, resp);
 
                 let _ = tx.send(None);
             }
@@ -1498,14 +1497,14 @@ impl Client {
         }
 
         if status == StatusCode::IM_A_TEAPOT {
-            warn!(
+            tracing::warn!(
                 "discord's api now runs off of teapots -- proceed to panic: {:?}",
                 resp,
             );
         }
 
         if status == StatusCode::TOO_MANY_REQUESTS {
-            warn!("429 response: {:?}", resp);
+            tracing::warn!("429 response: {:?}", resp);
         }
 
         let bytes = resp
@@ -1523,7 +1522,7 @@ impl Client {
 
         if let ApiError::General(ref general) = error {
             if let ErrorCode::Other(num) = general.code {
-                debug!("got unknown API error code variant: {}; {:?}", num, error);
+                tracing::debug!("got unknown API error code variant: {}; {:?}", num, error);
             }
         }
 


### PR DESCRIPTION
Remove the imports for `tracing` crate macros. In some cases, these are only needed when a feature is enabled, so we need to put `#[allow(unused)]` on them, but in a couple of cases these imports existed despite no longer being ever used. For consistency with the rest of the libraries and in general, don't import them and just call them via FQN.