### PR TITLE
gateway: simplify runtime spawns

### DIFF
--- a/gateway/src/queue/large_bot_queue.rs
+++ b/gateway/src/queue/large_bot_queue.rs
@@ -25,9 +25,7 @@ impl LargeBotQueue {
         for _ in 0..buckets {
             let (tx, rx) = unbounded();
 
-            tokio::spawn(async {
-                waiter(rx).await;
-            });
+            tokio::spawn(waiter(rx));
 
             queues.push(tx)
         }

--- a/gateway/src/queue/mod.rs
+++ b/gateway/src/queue/mod.rs
@@ -63,9 +63,7 @@ impl LocalQueue {
     pub fn new() -> Self {
         let (tx, rx) = unbounded();
 
-        tokio::spawn(async {
-            waiter(rx).await;
-        });
+        tokio::spawn(waiter(rx));
 
         Self(tx)
     }


### PR DESCRIPTION
Simplify some runtime spawns by ignoring the return value of a spawn since they don't need to be used and simply moving futures into `tokio::spawn` rather than wrapping futures in an `async {}` block.