### PR TITLE
http/update_guild: add 'banner' field

### DIFF
--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -75,6 +75,7 @@
 )]
 #![allow(
     clippy::module_name_repetitions,
+    clippy::option_option,
     clippy::pub_enum_variant_names,
     clippy::must_use_candidate,
     clippy::missing_errors_doc

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -75,7 +75,6 @@
 )]
 #![allow(
     clippy::module_name_repetitions,
-    clippy::option_option,
     clippy::pub_enum_variant_names,
     clippy::must_use_candidate,
     clippy::missing_errors_doc

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -32,6 +32,7 @@ impl Error for UpdateGuildError {}
 struct UpdateGuildFields {
     afk_channel_id: Option<ChannelId>,
     afk_timeout: Option<u64>,
+    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
     banner: Option<Option<String>>,
     default_message_notifications: Option<DefaultMessageNotificationLevel>,

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -32,6 +32,7 @@ impl Error for UpdateGuildError {}
 struct UpdateGuildFields {
     afk_channel_id: Option<ChannelId>,
     afk_timeout: Option<u64>,
+    banner: Option<Option<String>>,
     default_message_notifications: Option<DefaultMessageNotificationLevel>,
     explicit_content_filter: Option<ExplicitContentFilter>,
     icon: Option<String>,
@@ -82,6 +83,18 @@ impl<'a> UpdateGuild<'a> {
     /// Set how much time it takes for a voice user to be considered AFK.
     pub fn afk_timeout(mut self, afk_timeout: u64) -> Self {
         self.fields.afk_timeout.replace(afk_timeout);
+
+        self
+    }
+
+    /// Set the banner.
+    ///
+    /// This is a base64 encoded 16:9 PNG or JPEG image. Pass `None` to remove
+    /// the banner.
+    ///
+    /// The server must have the `BANNER` feature.
+    pub fn banner(mut self, banner: impl Into<Option<String>>) -> Self {
+        self.fields.banner.replace(banner.into());
 
         self
     }

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -32,6 +32,7 @@ impl Error for UpdateGuildError {}
 struct UpdateGuildFields {
     afk_channel_id: Option<ChannelId>,
     afk_timeout: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     banner: Option<Option<String>>,
     default_message_notifications: Option<DefaultMessageNotificationLevel>,
     explicit_content_filter: Option<ExplicitContentFilter>,


### PR DESCRIPTION
Add the `banner` field to the JSON body. This field is nullable, and is a 16:9 PNG or JPEG base64 encoded image.

Discord docs: <https://discord.com/developers/docs/resources/guild#modify-guild-json-params>