### PR TITLE
gateway,http,model: consolidate imports

### DIFF
--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -1,11 +1,13 @@
 use super::error::{Error, Result};
-use crate::shard::ResumeSession;
 use crate::{
     queue::{LocalQueue, Queue},
-    shard::config::{ShardConfig, ShardConfigBuilder},
+    shard::{
+        config::{ShardConfig, ShardConfigBuilder},
+        ResumeSession,
+    },
 };
-use std::collections::HashMap;
 use std::{
+    collections::HashMap,
     convert::TryFrom,
     ops::{Bound, RangeBounds},
     sync::Arc,

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -2,9 +2,8 @@ use super::{
     config::{ClusterConfig, ShardScheme},
     error::{Error, Result},
 };
-use crate::shard::ResumeSession;
 use crate::{
-    shard::{Information, Shard},
+    shard::{Information, ResumeSession, Shard},
     EventTypeFlags,
 };
 use futures_util::{

--- a/gateway/src/queue.rs
+++ b/gateway/src/queue.rs
@@ -12,6 +12,7 @@ use futures_channel::{
 use futures_util::{sink::SinkExt, stream::StreamExt};
 use std::{fmt::Debug, time::Duration};
 use tokio::time::delay_for;
+
 #[allow(unused_imports)]
 use tracing::{info, warn};
 

--- a/gateway/src/queue/day_limiter.rs
+++ b/gateway/src/queue/day_limiter.rs
@@ -1,10 +1,9 @@
 use crate::shard::error::{Error, Result};
-
-use tokio::time::delay_until;
-
 use std::time::Duration;
-
-use tokio::{sync::Mutex, time::Instant};
+use tokio::{
+    sync::Mutex,
+    time::{self, Instant},
+};
 use tracing::warn;
 
 #[derive(Debug)]
@@ -49,7 +48,7 @@ impl DayLimiter {
             lock.current += 1;
         } else {
             let wait = lock.last_check + lock.next_reset;
-            delay_until(wait).await;
+            time::delay_until(wait).await;
             if let Ok(info) = lock.http.gateway().authed().await {
                 let last_check = Instant::now();
                 let next_reset = Duration::from_millis(info.session_start_limit.remaining);

--- a/gateway/src/shard/error.rs
+++ b/gateway/src/shard/error.rs
@@ -1,12 +1,8 @@
 //! The error type of why errors occur in the shard module.
 
-use futures_channel::mpsc::TrySendError;
-#[cfg(not(feature = "simd-json"))]
-use serde_json::Error as JsonError;
-#[cfg(feature = "simd-json")]
-use simd_json::Error as JsonError;
-
+use super::processor::Error as ProcessorError;
 use async_tungstenite::tungstenite::{Error as TungsteniteError, Message as TungsteniteMessage};
+use futures_channel::mpsc::TrySendError;
 use std::{
     error::Error as StdError,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -14,7 +10,10 @@ use std::{
 };
 use twilight_http::Error as HttpError;
 
-use super::processor::Error as ProcessorError;
+#[cfg(not(feature = "simd-json"))]
+use serde_json::Error as JsonError;
+#[cfg(feature = "simd-json")]
+use simd_json::Error as JsonError;
 
 /// A result enum with the error type being the shard's [`Error`] type.
 ///

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -7,20 +7,21 @@ use super::{
     stage::Stage,
 };
 use crate::{listener::Listeners, EventTypeFlags};
+use async_tungstenite::tungstenite::{
+    protocol::{frame::coding::CloseCode, CloseFrame},
+    Message,
+};
 use futures_util::{
     future::{self, AbortHandle},
     stream::Stream,
 };
-
 use once_cell::sync::OnceCell;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
+use std::{
+    borrow::Cow,
+    sync::{atomic::Ordering, Arc},
+};
 use tokio::sync::watch::Receiver as WatchReceiver;
 use tracing::debug;
-
-use async_tungstenite::tungstenite::protocol::{frame::coding::CloseCode, CloseFrame};
-use async_tungstenite::tungstenite::Message;
-use std::borrow::Cow;
 use twilight_model::gateway::event::Event;
 
 /// Information about a shard, including its latency, current session sequence,

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -40,7 +40,6 @@ pub use self::{
     stage::Stage,
 };
 
-use async_tungstenite::tokio::ConnectStream;
-use async_tungstenite::WebSocketStream;
+use async_tungstenite::{tokio::ConnectStream, WebSocketStream};
 
 type ShardStream = WebSocketStream<ConnectStream>;

--- a/gateway/src/shard/processor/error.rs
+++ b/gateway/src/shard/processor/error.rs
@@ -3,13 +3,14 @@
 use async_tungstenite::tungstenite::{Error as TungsteniteError, Message as TungsteniteMessage};
 use flate2::DecompressError;
 use futures_channel::mpsc::TrySendError;
+use std::{fmt, str::Utf8Error};
+use twilight_model::gateway::GatewayIntents;
+use url::ParseError;
+
 #[cfg(not(feature = "simd-json"))]
 use serde_json::Error as JsonError;
 #[cfg(feature = "simd-json")]
 use simd_json::Error as JsonError;
-use std::{fmt, str::Utf8Error};
-use twilight_model::gateway::GatewayIntents;
-use url::ParseError;
 
 /// A result enum with the error type being the shard processor's [`Error`] type.
 ///

--- a/gateway/src/shard/processor/error.rs
+++ b/gateway/src/shard/processor/error.rs
@@ -1,18 +1,15 @@
 //! The error type of why errors occur in the shard processor module.
 
-use std::fmt;
-use std::str::Utf8Error;
-
+use async_tungstenite::tungstenite::{Error as TungsteniteError, Message as TungsteniteMessage};
 use flate2::DecompressError;
 use futures_channel::mpsc::TrySendError;
 #[cfg(not(feature = "simd-json"))]
 use serde_json::Error as JsonError;
 #[cfg(feature = "simd-json")]
 use simd_json::Error as JsonError;
-use url::ParseError;
-
-use async_tungstenite::tungstenite::{Error as TungsteniteError, Message as TungsteniteMessage};
+use std::{fmt, str::Utf8Error};
 use twilight_model::gateway::GatewayIntents;
+use url::ParseError;
 
 /// A result enum with the error type being the shard processor's [`Error`] type.
 ///

--- a/gateway/src/shard/processor/inflater.rs
+++ b/gateway/src/shard/processor/inflater.rs
@@ -1,6 +1,5 @@
-use std::convert::TryInto;
-
 use flate2::{Decompress, DecompressError, FlushDecompress};
+use std::convert::TryInto;
 use tracing::trace;
 
 #[cfg(feature = "metrics")]

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -3,6 +3,7 @@ use super::{
     error::{Error, Result},
     heartbeat::{Heartbeater, Heartbeats},
 };
+use async_tungstenite::tungstenite::{protocol::CloseFrame, Message as TungsteniteMessage};
 use futures_channel::mpsc::UnboundedSender;
 use futures_util::{
     future::{self, AbortHandle},
@@ -15,12 +16,10 @@ use std::{
         atomic::{AtomicU64, AtomicU8, Ordering},
         Arc,
     },
+    time::Duration,
 };
-use twilight_model::gateway::payload::Heartbeat;
-
-use async_tungstenite::tungstenite::{protocol::CloseFrame, Message as TungsteniteMessage};
-use std::time::Duration;
 use tokio::time::{interval, Interval};
+use twilight_model::gateway::payload::Heartbeat;
 
 #[derive(Debug)]
 pub struct Session {

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -31,8 +31,6 @@ use twilight_model::{
 };
 use url::Url;
 
-use crate::json_from_slice;
-
 struct State {
     http: ReqwestClient,
     ratelimiter: Option<Ratelimiter>,
@@ -1470,7 +1468,7 @@ impl Client {
 
         let mut bytes_b = bytes.as_ref().to_vec();
 
-        let result = json_from_slice(&mut bytes_b);
+        let result = crate::json_from_slice(&mut bytes_b);
 
         result.map_err(|source| Error::Parsing {
             body: (*bytes).to_vec(),

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -1,11 +1,6 @@
 use crate::{api_error::ApiError, ratelimiting::RatelimitError};
 use futures_channel::oneshot::Canceled;
 use reqwest::{header::InvalidHeaderValue, Error as ReqwestError, StatusCode};
-#[cfg(not(feature = "simd-json"))]
-use serde_json::Error as JsonError;
-#[cfg(feature = "simd-json")]
-use simd_json::Error as JsonError;
-
 use std::{
     error::Error as StdError,
     fmt::{Display, Error as FmtError, Formatter, Result as FmtResult},
@@ -13,6 +8,11 @@ use std::{
     result::Result as StdResult,
 };
 use url::ParseError as UrlParseError;
+
+#[cfg(not(feature = "simd-json"))]
+use serde_json::Error as JsonError;
+#[cfg(feature = "simd-json")]
+use simd_json::Error as JsonError;
 
 pub type Result<T, E = Error> = StdResult<T, E>;
 

--- a/http/src/ratelimiting/mod.rs
+++ b/http/src/ratelimiting/mod.rs
@@ -8,8 +8,8 @@ pub use self::{
     headers::RatelimitHeaders,
 };
 
-use self::bucket::{Bucket, BucketQueueTask};
 use crate::routing::Path;
+use bucket::{Bucket, BucketQueueTask};
 use futures_channel::oneshot::{self, Receiver, Sender};
 use futures_util::lock::Mutex;
 use std::{

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{
     id::{ChannelId, UserId},
@@ -116,7 +115,7 @@ impl<'a> CreateInvite<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::CreateInvite {
                     channel_id: self.channel_id.0,
@@ -124,7 +123,7 @@ impl<'a> CreateInvite<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::CreateInvite {
                     channel_id: self.channel_id.0,
                 },

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -1,5 +1,4 @@
 use super::allowed_mentions::{AllowedMentions, AllowedMentionsBuilder, Unspecified};
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use reqwest::{
     multipart::{Form, Part},
@@ -202,7 +201,7 @@ impl<'a> CreateMessage<'a> {
         self.fut.replace(Box::pin(self.http.request(
             if self.attachments.is_empty() {
                 Request::from((
-                    json_to_vec(&self.fields)?,
+                    crate::json_to_vec(&self.fields)?,
                     Route::CreateMessage {
                         channel_id: self.channel_id.0,
                     },
@@ -215,7 +214,7 @@ impl<'a> CreateMessage<'a> {
                 }
 
                 Request::from((
-                    json_to_vec(&self.fields)?,
+                    crate::json_to_vec(&self.fields)?,
                     form,
                     Route::CreateMessage {
                         channel_id: self.channel_id.0,

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::id::{ChannelId, MessageId};
 
@@ -52,7 +51,7 @@ impl<'a> DeleteMessages<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::DeleteMessages {
                     channel_id: self.channel_id.0,
@@ -60,7 +59,7 @@ impl<'a> DeleteMessages<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::DeleteMessages {
                     channel_id: self.channel_id.0,
                 },

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::{channel::message::allowed_mentions::AllowedMentions, prelude::*};
 use std::{
     error::Error,
@@ -201,7 +200,7 @@ impl<'a> UpdateMessage<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields)?,
             Route::UpdateMessage {
                 channel_id: self.channel_id.0,
                 message_id: self.message_id.0,

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use std::{
     error::Error,
@@ -247,7 +246,7 @@ impl<'a> UpdateChannel<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::UpdateChannel {
                     channel_id: self.channel_id.0,
@@ -255,7 +254,7 @@ impl<'a> UpdateChannel<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::UpdateChannel {
                     channel_id: self.channel_id.0,
                 },

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{guild::Permissions, id::ChannelId};
 
@@ -53,7 +52,7 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::UpdatePermissionOverwrite {
                     channel_id: self.channel_id.0,
@@ -62,7 +61,7 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::UpdatePermissionOverwrite {
                     channel_id: self.channel_id.0,
                     target_id: self.target_id,

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{channel::Webhook, id::ChannelId};
 
@@ -72,7 +71,7 @@ impl<'a> CreateWebhook<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::CreateWebhook {
                     channel_id: self.channel_id.0,
@@ -80,7 +79,7 @@ impl<'a> CreateWebhook<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::CreateWebhook {
                     channel_id: self.channel_id.0,
                 },

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{
     channel::{embed::Embed, Message},
@@ -126,7 +125,7 @@ impl<'a> ExecuteWebhook<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields)?,
             Route::ExecuteWebhook {
                 token: self.token.to_owned(),
                 wait: self.fields.wait,

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{
     channel::Webhook,
@@ -71,7 +70,7 @@ impl<'a> UpdateWebhook<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::UpdateWebhook {
                     token: None,
@@ -80,7 +79,7 @@ impl<'a> UpdateWebhook<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::UpdateWebhook {
                     token: None,
                     webhook_id: self.webhook_id.0,

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{channel::Webhook, id::WebhookId};
 
@@ -50,7 +49,7 @@ impl<'a> UpdateWebhookWithToken<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields)?,
             Route::UpdateWebhook {
                 token: Some(self.token.clone()),
                 webhook_id: self.webhook_id.0,

--- a/http/src/request/guild/create_guild.rs
+++ b/http/src/request/guild/create_guild.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use std::{
     error::Error,
@@ -187,7 +186,7 @@ impl<'a> CreateGuild<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields)?,
             Route::CreateGuild,
         )))));
 

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use std::{
     error::Error,
@@ -238,7 +237,7 @@ impl<'a> CreateGuildChannel<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::CreateChannel {
                     guild_id: self.guild_id.0,
@@ -246,7 +245,7 @@ impl<'a> CreateGuildChannel<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::CreateChannel {
                     guild_id: self.guild_id.0,
                 },

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{
     guild::Emoji,
@@ -69,7 +68,7 @@ impl<'a> CreateEmoji<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::CreateEmoji {
                     guild_id: self.guild_id.0,
@@ -77,7 +76,7 @@ impl<'a> CreateEmoji<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::CreateEmoji {
                     guild_id: self.guild_id.0,
                 },

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{
     guild::Emoji,
@@ -58,7 +57,7 @@ impl<'a> UpdateEmoji<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::UpdateEmoji {
                     emoji_id: self.emoji_id.0,
@@ -67,7 +66,7 @@ impl<'a> UpdateEmoji<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::UpdateEmoji {
                     emoji_id: self.emoji_id.0,
                     guild_id: self.guild_id.0,

--- a/http/src/request/guild/integration/create_guild_integration.rs
+++ b/http/src/request/guild/integration/create_guild_integration.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::id::{GuildId, IntegrationId};
 
@@ -52,7 +51,7 @@ impl<'a> CreateGuildIntegration<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::CreateGuildIntegration {
                     guild_id: self.guild_id.0,
@@ -60,7 +59,7 @@ impl<'a> CreateGuildIntegration<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::CreateGuildIntegration {
                     guild_id: self.guild_id.0,
                 },

--- a/http/src/request/guild/integration/update_guild_integration.rs
+++ b/http/src/request/guild/integration/update_guild_integration.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::id::{GuildId, IntegrationId};
 
@@ -76,7 +75,7 @@ impl<'a> UpdateGuildIntegration<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::UpdateGuildIntegration {
                     guild_id: self.guild_id.0,
@@ -85,7 +84,7 @@ impl<'a> UpdateGuildIntegration<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::UpdateGuildIntegration {
                     guild_id: self.guild_id.0,
                     integration_id: self.integration_id.0,

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -1,10 +1,6 @@
 use crate::request::prelude::*;
 use bytes::Bytes;
 use serde::de::DeserializeSeed;
-#[cfg(not(feature = "simd-json"))]
-use serde_json::Value;
-#[cfg(feature = "simd-json")]
-use simd_json::value::OwnedValue as Value;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -16,6 +12,11 @@ use twilight_model::{
     guild::member::{Member, MemberDeserializer},
     id::{GuildId, UserId},
 };
+
+#[cfg(not(feature = "simd-json"))]
+use serde_json::Value;
+#[cfg(feature = "simd-json")]
+use simd_json::value::OwnedValue as Value;
 
 /// The error created when the members can not be fetched as configured.
 #[derive(Clone, Debug)]

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -1,9 +1,5 @@
 use crate::request::prelude::*;
 use serde::de::DeserializeSeed;
-#[cfg(not(feature = "simd-json"))]
-use serde_json::Value;
-#[cfg(feature = "simd-json")]
-use simd_json::value::OwnedValue as Value;
 use std::{
     future::Future,
     pin::Pin,
@@ -13,6 +9,11 @@ use twilight_model::{
     guild::member::{Member, MemberDeserializer},
     id::{GuildId, UserId},
 };
+
+#[cfg(not(feature = "simd-json"))]
+use serde_json::Value;
+#[cfg(feature = "simd-json")]
+use simd_json::value::OwnedValue as Value;
 
 /// Get a member of a guild, by id.
 pub struct GetMember<'a> {

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use std::{
     error::Error,
@@ -131,7 +130,7 @@ impl<'a> UpdateGuildMember<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::UpdateMember {
                     guild_id: self.guild_id.0,
@@ -140,7 +139,7 @@ impl<'a> UpdateGuildMember<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::UpdateMember {
                     guild_id: self.guild_id.0,
                     user_id: self.user_id.0,

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{
     guild::{Permissions, Role},
@@ -100,7 +99,7 @@ impl<'a> CreateRole<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::CreateRole {
                     guild_id: self.guild_id.0,
@@ -108,7 +107,7 @@ impl<'a> CreateRole<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::CreateRole {
                     guild_id: self.guild_id.0,
                 },

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{
     guild::{Permissions, Role},
@@ -82,7 +81,7 @@ impl<'a> UpdateRole<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::UpdateRole {
                     guild_id: self.guild_id.0,
@@ -91,7 +90,7 @@ impl<'a> UpdateRole<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::UpdateRole {
                     guild_id: self.guild_id.0,
                     role_id: self.role_id.0,

--- a/http/src/request/guild/role/update_role_positions.rs
+++ b/http/src/request/guild/role/update_role_positions.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{
     guild::Role,
@@ -31,7 +30,7 @@ impl<'a> UpdateRolePositions<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            json_to_vec(&self.roles)?,
+            crate::json_to_vec(&self.roles)?,
             Route::UpdateRolePositions {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/guild/update_current_user_nick.rs
+++ b/http/src/request/guild/update_current_user_nick.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::id::GuildId;
 
@@ -27,7 +26,7 @@ impl<'a> UpdateCurrentUserNick<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields)?,
             Route::UpdateNickname {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use std::{
     error::Error,
@@ -247,7 +246,7 @@ impl<'a> UpdateGuild<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 headers,
                 Route::UpdateGuild {
                     guild_id: self.guild_id.0,
@@ -255,7 +254,7 @@ impl<'a> UpdateGuild<'a> {
             ))
         } else {
             Request::from((
-                json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields)?,
                 Route::UpdateGuild {
                     guild_id: self.guild_id.0,
                 },

--- a/http/src/request/guild/update_guild_channel_positions.rs
+++ b/http/src/request/guild/update_guild_channel_positions.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::id::{ChannelId, GuildId};
 
@@ -38,7 +37,7 @@ impl<'a> UpdateGuildChannelPositions<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            json_to_vec(&self.positions)?,
+            crate::json_to_vec(&self.positions)?,
             Route::UpdateGuildChannels {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/guild/update_guild_widget.rs
+++ b/http/src/request/guild/update_guild_widget.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{
     guild::GuildWidget,
@@ -45,7 +44,7 @@ impl<'a> UpdateGuildWidget<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields)?,
             Route::UpdateGuildWidget {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/user/create_private_channel.rs
+++ b/http/src/request/user/create_private_channel.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use twilight_model::{channel::PrivateChannel, id::UserId};
 
@@ -26,7 +25,7 @@ impl<'a> CreatePrivateChannel<'a> {
     }
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields)?,
             Route::CreatePrivateChannel,
         )))));
 

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -1,4 +1,3 @@
-use crate::json_to_vec;
 use crate::request::prelude::*;
 use std::{
     error::Error,
@@ -90,7 +89,7 @@ impl<'a> UpdateCurrentUser<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields)?,
             Route::UpdateCurrentUser,
         )))));
 

--- a/model/src/gateway/event/dispatch.rs
+++ b/model/src/gateway/event/dispatch.rs
@@ -1,5 +1,4 @@
-use super::super::payload::*;
-use super::EventType;
+use super::{super::payload::*, EventType};
 use serde::{
     de::{Deserialize, DeserializeSeed, Deserializer, Error as DeError, IgnoredAny},
     Serialize,

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -1,5 +1,4 @@
-use super::super::OpCode;
-use super::{DispatchEvent, DispatchEventWithTypeDeserializer};
+use super::{super::OpCode, DispatchEvent, DispatchEventWithTypeDeserializer};
 use serde::{
     de::{
         value::U8Deserializer, DeserializeSeed, Deserializer, Error as DeError, IgnoredAny,

--- a/model/src/gateway/event/mod.rs
+++ b/model/src/gateway/event/mod.rs
@@ -7,12 +7,10 @@ mod dispatch;
 mod kind;
 
 pub use self::{
-    dispatch::DispatchEvent,
+    dispatch::{DispatchEvent, DispatchEventWithTypeDeserializer},
     gateway::{GatewayEvent, GatewayEventDeserializer},
     kind::EventType,
 };
-
-pub use self::dispatch::DispatchEventWithTypeDeserializer;
 
 use self::shard::*;
 use super::payload::*;

--- a/model/src/gateway/payload/invite_create.rs
+++ b/model/src/gateway/payload/invite_create.rs
@@ -1,6 +1,8 @@
-use crate::id::{ChannelId, GuildId, UserId};
-use crate::invite::TargetUserType;
-use crate::user::User;
+use crate::{
+    id::{ChannelId, GuildId, UserId},
+    invite::TargetUserType,
+    user::User,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]

--- a/model/src/gateway/payload/member_chunk.rs
+++ b/model/src/gateway/payload/member_chunk.rs
@@ -3,10 +3,9 @@ use crate::{
     guild::member::{Member, MemberMapDeserializer},
     id::{GuildId, UserId},
 };
-use serde::Serialize;
 use serde::{
     de::{Deserializer, Error as DeError, IgnoredAny, MapAccess, Visitor},
-    Deserialize,
+    Deserialize, Serialize,
 };
 use std::{
     collections::HashMap,


### PR DESCRIPTION
Consolidate and re-order imports, combining multiple imports from the same crate into one and not importing functions, preferring to import their parent module.