### PR TITLE
utils/mention: fix grammatical typo in readme

### DIFF
--- a/utils/mention/README.md
+++ b/utils/mention/README.md
@@ -19,7 +19,7 @@ twilight-mention = { branch = "trunk", git = "https://github.com/twilight-rs/twi
 
 ## Examples
 
-Create a mention formatter a user ID, and then format it in a message:
+Create a mention formatter for a user ID, and then format it in a message:
 
 ```rust
 use twilight_mention::Mention;

--- a/utils/mention/src/lib.rs
+++ b/utils/mention/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! ## Examples
 //!
-//! Create a mention formatter a user ID, and then format it in a message:
+//! Create a mention formatter for a user ID, and then format it in a message:
 //!
 //! ```rust
 //! use twilight_mention::Mention;


### PR DESCRIPTION
Fix a grammatical typo in the `twilight-mention` README that left out a word.