### PR TITLE
workflow/lint: run clippy on tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace
+          args: --workspace --tests
 
   rustfmt:
     name: Format


### PR DESCRIPTION
Run clippy on tests in crates by using Clippy's `--tests` flag.

Closes #410.