### PR TITLE
Add Copy derive and conversion helper to MessageType

### DIFF
--- a/model/src/channel/message/kind.rs
+++ b/model/src/channel/message/kind.rs
@@ -1,6 +1,6 @@
 use crate::channel::ConversionError;
-use core::convert::TryFrom;
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use std::convert::TryFrom;
 
 #[derive(
     Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,

--- a/model/src/channel/message/kind.rs
+++ b/model/src/channel/message/kind.rs
@@ -1,3 +1,5 @@
+use crate::channel::ConversionError;
+use core::convert::TryFrom;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(
@@ -20,4 +22,31 @@ pub enum MessageType {
     ChannelFollowAdd = 12,
     GuildDiscoveryDisqualified = 14,
     GuildDiscoveryRequalified = 15,
+}
+
+impl TryFrom<u8> for MessageType {
+    type Error = ConversionError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        let message_type = match value {
+            0 => MessageType::Regular,
+            1 => MessageType::RecipientAdd,
+            2 => MessageType::RecipientRemove,
+            3 => MessageType::Call,
+            4 => MessageType::ChannelNameChange,
+            5 => MessageType::ChannelIconChange,
+            6 => MessageType::ChannelMessagePinned,
+            7 => MessageType::GuildMemberJoin,
+            8 => MessageType::UserPremiumSub,
+            9 => MessageType::UserPremiumSubTier1,
+            10 => MessageType::UserPremiumSubTier2,
+            11 => MessageType::UserPremiumSubTier3,
+            12 => MessageType::ChannelFollowAdd,
+            14 => MessageType::GuildDiscoveryDisqualified,
+            15 => MessageType::GuildDiscoveryRequalified,
+            _ => return Err(ConversionError::MessageType(value)),
+        };
+
+        Ok(message_type)
+    }
 }

--- a/model/src/channel/message/kind.rs
+++ b/model/src/channel/message/kind.rs
@@ -1,6 +1,8 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(Clone, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr)]
+#[derive(
+    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
+)]
 #[repr(u8)]
 pub enum MessageType {
     Regular = 0,

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -32,8 +32,23 @@ use serde::{
 use serde_mappable_seq::Key;
 use std::{
     collections::HashMap,
-    fmt::{Formatter, Result as FmtResult},
+    fmt::{self, Formatter, Result as FmtResult},
 };
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ConversionError {
+    MessageType(u8),
+}
+
+impl fmt::Display for ConversionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            ConversionError::MessageType(num) => {
+                write!(f, "Could not convert {} into a valid MessageType!", num)
+            }
+        }
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(untagged)]


### PR DESCRIPTION
This PR just adds two things: 
 - A simple copy derive to `MessageType` to give it a cheaper duplication path and to avoid needing to call `.clone()` on it. 
- A `TryFrom<u8> for MessageType` implementation

Side note : Wow, that derive is ugly when formatted. 