### PR TITLE
http/request: provide input in error variants

### DIFF
--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -13,13 +13,16 @@ use twilight_model::{
 #[derive(Clone, Debug)]
 pub enum GetChannelMessagesError {
     /// The maximum number of messages to retrieve is either 0 or more than 100.
-    LimitInvalid,
+    LimitInvalid {
+        /// Provided maximum number of messages to retrieve.
+        limit: u64,
+    },
 }
 
 impl Display for GetChannelMessagesError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::LimitInvalid => f.write_str("the limit is invalid"),
+            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
         }
     }
 }
@@ -133,7 +136,7 @@ impl<'a> GetChannelMessages<'a> {
     /// [`GetChannelMessages::LimitInvalid`]: enum.GetChannelMessages.html#variant.LimitInvalid
     pub fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesError> {
         if !validate::get_channel_messages_limit(limit) {
-            return Err(GetChannelMessagesError::LimitInvalid);
+            return Err(GetChannelMessagesError::LimitInvalid { limit });
         }
 
         self.fields.limit.replace(limit);

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -12,13 +12,16 @@ use twilight_model::{
 #[derive(Clone, Debug)]
 pub enum GetChannelMessagesConfiguredError {
     /// The maximum number of messages to retrieve is either 0 or more than 100.
-    LimitInvalid,
+    LimitInvalid {
+        /// Provided maximum number of messages to retrieve.
+        limit: u64,
+    },
 }
 
 impl Display for GetChannelMessagesConfiguredError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::LimitInvalid => f.write_str("the limit is invalid"),
+            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
         }
     }
 }
@@ -78,7 +81,7 @@ impl<'a> GetChannelMessagesConfigured<'a> {
     /// [`GetChannelMessagesConfiguredError::LimitInvalid`]: enum.GetChannelMessagesConfiguredError.html#variant.LimitInvalid
     pub fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesConfiguredError> {
         if !validate::get_channel_messages_limit(limit) {
-            return Err(GetChannelMessagesConfiguredError::LimitInvalid);
+            return Err(GetChannelMessagesConfiguredError::LimitInvalid { limit });
         }
 
         self.fields.limit.replace(limit);

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -12,13 +12,16 @@ use twilight_model::{
 #[derive(Clone, Debug)]
 pub enum GetReactionsError {
     /// The number of reactions to retrieve must be between 1 and 100, inclusive.
-    LimitInvalid,
+    LimitInvalid {
+        /// The provided maximum number of reactions to get.
+        limit: u64,
+    },
 }
 
 impl Display for GetReactionsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::LimitInvalid => f.write_str("the limit is invalid"),
+            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
         }
     }
 }
@@ -88,7 +91,7 @@ impl<'a> GetReactions<'a> {
     /// [`GetReactionsError::LimitInvalid`]: enum.GetReactionsError.html#variant.LimitInvalid
     pub fn limit(mut self, limit: u64) -> Result<Self, GetReactionsError> {
         if !validate::get_reactions_limit(limit) {
-            return Err(GetReactionsError::LimitInvalid);
+            return Err(GetReactionsError::LimitInvalid { limit });
         }
 
         self.fields.limit.replace(limit);

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -13,19 +13,30 @@ use twilight_model::{
 pub enum UpdateChannelError {
     /// The length of the name is either fewer than 2 UTF-16 characters or
     /// more than 100 UTF-16 characters.
-    NameInvalid,
+    NameInvalid {
+        /// Provided name.
+        name: String,
+    },
     /// The seconds of the rate limit per user is more than 21600.
-    RateLimitPerUserInvalid,
+    RateLimitPerUserInvalid {
+        /// Provided ratelimit is invalid.
+        rate_limit_per_user: u64,
+    },
     /// The length of the topic is more than 1024 UTF-16 characters.
-    TopicInvalid,
+    TopicInvalid {
+        /// Provided topic.
+        topic: String,
+    },
 }
 
 impl Display for UpdateChannelError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::NameInvalid => f.write_str("the length of the name is invalid"),
-            Self::RateLimitPerUserInvalid => f.write_str("the rate limit per user is invalid"),
-            Self::TopicInvalid => f.write_str("the topic is invalid"),
+            Self::NameInvalid { .. } => f.write_str("the length of the name is invalid"),
+            Self::RateLimitPerUserInvalid { .. } => {
+                f.write_str("the rate limit per user is invalid")
+            }
+            Self::TopicInvalid { .. } => f.write_str("the topic is invalid"),
         }
     }
 }
