### PR TITLE
gateway: remove metrics imports

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -38,9 +38,6 @@ use twilight_model::gateway::{
     },
 };
 
-#[cfg(feature = "metrics")]
-use metrics::counter;
-
 /// Runs in the background and processes incoming events, and then broadcasts
 /// to all listeners.
 #[derive(Debug)]
@@ -220,7 +217,7 @@ impl ShardProcessor {
         match event {
             Dispatch(seq, dispatch) => {
                 #[cfg(feature = "metrics")]
-                counter!("GatewayEvent", 1, "GatewayEvent" => "Dispatch");
+                metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "Dispatch");
                 self.session.set_seq(*seq);
 
                 // this lint is wrong and generates invalid code
@@ -254,7 +251,7 @@ impl ShardProcessor {
             }
             Heartbeat(seq) => {
                 #[cfg(feature = "metrics")]
-                counter!("GatewayEvent", 1, "GatewayEvent" => "Heartbeat");
+                metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "Heartbeat");
                 if *seq > self.session.seq() + 1 {
                     self.resume().await?;
                 }
@@ -267,7 +264,7 @@ impl ShardProcessor {
             }
             Hello(interval) => {
                 #[cfg(feature = "metrics")]
-                counter!("GatewayEvent", 1, "GatewayEvent" => "Hello");
+                metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "Hello");
                 debug!("[EVENT] Hello({})", interval);
 
                 if self.session.stage() == Stage::Resuming && self.resume.is_some() {
@@ -299,24 +296,24 @@ impl ShardProcessor {
             }
             HeartbeatAck => {
                 #[cfg(feature = "metrics")]
-                counter!("GatewayEvent", 1, "GatewayEvent" => "HeartbeatAck");
+                metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "HeartbeatAck");
                 self.session.heartbeats.receive().await;
             }
             InvalidateSession(true) => {
                 #[cfg(feature = "metrics")]
-                counter!("GatewayEvent", 1, "GatewayEvent" => "InvalidateSessionTrue");
+                metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "InvalidateSessionTrue");
                 debug!("[EVENT] InvalidateSession(true)");
                 self.resume().await?;
             }
             InvalidateSession(false) => {
                 #[cfg(feature = "metrics")]
-                counter!("GatewayEvent", 1, "GatewayEvent" => "InvalidateSessionFalse");
+                metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "InvalidateSessionFalse");
                 debug!("[EVENT] InvalidateSession(false)");
                 self.reconnect(true).await;
             }
             Reconnect => {
                 #[cfg(feature = "metrics")]
-                counter!("GatewayEvent", 1, "GatewayEvent" => "Reconnect");
+                metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "Reconnect");
                 debug!("[EVENT] Reconnect");
                 let frame = CloseFrame {
                     code: CloseCode::Restart,

--- a/gateway/src/shard/processor/inflater.rs
+++ b/gateway/src/shard/processor/inflater.rs
@@ -2,9 +2,6 @@ use flate2::{Decompress, DecompressError, FlushDecompress};
 use std::convert::TryInto;
 use tracing::trace;
 
-#[cfg(feature = "metrics")]
-use metrics::gauge;
-
 const ZLIB_SUFFIX: [u8; 4] = [0x00, 0x00, 0xff, 0xff];
 const INTERNAL_BUFFER_SIZE: usize = 32 * 1024;
 
@@ -76,15 +73,15 @@ impl Inflater {
             }
             #[cfg(feature = "metrics")]
             {
-                gauge!(
+                metrics::gauge!(
                     format!("Inflater-Capacity-{}", self.shard[0]),
                     self.buffer.capacity().try_into().unwrap_or(-1)
                 );
-                gauge!(
+                metrics::gauge!(
                     format!("InflaterIn-{}", self.shard[0]),
                     self.decompress.total_in().try_into().unwrap_or(-1)
                 );
-                gauge!(
+                metrics::gauge!(
                     format!("InflaterOut-{}", self.shard[0]),
                     self.decompress.total_out().try_into().unwrap_or(-1)
                 );


### PR DESCRIPTION
Remove the imports for `metrics` crate macros. It's just simpler to reference the crate instead of conditionally importing the macros at the top, since in their usage they are already bounded by the conditional feature.