### PR TITLE
http/request: nullable fields

### DIFF
--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -6,11 +6,17 @@ use twilight_model::{
 
 #[derive(Default, Serialize)]
 struct CreateInviteFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     max_age: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     max_uses: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     temporary: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     unique: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     target_user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     target_user_type: Option<TargetUserType>,
 }
 

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -46,11 +46,17 @@ impl Error for CreateMessageError {
 
 #[derive(Default, Serialize)]
 pub(crate) struct CreateMessageFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     embed: Option<Embed>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     nonce: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     payload_json: Option<Vec<u8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     tts: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) allowed_mentions: Option<AllowedMentions>,
 }
 

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -36,15 +36,24 @@ impl Error for UpdateChannelError {}
 // but it does require them to be non-null.
 #[derive(Default, Serialize)]
 struct UpdateChannelFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     bitrate: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     nsfw: Option<bool>,
-    parent_id: Option<ChannelId>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_id: Option<Option<ChannelId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     permission_overwrites: Option<Vec<PermissionOverwrite>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     position: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     rate_limit_per_user: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     topic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     user_limit: Option<u64>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -130,8 +139,8 @@ impl<'a> UpdateChannel<'a> {
 
     /// If this is specified, and the parent ID is a `ChannelType::CategoryChannel`, move this
     /// channel to a child of the category channel.
-    pub fn parent_id(mut self, parent_id: ChannelId) -> Self {
-        self.fields.parent_id.replace(parent_id);
+    pub fn parent_id(mut self, parent_id: impl Into<Option<ChannelId>>) -> Self {
+        self.fields.parent_id.replace(parent_id.into());
 
         self
     }

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -3,6 +3,7 @@ use twilight_model::{channel::Webhook, id::ChannelId};
 
 #[derive(Serialize)]
 struct CreateWebhookFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     avatar: Option<String>,
     name: String,
 }

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -6,13 +6,21 @@ use twilight_model::{
 
 #[derive(Default, Serialize)]
 struct ExecuteWebhookFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     avatar_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     embeds: Option<Vec<Embed>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     file: Option<Vec<u8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     payload_json: Option<Vec<u8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     tts: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     username: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     wait: Option<bool>,
 }
 

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -6,9 +6,15 @@ use twilight_model::{
 
 #[derive(Default, Serialize)]
 struct UpdateWebhookFields {
-    avatar: Option<String>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    avatar: Option<Option<String>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     channel_id: Option<ChannelId>,
-    name: Option<String>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<Option<String>>,
 }
 
 /// Update a webhook by ID.
@@ -39,7 +45,7 @@ impl<'a> UpdateWebhook<'a> {
     /// base64-encoded image.
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<String>) -> Self {
+    pub fn avatar(mut self, avatar: impl Into<Option<String>>) -> Self {
         self.fields.avatar.replace(avatar.into());
 
         self
@@ -53,7 +59,7 @@ impl<'a> UpdateWebhook<'a> {
     }
 
     /// Change the name of the webhook.
-    pub fn name(mut self, name: impl Into<String>) -> Self {
+    pub fn name(mut self, name: impl Into<Option<String>>) -> Self {
         self.fields.name.replace(name.into());
 
         self

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -3,8 +3,12 @@ use twilight_model::{channel::Webhook, id::WebhookId};
 
 #[derive(Default, Serialize)]
 struct UpdateWebhookWithTokenFields {
-    avatar: Option<String>,
-    name: Option<String>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    avatar: Option<Option<String>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<Option<String>>,
 }
 
 /// Update a webhook, with a token, by ID.
@@ -34,14 +38,14 @@ impl<'a> UpdateWebhookWithToken<'a> {
     /// base64-encoded image.
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<String>) -> Self {
+    pub fn avatar(mut self, avatar: impl Into<Option<String>>) -> Self {
         self.fields.avatar.replace(avatar.into());
 
         self
     }
 
     /// Change the name of the webhook.
-    pub fn name(mut self, name: impl Into<String>) -> Self {
+    pub fn name(mut self, name: impl Into<Option<String>>) -> Self {
         self.fields.name.replace(name.into());
 
         self

--- a/http/src/request/guild/create_guild.rs
+++ b/http/src/request/guild/create_guild.rs
@@ -41,13 +41,20 @@ impl Error for CreateGuildError {}
 
 #[derive(Serialize)]
 struct CreateGuildFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     channels: Option<Vec<GuildChannel>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     default_message_notifications: Option<DefaultMessageNotificationLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     explicit_content_filter: Option<ExplicitContentFilter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     icon: Option<String>,
     name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     region: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     roles: Option<Vec<Role>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     verification_level: Option<VerificationLevel>,
 }
 

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -34,16 +34,24 @@ impl Error for CreateGuildChannelError {}
 
 #[derive(Serialize)]
 struct CreateGuildChannelFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     bitrate: Option<u64>,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     kind: Option<ChannelType>,
     name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     nsfw: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     parent_id: Option<ChannelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     permission_overwrites: Option<Vec<PermissionOverwrite>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     position: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     rate_limit_per_user: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     topic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     user_limit: Option<u64>,
 }
 

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -8,6 +8,7 @@ use twilight_model::{
 struct CreateEmojiFields {
     image: String,
     name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     roles: Option<Vec<RoleId>>,
 }
 

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -6,7 +6,9 @@ use twilight_model::{
 
 #[derive(Default, Serialize)]
 struct UpdateEmojiFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     roles: Option<Vec<RoleId>>,
 }
 

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -27,10 +27,17 @@ impl Error for UpdateGuildMemberError {}
 
 #[derive(Default, Serialize)]
 struct UpdateGuildMemberFields {
-    channel_id: Option<ChannelId>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    channel_id: Option<Option<ChannelId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     deaf: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     mute: Option<bool>,
-    nick: Option<String>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nick: Option<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     roles: Option<Vec<RoleId>>,
 }
 
@@ -68,7 +75,7 @@ impl<'a> UpdateGuildMember<'a> {
     }
 
     /// Move the member to a different voice channel.
-    pub fn channel_id(mut self, channel_id: impl Into<ChannelId>) -> Self {
+    pub fn channel_id(mut self, channel_id: impl Into<Option<ChannelId>>) -> Self {
         self.fields.channel_id.replace(channel_id.into());
 
         self
@@ -98,13 +105,15 @@ impl<'a> UpdateGuildMember<'a> {
     /// too long.
     ///
     /// [`UpdateGuildMemberError::NicknameInvalid`]: enum.UpdateGuildMemberError.html#variant.NicknameInvalid
-    pub fn nick(self, nick: impl Into<String>) -> Result<Self, UpdateGuildMemberError> {
+    pub fn nick(self, nick: impl Into<Option<String>>) -> Result<Self, UpdateGuildMemberError> {
         self._nick(nick.into())
     }
 
-    fn _nick(mut self, nick: String) -> Result<Self, UpdateGuildMemberError> {
-        if !validate::nickname(&nick) {
-            return Err(UpdateGuildMemberError::NicknameInvalid);
+    fn _nick(mut self, nick: Option<String>) -> Result<Self, UpdateGuildMemberError> {
+        if let Some(nick) = nick.as_ref() {
+            if !validate::nickname(&nick) {
+                return Err(UpdateGuildMemberError::NicknameInvalid);
+            }
         }
 
         self.fields.nick.replace(nick);

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -6,10 +6,15 @@ use twilight_model::{
 
 #[derive(Default, Serialize)]
 struct CreateRoleFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     mentionable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     permissions: Option<Permissions>,
 }
 

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -6,10 +6,17 @@ use twilight_model::{
 
 #[derive(Default, Serialize)]
 struct UpdateRoleFields {
-    color: Option<u64>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    color: Option<Option<u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     mentionable: Option<bool>,
-    name: Option<String>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     permissions: Option<Permissions>,
 }
 
@@ -36,8 +43,8 @@ impl<'a> UpdateRole<'a> {
     }
 
     /// Set the color of the role.
-    pub fn color(mut self, color: u64) -> Self {
-        self.fields.color.replace(color);
+    pub fn color(mut self, color: impl Into<Option<u64>>) -> Self {
+        self.fields.color.replace(color.into());
 
         self
     }
@@ -57,7 +64,7 @@ impl<'a> UpdateRole<'a> {
     }
 
     /// Set the name of the role.
-    pub fn name(mut self, name: impl Into<String>) -> Self {
+    pub fn name(mut self, name: impl Into<Option<String>>) -> Self {
         self.fields.name.replace(name.into());
 
         self

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -30,25 +30,48 @@ impl Error for UpdateGuildError {}
 
 #[derive(Default, Serialize)]
 struct UpdateGuildFields {
-    afk_channel_id: Option<ChannelId>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    afk_channel_id: Option<Option<ChannelId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     afk_timeout: Option<u64>,
     #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
     banner: Option<Option<String>>,
-    default_message_notifications: Option<DefaultMessageNotificationLevel>,
-    explicit_content_filter: Option<ExplicitContentFilter>,
-    icon: Option<String>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_message_notifications: Option<Option<DefaultMessageNotificationLevel>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    explicit_content_filter: Option<Option<ExplicitContentFilter>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    icon: Option<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     owner_id: Option<UserId>,
-    region: Option<String>,
-    splash: Option<String>,
-    system_channel_id: Option<ChannelId>,
-    verification_level: Option<VerificationLevel>,
-    rules_channel_id: Option<ChannelId>,
-    public_updates_channel_id: Option<ChannelId>,
-    preferred_locale: Option<String>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    region: Option<Option<String>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    splash: Option<Option<String>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_channel_id: Option<Option<ChannelId>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    verification_level: Option<Option<VerificationLevel>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rules_channel_id: Option<Option<ChannelId>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    public_updates_channel_id: Option<Option<ChannelId>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preferred_locale: Option<Option<String>>,
 }
 
 /// Update a guild.
@@ -76,7 +99,7 @@ impl<'a> UpdateGuild<'a> {
     }
 
     /// Set the voice channel where AFK voice users are sent.
-    pub fn afk_channel_id(mut self, afk_channel_id: impl Into<ChannelId>) -> Self {
+    pub fn afk_channel_id(mut self, afk_channel_id: impl Into<Option<ChannelId>>) -> Self {
         self.fields.afk_channel_id.replace(afk_channel_id.into());
 
         self
@@ -107,11 +130,11 @@ impl<'a> UpdateGuild<'a> {
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#create-guild
     pub fn default_message_notifications(
         mut self,
-        default_message_notifications: DefaultMessageNotificationLevel,
+        default_message_notifications: impl Into<Option<DefaultMessageNotificationLevel>>,
     ) -> Self {
         self.fields
             .default_message_notifications
-            .replace(default_message_notifications);
+            .replace(default_message_notifications.into());
 
         self
     }
@@ -119,11 +142,11 @@ impl<'a> UpdateGuild<'a> {
     /// Set the explicit content filter level.
     pub fn explicit_content_filter(
         mut self,
-        explicit_content_filter: ExplicitContentFilter,
+        explicit_content_filter: impl Into<Option<ExplicitContentFilter>>,
     ) -> Self {
         self.fields
             .explicit_content_filter
-            .replace(explicit_content_filter);
+            .replace(explicit_content_filter.into());
 
         self
     }
@@ -135,7 +158,7 @@ impl<'a> UpdateGuild<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn icon(mut self, icon: impl Into<String>) -> Self {
+    pub fn icon(mut self, icon: impl Into<Option<String>>) -> Self {
         self.fields.icon.replace(icon.into());
 
         self
@@ -179,7 +202,7 @@ impl<'a> UpdateGuild<'a> {
     /// information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/voice#voice-region-object
-    pub fn region(mut self, region: impl Into<String>) -> Self {
+    pub fn region(mut self, region: impl Into<Option<String>>) -> Self {
         self.fields.region.replace(region.into());
 
         self
@@ -188,14 +211,14 @@ impl<'a> UpdateGuild<'a> {
     /// Set the guild's splash image.
     ///
     /// Requires the guild to have the `INVITE_SPLASH` feature enabled.
-    pub fn splash(mut self, splash: impl Into<String>) -> Self {
+    pub fn splash(mut self, splash: impl Into<Option<String>>) -> Self {
         self.fields.splash.replace(splash.into());
 
         self
     }
 
     /// Set the channel where events such as welcome messages are posted.
-    pub fn system_channel(mut self, system_channel_id: impl Into<ChannelId>) -> Self {
+    pub fn system_channel(mut self, system_channel_id: impl Into<Option<ChannelId>>) -> Self {
         self.fields
             .system_channel_id
             .replace(system_channel_id.into());
@@ -208,7 +231,7 @@ impl<'a> UpdateGuild<'a> {
     /// Requires the guild to be `PUBLIC`. Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild
-    pub fn rules_channel(mut self, rules_channel_id: impl Into<ChannelId>) -> Self {
+    pub fn rules_channel(mut self, rules_channel_id: impl Into<Option<ChannelId>>) -> Self {
         self.fields
             .rules_channel_id
             .replace(rules_channel_id.into());
@@ -221,7 +244,7 @@ impl<'a> UpdateGuild<'a> {
     /// Requires the guild to be `PUBLIC`.
     pub fn public_updates_channel(
         mut self,
-        public_updates_channel_id: impl Into<ChannelId>,
+        public_updates_channel_id: impl Into<Option<ChannelId>>,
     ) -> Self {
         self.fields
             .public_updates_channel_id
@@ -233,7 +256,7 @@ impl<'a> UpdateGuild<'a> {
     /// Set the preferred locale for the guild.
     ///
     /// Defaults to `en-US`. Requires the guild to be `PUBLIC`.
-    pub fn preferred_locale(mut self, preferred_locale: impl Into<String>) -> Self {
+    pub fn preferred_locale(mut self, preferred_locale: impl Into<Option<String>>) -> Self {
         self.fields
             .preferred_locale
             .replace(preferred_locale.into());
@@ -244,8 +267,13 @@ impl<'a> UpdateGuild<'a> {
     /// Set the verification level. Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#guild-object-verification-level
-    pub fn verification_level(mut self, verification_level: VerificationLevel) -> Self {
-        self.fields.verification_level.replace(verification_level);
+    pub fn verification_level(
+        mut self,
+        verification_level: impl Into<Option<VerificationLevel>>,
+    ) -> Self {
+        self.fields
+            .verification_level
+            .replace(verification_level.into());
 
         self
     }

--- a/http/src/request/guild/update_guild_widget.rs
+++ b/http/src/request/guild/update_guild_widget.rs
@@ -6,7 +6,10 @@ use twilight_model::{
 
 #[derive(Default, Serialize)]
 struct UpdateGuildWidgetFields {
-    channel_id: Option<ChannelId>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    channel_id: Option<Option<ChannelId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
 }
 
@@ -29,7 +32,7 @@ impl<'a> UpdateGuildWidget<'a> {
     }
 
     /// Set which channel to display on the widget.
-    pub fn channel_id(mut self, channel_id: impl Into<ChannelId>) -> Self {
+    pub fn channel_id(mut self, channel_id: impl Into<Option<ChannelId>>) -> Self {
         self.fields.channel_id.replace(channel_id.into());
 
         self

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -25,8 +25,9 @@ impl Error for UpdateCurrentUserError {}
 
 #[derive(Default, Serialize)]
 struct UpdateCurrentUserFields {
+    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<String>,
+    avatar: Option<Option<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     username: Option<String>,
 }
@@ -57,7 +58,7 @@ impl<'a> UpdateCurrentUser<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<String>) -> Self {
+    pub fn avatar(mut self, avatar: impl Into<Option<String>>) -> Self {
         self.fields.avatar.replace(avatar.into());
 
         self


### PR DESCRIPTION
Update requests to allow for nullable fields, that is fields that are `Option<Option<T>>`. When `None`, the field is not included in the JSON payload, when `Some(None)` the field is included with a null value, and when `Some(Some(T))` the field is included with T value.

Closes #281.