### PR TITLE
project: fix all clippy lints

### DIFF
--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -168,30 +168,30 @@ mod tests {
         let message_unicode_2 = "!\u{3b4} is delta";
 
         // Case insensitive - ASCII
-        let Command { name, .. } = parser
+        let command = parser
             .parse(message_ascii)
             .expect("Parser is case sensitive");
         assert_eq!(
-            "echo", name,
+            "echo", command.name,
             "Command name should have the same case as in the CommandParserConfig"
         );
 
         // Case insensitive - Unicode
         parser.config.add_command("wei\u{df}", false);
-        let Command { name, .. } = parser
+        let command = parser
             .parse(message_unicode)
             .expect("Parser is case sensitive");
         assert_eq!(
-            "wei\u{df}", name,
+            "wei\u{df}", command.name,
             "Command name should have the same case as in the CommandParserConfig"
         );
 
         parser.config.add_command("\u{394}", false);
-        let Command { name, .. } = parser
+        let command = parser
             .parse(message_unicode_2)
             .expect("Parser is case sensitive");
         assert_eq!(
-            "\u{394}", name,
+            "\u{394}", command.name,
             "Command name should have the same case as in the CommandParserConfig"
         );
 

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -392,7 +392,7 @@ mod tests {
             proxy_icon_url: None,
             url: None,
         });