@@ -122,7 +133,7 @@ impl<'a> UpdateChannel<'a> {
 
     fn _name(mut self, name: String) -> Result<Self, UpdateChannelError> {
         if !validate::channel_name(&name) {
-            return Err(UpdateChannelError::NameInvalid);
+            return Err(UpdateChannelError::NameInvalid { name });
         }
 
         self.fields.name.replace(name);
@@ -186,7 +197,9 @@ impl<'a> UpdateChannel<'a> {
         rate_limit_per_user: u64,
     ) -> Result<Self, UpdateChannelError> {
         if rate_limit_per_user > 21600 {
-            return Err(UpdateChannelError::RateLimitPerUserInvalid);
+            return Err(UpdateChannelError::RateLimitPerUserInvalid {
+                rate_limit_per_user,
+            });
         }
 
         self.fields.rate_limit_per_user.replace(rate_limit_per_user);
@@ -211,7 +224,7 @@ impl<'a> UpdateChannel<'a> {
 
     fn _topic(mut self, topic: String) -> Result<Self, UpdateChannelError> {
         if topic.chars().count() > 1024 {
-            return Err(UpdateChannelError::TopicInvalid);
+            return Err(UpdateChannelError::TopicInvalid { topic });
         }
 
         self.fields.topic.replace(topic);

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -9,13 +9,16 @@ use twilight_model::id::{GuildId, UserId};
 #[derive(Clone, Debug)]
 pub enum CreateBanError {
     /// The number of days' worth of messages to delete is greater than 7.
-    DeleteMessageDaysInvalid,
+    DeleteMessageDaysInvalid {
+        /// Provided number of days' worth of messages to delete.
+        days: u64,
+    },
 }
 
 impl Display for CreateBanError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::DeleteMessageDaysInvalid => {
+            Self::DeleteMessageDaysInvalid { .. } => {
                 f.write_str("the number of days' worth of messages to delete is invalid")
             }
         }
@@ -85,7 +88,7 @@ impl<'a> CreateBan<'a> {
     /// [`CreateBanError::DeleteMessageDaysInvalid`]: enum.CreateBanError.html#variant.DeleteMessageDaysInvalid
     pub fn delete_message_days(mut self, days: u64) -> Result<Self, CreateBanError> {
         if !validate::ban_delete_message_days(days) {
-            return Err(CreateBanError::DeleteMessageDaysInvalid);
+            return Err(CreateBanError::DeleteMessageDaysInvalid { days });
         }
 
         self.fields.delete_message_days.replace(days);

--- a/http/src/request/guild/create_guild.rs
+++ b/http/src/request/guild/create_guild.rs
@@ -16,23 +16,32 @@ use twilight_model::{
 pub enum CreateGuildError {
     /// The name of the guild is either fewer than 2 UTF-16 characters or more than 100 UTF-16
     /// characters.
-    NameInvalid,
+    NameInvalid {
+        /// Provided name.
+        name: String,
+    },
     /// The number of channels provided is too many.
     ///
     /// The maximum amount is 500.
-    TooManyChannels,
+    TooManyChannels {
+        /// Provided channels.
+        channels: Vec<GuildChannel>,
+    },
     /// The number of roles provided is too many.
     ///
     /// The maximum amount is 250.
-    TooManyRoles,
+    TooManyRoles {
+        /// Provided roles.
+        roles: Vec<Role>,
+    },
 }
 
 impl Display for CreateGuildError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::NameInvalid => f.write_str("the guild name is invalid"),
-            Self::TooManyChannels => f.write_str("too many channels were provided"),
-            Self::TooManyRoles => f.write_str("too many roles were provided"),
+            Self::NameInvalid { .. } => f.write_str("the guild name is invalid"),
+            Self::TooManyChannels { .. } => f.write_str("too many channels were provided"),
+            Self::TooManyRoles { .. } => f.write_str("too many roles were provided"),
         }
     }
 }
@@ -81,7 +90,7 @@ impl<'a> CreateGuild<'a> {
 
     fn _new(http: &'a Client, name: String) -> Result<Self, CreateGuildError> {
         if !validate::guild_name(&name) {
-            return Err(CreateGuildError::NameInvalid);
+            return Err(CreateGuildError::NameInvalid { name });
         }
 
         Ok(Self {
@@ -113,7 +122,7 @@ impl<'a> CreateGuild<'a> {
         // Error 30013
         // <https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#json>
         if channels.len() > 500 {
-            return Err(CreateGuildError::TooManyChannels);
+            return Err(CreateGuildError::TooManyChannels { channels });
         }
 
         self.fields.channels.replace(channels);
@@ -183,7 +192,7 @@ impl<'a> CreateGuild<'a> {
     /// [`CreateGuildError::TooManyRoles`]: enum.CreateGuildError.html#variant.TooManyRoles
     pub fn roles(mut self, roles: Vec<Role>) -> Result<Self, CreateGuildError> {
         if roles.len() > 250 {
-            return Err(CreateGuildError::TooManyRoles);
+            return Err(CreateGuildError::TooManyRoles { roles });
         }
 
         self.fields.roles.replace(roles);

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -13,19 +13,30 @@ use twilight_model::{
 pub enum CreateGuildChannelError {
     /// The length of the name is either fewer than 2 UTF-16 characters or
     /// more than 100 UTF-16 characters.
-    NameInvalid,
+    NameInvalid {
+        /// Provided name.
+        name: String,
+    },
     /// The seconds of the rate limit per user is more than 21600.
-    RateLimitPerUserInvalid,
+    RateLimitPerUserInvalid {
+        /// Provided ratelimit.
+        rate_limit_per_user: u64,
+    },
     /// The length of the topic is more than 1024 UTF-16 characters.
-    TopicInvalid,
+    TopicInvalid {
+        /// Provided topic.
+        topic: String,
+    },
 }
 
 impl Display for CreateGuildChannelError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::NameInvalid => f.write_str("the length of the name is invalid"),
-            Self::RateLimitPerUserInvalid => f.write_str("the rate limit per user is invalid"),
-            Self::TopicInvalid => f.write_str("the topic is invalid"),
+            Self::NameInvalid { .. } => f.write_str("the length of the name is invalid"),
+            Self::RateLimitPerUserInvalid { .. } => {
+                f.write_str("the rate limit per user is invalid")
+            }
+            Self::TopicInvalid { .. } => f.write_str("the topic is invalid"),
         }
     }
 }
@@ -97,7 +108,7 @@ impl<'a> CreateGuildChannel<'a> {
         name: String,
     ) -> Result<Self, CreateGuildChannelError> {
         if !validate::channel_name(&name) {
-            return Err(CreateGuildChannelError::NameInvalid);
+            return Err(CreateGuildChannelError::NameInvalid { name });
         }
 
         Ok(Self {
@@ -189,7 +200,9 @@ impl<'a> CreateGuildChannel<'a> {
         rate_limit_per_user: u64,
     ) -> Result<Self, CreateGuildChannelError> {
         if rate_limit_per_user > 21600 {
-            return Err(CreateGuildChannelError::RateLimitPerUserInvalid);
+            return Err(CreateGuildChannelError::RateLimitPerUserInvalid {
+                rate_limit_per_user,
+            });
         }
 
         self.fields.rate_limit_per_user.replace(rate_limit_per_user);
@@ -214,7 +227,7 @@ impl<'a> CreateGuildChannel<'a> {
 
     fn _topic(mut self, topic: String) -> Result<Self, CreateGuildChannelError> {
         if topic.chars().count() > 1024 {
-            return Err(CreateGuildChannelError::TopicInvalid);
+            return Err(CreateGuildChannelError::TopicInvalid { topic });
         }
 
         self.fields.topic.replace(topic);

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -18,7 +18,7 @@ pub enum CreateGuildPruneError {
 impl Display for CreateGuildPruneError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::DaysInvalid => f.write_str("the number of days is invalid"),
+            Self::DaysInvalid { .. } => f.write_str("the number of days is invalid"),
         }
     }
 }

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -12,13 +12,16 @@ use twilight_model::{
 #[derive(Clone, Debug)]
 pub enum GetAuditLogError {
     /// The limit is either 0 or more than 100.
-    LimitInvalid,
+    LimitInvalid {
+        /// Provided maximum number of audit logs to get.
+        limit: u64,
+    },
 }
 
 impl Display for GetAuditLogError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::LimitInvalid => f.write_str("the limit is invalid"),
+            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
         }
     }
 }
@@ -95,7 +98,7 @@ impl<'a> GetAuditLog<'a> {
     /// [`GetAuditLogError::LimitInvalid`]: enum.GetAuditLogError.html#variant.LimitInvalid
     pub fn limit(mut self, limit: u64) -> Result<Self, GetAuditLogError> {
         if !validate::get_audit_log_limit(limit) {
-            return Err(GetAuditLogError::LimitInvalid);
+            return Err(GetAuditLogError::LimitInvalid { limit });
         }
 
         self.fields.limit.replace(limit);

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -22,13 +22,16 @@ use simd_json::value::OwnedValue as Value;
 #[derive(Clone, Debug)]
 pub enum GetGuildMembersError {
     /// The limit is either 0 or more than 1000.
-    LimitInvalid,
+    LimitInvalid {
+        /// Provided limit.
+        limit: u64,
+    },
 }
 
 impl Display for GetGuildMembersError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::LimitInvalid => f.write_str("the limit is invalid"),
+            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
         }
     }
 }
@@ -106,7 +109,7 @@ impl<'a> GetGuildMembers<'a> {
     /// [`GetGuildMembersError::LimitInvalid`]: enum.GetGuildMembersError.html#variant.LimitInvalid
     pub fn limit(mut self, limit: u64) -> Result<Self, GetGuildMembersError> {
         if !validate::get_guild_members_limit(limit) {
-            return Err(GetGuildMembersError::LimitInvalid);
+            return Err(GetGuildMembersError::LimitInvalid { limit });
         }
 
         self.fields.limit.replace(limit);

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -12,13 +12,13 @@ use twilight_model::{
 #[derive(Clone, Debug)]
 pub enum UpdateGuildMemberError {
     /// The nickname is either empty or the length is more than 32 UTF-16 characters.
-    NicknameInvalid,
+    NicknameInvalid { nickname: String },
 }
 
 impl Display for UpdateGuildMemberError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::NicknameInvalid => f.write_str("the nickname length is invalid"),
+            Self::NicknameInvalid { .. } => f.write_str("the nickname length is invalid"),
         }
     }
 }
@@ -112,7 +112,9 @@ impl<'a> UpdateGuildMember<'a> {
     fn _nick(mut self, nick: Option<String>) -> Result<Self, UpdateGuildMemberError> {
         if let Some(nick) = nick.as_ref() {
             if !validate::nickname(&nick) {
-                return Err(UpdateGuildMemberError::NicknameInvalid);
+                return Err(UpdateGuildMemberError::NicknameInvalid {
+                    nickname: nick.to_owned(),
+                });
             }
         }
 

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -15,13 +15,16 @@ use twilight_model::{
 pub enum UpdateGuildError {
     /// The name length is either fewer than 2 UTF-16 characters or more than 100 UTF-16
     /// characters.
-    NameInvalid,
+    NameInvalid {
+        /// Provided name.
+        name: String,
+    },
 }
 
 impl Display for UpdateGuildError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::NameInvalid => f.write_str("the name's length is invalid"),
+            Self::NameInvalid { .. } => f.write_str("the name's length is invalid"),
         }
     }
 }
@@ -181,7 +184,7 @@ impl<'a> UpdateGuild<'a> {
 
     fn _name(mut self, name: String) -> Result<Self, UpdateGuildError> {
         if !validate::guild_name(&name) {
-            return Err(UpdateGuildError::NameInvalid);
+            return Err(UpdateGuildError::NameInvalid { name });
         }
 
         self.fields.name.replace(name);

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -9,13 +9,16 @@ use twilight_model::{guild::PartialGuild, id::GuildId};
 #[derive(Clone, Debug)]
 pub enum GetCurrentUserGuildsError {
     /// The maximum number of guilds to retrieve is 0 or more than 100.
-    LimitInvalid,
+    LimitInvalid {
+        /// Provided maximum number of guilds to retrieve.
+        limit: u64,
+    },
 }
 
 impl Display for GetCurrentUserGuildsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::LimitInvalid => f.write_str("the limit is invalid"),
+            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
         }
     }
 }
@@ -98,7 +101,7 @@ impl<'a> GetCurrentUserGuilds<'a> {
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/user#get-current-user-guilds-query-string-params
     pub fn limit(mut self, limit: u64) -> Result<Self, GetCurrentUserGuildsError> {
         if !validate::get_current_user_guilds_limit(limit) {
-            return Err(GetCurrentUserGuildsError::LimitInvalid);
+            return Err(GetCurrentUserGuildsError::LimitInvalid { limit });
         }
 
         self.fields.limit.replace(limit);

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -10,13 +10,16 @@ use twilight_model::user::User;
 pub enum UpdateCurrentUserError {
     /// The length of the username is either fewer than 2 UTF-16 characters or more than 32 UTF-16
     /// characters.
-    UsernameInvalid,
+    UsernameInvalid {
+        /// Provided username.
+        username: String,
+    },
 }
 
 impl Display for UpdateCurrentUserError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::UsernameInvalid => f.write_str("the username length is invalid"),
+            Self::UsernameInvalid { .. } => f.write_str("the username length is invalid"),
         }
     }
 }
@@ -80,7 +83,7 @@ impl<'a> UpdateCurrentUser<'a> {
 
     fn _username(mut self, username: String) -> Result<Self, UpdateCurrentUserError> {
         if !validate::username(&username) {
-            return Err(UpdateCurrentUserError::UsernameInvalid);
+            return Err(UpdateCurrentUserError::UsernameInvalid { username });
         }
 
         self.fields.username.replace(username);


### PR DESCRIPTION
In HTTP requests, provide the input in error variants, such as providing the content the user gave when creating a message.

Closes #216.