### PR TITLE
http: remove comments

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1555,7 +1555,7 @@ impl From<ReqwestClient> for Client {
     }
 }
 
-// parse the webhook id and token, if it exists in the string
+/// Parse the webhook ID and token, if it exists in the string.
 fn parse_webhook_url(
     url: impl AsRef<str>,
 ) -> std::result::Result<(WebhookId, Option<String>), UrlError> {

--- a/http/src/ratelimiting/bucket.rs
+++ b/http/src/ratelimiting/bucket.rs
@@ -15,7 +15,6 @@ use std::{
 };
 use tokio::time::{delay_for, timeout};
 use tracing::debug;
-//use tokio::future::FutureExt as _;
 
 #[derive(Clone, Debug)]
 pub enum TimeRemaining {

--- a/http/src/ratelimiting/mod.rs
+++ b/http/src/ratelimiting/mod.rs
@@ -21,10 +21,10 @@ use std::{
 };
 use tracing::debug;
 
-// Global lock. We use a pair to avoid actually locking the mutex every check.
-// This allows futures to only wait on the global lock when a global ratelimit
-// is in place by, in turn, waiting for a guard, and then each immediately
-// dropping it.
+/// Global lock. We use a pair to avoid actually locking the mutex every check.
+/// This allows futures to only wait on the global lock when a global ratelimit
+/// is in place by, in turn, waiting for a guard, and then each immediately
+/// dropping it.
 #[derive(Debug, Default)]
 struct GlobalLockPair(Mutex<()>, AtomicBool);
 

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -29,13 +29,13 @@ struct GetChannelMessagesConfiguredFields {
     limit: Option<u64>,
 }
 
-// nb: after, around, and before are mutually exclusive, so we use this
-// "configured" request to utilize the type system to prevent these from being
-// set in combination.
 /// This struct is returned when one of `after`, `around`, or `before` is specified in
 /// [`GetChannelMessages`].
 ///
 /// [`GetChannelMessages`]: ../get_channel_messages/struct.GetChannelMessages.html
+// nb: after, around, and before are mutually exclusive, so we use this
+// "configured" request to utilize the type system to prevent these from being
+// set in combination.
 pub struct GetChannelMessagesConfigured<'a> {
     after: Option<MessageId>,
     around: Option<MessageId>,


### PR DESCRIPTION
In the `http` crate, remove comments by either removing them completely (in one case, removing a commented out import), re-ordering their position, or upgrading them to documentation comments.