### PR TITLE
project: fix dead links

### DIFF
--- a/builders/src/embed.rs
+++ b/builders/src/embed.rs
@@ -3,7 +3,8 @@ use twilight_model::channel::embed::*;
 /// Create an embed via a builder.
 ///
 /// If uploading an image as an attachment, set as the image or thumbnail with
-/// `attachment://{filename}.{extension}`. Refer to [the discord docs] for more information.
+/// `attachment://{filename}.{extension}`. Refer to [the discord docs] for more
+/// information.
 ///
 /// # Examples
 ///

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -80,10 +80,8 @@ pub type Result<T> = std::result::Result<T, InMemoryCacheError>;
 
 /// Error type for [`InMemoryCache`] operations.
 ///
-/// Currently this is empty as no error can occur. This exists only to satisfy
-/// the `Cache`'s associated type [`Cache::Error`].
+/// Currently this is empty as no error can occur.
 ///
-/// [`Cache::Error`]: trait.Cache.html#type.Error
 /// [`InMemoryCache`]: struct.InMemoryCache.html
 #[derive(Clone, Debug)]
 pub enum InMemoryCacheError {}
@@ -122,9 +120,8 @@ struct InMemoryCacheRef {
 /// A thread-safe, in-memory-process cache of Discord data. It can be cloned and
 /// sent to other threads.
 ///
-/// This is an implementation of [`Cache`] designed to be used by only the
-/// current process. If the cache needs to be used by other processes, consider
-/// using [`twilight-cache-redis`] or another cache.
+/// This is an implementation of a cache designed to be used by only the
+/// current process.
 ///
 /// # Public Immutability
 ///
@@ -155,18 +152,10 @@ struct InMemoryCacheRef {
 ///
 /// - the "last message id" field of channels will *not* be kept up to date as
 /// - messages come in.
-///
-/// [`Cache`]: trait.Cache.html
-/// [`twilight-cache-redis`]: https://github.com/twilight-rs/cache-redis
 #[derive(Clone, Debug, Default)]
 pub struct InMemoryCache(Arc<InMemoryCacheRef>);
 
 /// Implemented methods and types for the cache.
-///
-/// **Note**: This section may *appear* empty. Please read the implementation
-/// in the [`Cache` trait implementation].
-///
-/// [`Cache` trait implementation]: #impl-Cache
 impl InMemoryCache {
     /// Creates a new, empty cache.
     ///

--- a/command-parser/README.md
+++ b/command-parser/README.md
@@ -4,7 +4,8 @@
 
 # twilight-command-parser
 
-`twilight-command-parser` is a command parser for the [`twilight`] ecosystem.
+`twilight-command-parser` is a command parser for the [`twilight-rs`]
+ecosystem.
 
 Included is a mutable configuration that allows you to specify the command
 names and prefixes. The parser parses out commands matching an available
@@ -61,6 +62,6 @@ match parser.parse("!echo a message") {
 [license link]: https://opensource.org/licenses/ISC
 [rust badge]: https://img.shields.io/badge/rust-1.36+-93450a.svg?style=flat-square
 [rust link]: https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html
-[`twilight`]: https://twilight.valley.cafe
+[`twilight-rs`]: https://github.com/twilight-rs/twilight
 
 <!-- cargo-sync-readme end -->

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -27,10 +27,10 @@ impl<'a> CommandParserConfig<'a> {
 
     /// Returns a mutable reference to the commands.
     ///
-    /// Use the [`add_command`] and [`remove_command`] methods for an easier way
-    /// to manage commands.
+    /// Use the [`command`] and [`remove_command`] methods for an easier way to
+    /// manage commands.
     ///
-    /// [`add_command`]: #method.add_command
+    /// [`command`]: #method.command
     /// [`remove_command`]: #method.remove_command
     pub fn commands_mut(&mut self) -> &mut HashSet<CaseSensitivity> {
         &mut self.commands

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -2,7 +2,8 @@
 //!
 //! # twilight-command-parser
 //!
-//! `twilight-command-parser` is a command parser for the [`twilight`] ecosystem.
+//! `twilight-command-parser` is a command parser for the [`twilight-rs`]
+//! ecosystem.
 //!
 //! Included is a mutable configuration that allows you to specify the command
 //! names and prefixes. The parser parses out commands matching an available
@@ -59,7 +60,7 @@
 //! [license link]: https://opensource.org/licenses/ISC
 //! [rust badge]: https://img.shields.io/badge/rust-1.36+-93450a.svg?style=flat-square
 //! [rust link]: https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html
-//! [`twilight`]: https://twilight.valley.cafe
+//! [`twilight-rs`]: https://github.com/twilight-rs/twilight
 
 #![deny(
     clippy::all,

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -124,7 +124,7 @@ impl ClusterConfig {
     ///
     /// Refer to [`shard::config::ClusterConfigBuilder`]'s methods for the default values.
     ///
-    /// [`shard::config::ClusterConfigBuilder`]: ../../shard/config/struct.ClusterConfigBuilder.html#methods
+    /// [`shard::config::ClusterConfigBuilder`]: ../../shard/config/struct.ShardConfigBuilder.html#methods
     pub fn shard_config(&self) -> &ShardConfig {
         &self.shard_config
     }

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -45,7 +45,7 @@ impl Cluster {
     /// Returns [`Error::GettingGatewayInfo`] if there was an HTTP error getting
     /// the gateway information.
     ///
-    /// [`Error::GettingGatewayInfo`]: ../error/enum.Error.html#variant.GettingGatewayInfo
+    /// [`Error::GettingGatewayInfo`]: ./error/enum.Error.html#variant.GettingGatewayInfo
     pub async fn new(config: impl Into<ClusterConfig>) -> Result<Self> {
         Self::_new(config.into()).await
     }
@@ -137,9 +137,9 @@ impl Cluster {
     /// Returns [`Error::GettingGatewayInfo`] if the [configured shard scheme]
     /// is [`ShardScheme::Auto`].
     ///
-    /// [`Error::GettingGatewayInfo`]: enum.Error.html#variant.GettingGatewayInfo
-    /// [`ShardScheme::Auto`]: config/enum.ShardScheme.html#variant.Auto
-    /// [configured shard scheme]: config/struct.ClusterConfig.html#method.shard_scheme
+    /// [`Error::GettingGatewayInfo`]: ./error/enum.Error.html#variant.GettingGatewayInfo
+    /// [`ShardScheme::Auto`]: ./config/enum.ShardScheme.html#variant.Auto
+    /// [configured shard scheme]: ./config/struct.ClusterConfig.html#method.shard_scheme
     pub async fn up(&self) {
         future::join_all(
             (self.0.shard_from..=self.0.shard_to)

--- a/gateway/src/cluster/mod.rs
+++ b/gateway/src/cluster/mod.rs
@@ -1,60 +1,59 @@
-//! The [`Cluster`] is a manager for running and maintaing multiple shards,
-//! bringing their event streams into one unified stream.
+//! The cluster is a manager for running and maintaing multiple shards, bringing
+//! their event streams into one unified stream.
 //!
 //! # Examples
 //!
 //! Start a cluster of 10 shards and print when a shard is connected,
 //! disconnected, and when new commands come in:
-///
-/// ```no_run
-/// use twilight_gateway::{cluster::{Cluster, ClusterConfig}, Event};
-/// use futures::StreamExt;
-/// use std::env;
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-///     let token = env::var("DISCORD_TOKEN")?;
-///     let cluster = Cluster::new(token).await?;
-///
-///     cluster.up().await;
-///
-///     let mut events = cluster.events().await;
-///
-///     while let Some((shard_id, event)) = events.next().await {
-///         tokio::spawn(handle_event(cluster.clone(), shard_id, event));
-///     }
-///
-///     println!("Cluster is now shutdown");
-///
-///     Ok(())
-/// }
-///
-/// async fn handle_event(cluster: Cluster, shard_id: u64, event: Event) {
-///     match event {
-///         Event::ShardConnected { .. } => {
-///             println!("Shard {} is now connected", shard_id);
-///         },
-///         Event::ShardDisconnected { .. } => {
-///             println!("Shard {} is now disconnected", shard_id);
-///         },
-///         Event::MessageCreate(msg) if msg.content == "!latency" => {
-///             if let Some(shard) = cluster.shard(shard_id).await {
-///                 if let Ok(info) = shard.info().await {
-///                     println!("Shard {}'s latency is {:?}", shard_id, info.latency());
-///                 }
-///             }
-///         },
-///         Event::MessageCreate(msg) if msg.content == "!shutdown" => {
-///             println!("Got a shutdown request from shard {}", shard_id);
-///
-///             cluster.down().await;
-///         },
-///         _ => {},
-///     }
-/// }
-/// ```
-///
-/// [`Cluster`]: struct.Cluster.html
+//!
+//! ```no_run
+//! use twilight_gateway::{cluster::{Cluster, ClusterConfig}, Event};
+//! use futures::StreamExt;
+//! use std::env;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//!     let token = env::var("DISCORD_TOKEN")?;
+//!     let cluster = Cluster::new(token).await?;
+//!
+//!     cluster.up().await;
+//!
+//!     let mut events = cluster.events().await;
+//!
+//!     while let Some((shard_id, event)) = events.next().await {
+//!         tokio::spawn(handle_event(cluster.clone(), shard_id, event));
+//!     }
+//!
+//!     println!("Cluster is now shutdown");
+//!
+//!     Ok(())
+//! }
+//!
+//! async fn handle_event(cluster: Cluster, shard_id: u64, event: Event) {
+//!     match event {
+//!         Event::ShardConnected { .. } => {
+//!             println!("Shard {} is now connected", shard_id);
+//!         },
+//!         Event::ShardDisconnected { .. } => {
+//!             println!("Shard {} is now disconnected", shard_id);
+//!         },
+//!         Event::MessageCreate(msg) if msg.content == "!latency" => {
+//!             if let Some(shard) = cluster.shard(shard_id).await {
+//!                 if let Ok(info) = shard.info().await {
+//!                     println!("Shard {}'s latency is {:?}", shard_id, info.latency());
+//!                 }
+//!             }
+//!         },
+//!         Event::MessageCreate(msg) if msg.content == "!shutdown" => {
+//!             println!("Got a shutdown request from shard {}", shard_id);
+//!
+//!             cluster.down().await;
+//!         },
+//!         _ => {},
+//!     }
+//! }
+//! ```
+
 pub mod config;
 pub mod error;
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -93,11 +93,13 @@ pub mod shard;
 mod event;
 mod listener;
 
+#[doc(no_inline)]
 pub use self::{
     cluster::{Cluster, ClusterConfig},
     event::EventTypeFlags,
     shard::{Shard, ShardConfig},
 };
+#[doc(no_inline)]
 pub use twilight_model::gateway::event::{Event, EventType};
 
 #[cfg(not(feature = "simd-json"))]

--- a/gateway/src/queue/mod.rs
+++ b/gateway/src/queue/mod.rs
@@ -45,8 +45,9 @@ pub trait Queue: Debug + Send + Sync {
 /// If you can't use this, look into an alternative implementation of the
 /// [`Queue`], such as the [`gateway-queue`] broker.
 ///
-/// [`LargeBotQueue`]: ./queue/struct.LargeBotQueue.html
+/// [`LargeBotQueue`]: ./struct.LargeBotQueue.html
 /// [`Cluster`]: ../cluster/struct.Cluster.html
+/// [`Queue`]: trait.Queue.html
 /// [`Shard`]: ../shard/struct.Shard.html
 /// [`gateway-queue`]: https://github.com/twilight-rs/gateway-queue
 #[derive(Clone, Debug)]

--- a/gateway/src/shard/event.rs
+++ b/gateway/src/shard/event.rs
@@ -10,8 +10,8 @@
 //! the type of an event and to filter events from event streams via
 //! [`Shard::some_events`].
 //!
-//! [`Event`]: enum.Event.html
-//! [`EventType`]: ../struct.EventType.html
+//! [`Event`]: ../../../twilight_model/gateway/event/enum.Event.html
+//! [`EventType`]: ../../../twilight_model/gateway/event/enum.EventType.html
 //! [`Shard::some_events`]: ../struct.Shard.html#method.some_events
 
 use crate::EventTypeFlags;

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -220,7 +220,7 @@ impl Shard {
     /// [`Event::ShardConnected`]: ../../twilight_model/gateway/event/enum.Event.html#variant.ShardConnected
     /// [`Event::ShardDisconnected`]: ../../twilight_model/gateway/event/enum.Event.html#variant.ShardDisconnected
     /// [`futures::stream::Stream`]: https://docs.rs/futures/*/futures/stream/trait.Stream.html
-    pub async fn some_events(&self, event_types: EventTypeFlags) -> impl Stream<Item = Event> {
+    pub async fn some_events(&self, event_types: EventTypeFlags) -> Events {
         let rx = self.0.listeners.add(event_types);
 
         Events::new(event_types, rx)

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -61,7 +61,7 @@ impl Information {
     /// For example, once a shard is fully booted then it will be
     /// [`Connected`].
     ///
-    /// [`Connected`]: enum.Stage.html
+    /// [`Connected`]: stage/enum.Stage.html#variant.Connected
     pub fn stage(&self) -> Stage {
         self.stage
     }
@@ -133,7 +133,7 @@ impl Shard {
     ///
     /// # Errors
     ///
-    /// Errors if the `ShardProcessor` could not be started.
+    /// Errors if the shard's processor could not be started.
     pub async fn start(&mut self) -> Result<()> {
         let url = self
             .0
@@ -172,10 +172,10 @@ impl Shard {
     ///
     /// The returned event stream implements [`futures::stream::Stream`].
     ///
-    /// All event types except for [`EventType::SHARD_PAYLOAD`] are enabled.
+    /// All event types except for [`EventType::ShardPayload`] are enabled.
     /// If you need to enable it, consider calling [`some_events`] instead.
     ///
-    /// [`EventType::SHARD_PAYLOAD`]: events/struct.EventType.html#const.SHARD_PAYLOAD
+    /// [`EventType::ShardPayload`]: ../../twilight_model/gateway/event/enum.EventType.html#variant.ShardPayload
     /// [`futures::stream::Stream`]: https://docs.rs/futures/*/futures/stream/trait.Stream.html
     /// [`some_events`]: #method.some_events
     pub async fn events(&self) -> Events {
@@ -217,8 +217,10 @@ impl Shard {
     /// # Ok(()) }
     /// ```
     ///
+    /// [`Event::ShardConnected`]: ../../twilight_model/gateway/event/enum.Event.html#variant.ShardConnected
+    /// [`Event::ShardDisconnected`]: ../../twilight_model/gateway/event/enum.Event.html#variant.ShardDisconnected
     /// [`futures::stream::Stream`]: https://docs.rs/futures/*/futures/stream/trait.Stream.html
-    pub async fn some_events(&self, event_types: EventTypeFlags) -> Events {
+    pub async fn some_events(&self, event_types: EventTypeFlags) -> impl Stream<Item = Event> {
         let rx = self.0.listeners.add(event_types);
 
         Events::new(event_types, rx)
@@ -229,9 +231,9 @@ impl Shard {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Shutdown`] if the shard isn't actively running.
+    /// Returns [`Error::Stopped`] if the shard isn't actively running.
     ///
-    /// [`Error::Shutdown`]: error/enum.Error.html
+    /// [`Error::Stopped`]: error/enum.Error.html#variant.Stopped
     pub async fn info(&self) -> Result<Information> {
         let session = self.session()?;
 
@@ -253,9 +255,9 @@ impl Shard {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Shutdown`] if the shard isn't actively running.
+    /// Returns [`Error::Stopped`] if the shard isn't actively running.
     ///
-    /// [`Error::Shutdown`]: error/enum.Error.html
+    /// [`Error::Stopped`]: error/enum.Error.html#variant.Stopped
     pub fn session(&self) -> Result<Arc<Session>> {
         let session = self.0.session.get().ok_or(Error::Stopped)?;
 
@@ -273,9 +275,9 @@ impl Shard {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Shutdown`] if the shard isn't actively running.
+    /// Returns [`Error::Stopped`] if the shard isn't actively running.
     ///
-    /// [`Error::Shutdown`]: error/enum.Error.html
+    /// [`Error::Stopped`]: error/enum.Error.html#variant.Stopped
     pub fn sink(&self) -> Result<ShardSink> {
         let session = self.session()?;
 
@@ -288,9 +290,9 @@ impl Shard {
     /// Fails if command could not be serialized, or if the command could
     /// not be sent.
     ///
-    /// Returns [`Error::Shutdown`] if the shard isn't actively running.
+    /// Returns [`Error::Stopped`] if the shard isn't actively running.
     ///
-    /// [`Error::Shutdown`]: error/enum.Error.html
+    /// [`Error::Stopped`]: error/enum.Error.html#variant.Stopped
     pub async fn command(&self, com: &impl serde::Serialize) -> Result<()> {
         let payload = Message::Text(
             crate::json_to_string(&com)

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -14,13 +14,14 @@
 //!
 //! [`ShardConfig`]: config/struct.ShardConfig.html
 //! [`ShardConfigBuilder`]: config/struct.ShardConfigBuilder.html
-//! [`Event`]: event/enum.Event.html
+//! [`Event`]: ../../twilight_model/gateway/event/enum.Event.html
 //! [`Shard`]: struct.Shard.html
-//! [`Stage`]: enum.Stage.html
-//! [`Disconnected`]: enum.Stage.html#variant.Disconnected
-//! [`Resuming`]: enum.Stage.html#variant.Resuming
-//! [channel deletions]: event/enum.Event.html#variant.ChannelDelete
-//! [new messages]: event/enum.Event.html#variant.MessageCreate
+//! [`Stage`]: stage/enum.Stage.html
+//! [`Disconnected`]: stage/enum.Stage.html#variant.Disconnected
+//! [`Resuming`]: stage/enum.Stage.html#variant.Resuming
+//! [channel deletions]: ../../twilight_model/gateway/event/enum.Event.html#variant.ChannelDelete
+//! [information about itself]: struct.Shard.html#method.info
+//! [new messages]: ../../twilight_model/gateway/event/enum.Event.html#variant.MessageCreate
 
 pub mod config;
 pub mod error;

--- a/gateway/src/shard/stage.rs
+++ b/gateway/src/shard/stage.rs
@@ -1,15 +1,13 @@
-//! Utilities for knowing and parsing the current connection stage of a
-//! [`Shard`].
+//! Utilities for knowing and parsing the current connection stage of a shard.
 //!
 //! Included is the [`Stage`], which is an enum representing the connection
 //! stage with variants such as [`Connecting`] or [`Disconnected`].
 //!
-//! The `Stage` also has some parsing capability, so an error type for
+//! The [`Stage`] also has some parsing capability, so an error type for
 //! conversion reasons is included.
 //!
 //! [`Connecting`]: enum.Stage.html#variant.Connecting
 //! [`Disconnected`]: enum.Stage.html#variant.Disconnected
-//! [`Shard`]: ../struct.Shard.html
 //! [`Stage`]: enum.Stage.html
 
 use std::{
@@ -43,7 +41,7 @@ impl Error for StageConversionError {}
 
 /// The current connection stage of a [`Shard`].
 ///
-/// [`Shard`]: struct.Shard.html
+/// [`Shard`]: ../struct.Shard.html
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum Stage {

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -10,7 +10,7 @@ use std::{sync::Arc, time::Duration};
 #[derive(Clone, Debug)]
 /// A builder for [`Client`].
 ///
-/// [`Client`]: ../struct.Client.html
+/// [`Client`]: struct.Client.html
 pub struct ClientBuilder {
     pub(crate) default_allowed_mentions: Option<AllowedMentions>,
     pub(crate) proxy: Option<Proxy>,
@@ -24,7 +24,7 @@ pub struct ClientBuilder {
 impl ClientBuilder {
     /// Create a new builder to create a [`Client`].
     ///
-    /// [`Client`]: ../struct.Client.html
+    /// [`Client`]: struct.Client.html
     pub fn new() -> Self {
         Self::default()
     }
@@ -35,7 +35,7 @@ impl ClientBuilder {
     ///
     /// Errors if `reqwest` fails to build the client.
     ///
-    /// [`Client`]: ../struct.Client.html
+    /// [`Client`]: struct.Client.html
     pub fn build(self) -> Result<Client> {
         let mut builder = ReqwestClientBuilder::new().timeout(self.timeout);
 
@@ -100,7 +100,9 @@ impl ClientBuilder {
     /// before making a request.
     ///
     /// If this method is not called at all then a default ratelimiter will be
-    /// created by `ClientBuilder::build`.
+    /// created by [`ClientBuilder::build`].
+    ///
+    /// [`ClientBuilder::build`]: #method.build
     pub fn ratelimiter(&mut self, ratelimiter: impl Into<Option<Ratelimiter>>) -> &mut Self {
         self.ratelimiter = ratelimiter.into();
 

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -86,7 +86,7 @@ impl Debug for State {
 /// `client`.
 ///
 /// [here]: https://discord.com/developers/applications
-/// [`ClientBuilder`]: ../struct.ClientBuilder.html
+/// [`ClientBuilder`]: struct.ClientBuilder.html
 #[derive(Clone, Debug)]
 pub struct Client {
     state: Arc<State>,
@@ -323,9 +323,9 @@ impl Client {
     /// Returns a [`UpdateChannelError::TopicInvalid`] when the length of the topic is more than
     /// 1024 UTF-16 characters.
     ///
-    /// [`UpdateChannelError::NameInvalid`]: ../enum.UpdateChannelError.html#variant.NameInvalid
-    /// [`UpdateChannelError::RateLimitPerUserInvalid`]: ../enum.UpdateChannelError.html#variant.RateLimitPerUserInvalid
-    /// [`UpdateChannelError::TopicInvalid`]: ../enum.UpdateChannelError.html#variant.TopicInvalid
+    /// [`UpdateChannelError::NameInvalid`]: ../request/channel/update_channel/enum.UpdateChannelError.html#variant.NameInvalid
+    /// [`UpdateChannelError::RateLimitPerUserInvalid`]: ../request/channel/update_channel/enum.UpdateChannelError.html#variant.RateLimitPerUserInvalid
+    /// [`UpdateChannelError::TopicInvalid`]: ../request/channel/update_channel/enum.UpdateChannelError.html#variant.TopicInvalid
     pub fn update_channel(&self, channel_id: ChannelId) -> UpdateChannel<'_> {
         UpdateChannel::new(self, channel_id)
     }
@@ -376,7 +376,7 @@ impl Client {
     /// [`before`]: ../request/channel/message/get_channel_messages/struct.GetChannelMessages.html#method.before
     /// [`GetChannelMessagesConfigured`]: ../request/channel/message/get_channel_messages_configured/struct.GetChannelMessagesConfigured.html
     /// [`limit`]: ../request/channel/message/get_channel_messages/struct.GetChannelMessages.html#method.limit
-    /// [`GetChannelMessages::LimitInvalid`]: ../request/channel/message/get_channel_messages/enum.GetChannelMessages.html#variant.LimitInvalid
+    /// [`GetChannelMessages::LimitInvalid`]: ../request/channel/message/get_channel_messages/enum.GetChannelMessagesError.html#variant.LimitInvalid
     pub fn channel_messages(&self, channel_id: ChannelId) -> GetChannelMessages<'_> {
         GetChannelMessages::new(self, channel_id)
     }
@@ -622,7 +622,7 @@ impl Client {
     ///
     /// Returns [`CreateGuildError::NameInvalid`] if the name length is too short or too long.
     ///
-    /// [`CreateGuildError::NameInvalid`]: ../request/guild/enum.CreateGuildError.html#variant.NameInvalid
+    /// [`CreateGuildError::NameInvalid`]: ../request/guild/create_guild/enum.CreateGuildError.html#variant.NameInvalid
     pub fn create_guild(
         &self,
         name: impl Into<String>,

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -64,13 +64,13 @@ struct GetChannelMessagesFields {
 /// Returns [`GetChannelMessages::LimitInvalid`] if the amount is less than 1 or greater than 100.
 ///
 /// [`ChannelId`]: ../../../../../twilight_model/id/struct.ChannelId.html
-/// [`after`]: struct.GetChannelMessages.html#method.after
-/// [`around`]: struct.GetChannelMessages.html#method.around
-/// [`before`]: struct.GetChannelMessages.html#method.before
+/// [`after`]: #method.after
+/// [`around`]: #method.around
+/// [`before`]: #method.before
 /// [`GetChannelMessagesConfigured`]:
 /// ../get_channel_messages_configured/struct.GetChannelMessagesConfigured.html
-/// [`limit`]: struct.GetChannelMessages.html#method.limit
-/// [`GetChannelMessages::LimitInvalid`]: enum.GetChannelMessages.html#variant.LimitInvalid
+/// [`limit`]: #method.limit
+/// [`GetChannelMessages::LimitInvalid`]: enum.GetChannelMessagesError.html#variant.LimitInvalid
 pub struct GetChannelMessages<'a> {
     channel_id: ChannelId,
     fields: GetChannelMessagesFields,
@@ -130,7 +130,7 @@ impl<'a> GetChannelMessages<'a> {
     /// Returns [`GetChannelMessages::LimitInvalid`] if the amount is less than 1 or greater than
     /// 100.
     ///
-    /// [`GetChannelMessages::LimitInvalid`]: enum.GetChannelMessages.html#variant.LimitInvalid
+    /// [`GetChannelMessages::LimitInvalid`]: enum.GetChannelMessagesError.html#variant.LimitInvalid
     pub fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesError> {
         if !validate::get_channel_messages_limit(limit) {
             return Err(GetChannelMessagesError::LimitInvalid);

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -200,11 +200,11 @@ impl<'a> UpdateChannel<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateGuildChannel::TopicInvalid`] if the topic length is
+    /// Returns [`UpdateGuildChannel::TopicInvalid`] if the topic length is
     /// too long.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure
-    /// [`CreateGuildChannel::TopicInvalid`]: enum.UpdateChannelError.html#variant.TopicInvalid
+    /// [`UpdateGuildChannel::TopicInvalid`]: enum.UpdateChannelError.html#variant.TopicInvalid
     pub fn topic(self, topic: impl Into<String>) -> Result<Self, UpdateChannelError> {
         self._topic(topic.into())
     }

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -76,9 +76,9 @@ struct UpdateChannelFields {
 /// Returns a [`UpdateChannelError::TopicInvalid`] when the length of the topic is more than
 /// 1024 UTF-16 characters.
 ///
-/// [`UpdateChannelError::NameInvalid`]: ../enum.UpdateChannelError.html#variant.NameInvalid
-/// [`UpdateChannelError::RateLimitPerUserInvalid`]: ../enum.UpdateChannelError.html#variant.RateLimitPerUserInvalid
-/// [`UpdateChannelError::TopicInvalid`]: ../enum.UpdateChannelError.html#variant.TopicInvalid
+/// [`UpdateChannelError::NameInvalid`]: enum.UpdateChannelError.html#variant.NameInvalid
+/// [`UpdateChannelError::RateLimitPerUserInvalid`]: enum.UpdateChannelError.html#variant.RateLimitPerUserInvalid
+/// [`UpdateChannelError::TopicInvalid`]: enum.UpdateChannelError.html#variant.TopicInvalid
 pub struct UpdateChannel<'a> {
     channel_id: ChannelId,
     fields: UpdateChannelFields,
@@ -176,10 +176,10 @@ impl<'a> UpdateChannel<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`GetGuildPruneCountError::RateLimitPerUserInvalid`] if the amount is greater than
+    /// Returns [`UpdateChannelError::RateLimitPerUserInvalid`] if the amount is greater than
     /// 21600.
     ///
-    /// [`GetGuildPruneCountError::RateLimitPerUserInvalid`]: enum.GetGuildPruneCountError.html#variant.RateLimitPerUserInvalid
+    /// [`UpdateChannelError::RateLimitPerUserInvalid`]: enum.UpdateChannelError.html#variant.RateLimitPerUserInvalid
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure>
     pub fn rate_limit_per_user(
         mut self,
@@ -204,7 +204,7 @@ impl<'a> UpdateChannel<'a> {
     /// too long.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure
-    /// [`CreateGuildChannel::TopicInvalid`]: enum.CreateGuildChannel.html#variant.TopicInvalid
+    /// [`CreateGuildChannel::TopicInvalid`]: enum.UpdateChannelError.html#variant.TopicInvalid
     pub fn topic(self, topic: impl Into<String>) -> Result<Self, UpdateChannelError> {
         self._topic(topic.into())
     }

--- a/http/src/request/guild/create_guild.rs
+++ b/http/src/request/guild/create_guild.rs
@@ -67,7 +67,7 @@ struct CreateGuildFields {
 ///
 /// Returns [`CreateGuildError::NameInvalid`] if the name length is too short or too long.
 ///
-/// [`CreateGuildError::NameInvalid`]: ../request/guild/enum.CreateGuildError.html#variant.NameInvalid
+/// [`CreateGuildError::NameInvalid`]: enum.CreateGuildError.html#variant.NameInvalid
 pub struct CreateGuild<'a> {
     fields: CreateGuildFields,
     fut: Option<Pending<'a, PartialGuild>>,

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -203,7 +203,7 @@ impl<'a> CreateGuildChannel<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateGuildChannel::TopicInvalid`] if the topic length is
+    /// Returns [`CreateGuildChannelError::TopicInvalid`] if the topic length is
     /// too long.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -71,9 +71,9 @@ struct CreateGuildChannelFields {
 /// Returns a [`CreateGuildChannelError::TopicInvalid`] when the length of the topic is more than
 /// 1024 UTF-16 characters.
 ///
-/// [`CreateGuildChannelError::NameInvalid`]: ../request/guild/create_guild_channel/enum.CreateGuildChannelError.html#variant.NameInvalid
-/// [`CreateGuildChannelError::RateLimitPerUserInvalid`]: ../request/guild/create_guild_channel/enum.CreateGuildChannelError.html#variant.RateLimitPerUserInvalid
-/// [`CreateGuildChannelError::TopicInvalid`]: ../request/guild/create_guild_channel/enum.CreateGuildChannelError.html#variant.TopicInvalid
+/// [`CreateGuildChannelError::NameInvalid`]: enum.CreateGuildChannelError.html#variant.NameInvalid
+/// [`CreateGuildChannelError::RateLimitPerUserInvalid`]: enum.CreateGuildChannelError.html#variant.RateLimitPerUserInvalid
+/// [`CreateGuildChannelError::TopicInvalid`]: enum.CreateGuildChannelError.html#variant.TopicInvalid
 pub struct CreateGuildChannel<'a> {
     fields: CreateGuildChannelFields,
     fut: Option<Pending<'a, GuildChannel>>,
@@ -183,7 +183,7 @@ impl<'a> CreateGuildChannel<'a> {
     /// 21600.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure
-    /// [`GetGuildPruneCountError::RateLimitPerUserInvalid`]: enum.GetGuildPruneCountError.html#variant.RateLimitPerUserInvalid
+    /// [`GetGuildPruneCountError::RateLimitPerUserInvalid`]: ../get_guild_prune_count/enum.GetGuildPruneCountError.html#variant.RateLimitPerUserInvalid
     pub fn rate_limit_per_user(
         mut self,
         rate_limit_per_user: u64,
@@ -207,7 +207,7 @@ impl<'a> CreateGuildChannel<'a> {
     /// too long.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure
-    /// [`CreateGuildChannel::TopicInvalid`]: enum.CreateGuildChannel.html#variant.TopicInvalid
+    /// [`CreateGuildChannelError::TopicInvalid`]: enum.CreateGuildChannelError.html#variant.TopicInvalid
     pub fn topic(self, topic: impl Into<String>) -> Result<Self, CreateGuildChannelError> {
         self._topic(topic.into())
     }

--- a/http/src/request/guild/mod.rs
+++ b/http/src/request/guild/mod.rs
@@ -8,6 +8,7 @@ pub mod get_guild_prune_count;
 pub mod integration;
 pub mod member;
 pub mod role;
+pub mod update_guild;
 
 mod delete_guild;
 mod get_guild;
@@ -19,7 +20,6 @@ mod get_guild_voice_regions;
 mod get_guild_webhooks;
 mod get_guild_widget;
 mod update_current_user_nick;
-mod update_guild;
 mod update_guild_channel_positions;
 mod update_guild_widget;
 

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -87,10 +87,6 @@ impl EmbedValidationError {
     pub const DESCRIPTION_LENGTH: usize = 2048;
 
     /// The maximum combined embed length in codepoints.
-    ///
-    /// See the [`embed`] function for more information.
-    ///
-    /// [`embed`]: fn.embed.html
     pub const EMBED_TOTAL_LENGTH: usize = 6000;
 
     /// The maximum number of fields in an embed.

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -108,7 +108,7 @@ impl Lavalink {
     /// Provide `None` for the `resume` parameter to disable session resume
     /// capability. See the [`Resume`] documentation for defaults.
     ///
-    /// [`Resume`]: node/struct.Resume.html
+    /// [`Resume`]: ../node/struct.Resume.html
     /// [`new`]: #method.new
     pub fn new_with_resume(
         user_id: UserId,
@@ -303,7 +303,7 @@ impl Lavalink {
     /// Returns [`ClientError::NodesUnconfigured`] if there are no configured
     /// nodes available in the client.
     ///
-    /// [`ClientError::NodesUnconfigured`]: struct.ClientError.html#variant.NodesUnconfigured
+    /// [`ClientError::NodesUnconfigured`]: enum.ClientError.html#variant.NodesUnconfigured
     /// [`Node::penalty`]: ../node/struct.Node.html#method.penalty
     pub async fn best(&self) -> Result<Node, ClientError> {
         let mut lowest = i32::MAX;
@@ -338,7 +338,7 @@ impl Lavalink {
     /// configured via [`add`].
     ///
     /// [`ClientError::NodesUnconfigured`]: enum.ClientError.html#variant.NodesUnconfigured
-    /// [`PlayerManager::get`]: player/struct.PlayerManager.html#method.get
+    /// [`PlayerManager::get`]: ../player/struct.PlayerManager.html#method.get
     /// [`add`]: #method.add
     pub async fn player(&self, guild_id: GuildId) -> Result<Ref<'_, GuildId, Player>, ClientError> {
         if let Some(player) = self.players().get(&guild_id) {

--- a/model/src/gateway/event/mod.rs
+++ b/model/src/gateway/event/mod.rs
@@ -20,9 +20,9 @@ use super::payload::*;
 /// This brings together all of the types of [`DispatchEvent`]s,
 /// [`GatewayEvent`]s, and [`ShardEvent`]s.
 ///
-/// [`DispatchEvent`]: struct.DispatchEvent.html
-/// [`GatewayEvent`]: struct.GatewayEvent.html
-/// [`ShardEvent`]: shard/struct.ShardEvent.html
+/// [`DispatchEvent`]: enum.DispatchEvent.html
+/// [`GatewayEvent`]: gateway/enum.GatewayEvent.html
+/// [`ShardEvent`]: shard/enum.ShardEvent.html
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Event {
     /// A user was banned from a guild.


### PR DESCRIPTION
Fix all of the dead links using the `cargo-deadlinks` crate, and fix the broken links that had a name but didn't have an anchor URL.

Closes #202.