### PR TITLE
Resume connection when SocketForwarder ends event stream

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -200,7 +200,7 @@ impl Display for ReceivingEventError {
             Self::ParsingPayload { source } => Display::fmt(source, f),
             Self::PayloadNotUtf8 { .. } => {
                 f.write_str("the payload from Discord wasn't UTF-8 valid")
-            },
+            }
             Self::EventStreamEnded => f.write_str("event stream from gateway ended"),
         }
     }
@@ -337,9 +337,7 @@ impl ShardProcessor {
                     return;
                 }
                 Err(ReceivingEventError::EventStreamEnded) => {
-                    tracing::warn!(
-                        "event stream ended, reconnecting"
-                    );
+                    tracing::warn!("event stream ended, reconnecting");
 
                     self.resume().await;
                     continue;

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -337,7 +337,7 @@ impl ShardProcessor {
                     return;
                 }
                 Err(ReceivingEventError::EventStreamEnded) => {
-                    tracing::warn!("event stream ended, reconnecting");
+                    tracing::debug!("event stream ended, reconnecting");
 
                     self.resume().await;
                     continue;
@@ -648,11 +648,11 @@ impl ShardProcessor {
         loop {
             // Returns None when the socket forwarder has ended, meaning the
             // connection was dropped.
-            let msg = if let Some(msg) = self.rx.next().await {
-                msg
-            } else {
-                break Err(ReceivingEventError::EventStreamEnded);
-            };
+            let msg = self
+                .rx
+                .next()
+                .await
+                .ok_or(ReceivingEventError::EventStreamEnded)?;
 
             match msg {
                 Message::Binary(bin) => {

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -336,6 +336,15 @@ impl ShardProcessor {
                     self.listeners.remove_all();
                     return;
                 }
+                Err(ReceivingEventError::SocketForwarder) => {
+                    tracing::warn!(
+                        "socket forwarder is closed, reconnect"
+                    );
+
+                    // Inflater gets reset in the reconnect call.
+                    self.reconnect(true).await;
+                    continue;
+                }
                 Err(err) => {
                     tracing::warn!("error receiving gateway event: {:?}", err.source());
                     continue;

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -338,10 +338,9 @@ impl ShardProcessor {
                 }
                 Err(ReceivingEventError::SocketForwarder) => {
                     tracing::warn!(
-                        "socket forwarder is closed, reconnect"
+                        "socket forwarder is closed, reconnecting"
                     );
 
-                    // Inflater gets reset in the reconnect call.
                     self.reconnect(true).await;
                     continue;
                 }

--- a/gateway/src/shard/processor/socket_forwarder.rs
+++ b/gateway/src/shard/processor/socket_forwarder.rs
@@ -60,17 +60,17 @@ impl SocketForwarder {
                 }
                 Either::Right((Ok(Some(Err(err))), _)) => {
                     tracing::warn!("socket errored, closing tx: {}", err);
-                    //self.tx.close_channel();
+                    self.tx.close_channel();
                     break;
                 }
                 Either::Right((Ok(None), _)) => {
                     tracing::debug!("socket ended, closing tx");
-                    //self.tx.close_channel();
+                    self.tx.close_channel();
                     break;
                 }
                 Either::Right((Err(why), _)) => {
                     tracing::warn!("socket errored, closing tx: {}", why);
-                    //self.tx.close_channel();
+                    self.tx.close_channel();
                     break;
                 }
             }

--- a/gateway/src/shard/processor/socket_forwarder.rs
+++ b/gateway/src/shard/processor/socket_forwarder.rs
@@ -60,17 +60,17 @@ impl SocketForwarder {
                 }
                 Either::Right((Ok(Some(Err(err))), _)) => {
                     tracing::warn!("socket errored, closing tx: {}", err);
-                    self.tx.close_channel();
+                    //self.tx.close_channel();
                     break;
                 }
                 Either::Right((Ok(None), _)) => {
                     tracing::debug!("socket ended, closing tx");
-                    self.tx.close_channel();
+                    //self.tx.close_channel();
                     break;
                 }
                 Either::Right((Err(why), _)) => {
                     tracing::warn!("socket errored, closing tx: {}", why);
-                    self.tx.close_channel();
+                    //self.tx.close_channel();
                     break;
                 }
             }


### PR DESCRIPTION
I some cases the gateway would panic because it would attempt 
to get a event twice after there no longer was any sender. 
This causes a panic in `futures_channel`.