### PR TITLE
project: make log messages consistent

### DIFF
--- a/gateway/src/queue/day_limiter.rs
+++ b/gateway/src/queue/day_limiter.rs
@@ -52,7 +52,7 @@ impl DayLimiter {
             if let Ok(info) = lock.http.gateway().authed().await {
                 let last_check = Instant::now();
                 let next_reset = Duration::from_millis(info.session_start_limit.remaining);
-                tracing::info!("Next session start limit reset in: {:.2?}", next_reset);
+                tracing::info!("next session start limit reset in: {:.2?}", next_reset);
                 let total = info.session_start_limit.total;
                 let remaining = info.session_start_limit.remaining;
                 assert!(total >= remaining);
@@ -62,7 +62,7 @@ impl DayLimiter {
                 lock.total = total;
                 lock.current = current + 1;
             } else {
-                warn!("Unable to get new session limits, skipping it. (This may cause bad things)")
+                warn!("unable to get new session limits, skipping (this may cause bad things)")
             }
         }
     }

--- a/gateway/src/queue/large_bot_queue.rs
+++ b/gateway/src/queue/large_bot_queue.rs
@@ -60,10 +60,7 @@ async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
     const DUR: Duration = Duration::from_secs(6);
     while let Some(req) = rx.next().await {
         if let Err(err) = req.send(()) {
-            warn!(
-                "[LargeBotQueue/waiter] send failed with: {:?}, skipping",
-                err
-            );
+            warn!("skipping, send failed with: {:?}", err);
         }
         delay_for(DUR).await;
     }
