### PR TITLE
lavalink/model: expose incoming, outgoing modules

### DIFF
--- a/lavalink/src/model.rs
+++ b/lavalink/src/model.rs
@@ -32,7 +32,8 @@ pub enum Opcode {
     Volume,
 }
 
-mod outgoing {
+pub mod outgoing {
+    //! Events that clients send to Lavalink.
     use super::Opcode;
     use serde::{Deserialize, Serialize};
     use twilight_model::{gateway::payload::VoiceServerUpdate, id::GuildId};
@@ -456,7 +457,9 @@ mod outgoing {
     }
 }
 
-mod incoming {
+pub mod incoming {
+    //! Events that Lavalink sends to clients.
+
     use super::Opcode;
     use serde::{Deserialize, Serialize};
     use twilight_model::id::GuildId;
@@ -625,7 +628,16 @@ mod incoming {
     }
 }
 
-pub use self::{incoming::*, outgoing::*};
+pub use self::{
+    incoming::{
+        IncomingEvent, PlayerUpdate, PlayerUpdateState, Stats, StatsCpu, StatsFrames, StatsMemory,
+        TrackEnd, TrackEventType, TrackStart,
+    },
+    outgoing::{
+        Destroy, Equalizer, EqualizerBand, OutgoingEvent, Pause, Play, Seek, SlimVoiceServerUpdate,
+        Stop, VoiceUpdate, Volume,
+    },
+};
 
 #[cfg(test)]
 mod tests {

--- a/lavalink/src/model.rs
+++ b/lavalink/src/model.rs
@@ -34,6 +34,7 @@ pub enum Opcode {
 
 pub mod outgoing {
     //! Events that clients send to Lavalink.
+
     use super::Opcode;
     use serde::{Deserialize, Serialize};
     use twilight_model::{gateway::payload::VoiceServerUpdate, id::GuildId};


### PR DESCRIPTION
In the `twilight-lavalink` crate's `model` module, expose the `incoming` and `outgoing` modules while re-exporting their contents. This can make code and documentation navigation easier for people to find things relevant to a use case more easily.