### PR TITLE
http/create_message: use payload_json form field

### DIFF
--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -213,8 +213,10 @@ impl<'a> CreateMessage<'a> {
                     form = form.part(format!("{}", index), Part::stream(file).file_name(name));
                 }
 
+                let body = crate::json_to_vec(&self.fields)?;
+                form = form.part("payload_json", Part::bytes(body));
+
                 Request::from((
-                    crate::json_to_vec(&self.fields)?,
                     form,
                     Route::CreateMessage {
                         channel_id: self.channel_id.0,

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -178,6 +178,21 @@ impl From<(Vec<u8>, Route)> for Request {
     }
 }
 
+impl From<(Form, Route)> for Request {
+    fn from((form, route): (Form, Route)) -> Self {
+        let (method, path, path_str) = route.into_parts();
+
+        Self {
+            body: None,
+            form: Some(form),
+            headers: None,
+            method,
+            path,
+            path_str,
+        }
+    }
+}
+
 impl From<(Vec<u8>, Form, Route)> for Request {
     fn from((body, form, route): (Vec<u8>, Form, Route)) -> Self {
         let (method, path, path_str) = route.into_parts();


### PR DESCRIPTION
When sending a multipart request, use `payload_json` to pass parameters such as embeds and content.

Closes #358.