-        embed.color.replace(0xff0000);
+        embed.color.replace(0xff_00_00);
         embed.description.replace("a".repeat(100));
         embed.fields.push(EmbedField {
             inline: true,

--- a/model/benches/deserialization.rs
+++ b/model/benches/deserialization.rs
@@ -184,11 +184,11 @@ fn typing_start() {
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("gateway event role delete", |b| {
-        b.iter(|| gateway_event_role_delete())
+        b.iter(gateway_event_role_delete())
     });
-    c.bench_function("member chunk", |b| b.iter(|| member_chunk()));
-    c.bench_function("reaction", |b| b.iter(|| reaction()));
-    c.bench_function("typing start", |b| b.iter(|| typing_start()));
+    c.bench_function("member chunk", |b| b.iter(member_chunk()));
+    c.bench_function("reaction", |b| b.iter(reaction()));
+    c.bench_function("typing start", |b| b.iter(typing_start()));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/model/src/channel/reaction.rs
+++ b/model/src/channel/reaction.rs
@@ -168,12 +168,13 @@ mod tests {
     };
     use serde_test::Token;
 
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn test_reaction_with_member() {
         let expected = Reaction {
             channel_id: ChannelId(2),
             emoji: ReactionType::Unicode {
-                name: "🙂".to_owned(),
+                name: "a".to_owned(),
             },
             guild_id: Some(GuildId(1)),
             member: Some(Member {
@@ -221,7 +222,7 @@ mod tests {
                     len: 1,
                 },
                 Token::Str("name"),
-                Token::Str("🙂"),
+                Token::Str("a"),
                 Token::StructEnd,
                 Token::Str("guild_id"),
                 Token::Some,
@@ -308,7 +309,7 @@ mod tests {
         let expected = Reaction {
             channel_id: ChannelId(2),
             emoji: ReactionType::Unicode {
-                name: "🙂".to_owned(),
+                name: "a".to_owned(),
             },
             guild_id: None,
             member: None,
@@ -332,7 +333,7 @@ mod tests {
                     len: 1,
                 },
                 Token::Str("name"),
-                Token::Str("🙂"),
+                Token::Str("a"),
                 Token::StructEnd,
                 Token::Str("guild_id"),
                 Token::None,

--- a/model/src/gateway/connection_info/bot_connection_info.rs
+++ b/model/src/gateway/connection_info/bot_connection_info.rs
@@ -24,7 +24,7 @@ mod tests {
             session_start_limit: SessionStartLimit {
                 max_concurrency: 16,
                 remaining: 998,
-                reset_after: 84686789,
+                reset_after: 84_686_789,
                 total: 1000,
             },
             shards: 3,
@@ -48,7 +48,7 @@ mod tests {
                 Token::Str("remaining"),
                 Token::U64(998),
                 Token::Str("reset_after"),
-                Token::U64(84686789),
+                Token::U64(84_686_789),
                 Token::Str("total"),
                 Token::U64(1000),
                 Token::StructEnd,

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -618,7 +618,7 @@ mod tests {
         let mut json_deserializer = Deserializer::from_str(input);
         let event = deserializer.deserialize(&mut json_deserializer).unwrap();
 
-        assert!(matches!(event, GatewayEvent::Dispatch(1190911, _)));
+        assert!(matches!(event, GatewayEvent::Dispatch(1_190_911, _)));
     }
 
     // Test that events which are not documented to have any data will not fail if
@@ -693,7 +693,7 @@ mod tests {
         let mut json_deserializer = Deserializer::from_str(input);
         let event = deserializer.deserialize(&mut json_deserializer).unwrap();
 
-        assert!(matches!(event, GatewayEvent::Hello(41250)));
+        assert!(matches!(event, GatewayEvent::Hello(41_250)));
     }
 
     #[test]
@@ -767,7 +767,7 @@ mod tests {
             role_id: RoleId(2),
         };
         let dispatch = Box::new(DispatchEvent::RoleDelete(role_delete));
-        let event = GatewayEvent::Dispatch(2048, dispatch);
+        let event = GatewayEvent::Dispatch(2_048, dispatch);
 
         serde_test::assert_ser_tokens(
             &event,
@@ -782,7 +782,7 @@ mod tests {
                     variant: "GUILD_ROLE_DELETE",
                 },
                 Token::Str("s"),
-                Token::U64(2048),
+                Token::U64(2_048),
                 Token::Str("op"),
                 Token::U8(OpCode::Event as u8),
                 Token::Str("d"),

--- a/model/src/gateway/payload/member_chunk.rs
+++ b/model/src/gateway/payload/member_chunk.rs
@@ -204,6 +204,7 @@ mod tests {
     };
     use std::collections::HashMap;
 
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn test_simple_member_chunk() {
         let input = serde_json::json!({
@@ -221,7 +222,7 @@ mod tests {
                     "avatar": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                     "discriminator": "0001",
                     "id": "5",
-                    "public_flags": 131072,
+                    "public_flags": 131_072,
                     "username": "test",
                 },
             }, {

--- a/model/src/gateway/payload/member_update.rs
+++ b/model/src/gateway/payload/member_update.rs
@@ -26,8 +26,8 @@ mod tests {
             user: User {
                 name: "Twilight Sparkle".to_string(),
                 public_flags: None,
-                id: 424242.into(),
-                discriminator: 1234.to_string(),
+                id: 424_242.into(),
+                discriminator: 1_234.to_string(),
                 avatar: Some("cool image".to_string()),
                 bot: false,
                 email: None,
@@ -42,7 +42,7 @@ mod tests {
             premium_since: None,
             nick: Some("Twilight".to_string()),
             joined_at: "2017-02-27T22:21:50.121000+00:00".to_string(),
-            guild_id: 1234.into(),
+            guild_id: 1_234.into(),
         };
 
         serde_test::assert_tokens(

--- a/model/src/gateway/payload/typing_start.rs
+++ b/model/src/gateway/payload/typing_start.rs
@@ -154,6 +154,7 @@ mod tests {
     };
     use serde_test::Token;
 
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn test_typing_start_with_member() {
         let expected = TypingStart {
@@ -184,7 +185,7 @@ mod tests {
                     public_flags: None,
                 },
             }),
-            timestamp: 1500000000,
+            timestamp: 1_500_000_000,
             user_id: UserId(3),
         };
 
@@ -268,7 +269,7 @@ mod tests {
                 Token::StructEnd,
                 Token::StructEnd,
                 Token::Str("timestamp"),
-                Token::U64(1500000000),
+                Token::U64(1_500_000_000),
                 Token::Str("user_id"),
                 Token::NewtypeStruct { name: "UserId" },
                 Token::Str("3"),
@@ -283,7 +284,7 @@ mod tests {
             channel_id: ChannelId(2),
             guild_id: None,
             member: None,
-            timestamp: 1500000000,
+            timestamp: 1_500_000_000,
             user_id: UserId(3),
         };
 
@@ -302,7 +303,7 @@ mod tests {
                 Token::Str("member"),
                 Token::None,
                 Token::Str("timestamp"),
-                Token::U64(1500000000),
+                Token::U64(1_500_000_000),
                 Token::Str("user_id"),
                 Token::NewtypeStruct { name: "UserId" },
                 Token::Str("3"),

--- a/model/src/gateway/payload/voice_state_update.rs
+++ b/model/src/gateway/payload/voice_state_update.rs
@@ -164,10 +164,10 @@ mod tests {
         let expected = VoiceStateUpdate(VoiceState {
             channel_id: None,
             deaf: false,
-            guild_id: Some(GuildId(999999)),
+            guild_id: Some(GuildId(999_999)),
             member: Some(Member {
                 deaf: false,
-                guild_id: GuildId(999999),
+                guild_id: GuildId(999_999),
                 hoisted_role: Some(RoleId(123)),
                 joined_at: Some("2016-12-08T18:41:21.954000+00:00".to_string()),
                 mute: false,
@@ -175,7 +175,7 @@ mod tests {
                 premium_since: None,
                 roles: vec![RoleId(123), RoleId(124)],
                 user: User {
-                    id: UserId(1234123123123),
+                    id: UserId(1_234_123_123_123),
                     avatar: Some("a21312321231236060dfe562c".to_string()),
                     bot: false,
                     discriminator: "4242".to_string(),
@@ -197,7 +197,7 @@ mod tests {
             session_id: "asdasdas1da98da2b3ab3a".to_owned(),
             suppress: false,
             token: None,
-            user_id: UserId(123213),
+            user_id: UserId(123_213),
         });
 
         // Token stream here's `Member` has no `guild_id`, which deserialiser

--- a/model/src/gateway/session_start_limit.rs
+++ b/model/src/gateway/session_start_limit.rs
@@ -24,8 +24,8 @@ mod tests {
         let start = SessionStartLimit {
             max_concurrency: 16,
             remaining: 998,
-            reset_after: 84686789,
-            total: 1000,
+            reset_after: 84_686_789,
+            total: 1_000,
         };
 
         serde_test::assert_tokens(
@@ -40,9 +40,9 @@ mod tests {
                 Token::Str("remaining"),
                 Token::U64(998),
                 Token::Str("reset_after"),
-                Token::U64(84686789),
+                Token::U64(84_686_789),
                 Token::Str("total"),
-                Token::U64(1000),
+                Token::U64(1_000),
                 Token::StructEnd,
             ],
         );

--- a/model/src/guild/integration.rs
+++ b/model/src/guild/integration.rs
@@ -37,6 +37,7 @@ mod tests {
     use crate::id::{RoleId, UserId};
     use serde_test::Token;
 
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn test_guild_integration() {
         let value = GuildIntegration {

--- a/model/src/guild/permissions.rs
+++ b/model/src/guild/permissions.rs
@@ -106,6 +106,6 @@ mod tests {
         serde_test::assert_tokens(&permissions, &[Token::Str("8388608")]);
         // serde_test doesn't support a u128. Only test deserialization here
         // since it serializes into a string.
-        serde_test::assert_de_tokens(&permissions, &[Token::U64(8388608)]);
+        serde_test::assert_de_tokens(&permissions, &[Token::U64(8_388_608)]);
     }
 }


### PR DESCRIPTION
Fix all crates' clippy lints via `cargo clippy --tests`. The CI currently does not catch lints in tests.