### PR TITLE
lavalink/node: ignore when user drops rx

### DIFF
--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Initialize the tracing subscriber.
     tracing_subscriber::fmt::init();
 
-    let (state, _rx) = {
+    let state = {
         let token = env::var("DISCORD_TOKEN")?;
         let lavalink_host = SocketAddr::from_str(&env::var("LAVALINK_HOST")?)?;
         let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
@@ -45,21 +45,18 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let user_id = http.current_user().await?.id;
 
         let lavalink = Lavalink::new(user_id, shard_count);
-        let rx = lavalink.add(lavalink_host, lavalink_auth).await?;
+        lavalink.add(lavalink_host, lavalink_auth).await?;
 
         let mut shard = Shard::new(token);
         shard.start().await?;
 
-        (
-            State {
-                http,
-                lavalink,
-                reqwest: ReqwestClient::new(),
-                shard,
-                standby: Standby::new(),
-            },
-            rx,
-        )
+        State {
+            http,
+            lavalink,
+            reqwest: ReqwestClient::new(),
+            shard,
+            standby: Standby::new(),
+        }
     };
 
     let mut events = state.shard.events().await;

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -360,10 +360,6 @@ impl Connection {
 
     async fn run(mut self) -> Result<(), NodeError> {
         loop {
-            if self.node_to.is_closed() {
-                break;
-            }
-
             let from_lavalink = self.connection.next();
             let to_lavalink = self.node_from.next();
 


### PR DESCRIPTION
On every iteration of the node connection loop a branch would run to check if the user hadn't dropped the rx of events received from lavalink, and in the case that they did, break the loop. Not all users want to handle these, so just ignoring if the user closed the channel is fine.

Closes #296.