### PR TITLE
gateway/shard: return named event stream type

### DIFF
--- a/gateway/src/shard/event.rs
+++ b/gateway/src/shard/event.rs
@@ -29,8 +29,16 @@ use twilight_model::gateway::event::Event;
 /// event types returned by [`Events::event_types`] to see what events can come
 /// in through this stream.
 ///
+/// This implements [`futures::stream::Stream`].
+///
+/// # Examples
+///
+/// Refer to [`Shard::some_events`] for an example of how to use this.
+///
 /// [`Events::event_types`]: #method.event_types
 /// [`Shard`]: ../struct.Shard.html
+/// [`Shard::some_events`]: struct.Shard.html#method.some_events
+/// [`futures::stream::Stream`]: https://docs.rs/futures/*/futures/stream/trait.Stream.html
 pub struct Events {
     event_types: EventTypeFlags,
     rx: UnboundedReceiver<Event>,

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -11,10 +11,7 @@ use async_tungstenite::tungstenite::{
     protocol::{frame::coding::CloseCode, CloseFrame},
     Message,
 };
-use futures_util::{
-    future::{self, AbortHandle},
-    stream::Stream,
-};
+use futures_util::future::{self, AbortHandle};
 use once_cell::sync::OnceCell;
 use std::{
     borrow::Cow,
@@ -179,7 +176,7 @@ impl Shard {
     /// [`EventType::SHARD_PAYLOAD`]: events/struct.EventType.html#const.SHARD_PAYLOAD
     /// [`some_events`]: #method.some_events
     pub async fn events(&self) -> Events {
-        self.some_events(EventTypeFlags::default())
+        self.some_events(EventTypeFlags::default()).await
     }
 
     /// Creates a new filtered stream of events from the shard.

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -170,10 +170,13 @@ impl Shard {
     /// There can be multiple streams of events. All events will be broadcast to
     /// all streams of events.
     ///
+    /// The returned event stream implements [`futures::stream::Stream`].
+    ///
     /// All event types except for [`EventType::SHARD_PAYLOAD`] are enabled.
     /// If you need to enable it, consider calling [`some_events`] instead.
     ///
     /// [`EventType::SHARD_PAYLOAD`]: events/struct.EventType.html#const.SHARD_PAYLOAD
+    /// [`futures::stream::Stream`]: https://docs.rs/futures/*/futures/stream/trait.Stream.html
     /// [`some_events`]: #method.some_events
     pub async fn events(&self) -> Events {
         self.some_events(EventTypeFlags::default()).await
@@ -182,6 +185,8 @@ impl Shard {
     /// Creates a new filtered stream of events from the shard.
     ///
     /// Only the events specified in the bitflags will be sent over the stream.
+    ///
+    /// The returned event stream implements [`futures::stream::Stream`].
     ///
     /// # Examples
     ///
@@ -211,6 +216,8 @@ impl Shard {
     /// }
     /// # Ok(()) }
     /// ```
+    ///
+    /// [`futures::stream::Stream`]: https://docs.rs/futures/*/futures/stream/trait.Stream.html
     pub async fn some_events(&self, event_types: EventTypeFlags) -> Events {
         let rx = self.0.listeners.add(event_types);
 

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -178,10 +178,8 @@ impl Shard {
     ///
     /// [`EventType::SHARD_PAYLOAD`]: events/struct.EventType.html#const.SHARD_PAYLOAD
     /// [`some_events`]: #method.some_events
-    pub async fn events(&self) -> impl Stream<Item = Event> {
-        let rx = self.0.listeners.add(EventTypeFlags::default());
-
-        Events::new(EventTypeFlags::default(), rx)
+    pub async fn events(&self) -> Events {
+        self.some_events(EventTypeFlags::default())
     }
 
     /// Creates a new filtered stream of events from the shard.
@@ -216,7 +214,7 @@ impl Shard {
     /// }
     /// # Ok(()) }
     /// ```
-    pub async fn some_events(&self, event_types: EventTypeFlags) -> impl Stream<Item = Event> {
+    pub async fn some_events(&self, event_types: EventTypeFlags) -> Events {
         let rx = self.0.listeners.add(event_types);
 
         Events::new(event_types, rx)

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -24,9 +24,9 @@
 
 pub mod config;
 pub mod error;
-pub mod event;
 pub mod stage;
 
+mod event;
 mod r#impl;
 mod processor;
 mod sink;
@@ -34,6 +34,7 @@ mod sink;
 pub use self::{
     config::ShardConfig,
     error::{Error, Result},
+    event::Events,
     processor::heartbeat::Latency,
     r#impl::{Information, ResumeSession, Shard},
     sink::ShardSink,


### PR DESCRIPTION
Instead of returning a `impl Stream` from `Shard::events` and `Shard::some_events`, return the named `Events` type that implements `Stream`.