### PR TITLE
project: make readme badges consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <!-- cargo-sync-readme start -->
 
-[![license badge][]][license link] [![rust badge]][rust link]
+# twilight
+
+[![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 ![project logo][logo]
-
-# twilight
 
 `twilight` is an asynchronous, simple, and extensible set of libraries which can
 be used separately or in combination for the Discord API.
@@ -209,11 +209,12 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [Lavalink]: https://github.com/Frederikam/Lavalink
 [`http`]: https://crates.io/crates/http
 [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
-[license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
-[license link]: https://opensource.org/licenses/ISC
+[github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+[github link]: https://github.com/twilight-rs/twilight
+[license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
 [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png
-[rust badge]: https://img.shields.io/badge/rust-1.40+%20(stable)-93450a.svg?style=flat-square
-[rust link]: https://github.com/rust-lang/rust/milestone/66
+[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 [`twilight-embed-builder`]: https://github.com/twilight-rs/twilight/tree/trunk/utils/embed-builder
 [`twilight-lavalink`]: https://github.com/twilight-rs/twilight/tree/trunk/lavalink
 [`twilight-mention`]: https://github.com/twilight-rs/twilight/tree/trunk/utils/mention

--- a/command-parser/README.md
+++ b/command-parser/README.md
@@ -1,8 +1,8 @@
 <!-- cargo-sync-readme start -->
 
-[![license badge][]][license link] [![rust badge]][rust link]
-
 # twilight-command-parser
+
+[![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 `twilight-command-parser` is a command parser for the [`twilight-rs`]
 ecosystem.
@@ -57,10 +57,11 @@ match parser.parse("!echo a message") {
 }
 ```
 
-[license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
-[license link]: https://opensource.org/licenses/ISC
-[rust badge]: https://img.shields.io/badge/rust-1.36+-93450a.svg?style=flat-square
-[rust link]: https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html
+[github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+[github link]: https://github.com/twilight-rs/twilight
+[license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 [`twilight-rs`]: https://github.com/twilight-rs/twilight
 
 <!-- cargo-sync-readme end -->

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -1,6 +1,6 @@
-//! [![license badge][]][license link] [![rust badge]][rust link]
-//!
 //! # twilight-command-parser
+//!
+//! [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! `twilight-command-parser` is a command parser for the [`twilight-rs`]
 //! ecosystem.
@@ -55,10 +55,11 @@
 //! }
 //! ```
 //!
-//! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
-//! [license link]: https://opensource.org/licenses/ISC
-//! [rust badge]: https://img.shields.io/badge/rust-1.36+-93450a.svg?style=flat-square
-//! [rust link]: https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html
+//! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+//! [github link]: https://github.com/twilight-rs/twilight
+//! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 //! [`twilight-rs`]: https://github.com/twilight-rs/twilight
 
 #![deny(

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -2,6 +2,8 @@
 
 # twilight-gateway
 
+[![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+
 `twilight-gateway` is an implementation of Discord's sharding gateway sessions.
 This is responsible for receiving stateful events in real-time from Discord
 and sending *some* stateful information.
@@ -77,5 +79,10 @@ This is enabled by default.
 [`simd-json`]: https://crates.io/crates/simd-json
 [`twilight-http`]: https://twilight-rs.github.io/twilight/twilight_http/index.html
 [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
+[github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+[github link]: https://github.com/twilight-rs/twilight
+[license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -1,5 +1,7 @@
 //! # twilight-gateway
 //!
+//! [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//!
 //! `twilight-gateway` is an implementation of Discord's sharding gateway sessions.
 //! This is responsible for receiving stateful events in real-time from Discord
 //! and sending *some* stateful information.
@@ -75,6 +77,11 @@
 //! [`simd-json`]: https://crates.io/crates/simd-json
 //! [`twilight-http`]: https://twilight-rs.github.io/twilight/twilight_http/index.html
 //! [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
+//! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+//! [github link]: https://github.com/twilight-rs/twilight
+//! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/http/README.md
+++ b/http/README.md
@@ -2,6 +2,8 @@
 
 # twilight-http
 
+[![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+
 HTTP support for the twilight ecosystem.
 
 ## Features
@@ -65,5 +67,10 @@ This is enabled by default.
 [`rustls`]: https://crates.io/crates/rustls
 [`serde_json`]: https://crates.io/crates/serde_json
 [`simd-json`]: https://crates.io/crates/simd-json
+[github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+[github link]: https://github.com/twilight-rs/twilight
+[license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -1,5 +1,7 @@
 //! # twilight-http
 //!
+//! [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//!
 //! HTTP support for the twilight ecosystem.
 //!
 //! ## Features
@@ -63,6 +65,11 @@
 //! [`rustls`]: https://crates.io/crates/rustls
 //! [`serde_json`]: https://crates.io/crates/serde_json
 //! [`simd-json`]: https://crates.io/crates/simd-json
+//! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+//! [github link]: https://github.com/twilight-rs/twilight
+//! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -2,6 +2,8 @@
 
 # twilight-lavalink
 
+[![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+
 `twilight-lavalink` is a client for [Lavalink] as part of the twilight
 ecosystem.
 
@@ -100,7 +102,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 [`http`]: https://crates.io/crates/http
 [`rustls`]: https://crates.io/crates/rustls
 [client]: client/struct.Lavalink.html
+[github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+[github link]: https://github.com/twilight-rs/twilight
+[license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
 [node]: node/struct.Node.html
 [process]: client/struct.Lavalink.html#method.process
+[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -1,5 +1,7 @@
 //! # twilight-lavalink
 //!
+//! [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//!
 //! `twilight-lavalink` is a client for [Lavalink] as part of the twilight
 //! ecosystem.
 //!
@@ -98,8 +100,13 @@
 //! [`http`]: https://crates.io/crates/http
 //! [`rustls`]: https://crates.io/crates/rustls
 //! [client]: client/struct.Lavalink.html
+//! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+//! [github link]: https://github.com/twilight-rs/twilight
+//! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
 //! [node]: node/struct.Node.html
 //! [process]: client/struct.Lavalink.html#method.process
+//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/model/README.md
+++ b/model/README.md
@@ -1,8 +1,8 @@
 <!-- cargo-sync-readme start -->
 
-[![license badge][]][license link] [![rust badge]][rust link]
-
 # twilight-model
+
+[![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 See the [`twilight`] documentation for more information.
 
@@ -39,9 +39,10 @@ twilight-model = "0.1"
 
 [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
 [`twilight`]: https://docs.rs/twilight
-[license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
-[license link]: https://opensource.org/licenses/ISC
-[rust badge]: https://img.shields.io/badge/rust-1.31+-93450a.svg?style=flat-square
-[rust link]: https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html
+[github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+[github link]: https://github.com/twilight-rs/twilight
+[license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -1,6 +1,6 @@
-//! [![license badge][]][license link] [![rust badge]][rust link]
-//!
 //! # twilight-model
+//!
+//! [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! See the [`twilight`] documentation for more information.
 //!
@@ -37,10 +37,11 @@
 //!
 //! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
 //! [`twilight`]: https://docs.rs/twilight
-//! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
-//! [license link]: https://opensource.org/licenses/ISC
-//! [rust badge]: https://img.shields.io/badge/rust-1.31+-93450a.svg?style=flat-square
-//! [rust link]: https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html
+//! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+//! [github link]: https://github.com/twilight-rs/twilight
+//! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/standby/README.md
+++ b/standby/README.md
@@ -2,6 +2,8 @@
 
 # twilight-standby
 
+[![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+
 Standby is a utility to wait for an event to happen based on a predicate
 check. For example, you may have a command that has a reaction menu of ✅ and
 ❌. If you want to handle a reaction to these, using something like an
@@ -116,5 +118,10 @@ For more examples, check out each of the methods on [`Standby`].
 [`Standby::wait_for_message`]: struct.Standby.html#method.wait_for_message
 [`Standby::wait_for_message_stream`]: struct.Standby.html#method.wait_for_message_stream
 [`Standby::wait_for_reaction`]: struct.Standby.html#method.wait_for_reaction
+[github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+[github link]: https://github.com/twilight-rs/twilight
+[license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -1,5 +1,7 @@
 //! # twilight-standby
 //!
+//! [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//!
 //! Standby is a utility to wait for an event to happen based on a predicate
 //! check. For example, you may have a command that has a reaction menu of ✅ and
 //! ❌. If you want to handle a reaction to these, using something like an
@@ -116,6 +118,11 @@
 //! [`Standby::wait_for_message`]: struct.Standby.html#method.wait_for_message
 //! [`Standby::wait_for_message_stream`]: struct.Standby.html#method.wait_for_message_stream
 //! [`Standby::wait_for_reaction`]: struct.Standby.html#method.wait_for_reaction
+//! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+//! [github link]: https://github.com/twilight-rs/twilight
+//! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
 mod futures;
 

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -1,8 +1,8 @@
-//! [![license badge][]][license link] [![rust badge]][rust link]
+//! # twilight
+//!
+//! [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! ![project logo][logo]
-//!
-//! # twilight
 //!
 //! `twilight` is an asynchronous, simple, and extensible set of libraries which can
 //! be used separately or in combination for the Discord API.
@@ -207,11 +207,12 @@
 //! [Lavalink]: https://github.com/Frederikam/Lavalink
 //! [`http`]: https://crates.io/crates/http
 //! [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
-//! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
-//! [license link]: https://opensource.org/licenses/ISC
+//! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+//! [github link]: https://github.com/twilight-rs/twilight
+//! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
 //! [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png
-//! [rust badge]: https://img.shields.io/badge/rust-1.40+%20(stable)-93450a.svg?style=flat-square
-//! [rust link]: https://github.com/rust-lang/rust/milestone/66
+//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 //! [`twilight-embed-builder`]: https://github.com/twilight-rs/twilight/tree/trunk/utils/embed-builder
 //! [`twilight-lavalink`]: https://github.com/twilight-rs/twilight/tree/trunk/lavalink
 //! [`twilight-mention`]: https://github.com/twilight-rs/twilight/tree/trunk/utils/mention

--- a/utils/embed-builder/README.md
+++ b/utils/embed-builder/README.md
@@ -2,6 +2,8 @@
 
 # twilight-embed-builder
 
+[![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+
 `twilight-embed-builder` is a set of builder for the [`twilight-rs`]
 ecosystem to create a message embed, useful when creating or updating
 messages.
@@ -42,6 +44,11 @@ let embed = EmbedBuilder::new()
 ```
 
 [`twilight-rs`]: https://github.com/twilight-rs/twilight
+[github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+[github link]: https://github.com/twilight-rs/twilight
+[license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 [the discord docs]: https://discord.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
 
 <!-- cargo-sync-readme end -->

--- a/utils/embed-builder/src/lib.rs
+++ b/utils/embed-builder/src/lib.rs
@@ -1,5 +1,7 @@
 //! # twilight-embed-builder
 //!
+//! [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//!
 //! `twilight-embed-builder` is a set of builder for the [`twilight-rs`]
 //! ecosystem to create a message embed, useful when creating or updating
 //! messages.
@@ -44,6 +46,11 @@
 //! ```
 //!
 //! [`twilight-rs`]: https://github.com/twilight-rs/twilight
+//! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+//! [github link]: https://github.com/twilight-rs/twilight
+//! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 //! [the discord docs]: https://discord.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
 
 #![deny(

--- a/utils/mention/README.md
+++ b/utils/mention/README.md
@@ -2,6 +2,8 @@
 
 # twilight-mention
 
+[![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+
 `twilight-mention` is a utility crate for the Discord [`twilight-rs`]
 ecosystem to mention its model types.
 
@@ -30,5 +32,10 @@ let message = format!("Hey there, {}!", user_id.mention());
 ```
 
 [`twilight-rs`]: https://github.com/twilight-rs/twilight
+[github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+[github link]: https://github.com/twilight-rs/twilight
+[license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/utils/mention/src/lib.rs
+++ b/utils/mention/src/lib.rs
@@ -1,5 +1,7 @@
 //! # twilight-mention
 //!
+//! [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//!
 //! `twilight-mention` is a utility crate for the Discord [`twilight-rs`]
 //! ecosystem to mention its model types.
 //!
@@ -28,6 +30,11 @@
 //! ```
 //!
 //! [`twilight-rs`]: https://github.com/twilight-rs/twilight
+//! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
+//! [github link]: https://github.com/twilight-rs/twilight
+//! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
+//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,


### PR DESCRIPTION
Make the badges consistent across all of the crate READMEs (and slightly prettier). Some of them have different versions, and most out of them are no longer true. For example, the model crate requires 1.31+ (which is probably not be true), the command parser requires 1.36+, and the main crate requires 1.40+.

Our policy for now is to support latest stable, so instead all of these have been updated to mention "stable". Some of the READMEs don't have badges, to add them to those READMEs.