### PR TITLE
gateway: make much of the public api sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .build();
     let cache = InMemoryCache::from(cache_config);
 
-    let mut events = cluster.events().await;
+    let mut events = cluster.events();
     // Startup an event loop for each event in the event stream
     while let Some(event) = events.next().await {
         // Update the cache

--- a/gateway/examples/cluster/src/main.rs
+++ b/gateway/examples/cluster/src/main.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let cluster = Cluster::new(config).await?;
 
-    let mut events = cluster.events().await;
+    let mut events = cluster.events();
 
     let cluster_spawn = cluster.clone();
 

--- a/gateway/examples/intents/src/main.rs
+++ b/gateway/examples/intents/src/main.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     shard.start().await?;
     println!("Created shard");
 
-    let mut events = shard.events().await;
+    let mut events = shard.events();
 
     while let Some(event) = events.next().await {
         println!("Event: {:?}", event);

--- a/gateway/examples/metrics/src/main.rs
+++ b/gateway/examples/metrics/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     cluster.up().await;
     println!("Started cluster");
 
-    let mut events = cluster.events().await;
+    let mut events = cluster.events();
 
     // Start exporter in a seperate task
     tokio::task::spawn_blocking(move || exporter.run());

--- a/gateway/examples/queue/src/main.rs
+++ b/gateway/examples/queue/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     shard.start().await?;
     println!("Created shard");
 
-    let mut events = shard.events().await;
+    let mut events = shard.events();
 
     while let Some(event) = events.next().await {
         println!("Event: {:?}", event.kind());

--- a/gateway/examples/request-members/src/main.rs
+++ b/gateway/examples/request-members/src/main.rs
@@ -17,7 +17,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     shard.start().await?;
     println!("Created shard");
 
-    let mut events = shard.events().await;
+    let mut events = shard.events();
+
     while let Some(event) = events.next().await {
         match event {
             Event::GuildCreate(guildcreate) => {

--- a/gateway/examples/shard/src/main.rs
+++ b/gateway/examples/shard/src/main.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt::init();
 
     let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
-    let mut events = shard.events().await;
+    let mut events = shard.events();
 
     shard.start().await?;
     println!("Created shard");

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -125,7 +125,7 @@ pub struct ClusterConfig {
     shard_config: ShardConfig,
     shard_scheme: ShardScheme,
     queue: Arc<Box<dyn Queue>>,
-    resume_sessions: HashMap<u64, ResumeSession>,
+    pub(super) resume_sessions: HashMap<u64, ResumeSession>,
 }
 
 impl ClusterConfig {

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -3,9 +3,9 @@ use crate::{
     shard::{CommandError, Information, ResumeSession, Shard},
     EventTypeFlags,
 };
+use dashmap::DashMap;
 use futures_util::{
     future,
-    lock::Mutex,
     stream::{SelectAll, Stream, StreamExt},
 };
 use std::{
@@ -13,7 +13,7 @@ use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
     iter::FromIterator,
-    sync::{Arc, Weak},
+    sync::Arc,
 };
 use twilight_http::Error as HttpError;
 use twilight_model::gateway::event::Event;
@@ -92,7 +92,7 @@ struct ClusterRef {
     config: ClusterConfig,
     shard_from: u64,
     shard_to: u64,
-    shards: Mutex<HashMap<u64, Shard>>,
+    shards: DashMap<u64, Shard>,
 }
 
 /// A manager for multiple shards.
@@ -142,26 +142,25 @@ impl Cluster {
             metrics::gauge!("Cluster-Shard-Count", total.try_into().unwrap_or(-1));
         }
 
-        let mut shards = HashMap::new();
+        let shards = (from..=to)
+            .map(|idx| {
+                let mut shard_config = config.shard_config().clone();
+                shard_config.shard = [idx, total];
 
-        for idx in from..=to {
-            let mut shard_config = config.shard_config().clone();
-            shard_config.shard = [idx, total];
-            let resume_sessions = config.resume_sessions().get(&idx);
+                if let Some(data) = config.resume_sessions().get(&idx) {
+                    shard_config.session_id = Some(data.session_id.clone());
+                    shard_config.sequence = Some(data.sequence);
+                }
 
-            if let Some(data) = resume_sessions {
-                shard_config.session_id = Some(data.session_id.clone());
-                shard_config.sequence = Some(data.sequence);
-            };
-
-            shards.insert(idx, Shard::new(shard_config));
-        }
+                (idx, Shard::new(shard_config))
+            })
+            .collect();
 
         Ok(Self(Arc::new(ClusterRef {
             config,
             shard_from: from,
             shard_to: to,
-            shards: Mutex::new(shards),
+            shards,
         })))
     }
 
@@ -202,20 +201,16 @@ impl Cluster {
     /// ```
     pub async fn up(&self) {
         future::join_all(
-            (self.0.shard_from..=self.0.shard_to)
-                .map(|id| Self::start(Arc::downgrade(&self.0), id))
-                .collect::<Vec<_>>(),
+            (self.0.shard_from..=self.0.shard_to).map(|id| Self::start(Arc::clone(&self.0), id)),
         )
         .await;
     }
 
     /// Brings down the cluster, stopping all of the shards that it's managing.
-    pub async fn down(&self) {
-        let lock = self.0.shards.lock().await;
-
-        let tasks = lock.values().map(Shard::shutdown).collect::<Vec<_>>();
-
-        future::join_all(tasks).await;
+    pub fn down(&self) {
+        for r in self.0.shards.iter() {
+            r.value().shutdown();
+        }
     }
 
     /// Brings down the cluster in a resumable way and returns all info needed
@@ -227,26 +222,18 @@ impl Cluster {
     /// **Note**: Discord only allows resuming for a few minutes after
     /// disconnection. You may also not be able to resume if you missed too many
     /// events already.
-    pub async fn down_resumable(&self) -> HashMap<u64, ResumeSession> {
-        let lock = self.0.shards.lock().await;
-
-        let tasks = lock
-            .values()
-            .map(Shard::shutdown_resumable)
-            .collect::<Vec<_>>();
-
-        let sessions = future::join_all(tasks).await;
-
-        HashMap::from_iter(
-            sessions
-                .into_iter()
-                .filter_map(|(shard_id, session)| session.map(|session| (shard_id, session))),
-        )
+    pub fn down_resumable(&self) -> HashMap<u64, ResumeSession> {
+        self.0
+            .shards
+            .iter()
+            .map(|r| r.value().shutdown_resumable())
+            .filter_map(|(id, session)| session.map(|s| (id, s)))
+            .collect()
     }
 
     /// Returns a Shard by its ID.
-    pub async fn shard(&self, id: u64) -> Option<Shard> {
-        self.0.shards.lock().await.get(&id).cloned()
+    pub fn shard(&self, id: u64) -> Option<Shard> {
+        self.0.shards.get(&id).map(|r| r.value().clone())
     }
 
     /// Returns information about all shards.
@@ -266,7 +253,7 @@ impl Cluster {
     ///
     /// tokio::time::delay_for(Duration::from_secs(60)).await;
     ///
-    /// for (shard_id, info) in cluster.info().await {
+    /// for (shard_id, info) in cluster.info() {
     ///     println!(
     ///         "Shard {} is {} with an average latency of {:?}",
     ///         shard_id,
@@ -276,19 +263,12 @@ impl Cluster {
     /// }
     /// # Ok(()) }
     /// ```
-    pub async fn info(&self) -> HashMap<u64, Information> {
-        // Clone this out to prevent locking up access to all of the shards.
-        let shards = self.0.shards.lock().await.clone();
-
-        future::join_all(
-            shards
-                .into_iter()
-                .map(|(id, shard)| async move { (id, shard.info().await) }),
-        )
-        .await
-        .into_iter()
-        .filter_map(|(id, info)| info.map(|info| (id, info)).ok())
-        .collect::<HashMap<_, _>>()
+    pub fn info(&self) -> HashMap<u64, Information> {
+        self.0
+            .shards
+            .iter()
+            .filter_map(|r| r.value().info().ok().map(|info| (*r.key(), info)))
+            .collect()
     }
 
     /// Send a command to the specified shard.
@@ -308,26 +288,25 @@ impl Cluster {
         id: u64,
         value: &impl serde::Serialize,
     ) -> Result<(), ClusterCommandError> {
-        let shard = match self.0.shards.lock().await.get(&id) {
-            Some(shard) => shard.clone(),
-            None => return Err(ClusterCommandError::ShardNonexistent { id }),
-        };
+        let shard = self
+            .0
+            .shards
+            .get(&id)
+            .map(|r| r.value().clone())
+            .ok_or(ClusterCommandError::ShardNonexistent { id })?;
 
         shard
             .command(value)
             .await
-            .map_err(|source| ClusterCommandError::Sending { source })?;
-
-        Ok(())
+            .map_err(|source| ClusterCommandError::Sending { source })
     }
 
     /// Returns a stream of events from all shards managed by this Cluster.
     ///
     /// Each item in the stream contains both the shard's ID and the event
     /// itself.
-    pub async fn events(&self) -> impl Stream<Item = (u64, Event)> {
-        let shards = self.0.shards.lock().await.clone();
-        cluster_events(shards).await
+    pub fn events<'a>(&'a self) -> impl Stream<Item = (u64, Event)> + 'a {
+        self.some_events(EventTypeFlags::default())
     }
 
     /// Like [`events`], but filters the events so that the stream consumer
@@ -351,7 +330,7 @@ impl Cluster {
     /// let types = EventTypeFlags::MESSAGE_CREATE
     ///     | EventTypeFlags::MESSAGE_DELETE
     ///     | EventTypeFlags::MESSAGE_UPDATE;
-    /// let mut events = cluster.some_events(types).await;
+    /// let mut events = cluster.some_events(types);
     ///
     /// while let Some((shard_id, event)) = events.next().await {
     ///     match event {
@@ -366,9 +345,17 @@ impl Cluster {
     /// ```
     ///
     /// [`events`]: #method.events
-    pub async fn some_events(&self, types: EventTypeFlags) -> impl Stream<Item = (u64, Event)> {
-        let shards = self.0.shards.lock().await.clone();
-        cluster_some_events(shards, types).await
+    pub fn some_events<'a>(
+        &'a self,
+        types: EventTypeFlags,
+    ) -> impl Stream<Item = (u64, Event)> + 'a {
+        let stream = self
+            .0
+            .shards
+            .iter()
+            .map(|r| r.value().some_events(types).map(move |e| (*r.key(), e)));
+
+        SelectAll::from_iter(stream)
     }
 
     /// Queues a request to start a shard by ID and starts it once the queue
@@ -377,36 +364,11 @@ impl Cluster {
     /// Accepts weak references to the queue and map of shards, because by the
     /// time the future is polled the cluster may have already dropped, bringing
     /// down the queue and shards with it.
-    async fn start(cluster: Weak<ClusterRef>, shard_id: u64) -> Option<Shard> {
-        let cluster = cluster.upgrade()?;
-        let mut shard = cluster.shards.lock().await.get(&shard_id).cloned()?;
+    async fn start(cluster: Arc<ClusterRef>, shard_id: u64) -> Option<Shard> {
+        let mut shard = cluster.shards.get(&shard_id)?.value().clone();
+
         shard.start().await.ok()?;
 
         Some(shard)
     }
-}
-
-async fn cluster_events(
-    shards: impl IntoIterator<Item = (u64, Shard)>,
-) -> impl Stream<Item = (u64, Event)> {
-    let mut all = SelectAll::new();
-
-    for (id, shard) in shards {
-        all.push(shard.events().await.map(move |e| (id, e)));
-    }
-
-    all
-}
-
-async fn cluster_some_events(
-    shards: impl IntoIterator<Item = (u64, Shard)>,
-    types: EventTypeFlags,
-) -> impl Stream<Item = (u64, Event)> {
-    let mut all = SelectAll::new();
-
-    for (id, shard) in shards {
-        all.push(shard.some_events(types).await.map(move |e| (id, e)));
-    }
-
-    all
 }

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -230,7 +230,7 @@ impl Cluster {
             .lock()
             .expect("shards poisoned")
             .values()
-            .map(|shard| shard.shutdown_resumable())
+            .map(Shard::shutdown_resumable)
             .filter_map(|(id, session)| session.map(|s| (id, s)))
             .collect()
     }

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -237,7 +237,12 @@ impl Cluster {
 
     /// Returns a Shard by its ID.
     pub fn shard(&self, id: u64) -> Option<Shard> {
-        self.0.shards.lock().expect("shards poisoned").get(&id).cloned()
+        self.0
+            .shards
+            .lock()
+            .expect("shards poisoned")
+            .get(&id)
+            .cloned()
     }
 
     /// Returns information about all shards.
@@ -358,9 +363,9 @@ impl Cluster {
         types: EventTypeFlags,
     ) -> impl Stream<Item = (u64, Event)> + 'a {
         let shards = self.0.shards.lock().expect("shards poisoned").clone();
-        let stream = shards.into_iter().map(|(id, shard)| {
-            shard.some_events(types).map(move |e| (id, e))
-        });
+        let stream = shards
+            .into_iter()
+            .map(|(id, shard)| shard.some_events(types).map(move |e| (id, e)));
 
         SelectAll::from_iter(stream)
     }
@@ -372,7 +377,8 @@ impl Cluster {
     /// time the future is polled the cluster may have already dropped, bringing
     /// down the queue and shards with it.
     async fn start(cluster: Arc<ClusterRef>, shard_id: u64) -> Option<Shard> {
-        let mut shard = cluster.shards
+        let mut shard = cluster
+            .shards
             .lock()
             .expect("shards poisoned")
             .get(&shard_id)?

--- a/gateway/src/cluster/mod.rs
+++ b/gateway/src/cluster/mod.rs
@@ -18,7 +18,7 @@
 //!
 //!     cluster.up().await;
 //!
-//!     let mut events = cluster.events().await;
+//!     let mut events = cluster.events();
 //!
 //!     while let Some((shard_id, event)) = events.next().await {
 //!         tokio::spawn(handle_event(cluster.clone(), shard_id, event));
@@ -38,8 +38,8 @@
 //!             println!("Shard {} is now disconnected", shard_id);
 //!         },
 //!         Event::MessageCreate(msg) if msg.content == "!latency" => {
-//!             if let Some(shard) = cluster.shard(shard_id).await {
-//!                 if let Ok(info) = shard.info().await {
+//!             if let Some(shard) = cluster.shard(shard_id) {
+//!                 if let Ok(info) = shard.info() {
 //!                     println!("Shard {}'s latency is {:?}", shard_id, info.latency());
 //!                 }
 //!             }
@@ -47,7 +47,7 @@
 //!         Event::MessageCreate(msg) if msg.content == "!shutdown" => {
 //!             println!("Got a shutdown request from shard {}", shard_id);
 //!
-//!             cluster.down().await;
+//!             cluster.down();
 //!         },
 //!         _ => {},
 //!     }

--- a/gateway/tests/test_shard_state_events.rs
+++ b/gateway/tests/test_shard_state_events.rs
@@ -12,7 +12,7 @@ fn shard() -> Result<Shard, Box<dyn Error>> {
 #[tokio::test]
 async fn test_shard_event_emits() -> Result<(), Box<dyn Error>> {
     let mut shard = shard()?;
-    let mut events = shard.events().await;
+    let mut events = shard.events();
     shard.start().await?;
 
     assert!(matches!(events.next().await.unwrap(), Event::ShardConnecting(c) if c.shard_id == 0));
@@ -37,7 +37,7 @@ async fn test_shard_event_emits() -> Result<(), Box<dyn Error>> {
         Event::ShardResuming(_)
     ));
     assert!(matches!(events.next().await.unwrap(), Event::ShardConnecting(c) if c.shard_id == 0));
-    shard.shutdown().await;
+    shard.shutdown();
 
     Ok(())
 }

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -84,7 +84,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let mut shard = Shard::new(token);
     shard.start().await?;
 
-    let mut events = shard.events().await;
+    let mut events = shard.events();
 
     while let Some(event) = events.next().await {
         lavalink.process(&event).await?;

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         }
     };
 
-    let mut events = state.shard.events().await;
+    let mut events = state.shard.events();
 
     while let Some(event) = events.next().await {
         state.standby.process(&event);

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -82,7 +82,7 @@
 //!     let mut shard = Shard::new(token);
 //!     shard.start().await?;
 //!
-//!     let mut events = shard.events().await;
+//!     let mut events = shard.events();
 //!
 //!     while let Some(event) = events.next().await {
 //!         lavalink.process(&event).await?;

--- a/standby/README.md
+++ b/standby/README.md
@@ -71,7 +71,7 @@ use twilight_standby::Standby;
 async fn main() -> Result<(), Box<dyn Error>> {
     // Start a shard connected to the gateway to receive events.
     let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
-    let mut events = shard.events().await;
+    let mut events = shard.events();
     shard.start().await?;
 
     let standby = Standby::new();

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -71,7 +71,7 @@
 //! async fn main() -> Result<(), Box<dyn Error>> {
 //!     // Start a shard connected to the gateway to receive events.
 //!     let mut shard = Shard::new(env::var("DISCORD_TOKEN")?);
-//!     let mut events = shard.events().await;
+//!     let mut events = shard.events();
 //!     shard.start().await?;
 //!
 //!     let standby = Standby::new();

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -159,7 +159,7 @@
 //!         .build();
 //!     let cache = InMemoryCache::from(cache_config);
 //!
-//!     let mut events = cluster.events().await;
+//!     let mut events = cluster.events();
 //!     // Startup an event loop for each event in the event stream
 //!     while let Some(event) = events.next().await {
 //!         // Update the cache


### PR DESCRIPTION
Make much of the Cluster and Shard API synchronous. A lot of the functionality, mainly surrounding the usage of asynchronous Mutex locks, doesn't actually need to be asynchronous. The main benefit of async locks is when they're going to be held across context points, i.e. when an `await` is encountered. The running task may be switched to another on the same thread and, if acquiring the same lock, will deadlock. Since this can't happen due to the locks not being used in asynchronous contexts, there's no need for them, thus removing the need for their caller functions to be async.

This makes the following API surface sync:

- `Cluster::down`
- `Cluster::down_resumable`
- `Cluster::events`
- `Cluster::info`
- `Cluster::shard`
- `Cluster::some_events`
- `Shard::events`
- `Shard::info`
- `Shard::some_events`
- `Shard::shutdown`
- `Shard::shutdown_resumable`

The following Cluster and Shard API surface is still async:

- `Cluster::command` (due to ratelimiting)
- `Cluster::new` (due to retrieving bot user session availability)
- `Cluster::up` (waiting for the shards to be up)
- `Shard::command` (same as `Cluster::command`)
- `Shard::start` (same as `Cluster::up`)