### PR TITLE
cache, lavalink, model: remove unused dependencies

### DIFF
--- a/cache/trait/Cargo.toml
+++ b/cache/trait/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.1.0"
 
 [dependencies]
 async-trait = { default-features = false, version = "0.1" }
-twilight-model = { default-features = false, path = "../../model" }
 
 [dev-dependencies]
 static_assertions = { default-features = false, version = "1" }

--- a/lavalink/examples/basic-lavalink-bot/Cargo.toml
+++ b/lavalink/examples/basic-lavalink-bot/Cargo.toml
@@ -11,7 +11,6 @@ tracing-subscriber = "0.2"
 reqwest = { features = ["json"], version = "0.10" }
 serde_json = { version = "1" }
 tokio = { features = ["macros", "rt-threaded"], version = "0.2" }
-twilight-command-parser = { path = "../../../command-parser" }
 twilight-gateway = { path = "../../../gateway" }
 twilight-http = { path = "../../../http" }
 twilight-lavalink = { path = "../.." }

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.1.0"
 
 [dependencies]
 bitflags = { default-features = false, version = "1" }
-tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde-mappable-seq = { default-features = false, version = "0.1" }
 serde_repr = { default-features = false, version = "0.1" }


### PR DESCRIPTION
Remove unused dependencies from crates.

cache/trait:

- twilight-model

lavalink:

- twilight-command-parser

model:

- tracing