### PR TITLE
model/event: make dispatch event an untagged enum

### DIFF
--- a/model/src/gateway/event/dispatch.rs
+++ b/model/src/gateway/event/dispatch.rs
@@ -12,6 +12,7 @@ use serde::{
 ///
 /// [`DispatchEventWithTypeDeserializer`]: struct.DispatchEventWithTypeDeserializer.html
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(untagged)]
 pub enum DispatchEvent {
     BanAdd(BanAdd),
     BanRemove(BanRemove),

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -724,14 +724,7 @@ mod tests {
                 Token::Str("op"),
                 Token::U8(OpCode::Event as u8),
                 Token::Str("d"),
-                Token::NewtypeVariant {
-                    name: "DispatchEvent",
-                    variant: "RoleDelete",
-                },
-                Token::Struct {
-                    name: "RoleDelete",
-                    len: 2,
-                },
+                Token::Struct { name: "RoleDelete", len: 2 },
                 Token::Str("guild_id"),
                 Token::NewtypeStruct { name: "GuildId" },
                 Token::Str("1"),

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -724,7 +724,10 @@ mod tests {
                 Token::Str("op"),
                 Token::U8(OpCode::Event as u8),
                 Token::Str("d"),
-                Token::Struct { name: "RoleDelete", len: 2 },
+                Token::Struct {
+                    name: "RoleDelete",
+                    len: 2,
+                },
                 Token::Str("guild_id"),
                 Token::NewtypeStruct { name: "GuildId" },
                 Token::Str("1"),


### PR DESCRIPTION
Add a `#[serde(untagged)]` attribute to `twilight_model::gateway::event::DispatchEvent` to make it serialize into untagged enums instead of externally tagged enums.