### PR TITLE
model/category_channel: remove 'nsfw', 'parent_id'

### DIFF
--- a/model/src/channel/category_channel.rs
+++ b/model/src/channel/category_channel.rs
@@ -11,9 +11,51 @@ pub struct CategoryChannel {
     #[serde(rename = "type")]
     pub kind: ChannelType,
     pub name: String,
-    #[serde(default)]
-    pub nsfw: bool,
-    pub parent_id: Option<ChannelId>,
     pub permission_overwrites: Vec<PermissionOverwrite>,
     pub position: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CategoryChannel, ChannelId, ChannelType, GuildId};
+    use serde_test::Token;
+
+    #[test]
+    fn test_category_channel() {
+        let value = CategoryChannel {
+            guild_id: Some(GuildId(1)),
+            id: ChannelId(2),
+            kind: ChannelType::GuildCategory,
+            name: "category".to_owned(),
+            permission_overwrites: Vec::new(),
+            position: 2,
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "CategoryChannel",
+                    len: 6,
+                },
+                Token::Str("guild_id"),
+                Token::Some,
+                Token::NewtypeStruct { name: "GuildId" },
+                Token::Str("1"),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "ChannelId" },
+                Token::Str("2"),
+                Token::Str("type"),
+                Token::U8(4),
+                Token::Str("name"),
+                Token::Str("category"),
+                Token::Str("permission_overwrites"),
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
+                Token::Str("position"),
+                Token::I64(2),
+                Token::StructEnd,
+            ],
+        );
+    }
 }

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -340,9 +340,7 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
                     guild_id,
                     kind,
                     name,
-                    nsfw,
                     permission_overwrites,
-                    parent_id,
                     position,
                 })
             }
@@ -472,8 +470,6 @@ mod tests {
             id: ChannelId(123),
             kind: ChannelType::GuildCategory,
             name: "category".to_owned(),
-            nsfw: false,
-            parent_id: None,
             permission_overwrites: Vec::new(),
             position: 0,
         }
@@ -648,8 +644,6 @@ mod tests {
             guild_id: Some(GuildId(2)),
             kind: ChannelType::GuildCategory,
             name: "foo".to_owned(),
-            nsfw: false,
-            parent_id: None,
             permission_overwrites: Vec::new(),
             position: 3,
         });


### PR DESCRIPTION
Remove the `nsfw` and `parent_id` fields of `model::CategoryChannel`. Category channels don't have an NSFW configuration and can't have a parent category channel.

A test has been included.