### PR TITLE
model: handle new permissions scheme

### DIFF
--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -4,13 +4,16 @@ use crate::{
 };
 use serde::{
     de::{Deserializer, Error as DeError},
-    ser::{SerializeStruct, Serializer},
+    ser::{Error as SerError, SerializeStruct, Serializer},
     Deserialize, Serialize,
 };
+use std::convert::TryInto;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PermissionOverwrite {
+    pub allow_old: Permissions,
     pub allow: Permissions,
+    pub deny_old: Permissions,
     pub deny: Permissions,
     pub kind: PermissionOverwriteType,
 }
@@ -21,9 +24,15 @@ pub enum PermissionOverwriteType {
     Role(RoleId),
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize)]
 struct PermissionOverwriteData {
+    #[serde(rename = "allow")]
+    allow_old: Permissions,
+    #[serde(rename = "allow_new")]
     allow: Permissions,
+    #[serde(rename = "deny")]
+    deny_old: Permissions,
+    #[serde(rename = "deny_new")]
     deny: Permissions,
     id: String,
     #[serde(rename = "type")]
@@ -60,7 +69,9 @@ impl<'de> Deserialize<'de> for PermissionOverwrite {
         };
 
         Ok(Self {
+            allow_old: data.allow_old,
             allow: data.allow,
+            deny_old: data.deny_old,
             deny: data.deny,
             kind,
         })
@@ -71,8 +82,20 @@ impl Serialize for PermissionOverwrite {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut state = serializer.serialize_struct("PermissionOverwrite", 4)?;
 
-        state.serialize_field("allow", &self.allow.bits())?;
-        state.serialize_field("deny", &self.deny.bits())?;
+        state.serialize_field("allow_new", &self.allow)?;
+        let allow_bits: u64 = self
+            .allow_old
+            .bits()
+            .try_into()
+            .map_err(|_| SerError::custom("allow_old bits can't be a u64"))?;
+        state.serialize_field("allow", &allow_bits)?;
+        state.serialize_field("deny_new", &self.deny)?;
+        let deny_bits: u64 = self
+            .deny_old
+            .bits()
+            .try_into()
+            .map_err(|_| SerError::custom("deny_old bits can't be a u64"))?;
+        state.serialize_field("deny", &deny_bits)?;
 
         match &self.kind {
             PermissionOverwriteType::Member(id) => {
@@ -86,5 +109,40 @@ impl Serialize for PermissionOverwrite {
         }
 
         state.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PermissionOverwrite, PermissionOverwriteType, Permissions};
+    use crate::id::UserId;
+
+    #[test]
+    fn test_overwrite() {
+        let overwrite = PermissionOverwrite {
+            allow_old: Permissions::CREATE_INVITE,
+            allow: Permissions::CREATE_INVITE,
+            deny_old: Permissions::KICK_MEMBERS,
+            deny: Permissions::KICK_MEMBERS,
+            kind: PermissionOverwriteType::Member(UserId(12_345_678)),
+        };
+
+        // We can't use serde_test because it doesn't support 128 bit integers.
+        //
+        // <https://github.com/serde-rs/serde/issues/1281>
+        let input = r#"{
+  "allow_new": "1",
+  "allow": 1,
+  "deny_new": "2",
+  "deny": 2,
+  "id": "12345678",
+  "type": "member"
+}"#;
+
+        assert_eq!(
+            serde_json::from_str::<PermissionOverwrite>(input).unwrap(),
+            overwrite
+        );
+        assert_eq!(serde_json::to_string_pretty(&overwrite).unwrap(), input);
     }
 }

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -524,6 +524,7 @@ mod tests {
         "mentionable": false,
         "name": "@everyone",
         "permissions": 104193601,
+        "permissions_new": "104193601",
         "position": 0
       }
     ],
@@ -595,6 +596,7 @@ mod tests {
         "mentionable": false,
         "name": "@everyone",
         "permissions": 104324673,
+        "permissions_new": "104324673",
         "position": 0
       }
     ],

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -11,7 +11,7 @@ mod integration_account;
 mod mfa_level;
 mod partial_guild;
 mod partial_member;
-mod permissions;
+pub(crate) mod permissions;
 mod premium_tier;
 mod preview;
 mod prune;

--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -1,4 +1,7 @@
-use crate::{guild::Permissions, id::RoleId};
+use crate::{
+    guild::permissions::{self, Permissions},
+    id::RoleId,
+};
 use serde::{
     de::{DeserializeSeed, Deserializer, SeqAccess, Visitor},
     Deserialize, Serialize,
@@ -17,6 +20,9 @@ pub struct Role {
     pub managed: bool,
     pub mentionable: bool,
     pub name: String,
+    #[serde(rename = "permissions", serialize_with = "permissions::serialize_u64")]
+    pub permissions_old: Permissions,
+    #[serde(rename = "permissions_new")]
     pub permissions: Permissions,
     pub position: i64,
 }
@@ -62,5 +68,56 @@ impl<'de> DeserializeSeed<'de> for RoleMapDeserializer {
 
     fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
         deserializer.deserialize_seq(RoleMapDeserializerVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Permissions, Role, RoleId};
+    use serde_test::Token;
+
+    #[test]
+    fn test_role() {
+        let role = Role {
+            color: 0,
+            hoist: true,
+            id: RoleId(123),
+            managed: false,
+            mentionable: true,
+            name: "test".to_owned(),
+            permissions_old: Permissions::ADMINISTRATOR,
+            permissions: Permissions::ADMINISTRATOR,
+            position: 12,
+        };
+
+        serde_test::assert_tokens(
+            &role,
+            &[
+                Token::Struct {
+                    name: "Role",
+                    len: 9,
+                },
+                Token::Str("color"),
+                Token::U32(0),
+                Token::Str("hoist"),
+                Token::Bool(true),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "RoleId" },
+                Token::Str("123"),
+                Token::Str("managed"),
+                Token::Bool(false),
+                Token::Str("mentionable"),
+                Token::Bool(true),
+                Token::Str("name"),
+                Token::Str("test"),
+                Token::Str("permissions"),
+                Token::U64(8),
+                Token::Str("permissions_new"),
+                Token::Str("8"),
+                Token::Str("position"),
+                Token::I64(12),
+                Token::StructEnd,
+            ],
+        );
     }
 }


### PR DESCRIPTION
Permissions in Permission Overwrites and Roles now have two fields in the API: bitflags stored as an integer and another as a string.

Permission Overwrites now have the following fields:

- allow_new
- deny_new

Roles now have:

- permissions_new

For the motivations behind this change read the link in #365. This patch introduces support for these fields. To make a migration easier (or, requiring no effort), rename the Permission Overwrites' `allow` and `deny` fields to `allow_old` and `deny_old`, adding `allow_new` and `deny_new` as `allow` and `deny`. Additionally, do the same for Role's `permissions`: rename it to `permissions_old` and make the new one `permissions`. This can be done simply via `#[serde(rename)]`.

Tests for permissions, permission overwrites, and roles have been added.

Closes #365.