### PR TITLE
gateway: refactor event emissions

### DIFF
--- a/gateway/src/listener.rs
+++ b/gateway/src/listener.rs
@@ -12,6 +12,13 @@ pub struct Listener<T> {
     pub tx: UnboundedSender<T>,
 }
 
+impl<T> Listener<T> {
+    /// Return whether the listener wants (contains) an event type.
+    pub fn wants(&self, event_type: EventTypeFlags) -> bool {
+        self.events.contains(event_type)
+    }
+}
+
 #[derive(Debug)]
 struct ListenersRef<T> {
     id: AtomicU64,
@@ -42,6 +49,11 @@ impl<T> Listeners<T> {
 
     pub fn all(&self) -> &DashMap<u64, Listener<T>> {
         &self.0.listeners
+    }
+
+    /// Return the length of the listeners map.
+    pub fn len(&self) -> usize {
+        self.0.listeners.len()
     }
 
     pub fn remove_all(&self) {

--- a/gateway/src/shard/processor/emit.rs
+++ b/gateway/src/shard/processor/emit.rs
@@ -1,84 +1,112 @@
-use crate::{
-    listener::{Listener, Listeners},
-    EventTypeFlags,
-};
+use crate::{listener::Listeners, EventTypeFlags};
 use twilight_model::gateway::event::{shard::Payload, Event};
 
-pub async fn bytes(listeners: Listeners<Event>, bytes: &[u8]) {
-    for listener in listeners.all() {
-        if listener.events.contains(EventTypeFlags::SHARD_PAYLOAD) {
-            let event = Event::ShardPayload(Payload {
-                bytes: bytes.to_owned(),
-            });
-
-            // If the channel isn't active, this'll be caught by event emissions
-            // later.
-            let _ = listener.tx.unbounded_send(event);
-        }
-    }
-}
-
-pub fn event(listeners: &Listeners<Event>, event: Event) {
-    let listeners = listeners.all();
-    let mut remove_listeners = Vec::new();
-
-    // Take up to the last one so that we can later get the last and *move*
-    // the event into the listener's channel, rather than clone it like we
-    // do here.
-    //
-    // This avoids a clone, and for users with only 1 listener this will
-    // entirely avoid cloning.
-    let mut last = None;
-
-    for (idx, guard) in listeners.iter().enumerate() {
-        let id = *guard.key();
-        let listener = guard.value();
-        if idx == listeners.len() - 1 {
-            last = Some(*guard.key());
-
-            break;
-        }
-
-        let event_type = EventTypeFlags::from(event.kind());
-
-        if !listener.events.contains(event_type) {
-            tracing::trace!("listener {} doesn't want event type {:?}", id, event_type,);
-
-            continue;
-        }
-
-        if !_emit_to_listener(id, listener, event.clone()) {
-            remove_listeners.push(id);
-        }
-    }
-
-    if let Some(id) = last {
-        if let Some(listener) = listeners.get(&id) {
-            if !_emit_to_listener(id, listener.value(), event) {
-                remove_listeners.push(id);
-            }
-        }
-    }
-
-    for id in &remove_listeners {
-        tracing::debug!("removing listener {}", id);
-
-        listeners.remove(id);
-    }
-}
-
-/// Returns whether the channel is still active.
+/// Send some bytes to listeners that have subscribed to shard payloads.
 ///
-/// If the receiver dropped, return `false` so we know to remove it.
-/// These are unbounded channels, so we know it's not because it's full.
-fn _emit_to_listener(id: u64, listener: &Listener<Event>, event: Event) -> bool {
+/// Shard payload events aren't subscribed to by default and must be opted in
+/// to. If a listener has subscribed to them, then the input bytes will be
+/// cloned. This means that for most users, this will be a cheap check.
+#[tracing::instrument(level = "trace")]
+pub fn bytes(listeners: &Listeners<Event>, bytes: &[u8]) {
+    send_to_listeners(listeners, EventTypeFlags::SHARD_PAYLOAD, |_| {
+        Event::ShardPayload(Payload {
+            bytes: bytes.to_vec(),
+        })
+    });
+}
+
+/// Send an event to listeners that have subscribed to its event type.
+#[tracing::instrument(level = "trace")]
+pub fn event(listeners: &Listeners<Event>, event: Event) {
+    let listener_count = listeners.len();
     let event_type = EventTypeFlags::from(event.kind());
+    let mut event = Some(event);
 
-    if !listener.events.contains(event_type) {
-        tracing::trace!("listener {} doesn't want event type {:?}", id, event_type,);
+    send_to_listeners(listeners, event_type, |idx| {
+        // We conditionally move out the event from its Option here to avoid
+        // unnecessary clones on all but the last listener.
+        //
+        // If there are 2 listeners, then the first will be given a clone of
+        // the event. The last one will then be given ownership of the event.
+        if idx == listener_count {
+            tracing::trace!("moving event to send to listener");
 
-        return true;
+            event.take().unwrap()
+        } else {
+            tracing::trace!("cloning event to send to listener");
+
+            event.clone().unwrap()
+        }
+    })
+}
+
+fn send_to_listeners(
+    listeners: &Listeners<Event>,
+    event_type: EventTypeFlags,
+    mut f: impl FnMut(usize) -> Event,
+) {
+    let listener_count = listeners.len();
+    let mut idx = 0;
+
+    let span = tracing::trace_span!(
+        "beginning to iterate over listeners",
+        ?event_type,
+        ?listener_count,
+    );
+    let _span_enter = span.enter();
+
+    listeners.all().retain(|id, listener| {
+        let span = tracing::trace_span!("sending to listener", %id, ?event_type);
+        let _span_enter = span.enter();
+
+        idx += 1;
+
+        if !listener.wants(event_type) {
+            tracing::trace!("listener doesn't want event type");
+
+            return !listener.tx.is_closed();
+        }
+
+        listener.tx.unbounded_send(f(idx)).is_ok()
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{listener::Listeners, Event, EventTypeFlags};
+
+    #[test]
+    fn test_bytes_send() {
+        let listeners = Listeners::default();
+        let mut rx = listeners.add(EventTypeFlags::SHARD_PAYLOAD);
+        super::bytes(&listeners, &[1]);
+        assert_eq!(1, listeners.len());
+
+        assert!(matches!(rx.try_next(), Ok(Some(_))));
+        assert!(rx.try_next().is_err());
     }
 
-    listener.tx.unbounded_send(event).is_ok()
+    #[test]
+    fn test_event_removes_closed_channels() {
+        let listeners = Listeners::default();
+        let _ = listeners.add(EventTypeFlags::default());
+        super::event(&listeners, Event::GatewayReconnect);
+        assert!(listeners.all().is_empty());
+    }
+
+    #[test]
+    fn test_event_sends_to_rxs() {
+        let listeners = Listeners::default();
+        let mut rx1 = listeners.add(EventTypeFlags::default());
+        let mut rx2 = listeners.add(EventTypeFlags::default());
+        super::event(&listeners, Event::GatewayReconnect);
+        assert_eq!(2, listeners.len());
+
+        assert!(matches!(rx1.try_next(), Ok(Some(_))));
+        assert!(matches!(rx2.try_next(), Ok(Some(_))));
+
+        // now check that they didn't send the event twice
+        assert!(rx1.try_next().is_err());
+        assert!(rx2.try_next().is_err());
+    }
 }

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -475,7 +475,7 @@ impl ShardProcessor {
                         .map_err(|source| Error::Decompressing { source })?;
                     let msg_or_error = match decompressed_msg {
                         Some(json) => {
-                            emit::bytes(self.listeners.clone(), json).await;
+                            emit::bytes(&self.listeners, json);
 
                             let mut text = str::from_utf8_mut(json)
                                 .map_err(|source| Error::PayloadNotUtf8 { source })?;
@@ -531,7 +531,7 @@ impl ShardProcessor {
                 Message::Text(mut text) => {
                     tracing::trace!("text payload: {}", text);
 
-                    emit::bytes(self.listeners.clone(), text.as_bytes()).await;
+                    emit::bytes(&self.listeners, text.as_bytes());
 
                     // Safety: the buffer isn't used again after parsing.
                     break unsafe { Self::parse_gateway_event(&mut text) };


### PR DESCRIPTION
Refactor event emissions to be simpler, faster, reduce allocations, and remove duplicate code.

Instead of creating a `Vec` to store listener IDs to remove, iterating over listeners and determining what to remove, and then iterating over the vec to remove them, use `DashMap::retain` to directly remove listeners that have had their channels closed.

Additionally, simplify and remove code by abstracting the iteration and checks over the listeners map for the `bytes` and `event` emission functions to another function that both call. `bytes` and `event` provide a function to create events, and this function is called when sending an event to a listener channel.

`bytes` now takes a reference to the listeners map and is no longer an async fn.

Additionally, add documentation and tests.