### PR TITLE
model/partial_member: add missing 'nick' field

### DIFF
--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -81,7 +81,6 @@ mod tests {
             "id": "4",
             "member": {
                 "deaf": false,
-                "hoisted_role": null,
                 "joined_at": "2020-01-01T00:00:00.000000+00:00",
                 "mute": false,
                 "nick": null,
@@ -128,6 +127,7 @@ mod tests {
                 deaf: false,
                 joined_at: Some("2020-01-01T00:00:00.000000+00:00".to_owned()),
                 mute: false,
+                nick: None,
                 roles: Vec::new(),
             }),
             mention_channels: Vec::new(),

--- a/model/src/guild/partial_member.rs
+++ b/model/src/guild/partial_member.rs
@@ -6,5 +6,51 @@ pub struct PartialMember {
     pub deaf: bool,
     pub joined_at: Option<String>,
     pub mute: bool,
+    pub nick: Option<String>,
     pub roles: Vec<RoleId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PartialMember, RoleId};
+    use serde_test::Token;
+
+    #[test]
+    fn test_partial_member() {
+        let value = PartialMember {
+            deaf: true,
+            joined_at: Some("timestamp".to_owned()),
+            mute: true,
+            nick: Some("a nickname".to_owned()),
+            roles: vec![RoleId(1), RoleId(2)],
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "PartialMember",
+                    len: 5,
+                },
+                Token::Str("deaf"),
+                Token::Bool(true),
+                Token::Str("joined_at"),
+                Token::Some,
+                Token::Str("timestamp"),
+                Token::Str("mute"),
+                Token::Bool(true),
+                Token::Str("nick"),
+                Token::Some,
+                Token::Str("a nickname"),
+                Token::Str("roles"),
+                Token::Seq { len: Some(2) },
+                Token::NewtypeStruct { name: "RoleId" },
+                Token::Str("1"),
+                Token::NewtypeStruct { name: "RoleId" },
+                Token::Str("2"),
+                Token::SeqEnd,
+                Token::StructEnd,
+            ],
+        );
+    }
 }


### PR DESCRIPTION
Add the missing `nick` field to the `twilight_model::guild::PartialMember` type.

Member documentation can be found here:

<https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-structure>