### PR TITLE
model: add deserialization tracing

### DIFF
--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -18,6 +18,7 @@ serde = { default-features = false, features = ["derive"], version = "1" }
 serde-mappable-seq = { default-features = false, version = "0.1" }
 serde_repr = { default-features = false, version = "0.1" }
 serde-value = { default-features = false, version = "0.7" }
+tracing = { default-features = false, version = "0.1" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -183,9 +183,11 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
         let mut user_limit = None;
 
         let span = tracing::trace_span!("deserializing guild channel");
+        let _span_enter = span.enter();
 
         loop {
             let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+            let _span_child_enter = span_child.enter();
 
             let key = match map.next_key() {
                 Ok(Some(key)) => {
@@ -420,6 +422,7 @@ impl<'de> Visitor<'de> for GuildChannelMapVisitor {
             .map_or_else(HashMap::new, HashMap::with_capacity);
 
         let span = tracing::trace_span!("adding elements to guild channel map");
+        let _span_enter = span.enter();
 
         while let Some(channel) = seq.next_element::<GuildChannel>()? {
             let id = channel.id();

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -186,12 +186,12 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
         let _span_enter = span.enter();
 
         loop {
-            let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+            let span_child = tracing::trace_span!("iterating over element");
             let _span_child_enter = span_child.enter();
 
             let key = match map.next_key() {
                 Ok(Some(key)) => {
-                    tracing::trace!(parent: &span_child, ?key, "found key");
+                    tracing::trace!(?key, "found key");
 
                     key
                 }
@@ -200,7 +200,7 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
                     // Encountered when we run into an unknown key.
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!(parent: &span_child, "ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {:?}", why);
 
                     continue;
                 }
@@ -321,7 +321,6 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
         let parent_id = parent_id.unwrap_or_default();
 
         tracing::trace!(
-            parent: &span,
             %id,
             ?kind,
             %name,
@@ -334,7 +333,7 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
 
         Ok(match kind {
             ChannelType::GuildCategory => {
-                tracing::trace!(parent: &span, "handling category channel");
+                tracing::trace!("handling category channel");
 
                 GuildChannel::Category(CategoryChannel {
                     id,
@@ -351,7 +350,7 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
                 let bitrate = bitrate.ok_or_else(|| DeError::missing_field("bitrate"))?;
                 let user_limit = user_limit.ok_or_else(|| DeError::missing_field("user_limit"))?;
 
-                tracing::trace!(parent: &span, %bitrate, ?user_limit, "handling voice channel");
+                tracing::trace!(%bitrate, ?user_limit, "handling voice channel");
 
                 GuildChannel::Voice(VoiceChannel {
                     id,
@@ -371,7 +370,6 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
                 let topic = topic.unwrap_or_default();
 
                 tracing::trace!(
-                    parent: &span,
                     ?last_message_id,
                     ?last_pin_timestamp,
                     ?topic,
@@ -426,7 +424,7 @@ impl<'de> Visitor<'de> for GuildChannelMapVisitor {
 
         while let Some(channel) = seq.next_element::<GuildChannel>()? {
             let id = channel.id();
-            tracing::trace!(parent: &span, %id, ?channel);
+            tracing::trace!(%id, ?channel);
 
             map.insert(channel.id(), channel);
         }

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -30,7 +30,7 @@ struct PermissionOverwriteData {
     kind: PermissionOverwriteTypeName,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 enum PermissionOverwriteTypeName {
     Member,
@@ -41,14 +41,18 @@ impl<'de> Deserialize<'de> for PermissionOverwrite {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let data = PermissionOverwriteData::deserialize(deserializer)?;
 
+        let span = tracing::trace_span!("deserializing permission overwrite");
+
         let kind = match data.kind {
             PermissionOverwriteTypeName::Member => {
                 let id = UserId(data.id.parse().map_err(DeError::custom)?);
+                tracing::trace!(parent: &span, id = %id.0, kind = ?data.kind);
 
                 PermissionOverwriteType::Member(id)
             }
             PermissionOverwriteTypeName::Role => {
                 let id = RoleId(data.id.parse().map_err(DeError::custom)?);
+                tracing::trace!(parent: &span, id = %id.0, kind = ?data.kind);
 
                 PermissionOverwriteType::Role(id)
             }

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -42,6 +42,7 @@ impl<'de> Deserialize<'de> for PermissionOverwrite {
         let data = PermissionOverwriteData::deserialize(deserializer)?;
 
         let span = tracing::trace_span!("deserializing permission overwrite");
+        let _span_enter = span.enter();
 
         let kind = match data.kind {
             PermissionOverwriteTypeName::Member => {

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -47,13 +47,13 @@ impl<'de> Deserialize<'de> for PermissionOverwrite {
         let kind = match data.kind {
             PermissionOverwriteTypeName::Member => {
                 let id = UserId(data.id.parse().map_err(DeError::custom)?);
-                tracing::trace!(parent: &span, id = %id.0, kind = ?data.kind);
+                tracing::trace!(id = %id.0, kind = ?data.kind);
 
                 PermissionOverwriteType::Member(id)
             }
             PermissionOverwriteTypeName::Role => {
                 let id = RoleId(data.id.parse().map_err(DeError::custom)?);
-                tracing::trace!(parent: &span, id = %id.0, kind = ?data.kind);
+                tracing::trace!(id = %id.0, kind = ?data.kind);
 
                 PermissionOverwriteType::Role(id)
             }

--- a/model/src/channel/reaction.rs
+++ b/model/src/channel/reaction.rs
@@ -51,12 +51,12 @@ impl<'de> Visitor<'de> for ReactionVisitor {
         let _span_enter = span.enter();
 
         loop {
-            let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+            let span_child = tracing::trace_span!("iterating over element");
             let _span_child_enter = span_child.enter();
 
             let key = match map.next_key() {
                 Ok(Some(key)) => {
-                    tracing::trace!(parent: &span_child, ?key, "found key");
+                    tracing::trace!(?key, "found key");
 
                     key
                 }
@@ -65,7 +65,7 @@ impl<'de> Visitor<'de> for ReactionVisitor {
                     // Encountered when we run into an unknown key.
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!(parent: &span_child, "ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {:?}", why);
 
                     continue;
                 }
@@ -124,10 +124,10 @@ impl<'de> Visitor<'de> for ReactionVisitor {
         let message_id = message_id.ok_or_else(|| DeError::missing_field("message_id"))?;
         let user_id = user_id.ok_or_else(|| DeError::missing_field("user_id"))?;
 
-        tracing::trace!(parent: &span, ?channel_id, ?emoji, ?message_id, ?user_id);
+        tracing::trace!(?channel_id, ?emoji, ?message_id, ?user_id);
 
         if let (Some(guild_id), Some(member)) = (guild_id, member.as_mut()) {
-            tracing::trace!(parent: &span, %guild_id, ?member, "setting member guild id");
+            tracing::trace!(%guild_id, ?member, "setting member guild id");
 
             member.guild_id = guild_id;
         }

--- a/model/src/channel/reaction.rs
+++ b/model/src/channel/reaction.rs
@@ -48,9 +48,11 @@ impl<'de> Visitor<'de> for ReactionVisitor {
         let mut user_id = None;
 
         let span = tracing::trace_span!("deserializing reaction");
+        let _span_enter = span.enter();
 
         loop {
             let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+            let _span_child_enter = span_child.enter();
 
             let key = match map.next_key() {
                 Ok(Some(key)) => {

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -219,6 +219,7 @@ impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
         ];
 
         let span = tracing::trace_span!("deserializing gateway event");
+        let _span_enter = span.enter();
         tracing::trace!(parent: &span, event_type=?self.1, op=self.0);
 
         let op_deser: U8Deserializer<V::Error> = self.0.into_deserializer();
@@ -243,6 +244,7 @@ impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
 
                 loop {
                     let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+                    let _span_child_enter = span_child.enter();
 
                     let key = match map.next_key() {
                         Ok(Some(key)) => {

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -286,7 +286,7 @@ impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
                         Field::Op | Field::T => {
                             map.next_value::<IgnoredAny>()?;
 
-                            tracing::trace!(parent: &span_child, key=?key, "ignoring key")
+                            tracing::trace!(parent: &span_child, key=?key, "ignoring key");
                         }
                     }
                 }

--- a/model/src/gateway/payload/member_chunk.rs
+++ b/model/src/gateway/payload/member_chunk.rs
@@ -61,12 +61,12 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
         let _span_enter = span.enter();
 
         loop {
-            let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+            let span_child = tracing::trace_span!("iterating over element");
             let _span_child_enter = span_child.enter();
 
             let key = match map.next_key() {
                 Ok(Some(key)) => {
-                    tracing::trace!(parent: &span_child, ?key, "found key");
+                    tracing::trace!(?key, "found key");
 
                     key
                 }
@@ -75,7 +75,7 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
                     // Encountered when we run into an unknown key.
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!(parent: &span_child, "ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {:?}", why);
 
                     continue;
                 }
@@ -149,7 +149,6 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
         let mut presences = presences.unwrap_or_default();
 
         tracing::trace!(
-            parent: &span,
             %chunk_count,
             %chunk_index,
             ?guild_id,

--- a/model/src/gateway/payload/member_chunk.rs
+++ b/model/src/gateway/payload/member_chunk.rs
@@ -58,9 +58,11 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
         let mut presences = None;
 
         let span = tracing::trace_span!("deserializing member chunk");
+        let _span_enter = span.enter();
 
         loop {
             let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+            let _span_child_enter = span_child.enter();
 
             let key = match map.next_key() {
                 Ok(Some(key)) => {

--- a/model/src/gateway/payload/typing_start.rs
+++ b/model/src/gateway/payload/typing_start.rs
@@ -44,9 +44,11 @@ impl<'de> Visitor<'de> for TypingStartVisitor {
         let mut user_id = None;
 
         let span = tracing::trace_span!("deserializing typing start");
+        let _span_enter = span.enter();
 
         loop {
             let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+            let _span_child_enter = span_child.enter();
 
             let key = match map.next_key() {
                 Ok(Some(key)) => {

--- a/model/src/gateway/payload/typing_start.rs
+++ b/model/src/gateway/payload/typing_start.rs
@@ -47,12 +47,12 @@ impl<'de> Visitor<'de> for TypingStartVisitor {
         let _span_enter = span.enter();
 
         loop {
-            let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+            let span_child = tracing::trace_span!("iterating over element");
             let _span_child_enter = span_child.enter();
 
             let key = match map.next_key() {
                 Ok(Some(key)) => {
-                    tracing::trace!(parent: &span, ?key, "found key");
+                    tracing::trace!(?key, "found key");
 
                     key
                 }
@@ -61,7 +61,7 @@ impl<'de> Visitor<'de> for TypingStartVisitor {
                     // Encountered when we run into an unknown key.
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!(parent: &span_child, "ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {:?}", why);
 
                     continue;
                 }
@@ -114,7 +114,6 @@ impl<'de> Visitor<'de> for TypingStartVisitor {
         let user_id = user_id.ok_or_else(|| DeError::missing_field("user_id"))?;
 
         tracing::trace!(
-            parent: &span,
             %channel_id,
             ?guild_id,
             %timestamp,
@@ -122,7 +121,7 @@ impl<'de> Visitor<'de> for TypingStartVisitor {
         );
 
         if let (Some(guild_id), Some(member)) = (guild_id, member.as_mut()) {
-            tracing::trace!(parent: &span, %guild_id, ?member, "setting member guild id");
+            tracing::trace!(%guild_id, ?member, "setting member guild id");
 
             member.guild_id = guild_id;
         }

--- a/model/src/guild/emoji.rs
+++ b/model/src/guild/emoji.rs
@@ -57,6 +57,7 @@ impl<'de> Visitor<'de> for EmojiMapVisitor {
             .map_or_else(HashMap::new, HashMap::with_capacity);
 
         let span = tracing::trace_span!("adding elements to emoji map");
+        let _span_enter = span.enter();
 
         while let Some(emoji) = seq.next_element::<Emoji>()? {
             tracing::trace!(parent: &span, %emoji.id, ?emoji);

--- a/model/src/guild/emoji.rs
+++ b/model/src/guild/emoji.rs
@@ -56,7 +56,11 @@ impl<'de> Visitor<'de> for EmojiMapVisitor {
             .size_hint()
             .map_or_else(HashMap::new, HashMap::with_capacity);
 
+        let span = tracing::trace_span!("adding elements to emoji map");
+
         while let Some(emoji) = seq.next_element::<Emoji>()? {
+            tracing::trace!(parent: &span, %emoji.id, ?emoji);
+
             map.insert(emoji.id, emoji);
         }
 

--- a/model/src/guild/emoji.rs
+++ b/model/src/guild/emoji.rs
@@ -60,7 +60,7 @@ impl<'de> Visitor<'de> for EmojiMapVisitor {
         let _span_enter = span.enter();
 
         while let Some(emoji) = seq.next_element::<Emoji>()? {
-            tracing::trace!(parent: &span, %emoji.id, ?emoji);
+            tracing::trace!(%emoji.id, ?emoji);
 
             map.insert(emoji.id, emoji);
         }

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -226,12 +226,12 @@ impl<'de> Deserialize<'de> for Guild {
                 let _span_enter = span.enter();
 
                 loop {
-                    let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+                    let span_child = tracing::trace_span!("iterating over element");
                     let _span_child_enter = span_child.enter();
 
                     let key = match map.next_key() {
                         Ok(Some(key)) => {
-                            tracing::trace!(parent: &span_child, ?key, "found key");
+                            tracing::trace!(?key, "found key");
 
                             key
                         }
@@ -240,11 +240,7 @@ impl<'de> Deserialize<'de> for Guild {
                             // Encountered when we run into an unknown key.
                             map.next_value::<IgnoredAny>()?;
 
-                            tracing::trace!(
-                                parent: &span_child,
-                                "ran into an unknown key: {:?}",
-                                why
-                            );
+                            tracing::trace!("ran into an unknown key: {:?}", why);
 
                             continue;
                         }
@@ -637,7 +633,6 @@ impl<'de> Deserialize<'de> for Guild {
                 let widget_enabled = widget_enabled.unwrap_or_default();
 
                 tracing::trace!(
-                    parent: &span,
                     ?afk_channel_id,
                     %afk_timeout,
                     ?application_id,
@@ -673,7 +668,7 @@ impl<'de> Deserialize<'de> for Guild {
                 );
 
                 // Split in two due to generic impl only going up to 32.
-                tracing::trace!(parent: &span,
+                tracing::trace!(
                     ?premium_tier,
                     ?presences,
                     %region,

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -222,13 +222,27 @@ impl<'de> Deserialize<'de> for Guild {
                 let mut widget_channel_id = None::<Option<_>>;
                 let mut widget_enabled = None::<Option<_>>;
 
+                let span = tracing::trace_span!("deserializing guild");
+
                 loop {
+                    let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+
                     let key = match map.next_key() {
-                        Ok(Some(key)) => key,
+                        Ok(Some(key)) => {
+                            tracing::trace!(parent: &span_child, ?key, "found key");
+
+                            key
+                        }
                         Ok(None) => break,
-                        Err(_) => {
+                        Err(why) => {
                             // Encountered when we run into an unknown key.
                             map.next_value::<IgnoredAny>()?;
+
+                            tracing::trace!(
+                                parent: &span_child,
+                                "ran into an unknown key: {:?}",
+                                why
+                            );
 
                             continue;
                         }
@@ -619,6 +633,60 @@ impl<'de> Deserialize<'de> for Guild {
                 let mut voice_states = voice_states.unwrap_or_default();
                 let widget_channel_id = widget_channel_id.unwrap_or_default();
                 let widget_enabled = widget_enabled.unwrap_or_default();
+
+                tracing::trace!(
+                    parent: &span,
+                    ?afk_channel_id,
+                    %afk_timeout,
+                    ?application_id,
+                    ?approximate_member_count,
+                    ?approximate_presence_count,
+                    ?banner,
+                    ?channels,
+                    ?default_message_notifications,
+                    ?description,
+                    ?discovery_splash,
+                    ?embed_channel_id,
+                    ?embed_enabled,
+                    ?emojis,
+                    ?explicit_content_filter,
+                    ?features,
+                    ?icon,
+                    %id,
+                    ?large,
+                    ?lazy,
+                    ?joined_at,
+                    ?max_members,
+                    ?max_presences,
+                    ?max_video_channel_users,
+                    ?member_count,
+                    ?members,
+                    ?mfa_level,
+                    %name,
+                    %owner_id,
+                    ?owner,
+                    ?permissions,
+                    ?preferred_locale,
+                    ?premium_subscription_count,
+                );
+
+                // Split in two due to generic impl only going up to 32.
+                tracing::trace!(parent: &span,
+                    ?premium_tier,
+                    ?presences,
+                    %region,
+                    ?rules_channel_id,
+                    ?roles,
+                    ?splash,
+                    ?system_channel_flags,
+                    ?system_channel_id,
+                    ?unavailable,
+                    ?vanity_url_code,
+                    ?voice_states,
+                    ?widget_channel_id,
+                    ?widget_enabled,
+                    ?verification_level,
+                );
 
                 for channel in channels.values_mut() {
                     match channel {

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -223,9 +223,11 @@ impl<'de> Deserialize<'de> for Guild {
                 let mut widget_enabled = None::<Option<_>>;
 
                 let span = tracing::trace_span!("deserializing guild");
+                let _span_enter = span.enter();
 
                 loop {
                     let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+                    let _span_child_enter = span_child.enter();
 
                     let key = match map.next_key() {
                         Ok(Some(key)) => {

--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -44,7 +44,11 @@ impl<'de> Visitor<'de> for RoleMapDeserializerVisitor {
             .size_hint()
             .map_or_else(HashMap::new, HashMap::with_capacity);
 
+        let span = tracing::trace_span!("adding elements to role map");
+
         while let Some(role) = seq.next_element::<Role>()? {
+            tracing::trace!(parent: &span, %role.id, ?role);
+
             map.insert(role.id, role);
         }
 

--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -48,7 +48,7 @@ impl<'de> Visitor<'de> for RoleMapDeserializerVisitor {
         let _span_enter = span.enter();
 
         while let Some(role) = seq.next_element::<Role>()? {
-            tracing::trace!(parent: &span, %role.id, ?role);
+            tracing::trace!(%role.id, ?role);
 
             map.insert(role.id, role);
         }

--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -45,6 +45,7 @@ impl<'de> Visitor<'de> for RoleMapDeserializerVisitor {
             .map_or_else(HashMap::new, HashMap::with_capacity);
 
         let span = tracing::trace_span!("adding elements to role map");
+        let _span_enter = span.enter();
 
         while let Some(role) = seq.next_element::<Role>()? {
             tracing::trace!(parent: &span, %role.id, ?role);

--- a/model/src/voice/voice_state.rs
+++ b/model/src/voice/voice_state.rs
@@ -81,9 +81,11 @@ impl<'de> Visitor<'de> for VoiceStateVisitor {
         let mut user_id = None;
 
         let span = tracing::trace_span!("deserializing voice state");
+        let _span_enter = span.enter();
 
         loop {
             let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+            let _span_child_enter = span_child.enter();
 
             let key = match map.next_key() {
                 Ok(Some(key)) => {

--- a/model/src/voice/voice_state.rs
+++ b/model/src/voice/voice_state.rs
@@ -84,12 +84,12 @@ impl<'de> Visitor<'de> for VoiceStateVisitor {
         let _span_enter = span.enter();
 
         loop {
-            let span_child = tracing::trace_span!(parent: &span, "iterating over element");
+            let span_child = tracing::trace_span!("iterating over element");
             let _span_child_enter = span_child.enter();
 
             let key = match map.next_key() {
                 Ok(Some(key)) => {
-                    tracing::trace!(parent: &span_child, ?key, "found key");
+                    tracing::trace!(?key, "found key");
 
                     key
                 }
@@ -98,7 +98,7 @@ impl<'de> Visitor<'de> for VoiceStateVisitor {
                     // Encountered when we run into an unknown key.
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!(parent: &span_child, "ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {:?}", why);
 
                     continue;
                 }
@@ -205,7 +205,6 @@ impl<'de> Visitor<'de> for VoiceStateVisitor {
         let self_stream = self_stream.unwrap_or_default();
 
         tracing::trace!(
-            parent: &span,
             %deaf,
             %mute,
             %self_deaf,
@@ -217,7 +216,7 @@ impl<'de> Visitor<'de> for VoiceStateVisitor {
         );
 
         if let (Some(guild_id), Some(member)) = (guild_id, member.as_mut()) {
-            tracing::trace!(parent: &span, %guild_id, ?member, "setting member guild id");
+            tracing::trace!(%guild_id, ?member, "setting member guild id");
 
             member.guild_id = guild_id;
         }


### PR DESCRIPTION
Add tracing to the custom deserialization impls of models. This will step through the deserializer and won't repeat information that would be given from error returns.

Closes #251.