### PR TITLE
workflow/publish: setup ssh deploy key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Deploy docs
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_branch: gh-pages
           publish_dir: target/doc
           allow_empty_commit: true


### PR DESCRIPTION
Setup an SSH deploy key for doc deployment to gh-pages.

Closes #343.