@@ -81,11 +78,11 @@ impl Queue for LargeBotQueue {
 
         self.limiter.get().await;
         if let Err(err) = self.buckets[bucket].clone().send(tx).await {
-            warn!("[LargeBotQueue] send failed with: {:?}, skipping", err);
+            warn!("skipping, send failed with: {:?}", err);
             return;
         }
 
-        info!("Waiting for allowance on shard: {}!", shard_id[0]);
+        info!("waiting for allowance on shard {}", shard_id[0]);
 
         let _ = rx.await;
     }

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -155,7 +155,7 @@ impl Shard {
         tokio::spawn(async move {
             let _ = fut.await;
 
-            debug!("[Shard] Shard processor future ended");
+            debug!("shard processor future ended");
         });
 
         // We know that these haven't been set, so we can ignore this.

--- a/gateway/src/shard/processor/emit.rs
+++ b/gateway/src/shard/processor/emit.rs
@@ -44,11 +44,7 @@ pub fn event(listeners: &Listeners<Event>, event: Event) {
         let event_type = EventTypeFlags::from(event.kind());
 
         if !listener.events.contains(event_type) {
-            trace!(
-                "[ShardProcessor] Listener {} doesn't want event type {:?}",
-                id,
-                event_type,
-            );
+            trace!("listener {} doesn't want event type {:?}", id, event_type,);
 
             continue;
         }
@@ -67,7 +63,7 @@ pub fn event(listeners: &Listeners<Event>, event: Event) {
     }
 
     for id in &remove_listeners {
-        debug!("[ShardProcessor] Removing listener {}", id);
+        debug!("removing listener {}", id);
 
         listeners.remove(id);
     }
@@ -81,11 +77,7 @@ fn _emit_to_listener(id: u64, listener: &Listener<Event>, event: Event) -> bool 
     let event_type = EventTypeFlags::from(event.kind());
 
     if !listener.events.contains(event_type) {
-        trace!(
-            "[ShardProcessor] Listener {} doesn't want event type {:?}",
-            id,
-            event_type,
-        );
+        trace!("listener {} doesn't want event type {:?}", id, event_type,);
 
         return true;
     }

--- a/gateway/src/shard/processor/heartbeat.rs
+++ b/gateway/src/shard/processor/heartbeat.rs
@@ -112,7 +112,7 @@ impl Heartbeats {
             let millis = if let Ok(millis) = dur.as_millis().try_into() {
                 millis
             } else {
-                error!("Duration millis is more than u64: {:?}", dur);
+                error!("duration millis is more than u64: {:?}", dur);
 
                 return;
             };
@@ -215,11 +215,11 @@ impl Heartbeater {
             let bytes = crate::json_to_vec(&heartbeat)
                 .map_err(|source| Error::PayloadSerialization { source })?;
 
-            debug!("[Heartbeat] Sending heartbeat with seq: {}", seq);
+            debug!("sending heartbeat with seq: {}", seq);
             self.tx
                 .unbounded_send(TungsteniteMessage::Binary(bytes))
                 .map_err(|source| Error::SendingMessage { source })?;
-            debug!("[Heartbeat] Sent heartbeat with seq: {}", seq);
+            debug!("sent heartbeat with seq: {}", seq);
             self.heartbeats.send().await;
         }
     }

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -462,7 +462,7 @@ impl ShardProcessor {
                 msg
             } else {
                 if let Err(why) = self.resume().await {
-                    warn!("resuming failed, reconnecting:", why);
+                    warn!("resuming failed, reconnecting: {:?}", why);
                     self.reconnect(true).await;
                 }
                 continue;

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -64,10 +64,10 @@ impl ShardProcessor {
         let shard_id = config.shard();
         let resumable = config.sequence.is_some() && config.session_id.is_some();
         if !resumable {
-            debug!("Shard {:?} is not resumable", shard_id);
-            debug!("[ShardProcessor {:?}] Queueing", shard_id);
+            debug!("shard {:?} is not resumable", shard_id);
+            debug!("shard {:?} queued", shard_id);
             config.queue.request(shard_id).await;
-            debug!("[ShardProcessor {:?}] Finished queue", config.shard());
+            debug!("shard {:?} finished queue", config.shard());
         }
 
         let properties = IdentifyProperties::new("twilight.rs", "twilight.rs", OS, "", "");
@@ -114,7 +114,7 @@ impl ShardProcessor {
         };
 
         if resumable {
-            debug!("Shard {:?} resuming", shard_id);
+            debug!("resuming shard {:?}", shard_id);
             processor.resume().await?;
         }
 
@@ -127,10 +127,7 @@ impl ShardProcessor {
                 Ok(ev) => ev,
                 // The authorization is invalid, so we should just quit.
                 Err(Error::AuthorizationInvalid { shard_id, .. }) => {
-                    warn!(
-                        "The authorization for shard {} is invalid, quitting",
-                        shard_id
-                    );
+                    warn!("authorization for shard {} is invalid, quitting", shard_id);
                     self.listeners.remove_all();
 
                     return;
@@ -138,7 +135,7 @@ impl ShardProcessor {
                 // Reconnect as this error is often fatal!
                 Err(Error::Decompressing { source }) => {
                     warn!(
-                        "[gateway] Decompressing error, clears buffers and reconnect! {:?}",
+                        "decompressing failed, clearing buffers and reconnecting: {:?}",
                         source
                     );
 
@@ -148,7 +145,7 @@ impl ShardProcessor {
                 }
                 Err(Error::IntentsDisallowed { shard_id, .. }) => {
                     warn!(
-                        "At least one of the provided intents for shard {} are disallowed",
+                        "at least one of the provided intents for shard {} are disallowed",
                         shard_id
                     );
                     self.listeners.remove_all();
@@ -156,14 +153,14 @@ impl ShardProcessor {
                 }
                 Err(Error::IntentsInvalid { shard_id, .. }) => {
                     warn!(
-                        "At least one of the provided intents for shard {} are invalid",
+                        "at least one of the provided intents for shard {} are invalid",
                         shard_id
                     );
                     self.listeners.remove_all();
                     return;
                 }
                 Err(err) => {
-                    warn!("Error receiving gateway event: {:?}", err.source());
+                    warn!("error receiving gateway event: {:?}", err.source());
                     continue;
                 }
             };
@@ -172,7 +169,7 @@ impl ShardProcessor {
             // message or if the session didn't exist when it should, so do a
             // reconnect if this fails.
             if self.process(&gateway_event).await.is_err() {
-                debug!("Error processing event; reconnecting");
+                debug!("error processing event; reconnecting");
 
                 self.reconnect(true).await;
 
@@ -258,7 +255,7 @@ impl ShardProcessor {
                 }
 
                 if let Err(err) = self.session.heartbeat() {
-                    warn!("Error sending heartbeat; reconnecting: {}", err);
+                    warn!("error sending heartbeat; reconnecting: {}", err);
 
                     self.reconnect(true).await;
                 }
@@ -266,13 +263,13 @@ impl ShardProcessor {
             Hello(interval) => {
                 #[cfg(feature = "metrics")]
                 metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "Hello");
-                debug!("[EVENT] Hello({})", interval);
+                debug!("got hello with interval {}", interval);
 
                 if self.session.stage() == Stage::Resuming && self.resume.is_some() {
                     // Safe to unwrap so here as we have just checked that
                     // it is some.
                     let (seq, id) = self.resume.take().unwrap();
-                    warn!("Resuming with ({}, {})!", seq, id);
+                    warn!("resuming with sequence {}, session id {}", seq, id);
                     let payload = Resume::new(seq, &id, self.config.token());
 
                     // Set id so it is correct for next resume.
@@ -303,19 +300,19 @@ impl ShardProcessor {
             InvalidateSession(true) => {
                 #[cfg(feature = "metrics")]
                 metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "InvalidateSessionTrue");
-                debug!("[EVENT] InvalidateSession(true)");
+                debug!("got request to resume the session");
                 self.resume().await?;
             }
             InvalidateSession(false) => {
                 #[cfg(feature = "metrics")]
                 metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "InvalidateSessionFalse");
-                debug!("[EVENT] InvalidateSession(false)");
+                debug!("got request to invalidate the session and reconnect");
                 self.reconnect(true).await;
             }
             Reconnect => {
                 #[cfg(feature = "metrics")]
                 metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "Reconnect");
-                debug!("[EVENT] Reconnect");
+                debug!("got request to reconnect");
                 let frame = CloseFrame {
                     code: CloseCode::Restart,
                     reason: Cow::Borrowed("Reconnecting"),
@@ -329,7 +326,7 @@ impl ShardProcessor {
     }
 
     async fn reconnect(&mut self, full_reconnect: bool) {
-        info!("[reconnect] Reconnection started!");
+        info!("reconnection started");
         loop {
             // Await allowance if doing a full reconnect
             if full_reconnect {
@@ -357,7 +354,7 @@ impl ShardProcessor {
             let new_stream = match Self::connect(&self.url).await {
                 Ok(s) => s,
                 Err(why) => {
-                    warn!("Error reconnecting: {:?}", why);
+                    warn!("reconnecting failed: {:?}", why);
                     continue;
                 }
             };
@@ -373,14 +370,14 @@ impl ShardProcessor {
                 Ok(_) => (),
                 Err(why) => {
                     warn!(
-                        "Broadcast of new session failed, \
-                         This should not happen, please open \
-                         a issue on the repo. {}",
+                        "broadcast of new session failed, \
+                         this should not happen, please open \
+                         an issue on the twilight repo: {}",
                         why
                     );
                     warn!(
-                        "After this many of the commands on the \
-                         shard will no longer work."
+                        "after this many of the commands on the \
+                         shard will no longer work"
                     );
                 }
             };
@@ -404,7 +401,7 @@ impl ShardProcessor {
     }
 
     async fn resume(&mut self) -> Result<()> {
-        info!("[resume] Resume started!");
+        info!("resuming shard {:?}", self.config.shard());
         self.session.set_stage(Stage::Resuming);
         self.session.stop_heartbeater().await;
 
@@ -413,7 +410,7 @@ impl ShardProcessor {
         let id = if let Some(id) = self.session.id().await {
             id
         } else {
-            warn!("Was not able to get the id, reconnecting.");
+            warn!("session id unavailable, reconnecting");
             self.reconnect(true).await;
             return Ok(());
         };
@@ -429,13 +426,13 @@ impl ShardProcessor {
         match self.session.send(payload) {
             Ok(()) => Ok(()),
             Err(Error::PayloadSerialization { source }) => {
-                warn!("Failed to serialize message to send: {:?}", source);
+                warn!("serializing message to send failed: {:?}", source);
 
                 Err(Error::PayloadSerialization { source })
             }
             Err(Error::SendingMessage { source }) => {
-                warn!("Failed to send message: {:?}", source);
-                info!("Reconnecting");
+                warn!("sending message failed: {:?}", source);
+                info!("reconnecting shard {:?}", self.config.shard());
 
                 self.reconnect(true).await;
 
@@ -465,7 +462,7 @@ impl ShardProcessor {
                 msg
             } else {
                 if let Err(why) = self.resume().await {
-                    warn!("Resume failed with {}, reconnecting", why);
+                    warn!("resuming failed, reconnecting:", why);
                     self.reconnect(true).await;
                 }
                 continue;
@@ -494,7 +491,7 @@ impl ShardProcessor {
                     break msg_or_error;
                 }
                 Message::Close(close_frame) => {
-                    tracing::warn!("Got close code: {:?}.", close_frame);
+                    tracing::warn!("got close code: {:?}", close_frame);
                     emit::event(
                         &self.listeners,
                         Event::ShardDisconnected(Disconnected {
@@ -534,7 +531,7 @@ impl ShardProcessor {
                 }
                 Message::Ping(_) | Message::Pong(_) => {}
                 Message::Text(mut text) => {
-                    trace!("Text payload: {}", text);
+                    trace!("text payload: {}", text);
 
                     emit::bytes(self.listeners.clone(), text.as_bytes()).await;
 
@@ -591,7 +588,7 @@ impl ShardProcessor {
         gateway_deserializer
             .deserialize(&mut json_deserializer)
             .map_err(|source| {
-                tracing::debug!("Broken JSON: {}", json);
+                tracing::debug!("invalid JSON: {}", json);
 
                 Error::PayloadSerialization { source }
             })
@@ -630,7 +627,7 @@ impl ShardProcessor {
         gateway_deserializer
             .deserialize(&mut json_deserializer)
             .map_err(|source| {
-                tracing::debug!("Broken JSON: {}", json);
+                tracing::debug!("invalid JSON: {}", json);
 
                 Error::PayloadSerialization { source }
             })

--- a/gateway/src/shard/processor/inflater.rs
+++ b/gateway/src/shard/processor/inflater.rs
@@ -57,7 +57,7 @@ impl Inflater {
                 }
             }
 
-            trace!("in:out: {}:{}", self.compressed.len(), self.buffer.len());
+            trace!("in: {}, out: {}", self.compressed.len(), self.buffer.len());
             self.compressed.clear();
 
             #[allow(clippy::cast_precision_loss)]
@@ -65,7 +65,7 @@ impl Inflater {
                 // To get around the u64 → f64 precision loss lint
                 // it does really not matter that it happens here
                 trace!(
-                    "Data saved: {}KiB ({:.2}%)",
+                    "data saved: {}KiB ({:.2}%)",
                     ((self.decompress.total_out() - self.decompress.total_in()) / 1024),
                     ((self.decompress.total_in() as f64) / (self.decompress.total_out() as f64)
                         * 100.0)
@@ -86,7 +86,7 @@ impl Inflater {
                     self.decompress.total_out().try_into().unwrap_or(-1)
                 );
             }
-            trace!("Capacity: {}", self.buffer.capacity());
+            trace!("capacity: {}", self.buffer.capacity());
             Ok(Some(&mut self.buffer))
         } else {
             // Received a partial payload.

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1449,7 +1449,7 @@ impl Client {
                 let _ = tx.send(Some(v));
             }
             Err(why) => {
-                warn!("Err parsing headers: {:?}; {:?}", why, resp,);
+                warn!("header parsing failed: {:?}; {:?}", why, resp);
 
                 let _ = tx.send(None);
             }
@@ -1500,13 +1500,13 @@ impl Client {
 
         if status == StatusCode::IM_A_TEAPOT {
             warn!(
-                "Discord's API now runs off of teapots -- proceed to panic: {:?}",
+                "discord's api now runs off of teapots -- proceed to panic: {:?}",
                 resp,
             );
         }
 
         if status == StatusCode::TOO_MANY_REQUESTS {
-            warn!("Response got 429: {:?}", resp);
+            warn!("429 response: {:?}", resp);
         }
 
         let bytes = resp
@@ -1524,10 +1524,7 @@ impl Client {
 
         if let ApiError::General(ref general) = error {
             if let ErrorCode::Other(num) = general.code {
-                debug!(
-                    "Got an unknown API error code variant: {}; {:?}",
-                    num, error
-                );
+                debug!("got unknown API error code variant: {}; {:?}", num, error);
             }
         }
 

--- a/http/src/ratelimiting/mod.rs
+++ b/http/src/ratelimiting/mod.rs
@@ -58,7 +58,7 @@ impl Ratelimiter {
     }
 
     pub async fn get(&self, path: Path) -> Receiver<Sender<Option<RatelimitHeaders>>> {
-        debug!("Getting bucket for path: {:?}", path);
+        debug!("getting bucket for path: {:?}", path);
 
         let (tx, rx) = oneshot::channel();
         let (bucket, fresh) = self.entry(path.clone(), tx).await;
@@ -88,16 +88,16 @@ impl Ratelimiter {
 
         match buckets.entry(path.clone()) {
             Entry::Occupied(bucket) => {
-                debug!("Got existing bucket: {:?}", path);
+                debug!("got existing bucket: {:?}", path);
 
                 let bucket = bucket.into_mut();
                 bucket.queue.push(tx);
-                debug!("Added request into bucket queue: {:?}", path);
+                debug!("added request into bucket queue: {:?}", path);
 
                 (Arc::clone(&bucket), false)
             }
             Entry::Vacant(entry) => {
-                debug!("Making new bucket for path: {:?}", path);
+                debug!("making new bucket for path: {:?}", path);
                 let bucket = Bucket::new(path.clone());
                 bucket.queue.push(tx);
 

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -25,7 +25,7 @@ fn spawn(
 ) {
     tokio::spawn(async move {
         if let Err(why) = fut.await {
-            tracing::debug!("Got an error from a handler: {:?}", why);
+            tracing::debug!("handler error: {:?}", why);
         }
     });
 }
@@ -126,7 +126,7 @@ async fn join(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
 
 async fn leave(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     tracing::debug!(
-        "Got a leave command in channel {} by {}",
+        "leave command in channel {} by {}",
         msg.channel_id,
         msg.author.name
     );
@@ -158,7 +158,7 @@ async fn leave(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + 
 
 async fn play(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     tracing::debug!(
-        "Got a play command in channel {} by {}",
+        "play command in channel {} by {}",
         msg.channel_id,
         msg.author.name
     );
@@ -212,7 +212,7 @@ async fn play(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
 
 async fn pause(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     tracing::debug!(
-        "Got a pause command in channel {} by {}",
+        "pause command in channel {} by {}",
         msg.channel_id,
         msg.author.name
     );
@@ -235,7 +235,7 @@ async fn pause(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + 
 
 async fn seek(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     tracing::debug!(
-        "Got a seek command in channel {} by {}",
+        "seek command in channel {} by {}",
         msg.channel_id,
         msg.author.name
     );
@@ -269,7 +269,7 @@ async fn seek(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
 
 async fn stop(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     tracing::debug!(
-        "Got a stop command in channel {} by {}",
+        "stop command in channel {} by {}",
         msg.channel_id,
         msg.author.name
     );
@@ -289,7 +289,7 @@ async fn stop(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
 
 async fn volume(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     tracing::debug!(
-        "Got a volume command in channel {} by {}",
+        "volume command in channel {} by {}",
         msg.channel_id,
         msg.author.name
     );

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -152,7 +152,7 @@ impl Lavalink {
     /// [`ClientError::NodesUnconfigured`]: enum.ClientError.html#variant.NodesUnconfigured
     /// [crate documentation]: ../index.html#examples
     pub async fn process(&self, event: &Event) -> Result<(), ClientError> {
-        tracing::trace!("Processing event: {:?}", event);
+        tracing::trace!("processing event: {:?}", event);
 
         let (guild_id, half) = match event {
             Event::Ready(e) => {
@@ -165,7 +165,7 @@ impl Lavalink {
             Event::VoiceServerUpdate(e) => (e.guild_id, VoiceStateHalf::Server(e.clone())),
             Event::VoiceStateUpdate(e) => {
                 if e.0.user_id != self.0.user_id {
-                    tracing::trace!("Got a voice state update from another user");
+                    tracing::trace!("got voice state update from another user");
 
                     return Ok(());
                 }
@@ -176,7 +176,7 @@ impl Lavalink {
         };
 
         tracing::debug!(
-            "Got a voice server/state update for {:?}: {:?}",
+            "got voice server/state update for {:?}: {:?}",
             guild_id,
             half
         );
@@ -184,7 +184,7 @@ impl Lavalink {
         let guild_id = match guild_id {
             Some(guild_id) => guild_id,
             None => {
-                tracing::trace!("Processed event has no guild ID: {:?}", event);
+                tracing::trace!("event has no guild ID: {:?}", event);
 
                 return Ok(());
             }
@@ -195,7 +195,7 @@ impl Lavalink {
                 Some(existing_half) => existing_half,
                 None => {
                     tracing::debug!(
-                        "Guild {} is now waiting for other half; got: {:?}",
+                        "guild {} is now waiting for other half; got: {:?}",
                         guild_id,
                         half
                     );
@@ -205,7 +205,7 @@ impl Lavalink {
                 }
             };
             tracing::debug!(
-                "Got both halves for {}: {:?}; {:?}",
+                "got both halves for {}: {:?}; {:?}",
                 guild_id,
                 half,
                 existing_half.value()
@@ -216,7 +216,7 @@ impl Lavalink {
                     // We got the same half twice... weird, but let's just replace
                     // the existing one.
                     tracing::debug!(
-                        "Got the same server half twice for guild {}: {:?}",
+                        "got the same server half twice for guild {}: {:?}",
                         guild_id,
                         server
                     );
@@ -232,7 +232,7 @@ impl Lavalink {
                 (VoiceStateHalf::State(_), VoiceStateHalf::State(state)) => {
                     // Just like above, we got the same half twice...
                     tracing::debug!(
-                        "Got the same state half twice for guild {}: {:?}",
+                        "got the same state half twice for guild {}: {:?}",
                         guild_id,
                         state
                     );
@@ -248,16 +248,16 @@ impl Lavalink {
             }
         };
 
-        tracing::debug!("Removing guild {} from waiting list", guild_id);
+        tracing::debug!("removing guild {} from waiting list", guild_id);
         self.0.waiting.remove(&guild_id);
 
-        tracing::debug!("Getting player for guild {}", guild_id);
+        tracing::debug!("getting player for guild {}", guild_id);
         let player = self.player(guild_id).await?;
-        tracing::debug!("Sending voice update for guild {}: {:?}", guild_id, update);
+        tracing::debug!("sending voice update for guild {}: {:?}", guild_id, update);
         player
             .send(update)
             .map_err(|source| ClientError::SendingVoiceUpdate { source })?;
-        tracing::debug!("Sent voice update for guild {}", guild_id);
+        tracing::debug!("sent voice update for guild {}", guild_id);
 
         Ok(())
     }

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -244,10 +244,10 @@ impl Node {
             op: Opcode::Stats,
             uptime: 0,
         });
-        tracing::debug!("Starting connection to {}", config.address);
+        tracing::debug!("starting connection to {}", config.address);
         let (conn_loop, lavalink_tx, lavalink_rx) =
             Connection::connect(config.clone(), players.clone(), bilock_right).await?;
-        tracing::debug!("Started connection to {}", config.address);
+        tracing::debug!("started connection to {}", config.address);
 
         tokio::spawn(conn_loop.run());
 
@@ -368,12 +368,12 @@ impl Connection {
                     self.incoming(incoming).await?;
                 }
                 Either::Left((_, _)) => {
-                    tracing::debug!("Connection to {} closed, reconnecting", self.config.address);
+                    tracing::debug!("connection to {} closed, reconnecting", self.config.address);
                     self.connection = reconnect(&self.config).await?;
                 }
                 Either::Right((Some(outgoing), _)) => {
                     tracing::debug!(
-                        "Forwarding event to {}: {:?}",
+                        "forwarding event to {}: {:?}",
                         self.config.address,
                         outgoing
                     );
@@ -388,7 +388,7 @@ impl Connection {
                     self.connection.send(msg).await.unwrap();
                 }
                 Either::Right((_, _)) => {
-                    tracing::debug!("Node {} closed, ending connection", self.config.address);
+                    tracing::debug!("node {} closed, ending connection", self.config.address);
 
                     break;
                 }
@@ -400,20 +400,20 @@ impl Connection {
 
     async fn incoming(&mut self, incoming: Message) -> Result<bool, NodeError> {
         tracing::debug!(
-            "Received message from {}: {:?}",
+            "received message from {}: {:?}",
             self.config.address,
             incoming
         );
 
         let text = match incoming {
             Message::Close(_) => {
-                tracing::debug!("Got a close, closing connection");
+                tracing::debug!("got close, closing connection");
                 let _ = self.connection.send(Message::Close(None)).await;
 
                 return Ok(false);
             }
             Message::Ping(data) => {
-                tracing::debug!("Got a ping, sending a pong");
+                tracing::debug!("got ping, sending pong");
                 let msg = Message::Pong(data);
 
                 // We don't need to immediately care if a pong fails.
@@ -423,7 +423,7 @@ impl Connection {
             }
             Message::Text(text) => text,
             other => {
-                tracing::debug!("Got a pong or bytes payload: {:?}", other);
+                tracing::debug!("got pong or bytes payload: {:?}", other);
 
                 return Ok(true);
             }
@@ -432,7 +432,7 @@ impl Connection {
         let event = match serde_json::from_str(&text) {
             Ok(event) => event,
             Err(_) => {
-                tracing::warn!("Unknown message from Lavalink node: {}", text);
+                tracing::warn!("unknown message from lavalink node: {}", text);
 
                 return Ok(true);
             }
@@ -458,7 +458,7 @@ impl Connection {
             Some(player) => player,
             None => {
                 tracing::warn!(
-                    "Got invalid player update for guild {}: {:?}",
+                    "invalid player update for guild {}: {:?}",
                     update.guild_id,
                     update,
                 );
@@ -505,7 +505,7 @@ async fn reconnect(config: &NodeConfig) -> Result<WebSocketStream<ConnectStream>
 
         if let Some(value) = headers.get(header) {
             if value.as_bytes() == b"false" {
-                tracing::debug!("Session to node {} didn't resume", config.address);
+                tracing::debug!("session to node {} didn't resume", config.address);
 
                 let payload = serde_json::json!({
                     "op": "configureResuming",
@@ -516,7 +516,7 @@ async fn reconnect(config: &NodeConfig) -> Result<WebSocketStream<ConnectStream>
 
                 stream.send(msg).await.unwrap();
             } else {
-                tracing::debug!("Session to {} resumed", config.address);
+                tracing::debug!("session to {} resumed", config.address);
             }
         }
     }
@@ -535,7 +535,7 @@ async fn backoff(
         match async_tungstenite::tokio::connect_async(req).await {
             Ok((stream, res)) => return Ok((stream, res)),
             Err(source) => {
-                tracing::warn!("Failed to connect to node {}: {:?}", source, config.address);
+                tracing::warn!("failed to connect to node {}: {:?}", source, config.address);
 
                 if matches!(source, TungsteniteError::Http(status) if status == StatusCode::UNAUTHORIZED)
                 {
@@ -546,15 +546,15 @@ async fn backoff(
                 }
 
                 if seconds > 64 {
-                    tracing::debug!("No longer trying to connect to node {}", config.address);
+                    tracing::debug!("no longer trying to connect to node {}", config.address);
 
                     return Err(NodeError::Connecting { source });
                 }
 
                 tracing::debug!(
-                    "Trying to connect to node {} again in {} seconds",
-                    config.address,
+                    "waiting {} sceonds before attempting to connect to node {} again",
                     seconds,
+                    config.address,
                 );
                 tokio_time::delay_for(Duration::from_secs(seconds)).await;
 

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -122,7 +122,7 @@ impl Player {
 
     fn _send(&self, event: OutgoingEvent) -> Result<(), TrySendError<OutgoingEvent>> {
         tracing::debug!(
-            "Sending event on guild player {}: {:?}",
+            "sending event on guild player {}: {:?}",
             self.guild_id,
             event
         );

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -199,7 +199,7 @@ impl Standby {
     /// This function must be called when events are received in order for
     /// futures returned by methods to fulfill.
     pub fn process(&self, event: &Event) {
-        tracing::trace!("Processing event: {:?}", event);
+        tracing::trace!("processing event: {:?}", event);
 
         match event {
             Event::MessageCreate(e) => return self.process_message(e.0.channel_id, &e),
@@ -248,7 +248,7 @@ impl Standby {
         guild_id: GuildId,
         check: impl Into<Box<F>>,
     ) -> WaitForGuildEventFuture {
-        tracing::trace!("Waiting for event in guild {}", guild_id);
+        tracing::trace!("waiting for event in guild {}", guild_id);
         let (tx, rx) = oneshot::channel();
 
         {
@@ -303,7 +303,7 @@ impl Standby {
         guild_id: GuildId,
         check: impl Into<Box<F>>,
     ) -> WaitForGuildEventStream {
-        tracing::trace!("Waiting for event in guild {}", guild_id);
+        tracing::trace!("waiting for event in guild {}", guild_id);
         let (tx, rx) = mpsc::unbounded();
 
         {
@@ -354,7 +354,7 @@ impl Standby {
         event_type: EventType,
         check: impl Into<Box<F>>,
     ) -> WaitForEventFuture {
-        tracing::trace!("Waiting for event {:?}", event_type);
+        tracing::trace!("waiting for event {:?}", event_type);
         let (tx, rx) = oneshot::channel();
 
         {
@@ -409,7 +409,7 @@ impl Standby {
         event_type: EventType,
         check: impl Into<Box<F>>,
     ) -> WaitForEventStream {
-        tracing::trace!("Waiting for event {:?}", event_type);
+        tracing::trace!("waiting for event {:?}", event_type);
         let (tx, rx) = mpsc::unbounded();
 
         {
@@ -455,7 +455,7 @@ impl Standby {
         channel_id: ChannelId,
         check: impl Into<Box<F>>,
     ) -> WaitForMessageFuture {
-        tracing::trace!("Waiting for message in channel {}", channel_id);
+        tracing::trace!("waiting for message in channel {}", channel_id);
         let (tx, rx) = oneshot::channel();
 
         {
@@ -506,7 +506,7 @@ impl Standby {
         channel_id: ChannelId,
         check: impl Into<Box<F>>,
     ) -> WaitForMessageStream {
-        tracing::trace!("Waiting for message in channel {}", channel_id);
+        tracing::trace!("waiting for message in channel {}", channel_id);
         let (tx, rx) = mpsc::unbounded();
 
         {
@@ -552,7 +552,7 @@ impl Standby {
         message_id: MessageId,
         check: impl Into<Box<F>>,
     ) -> WaitForReactionFuture {
-        tracing::trace!("Waiting for reaction on message {}", message_id);
+        tracing::trace!("waiting for reaction on message {}", message_id);
         let (tx, rx) = oneshot::channel();
 
         {
@@ -606,7 +606,7 @@ impl Standby {
         message_id: MessageId,
         check: impl Into<Box<F>>,
     ) -> WaitForReactionStream {
-        tracing::trace!("Waiting for reaction on message {}", message_id);
+        tracing::trace!("waiting for reaction on message {}", message_id);
         let (tx, rx) = mpsc::unbounded();
 
         {
@@ -621,7 +621,7 @@ impl Standby {
     }
 
     fn process_event(&self, event: &Event) {
-        tracing::trace!("Processing event type {:?}", event);
+        tracing::trace!("processing event type {:?}", event);
         let kind = event.kind();
 
         let remove = match self.0.events.get_mut(&kind) {
@@ -631,14 +631,14 @@ impl Standby {
                 bystanders.is_empty()
             }
             None => {
-                tracing::trace!("Event type {:?} has no bystanders", kind);
+                tracing::trace!("event type {:?} has no bystanders", kind);
 
                 return;
             }
         };
 
         if remove {
-            tracing::trace!("Removing event type {:?}", kind);
+            tracing::trace!("removing event type {:?}", kind);
 
             self.0.events.remove(&kind);
         }
@@ -652,14 +652,14 @@ impl Standby {
                 bystanders.is_empty()
             }
             None => {
-                tracing::trace!("Guild {} has no event bystanders", guild_id);
+                tracing::trace!("guild {} has no event bystanders", guild_id);
 
                 return;
             }
         };
 
         if remove {
-            tracing::trace!("Removing guild {}", guild_id);
+            tracing::trace!("removing guild {}", guild_id);
 
             self.0.guilds.remove(&guild_id);
         }
@@ -673,14 +673,14 @@ impl Standby {
                 bystanders.is_empty()
             }
             None => {
-                tracing::trace!("Channel {} has no message bystanders", channel_id);
+                tracing::trace!("channel {} has no message bystanders", channel_id);
 
                 return;
             }
         };
 
         if remove {
-            tracing::trace!("Removing channel {}", channel_id);
+            tracing::trace!("removing channel {}", channel_id);
 
             self.0.messages.remove(&channel_id);
         }
@@ -694,32 +694,32 @@ impl Standby {
                 bystanders.is_empty()
             }
             None => {
-                tracing::trace!("Message {} has no reaction bystanders", message_id);
+                tracing::trace!("message {} has no reaction bystanders", message_id);
 
                 return;
             }
         };
 
         if remove {
-            tracing::trace!("Removing message {}", message_id);
+            tracing::trace!("removing message {}", message_id);
             self.0.reactions.remove(&message_id);
         }
     }
 
     /// Iterate over bystanders and remove the ones that match the predicate.
     fn iter_bystanders<E: Clone>(&self, bystanders: &mut Vec<Bystander<E>>, event: &E) {
-        tracing::trace!("Iterating over bystanders: {:?}", bystanders);
+        tracing::trace!("iterating over bystanders: {:?}", bystanders);
 
         let mut idx = 0;
 
         while idx < bystanders.len() {
-            tracing::trace!("Checking bystander");
+            tracing::trace!("checking bystander");
             let bystander = &mut bystanders[idx];
 
             let sender = match bystander.sender.take() {
                 Some(sender) => sender,
                 None => {
-                    tracing::trace!("Bystander has no sender, removing");
+                    tracing::trace!("bystander has no sender, removing");
                     bystanders.remove(idx);
                     idx += 1;
 
@@ -728,14 +728,14 @@ impl Standby {
             };
 
             if sender.is_closed() {
-                tracing::trace!("Bystander's rx dropped, removing");
+                tracing::trace!("bystander's rx dropped, removing");
                 bystanders.remove(idx);
 
                 continue;
             }
 
             if !(bystander.func)(event) {
-                tracing::trace!("Bystander check doesn't match, continuing");
+                tracing::trace!("bystander check doesn't match, continuing");
                 bystander.sender.replace(sender);
                 idx += 1;
 
@@ -745,7 +745,7 @@ impl Standby {
             match sender {
                 Sender::Oneshot(tx) => {
                     let _ = tx.send(event.clone());
-                    tracing::trace!("Bystander matched event, removing");
+                    tracing::trace!("bystander matched event, removing");
                     bystanders.remove(idx);
                 }
                 Sender::Mpsc(tx) => {


### PR DESCRIPTION
Make the logging messages included in traces consistent. This focuses
more on the grammar than the wording: lowercase messages, no periods at
the end, removing unnecessary words, and keeping errors at the end of
the message.

Closes #37.