### PR TITLE
gateway: inline eventtypeflags re-export docs

### DIFF
--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -93,10 +93,11 @@ pub mod shard;
 mod event;
 mod listener;
 
+pub use self::event::EventTypeFlags;
+
 #[doc(no_inline)]
 pub use self::{
     cluster::{Cluster, ClusterConfig},
-    event::EventTypeFlags,
     shard::{Shard, ShardConfig},
 };
 #[doc(no_inline)]


### PR DESCRIPTION
When re-exporting `event::EventTypeFlags`, inline the documentation. The `event` module is private, so re-exporting the `EventTypeFlags` without inlining the documentation causes it to have no documentation.

See the current <https://twilight-rs.github.io/twilight/twilight_gateway/index.html> for what this looks like before this patch.