### PR TITLE
gateway/shard: fix command send ratelimiter

### DIFF
--- a/gateway/examples/shard/src/main.rs
+++ b/gateway/examples/shard/src/main.rs
@@ -1,7 +1,6 @@
 use futures::StreamExt;
 use std::{env, error::Error};
-use twilight_gateway::{Event, Shard};
-use twilight_model::{gateway::payload::RequestGuildMembers, id::GuildId};
+use twilight_gateway::Shard;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {

--- a/gateway/examples/shard/src/main.rs
+++ b/gateway/examples/shard/src/main.rs
@@ -1,6 +1,7 @@
 use futures::StreamExt;
 use std::{env, error::Error};
-use twilight_gateway::Shard;
+use twilight_gateway::{Event, Shard};
+use twilight_model::{gateway::payload::RequestGuildMembers, id::GuildId};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -11,7 +11,10 @@ use async_tungstenite::tungstenite::{
     Error as TungsteniteError, Message,
 };
 use futures_channel::mpsc::TrySendError;
-use futures_util::future::{self, AbortHandle};
+use futures_util::{
+    future::{self, AbortHandle},
+    stream::StreamExt,
+};
 use once_cell::sync::OnceCell;
 use std::{
     borrow::Cow,
@@ -436,7 +439,7 @@ impl Shard {
         let message = Message::Text(json);
 
         // Tick ratelimiter.
-        session.ratelimit.lock().await.tick().await;
+        session.ratelimit.lock().await.next().await;
 
         session
             .tx

--- a/gateway/tests/test_shard_command_ratelimit.rs
+++ b/gateway/tests/test_shard_command_ratelimit.rs
@@ -1,0 +1,49 @@
+use futures_util::stream::StreamExt;
+use std::{
+    env,
+    time::{Duration, Instant},
+};
+use twilight_gateway::{Event, Shard};
+use twilight_model::{gateway::payload::RequestGuildMembers, id::GuildId};
+
+fn shard() -> Shard {
+    let token = env::var("DISCORD_TOKEN").unwrap();
+
+    Shard::new(token)
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_shard_command_ratelimit() {
+    let mut shard = shard();
+    let mut events = shard.events();
+    shard.start().await.unwrap();
+
+    assert!(matches!(
+        events.next().await.unwrap(),
+        Event::ShardConnecting(_)
+    ));
+    assert!(matches!(
+        events.next().await.unwrap(),
+        Event::ShardIdentifying(_)
+    ));
+    assert!(matches!(
+        events.next().await.unwrap(),
+        Event::GatewayHello(_)
+    ));
+    assert!(matches!(
+        events.next().await.unwrap(),
+        Event::ShardConnected(_)
+    ));
+    assert!(matches!(events.next().await.unwrap(), Event::Ready(_)));
+
+    // now that we're connected we can test sending
+    let payload = RequestGuildMembers::new_all(GuildId(644_743_296_891_224_113), None);
+    let now = Instant::now();
+    shard.command(&payload).await.unwrap();
+    assert!(now.elapsed() < Duration::from_millis(500));
+    // check that the ~500ms ratelimit has passed
+    shard.command(&payload).await.unwrap();
+    assert!(now.elapsed() > Duration::from_millis(500));
+    shard.shutdown();
+}


### PR DESCRIPTION
Fix the ratelimiter for sending events over the shard. The ratelimiter uses tokio's interval, which like documented in #268 and the comments of issue #193, isn't what you'd think it is at first glance.

Tokio's Interval will create an unbounded number of "tickets" available every specified duration, adding a new one each time that the duration has passed. This means that if you have an interval that refreshes every 5 seconds and take from it twice, it'll take 5 seconds to do in total. If you wait a few minutes and then take from it 10 times, all of those tickets will be immediately retrieved. This isn't what you want with a ratelimit.

Instead, use Tokio's Throttle. It's similar but has a differing detail: it will only keep 1 ticket available at a time. This means that if you wait a few minutes, take a ticket, and then try to immediately take another, unlike with the Interval you'll have to wait, since it counts down from when the *last* ticket was taken.

Closes #193.