### PR TITLE
Dont panic when recieving a voice state when guild caching isn't enabled

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -655,9 +655,8 @@ impl InMemoryCache {
 
         let user_id = vs.user_id;
 
-        // This won't panic because we always insert a hashmap for each guild that the bot knows
-        // about, and to even receive events for them, we must have a key for them already.
-        let mut guild_states = self.0.guild_voice_states.get_mut(&guild_id).unwrap();
+        // If then user isn't caching guilds, then simply ignore the update since theres nowhere to put it.
+        let mut guild_states = self.0.guild_voice_states.get_mut(&guild_id)?;
 
         // If a user leaves a voice channel, then the `VoiceState` object received contains no
         // channel id.

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -788,10 +788,12 @@ impl UpdateCache<InMemoryCache, InMemoryCacheError> for WebhooksUpdate {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::InMemoryConfig;
     use twilight_model::{
         channel::{ChannelType, GuildChannel, TextChannel},
         gateway::payload::ChannelDelete,
-        id::{ChannelId, GuildId},
+        id::{ChannelId, GuildId, UserId},
+        voice::VoiceState,
     };
 
     fn guild_channel_text() -> (GuildId, ChannelId, GuildChannel) {
@@ -853,5 +855,32 @@ mod tests {
             .get(&guild_id)
             .unwrap()
             .contains(&channel_id));
+    }
+
+    #[tokio::test]
+    async fn test_voice_states_with_no_cached_guilds() {
+        let cache = InMemoryCache::from(
+            InMemoryConfig::builder()
+                .event_types(crate::config::EventType::VOICE_STATE_UPDATE)
+                .build(),
+        );
+
+        cache
+            .update(&VoiceStateUpdate(VoiceState {
+                channel_id: None,
+                deaf: false,
+                guild_id: Some(GuildId(01)),
+                member: None,
+                mute: false,
+                self_deaf: false,
+                self_mute: false,
+                self_stream: false,
+                session_id: "38fj3jfkh3pfho3prh2".to_string(),
+                suppress: false,
+                token: None,
+                user_id: UserId(01),
+            }))
+            .await
+            .expect("Caching a voice state should not fail")
     }
 }


### PR DESCRIPTION
Fixes a report from the Twilight Discord. If a user doesn't enable caching guilds then its not possible to always have a place to put the voice states. In these cases, just ignore them and return `None`.

Fixes #411

A relevant test has been added as well.