### PR TITLE
http: Change color field to use a u32

### DIFF
--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -7,7 +7,7 @@ use twilight_model::{
 #[derive(Default, Serialize)]
 struct CreateRoleFields {
     #[serde(skip_serializing_if = "Option::is_none")]
-    color: Option<u64>,
+    color: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -57,7 +57,7 @@ impl<'a> CreateRole<'a> {
     }
 
     /// Set the color of the role.
-    pub fn color(mut self, color: u64) -> Self {
+    pub fn color(mut self, color: u32) -> Self {
         self.fields.color.replace(color);
 
         self

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -8,7 +8,7 @@ use twilight_model::{
 struct UpdateRoleFields {
     #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    color: Option<Option<u64>>,
+    color: Option<Option<u32>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -43,7 +43,7 @@ impl<'a> UpdateRole<'a> {
     }
 
     /// Set the color of the role.
-    pub fn color(mut self, color: impl Into<Option<u64>>) -> Self {
+    pub fn color(mut self, color: impl Into<Option<u32>>) -> Self {
         self.fields.color.replace(color.into());
 
         self


### PR DESCRIPTION
Updates `twilight-http` to use a `u32` instead of the `u64` for representing colors, as to stay consistent with the model.

Fixes #381