### PR TITLE
model/gateway: add 'max_concurrency' field

### DIFF
--- a/model/src/gateway/connection_info/bot_connection_info.rs
+++ b/model/src/gateway/connection_info/bot_connection_info.rs
@@ -1,9 +1,63 @@
 use crate::gateway::SessionStartLimit;
 use serde::{Deserialize, Serialize};
 
+/// Gateway information containing the recommended shard count and session
+/// availability.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct BotConnectionInfo {
+    /// Current session availability and session connection concurrency limits.
     pub session_start_limit: SessionStartLimit,
+    /// Recommended shard count to use.
     pub shards: u64,
+    /// URL to the gateway.
     pub url: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BotConnectionInfo, SessionStartLimit};
+    use serde_test::Token;
+
+    #[test]
+    fn test_connection_info() {
+        let info = BotConnectionInfo {
+            session_start_limit: SessionStartLimit {
+                max_concurrency: 16,
+                remaining: 998,
+                reset_after: 84686789,
+                total: 1000,
+            },
+            shards: 3,
+            url: "wss://gateway.discord.gg".to_owned(),
+        };
+
+        serde_test::assert_tokens(
+            &info,
+            &[
+                Token::Struct {
+                    name: "BotConnectionInfo",
+                    len: 3,
+                },
+                Token::Str("session_start_limit"),
+                Token::Struct {
+                    name: "SessionStartLimit",
+                    len: 4,
+                },
+                Token::Str("max_concurrency"),
+                Token::U64(16),
+                Token::Str("remaining"),
+                Token::U64(998),
+                Token::Str("reset_after"),
+                Token::U64(84686789),
+                Token::Str("total"),
+                Token::U64(1000),
+                Token::StructEnd,
+                Token::Str("shards"),
+                Token::U64(3),
+                Token::Str("url"),
+                Token::Str("wss://gateway.discord.gg"),
+                Token::StructEnd,
+            ],
+        );
+    }
 }

--- a/model/src/gateway/connection_info/mod.rs
+++ b/model/src/gateway/connection_info/mod.rs
@@ -4,7 +4,35 @@ pub use self::bot_connection_info::BotConnectionInfo;
 
 use serde::{Deserialize, Serialize};
 
+/// Gateway information containing the URL to connect to.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ConnectionInfo {
+    /// URL to the gateway.
     pub url: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ConnectionInfo;
+    use serde_test::Token;
+
+    #[test]
+    fn test_connection_info() {
+        let info = ConnectionInfo {
+            url: "wss://gateway.discord.gg".to_owned(),
+        };
+
+        serde_test::assert_tokens(
+            &info,
+            &[
+                Token::Struct {
+                    name: "ConnectionInfo",
+                    len: 1,
+                },
+                Token::Str("url"),
+                Token::Str("wss://gateway.discord.gg"),
+                Token::StructEnd,
+            ],
+        );
+    }
 }

--- a/model/src/gateway/session_start_limit.rs
+++ b/model/src/gateway/session_start_limit.rs
@@ -1,8 +1,50 @@
 use serde::{Deserialize, Serialize};
 
+/// Current gateway session utilisation status.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct SessionStartLimit {
+    /// Maximum number of session that may be started concurrently.
+    pub max_concurrency: u64,
+    /// Number of remaining sessions for a given time period.
     pub remaining: u64,
+    /// When the remaining sessions resets back to the total.
     pub reset_after: u64,
+    /// Total number of sessions that can be started within the given time
+    /// period.
     pub total: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SessionStartLimit;
+    use serde_test::Token;
+
+    #[test]
+    fn test_connection_info() {
+        let start = SessionStartLimit {
+            max_concurrency: 16,
+            remaining: 998,
+            reset_after: 84686789,
+            total: 1000,
+        };
+
+        serde_test::assert_tokens(
+            &start,
+            &[
+                Token::Struct {
+                    name: "SessionStartLimit",
+                    len: 4,
+                },
+                Token::Str("max_concurrency"),
+                Token::U64(16),
+                Token::Str("remaining"),
+                Token::U64(998),
+                Token::Str("reset_after"),
+                Token::U64(84686789),
+                Token::Str("total"),
+                Token::U64(1000),
+                Token::StructEnd,
+            ],
+        );
+    }
 }


### PR DESCRIPTION
Add `max_concurrency` to the session start limit struct, which indicates how many shard sessions may concurrently be started.

Documentation and tests have been added to go with it.