### PR TITLE
model/guild: add tests for a few types

### DIFF
--- a/model/src/guild/ban.rs
+++ b/model/src/guild/ban.rs
@@ -6,3 +6,64 @@ pub struct Ban {
     pub reason: Option<String>,
     pub user: User,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Ban, User};
+    use crate::id::UserId;
+    use serde_test::Token;
+
+    #[test]
+    fn test_ban() {
+        let ban = Ban {
+            reason: Some("foo".to_owned()),
+            user: User {
+                avatar: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned()),
+                bot: false,
+                discriminator: "0001".to_owned(),
+                email: None,
+                flags: None,
+                id: UserId(100_000_000_000_000_000),
+                locale: None,
+                mfa_enabled: None,
+                name: "test".to_owned(),
+                premium_type: None,
+                public_flags: None,
+                system: None,
+                verified: None,
+            },
+        };
+
+        serde_test::assert_de_tokens(
+            &ban,
+            &[
+                Token::Struct {
+                    name: "Ban",
+                    len: 2,
+                },
+                Token::Str("reason"),
+                Token::Some,
+                Token::Str("foo"),
+                Token::Str("user"),
+                Token::Struct {
+                    name: "User",
+                    len: 5,
+                },
+                Token::Str("avatar"),
+                Token::Some,
+                Token::Str("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                Token::Str("discriminator"),
+                Token::Str("0001"),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "UserId" },
+                Token::Str("100000000000000000"),
+                Token::Str("public_flags"),
+                Token::None,
+                Token::Str("username"),
+                Token::Str("test"),
+                Token::StructEnd,
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/guild/emoji.rs
+++ b/model/src/guild/emoji.rs
@@ -71,3 +71,99 @@ impl<'de> DeserializeSeed<'de> for EmojiMapDeserializer {
         deserializer.deserialize_seq(EmojiMapVisitor)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Emoji, EmojiId, User};
+    use crate::id::UserId;
+    use serde_test::Token;
+
+    #[test]
+    fn test_emoji() {
+        let emoji = Emoji {
+            animated: false,
+            available: true,
+            id: EmojiId(100_000_000_000_000_000),
+            managed: false,
+            name: "test".to_owned(),
+            require_colons: true,
+            roles: Vec::new(),
+            user: Some(User {
+                avatar: None,
+                bot: false,
+                discriminator: "0001".to_owned(),
+                email: None,
+                flags: None,
+                id: UserId(1),
+                locale: None,
+                mfa_enabled: None,
+                name: "test".to_owned(),
+                premium_type: None,
+                public_flags: None,
+                system: None,
+                verified: None,
+            }),
+        };
+
+        serde_test::assert_tokens(
+            &emoji,
+            &[
+                Token::Struct {
+                    name: "Emoji",
+                    len: 8,
+                },
+                Token::Str("animated"),
+                Token::Bool(false),
+                Token::Str("available"),
+                Token::Bool(true),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "EmojiId" },
+                Token::Str("100000000000000000"),
+                Token::Str("managed"),
+                Token::Bool(false),
+                Token::Str("name"),
+                Token::Str("test"),
+                Token::Str("require_colons"),
+                Token::Bool(true),
+                Token::Str("roles"),
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
+                Token::Str("user"),
+                Token::Some,
+                Token::Struct {
+                    name: "User",
+                    len: 13,
+                },
+                Token::Str("avatar"),
+                Token::None,
+                Token::Str("bot"),
+                Token::Bool(false),
+                Token::Str("discriminator"),
+                Token::Str("0001"),
+                Token::Str("email"),
+                Token::None,
+                Token::Str("flags"),
+                Token::None,
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "UserId" },
+                Token::Str("1"),
+                Token::Str("locale"),
+                Token::None,
+                Token::Str("mfa_enabled"),
+                Token::None,
+                Token::Str("username"),
+                Token::Str("test"),
+                Token::Str("premium_type"),
+                Token::None,
+                Token::Str("public_flags"),
+                Token::None,
+                Token::Str("system"),
+                Token::None,
+                Token::Str("verified"),
+                Token::None,
+                Token::StructEnd,
+                Token::StructEnd,
+            ],
+        )
+    }
+}

--- a/model/src/guild/prune.rs
+++ b/model/src/guild/prune.rs
@@ -4,3 +4,27 @@ use serde::{Deserialize, Serialize};
 pub struct GuildPrune {
     pub pruned: u64,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::GuildPrune;
+    use serde_test::Token;
+
+    #[test]
+    fn test_guild_prune() {
+        let prune = GuildPrune { pruned: 31 };
+
+        serde_test::assert_tokens(
+            &prune,
+            &[
+                Token::Struct {
+                    name: "GuildPrune",
+                    len: 1,
+                },
+                Token::Str("pruned"),
+                Token::U64(31),
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/guild/widget.rs
+++ b/model/src/guild/widget.rs
@@ -6,3 +6,33 @@ pub struct GuildWidget {
     pub channel_id: ChannelId,
     pub enabled: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{ChannelId, GuildWidget};
+    use serde_test::Token;
+
+    #[test]
+    fn test_guild_widget() {
+        let prune = GuildWidget {
+            channel_id: ChannelId(111_111_111_111_111_111),
+            enabled: true,
+        };
+
+        serde_test::assert_tokens(
+            &prune,
+            &[
+                Token::Struct {
+                    name: "GuildWidget",
+                    len: 2,
+                },
+                Token::Str("channel_id"),
+                Token::NewtypeStruct { name: "ChannelId" },
+                Token::Str("111111111111111111"),
+                Token::Str("enabled"),
+                Token::Bool(true),
+                Token::StructEnd,
+            ],
+        );
+    }
+}


### PR DESCRIPTION
Add `serde_test` unit tests for the following `guild` module types:

- Ban
- Emoji
- GuildPrune
- GuildWidget

This is a part of #31.