### PR TITLE
http: add fields and builders to create_guild

### DIFF
--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -1,0 +1,610 @@
+use super::{CategoryFields, GuildChannelFields, RoleFields, TextFields, VoiceFields};
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+use twilight_model::{
+    channel::{permission_overwrite::PermissionOverwrite, ChannelType},
+    guild::Permissions,
+    id::{ChannelId, RoleId},
+};
+
+/// Error building role fields.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum RoleFieldsError {
+    /// Color was larger than a valid RGB hexadecimal value.
+    ColorNotRgb {
+        /// Provided color hex value.
+        color: u32,
+    },
+    /// Invalid id for builders.
+    IdInvalid,
+}
+
+impl Display for RoleFieldsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::ColorNotRgb { color } => {
+                f.write_fmt(format_args!("the color {} is invalid", color))
+            }
+            Self::IdInvalid => f.write_str("the given id value is 1, which is not acceptable"),
+        }
+    }
+}
+
+impl Error for RoleFieldsError {}
+
+/// A builder for role fields.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[must_use = "must be built into a role"]
+pub struct RoleFieldsBuilder(RoleFields);
+
+impl RoleFieldsBuilder {
+    /// The maximumn accepted color value.
+    ///
+    /// This is used by [`color`].
+    ///
+    /// [`color`]: #method.color
+    pub const COLOR_MAXIMUM: u32 = 0xff_ff_ff;
+
+    /// The default `RoleId`.
+    ///
+    /// Any other id specified can not be 1.
+    pub const ROLE_ID: RoleId = RoleId(1);
+
+    /// Create a new default role field builder.
+    pub fn new(name: impl Into<String>) -> Self {
+        RoleFieldsBuilder(RoleFields {
+            color: None,
+            hoist: None,
+            id: Self::ROLE_ID,
+            mentionable: None,
+            name: name.into(),
+            permissions_old: None,
+            permissions: None,
+            position: None,
+        })
+    }
+
+    /// Build the role fields.
+    pub fn build(self) -> RoleFields {
+        self.0
+    }
+
+    /// Set the role color.
+    ///
+    /// This must be a valid hexadecimal RGB value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RoleFieldsError::ColorNotRgb`] if the color is not valid RGB.
+    ///
+    /// [`RoleFieldsError::ColorNotRgb`]: enum.RoleFieldsError.html#variant.ColorNotRgb
+    pub fn color(mut self, color: u32) -> Result<Self, RoleFieldsError> {
+        if color > Self::COLOR_MAXIMUM {
+            return Err(RoleFieldsError::ColorNotRgb { color });
+        }
+
+        self.0.color.replace(color);
+
+        Ok(self)
+    }
+
+    /// Show the role above other roles in the user list.
+    pub fn hoist(mut self) -> Self {
+        self.0.hoist.replace(true);
+
+        self
+    }
+
+    /// Set the id of the role.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RoleFieldsError::IdInvalid`] if the id is set to 1.
+    ///
+    /// [`RoleFieldsError::IdInvalid`]: enum.RoleFieldsError.html#variant.IdInvalid
+    pub fn id(mut self, id: RoleId) -> Result<Self, RoleFieldsError> {
+        if id == Self::ROLE_ID {
+            return Err(RoleFieldsError::IdInvalid);
+        }
+
+        self.0.id = id;
+
+        Ok(self)
+    }
+
+    /// Allow the role to be @mentioned.
+    pub fn mentionable(mut self) -> Self {
+        self.0.mentionable.replace(true);
+
+        self
+    }
+
+    /// Set the old permissions of the role.
+    pub fn permissions_old(mut self, permissions: Permissions) -> Self {
+        self.0.permissions_old.replace(permissions);
+
+        self
+    }
+
+    /// Set the permissions of the role.
+    pub fn permissions(mut self, permissions: Permissions) -> Self {
+        self.0.permissions.replace(permissions);
+
+        self
+    }
+
+    /// Set the position of the role.
+    pub fn position(mut self, position: i64) -> Self {
+        self.0.position.replace(position);
+
+        self
+    }
+}
+
+/// Error building text fields.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum TextFieldsError {
+    /// The name is too short.
+    NameTooShort {
+        /// The invalid name.
+        name: String,
+    },
+    /// The name is too long.
+    NameTooLong {
+        /// The invalid name.
+        name: String,
+    },
+    /// The rate limit is invalid.
+    RateLimitInvalid {
+        /// The incorrect rate limit.
+        limit: u64,
+    },
+    /// The topic is too long.
+    TopicTooLong {
+        /// The incorrect topic.
+        topic: String,
+    },
+}
+
+impl Display for TextFieldsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NameTooShort { name } => {
+                f.write_fmt(format_args!("the name is too short: {}", name.len()))
+            }
+            Self::NameTooLong { name } => {
+                f.write_fmt(format_args!("the name is too long: {}", name.len()))
+            }
+            Self::RateLimitInvalid { limit } => {
+                f.write_fmt(format_args!("the rate limit {} is invalid", limit))
+            }
+            Self::TopicTooLong { topic } => {
+                f.write_fmt(format_args!("the topic is too long: {}", topic.len()))
+            }
+        }
+    }
+}
+
+impl Error for TextFieldsError {}
+
+/// A builder for text fields.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[must_use = "must be built into a text channel"]
+pub struct TextFieldsBuilder(TextFields);
+
+impl TextFieldsBuilder {
+    /// The minimum number of UTF-16 code points that can be in a channel name.
+    ///
+    /// This is used by [`new`].
+    ///
+    /// [`new`]: #method.new
+    pub const MIN_NAME_LENGTH: usize = 2;
+
+    /// The maximum number of UTF-16 code points that can be in a channel name.
+    ///
+    /// This is used by [`new`].
+    ///
+    /// [`new`]: #method.new
+    pub const MAX_NAME_LENGTH: usize = 100;
+
+    /// The maximum length of a rate limit.
+    ///
+    /// This is used by [`rate_limit_per_user`].
+    ///
+    /// [`rate_limit_per_user`]: #method.rate_limit_per_user
+    pub const MAX_RATE_LIMIT: u64 = 21600;
+
+    /// The maximum number of UTF-16 code points that can be in a channel topic.
+    ///
+    /// This is used by [`topic`].
+    ///
+    /// [`topic`]: #method.topic
+    pub const MAX_TOPIC_LENGTH: usize = 1024;
+
+    /// Create a new text fields builder.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TextFieldsError::NameTooShort`] if the name is too short.
+    ///
+    /// Returns [`TextFieldsError::NameTooLong`] if the name is too long.
+    ///
+    /// [`TextFieldsError::NameTooShort`]: enum.TextFieldsError.html#variant.NameTooShort
+    /// [`TextFieldsError::NameTooLong`]: enum.TextFieldsError.html#variant.NameTooLong
+    pub fn new(name: impl Into<String>) -> Result<Self, TextFieldsError> {
+        Self::_new(name.into())
+    }
+
+    fn _new(name: String) -> Result<Self, TextFieldsError> {
+        if name.len() < Self::MIN_NAME_LENGTH {
+            return Err(TextFieldsError::NameTooShort { name });
+        }
+
+        if name.len() > Self::MAX_NAME_LENGTH {
+            return Err(TextFieldsError::NameTooLong { name });
+        }
+
+        Ok(TextFieldsBuilder(TextFields {
+            id: ChannelId(1),
+            kind: ChannelType::GuildText,
+            name,
+            nsfw: None,
+            permission_overwrites: None,
+            parent_id: None,
+            rate_limit_per_user: None,
+            topic: None,
+        }))
+    }
+
+    /// Build the text fields.
+    pub fn build(self) -> TextFields {
+        self.0
+    }
+
+    /// Make the channel NSFW.
+    pub fn nsfw(mut self) -> Self {
+        self.0.nsfw.replace(true);
+
+        self
+    }
+
+    /// Set the channel's permission overwrites.
+    pub fn permission_overwrites(mut self, overwrites: Vec<PermissionOverwrite>) -> Self {
+        self.0.permission_overwrites.replace(overwrites);
+
+        self
+    }
+
+    /// Set the channel's rate limit per user.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TextFieldsError::RateLimitInvalid`] if the rate limit is invalid.
+    ///
+    /// [`TextFieldsError::RateLimitInvalid`]: enum.TextFieldsError.html#variant.RateLimitInvalid
+    pub fn rate_limit_per_user(mut self, limit: u64) -> Result<Self, TextFieldsError> {
+        if limit > Self::MAX_RATE_LIMIT {
+            return Err(TextFieldsError::RateLimitInvalid { limit });
+        }
+
+        self.0.rate_limit_per_user.replace(limit);
+
+        Ok(self)
+    }
+
+    /// Set the channel's topic.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TextFieldsError::TopicTooLong`] if the topic is too long.
+    ///
+    /// [`TextFieldsError::TopicTooLong`]: enum.TextFieldsError.html#variant.TopicTooLong
+    pub fn topic(self, topic: impl Into<String>) -> Result<Self, TextFieldsError> {
+        self._topic(topic.into())
+    }
+
+    fn _topic(mut self, topic: String) -> Result<Self, TextFieldsError> {
+        if topic.len() > Self::MAX_TOPIC_LENGTH {
+            return Err(TextFieldsError::TopicTooLong { topic });
+        }
+
+        self.0.topic.replace(topic);
+
+        Ok(self)
+    }
+}
+
+/// Error building voice fields.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum VoiceFieldsError {
+    /// The name is too short.
+    NameTooShort {
+        /// The invalid name.
+        name: String,
+    },
+    /// THe name is too long.
+    NameTooLong {
+        /// The invalid name.
+        name: String,
+    },
+}
+
+impl Display for VoiceFieldsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NameTooShort { name } => {
+                f.write_fmt(format_args!("the name is too short: {}", name.len()))
+            }
+            Self::NameTooLong { name } => {
+                f.write_fmt(format_args!("the name is too long: {}", name.len()))
+            }
+        }
+    }
+}
+
+impl Error for VoiceFieldsError {}
+
+/// A builder for voice fields.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[must_use = "must be built into a voice channel"]
+pub struct VoiceFieldsBuilder(VoiceFields);
+
+impl VoiceFieldsBuilder {
+    /// The minimum number of UTF-16 code points that can be in a channel name.
+    ///
+    /// This is used by [`new`].
+    ///
+    /// [`new`]: #method.new
+    pub const MIN_NAME_LENGTH: usize = 2;
+
+    /// The maximum number of UTF-16 code points that can be in a channel name.
+    ///
+    /// This is used by [`new`].
+    ///
+    /// [`new`]: #method.new
+    pub const MAX_NAME_LENGTH: usize = 100;
+
+    /// Create a new voice fields builder.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VoiceFieldsError::NameTooShort`] if the name is too short.
+    ///
+    /// Returns [`VoiceFieldsError::NameTooLong`] if the name is too long.
+    ///
+    /// [`VoiceFieldsError::NameTooShort`]: enum.VoiceFieldsError.html#variant.NameTooShort
+    /// [`VoiceFieldsError::NameTooLong`]: enum.VoiceFieldsError.html#variant.NameTooLong
+    pub fn new(name: impl Into<String>) -> Result<Self, VoiceFieldsError> {
+        Self::_new(name.into())
+    }
+
+    fn _new(name: String) -> Result<Self, VoiceFieldsError> {
+        if name.len() < Self::MIN_NAME_LENGTH {
+            return Err(VoiceFieldsError::NameTooShort { name });
+        }
+
+        if name.len() > Self::MAX_NAME_LENGTH {
+            return Err(VoiceFieldsError::NameTooLong { name });
+        }
+
+        Ok(VoiceFieldsBuilder(VoiceFields {
+            bitrate: None,
+            id: ChannelId(1),
+            kind: ChannelType::GuildVoice,
+            name,
+            permission_overwrites: None,
+            parent_id: None,
+            user_limit: None,
+        }))
+    }
+
+    /// Build the voice fields.
+    pub fn build(self) -> VoiceFields {
+        self.0
+    }
+
+    /// Set the voice channel's bitrate.
+    pub fn bitrate(mut self, bitrate: u64) -> Self {
+        self.0.bitrate.replace(bitrate);
+
+        self
+    }
+
+    /// Set the channel's permission overwrites.
+    pub fn permission_overwrites(mut self, overwrites: Vec<PermissionOverwrite>) -> Self {
+        self.0.permission_overwrites.replace(overwrites);
+
+        self
+    }
+
+    /// Set the voice channel's user limit.
+    pub fn user_limit(mut self, limit: u64) -> Self {
+        self.0.user_limit.replace(limit);
+
+        self
+    }
+}
+
+/// Error creating category fields.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum CategoryFieldsError {
+    /// The name is too short.
+    NameTooShort {
+        /// The invalid name.
+        name: String,
+    },
+    /// THe name is too long.
+    NameTooLong {
+        /// The invalid name.
+        name: String,
+    },
+}
+
+impl Display for CategoryFieldsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::NameTooShort { name } => {
+                f.write_fmt(format_args!("the name is too short: {}", name.len()))
+            }
+            Self::NameTooLong { name } => {
+                f.write_fmt(format_args!("the name is too long: {}", name.len()))
+            }
+        }
+    }
+}
+
+impl Error for CategoryFieldsError {}
+
+/// A builder for a category channel, and its children.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[must_use = "must be built into a category channel"]
+pub struct CategoryFieldsBuilder {
+    fields: CategoryFields,
+    channels: Vec<GuildChannelFields>,
+}
+
+impl CategoryFieldsBuilder {
+    /// The minimum number of UTF-16 code points that can be in a channel name.
+    ///
+    /// This is used by [`new`].
+    ///
+    /// [`new`]: #method.new
+    pub const MIN_NAME_LENGTH: usize = 2;
+
+    /// The maximum number of UTF-16 code points that can be in a channel name.
+    ///
+    /// This is used by [`new`].
+    ///
+    /// [`new`]: #method.new
+    pub const MAX_NAME_LENGTH: usize = 100;
+
+    /// Create a new category fields builder.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CategoryFieldsError::NameTooShort`] if the name is too short.
+    ///
+    /// Returns [`CategoryFieldsError::NameTooLong`] if the name is too long.
+    ///
+    /// [`CategoryFieldsError::NameTooShort`]: enum.CategoryFieldsError.html#variant.NameTooShort
+    /// [`CategoryFieldsError::NameTooLong`]: enum.CategoryFieldsError.html#variant.NameTooLong
+    pub fn new(name: impl Into<String>) -> Result<Self, CategoryFieldsError> {
+        Self::_new(name.into())
+    }
+
+    fn _new(name: String) -> Result<Self, CategoryFieldsError> {
+        if name.len() < Self::MIN_NAME_LENGTH {
+            return Err(CategoryFieldsError::NameTooShort { name });
+        }
+
+        if name.len() > Self::MAX_NAME_LENGTH {
+            return Err(CategoryFieldsError::NameTooLong { name });
+        }
+
+        Ok(Self {
+            fields: CategoryFields {
+                id: ChannelId(1),
+                name,
+                kind: ChannelType::GuildCategory,
+                permission_overwrites: None,
+            },
+            channels: Vec::new(),
+        })
+    }
+
+    /// Build the category into a list of itself and its children, with an id.
+    pub fn build(self, id: ChannelId) -> Vec<GuildChannelFields> {
+        let mut channels = self
+            .channels
+            .iter()
+            .map(|c| match c.to_owned() {
+                GuildChannelFields::Text(t) => GuildChannelFields::Text(TextFields {
+                    parent_id: Some(id),
+                    ..t
+                }),
+                GuildChannelFields::Voice(v) => GuildChannelFields::Voice(VoiceFields {
+                    parent_id: Some(id),
+                    ..v
+                }),
+                GuildChannelFields::Category(_) => unreachable!(),
+            })
+            .collect::<Vec<GuildChannelFields>>();
+
+        channels.insert(0, GuildChannelFields::Category(self._build(id)));
+
+        channels
+    }
+
+    fn _build(self, id: ChannelId) -> CategoryFields {
+        CategoryFields { id, ..self.fields }
+    }
+
+    /// Add a child text channel.
+    pub fn add_text(mut self, channel: impl Into<TextFields>) -> Self {
+        self.channels.push(GuildChannelFields::Text(channel.into()));
+
+        self
+    }
+
+    /// add a child voice channel.
+    pub fn add_voice(mut self, channel: impl Into<VoiceFields>) -> Self {
+        self.channels
+            .push(GuildChannelFields::Voice(channel.into()));
+
+        self
+    }
+}
+
+/// A builder for a list of channels.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[must_use = "must be built into a list of channnels"]
+pub struct GuildChannelFieldsBuilder(Vec<GuildChannelFields>);
+
+impl GuildChannelFieldsBuilder {
+    /// Create a new channels builder.
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Build the list of channels.
+    pub fn build(self) -> Vec<GuildChannelFields> {
+        self.0
+    }
+
+    /// Add a text channel to the builder.
+    pub fn add_text(mut self, channel: impl Into<TextFields>) -> Self {
+        self.0.push(GuildChannelFields::Text(channel.into()));
+
+        self
+    }
+
+    /// Add a voice channel to the builder.
+    pub fn add_voice(mut self, channel: impl Into<VoiceFields>) -> Self {
+        self.0.push(GuildChannelFields::Voice(channel.into()));
+
+        self
+    }
+
+    /// Add a category channel, and all its children to the builder.
+    pub fn add_category(mut self, channel: CategoryFieldsBuilder) -> Self {
+        let last_id = self
+            .0
+            .iter()
+            .rev()
+            .find(|c| matches!(c, GuildChannelFields::Category(_)))
+            .map(|c| c.to_owned().id())
+            .unwrap_or(ChannelId(1));
+
+        let mut channels = channel.build(ChannelId(last_id.0 + 1));
+
+        self.0.append(&mut channels);
+
+        self
+    }
+}


### PR DESCRIPTION
This PR is the second attempt at fixing #380, the first being #393.

It adds field structs for roles, category channels, text channels, and voice channels, which are serialized into JSON expected by [Discord](https://discord.com/developers/docs/resources/guild#create-guild). 

It also adds builders, which assist in creating these fields. The channel and category builders work together to ensure all children channels end up under their respective categories.

Something to discuss: How should we expose the builders and builder errors to the public API? It currently looks like this: 
![](https://kylie.is-pretty.cool/2Lcm7RS.png)

Tests still need to be added.

Fixes #380.