### PR TITLE
gateway/inflater: refactor internals

### DIFF
--- a/gateway/src/shard/processor/inflater.rs
+++ b/gateway/src/shard/processor/inflater.rs
@@ -1,5 +1,5 @@
 use flate2::{Decompress, DecompressError, FlushDecompress};
-use std::convert::TryInto;
+use std::{convert::TryInto, mem};
 
 const ZLIB_SUFFIX: [u8; 4] = [0x00, 0x00, 0xff, 0xff];
 const INTERNAL_BUFFER_SIZE: usize = 32 * 1024;
@@ -15,113 +15,164 @@ pub struct Inflater {
 }
 
 impl Inflater {
+    /// Create a new inflater for a shard.
     pub fn new(shard: [u64; 2]) -> Self {
         Self {
-            decompress: Decompress::new(true),
+            buffer: Vec::with_capacity(INTERNAL_BUFFER_SIZE),
             compressed: Vec::new(),
-            internal_buffer: Vec::with_capacity(INTERNAL_BUFFER_SIZE),
-            buffer: Vec::with_capacity(32 * 1024),
             countdown_to_resize: u8::max_value(),
+            decompress: Decompress::new(true),
+            internal_buffer: Vec::with_capacity(INTERNAL_BUFFER_SIZE),
             shard,
         }
     }
 
+    /// Extend the internal compressed buffer with bytes.
     pub fn extend(&mut self, slice: &[u8]) {
         self.compressed.extend_from_slice(&slice);
     }
 
+    /// Decompress the next message if a complete payload was received.
+    ///
+    /// Returns `None` if an incomplete payload was received.
+    ///
+    /// # Errors
+    ///
+    /// This returns `flate2`'s `DecompressError` as its method's type signature
+    /// indicates it can return an error, however in reality in versions up to
+    /// 1.0.17 it won't.
+    #[tracing::instrument(level = "trace")]
     pub fn msg(&mut self) -> Result<Option<&mut [u8]>, DecompressError> {
         let length = self.compressed.len();
-        if length >= 4 && self.compressed[(length - 4)..] == ZLIB_SUFFIX {
-            // There is a payload to be decompressed.
-            let before = self.decompress.total_in();
-            let mut offset = 0;
-            loop {
-                self.internal_buffer.clear();
 
-                self.decompress.decompress_vec(
-                    &self.compressed[offset..],
-                    &mut self.internal_buffer,
-                    FlushDecompress::Sync,
-                )?;
-
-                offset = (self.decompress.total_in() - before)
-                    .try_into()
-                    .unwrap_or(0);
-                self.buffer.extend_from_slice(&self.internal_buffer[..]);
-                if self.internal_buffer.len() < self.internal_buffer.capacity()
-                    || offset > self.compressed.len()
-                {
-                    break;
-                }
-            }
-
-            tracing::trace!("in: {}, out: {}", self.compressed.len(), self.buffer.len());
-            self.compressed.clear();
-
-            #[allow(clippy::cast_precision_loss)]
-            {
-                // To get around the u64 → f64 precision loss lint
-                // it does really not matter that it happens here
-                tracing::trace!(
-                    "data saved: {}KiB ({:.2}%)",
-                    ((self.decompress.total_out() - self.decompress.total_in()) / 1024),
-                    ((self.decompress.total_in() as f64) / (self.decompress.total_out() as f64)
-                        * 100.0)
-                );
-            }
-            #[cfg(feature = "metrics")]
-            {
-                metrics::gauge!(
-                    format!("Inflater-Capacity-{}", self.shard[0]),
-                    self.buffer.capacity().try_into().unwrap_or(-1)
-                );
-                metrics::gauge!(
-                    format!("InflaterIn-{}", self.shard[0]),
-                    self.decompress.total_in().try_into().unwrap_or(-1)
-                );
-                metrics::gauge!(
-                    format!("InflaterOut-{}", self.shard[0]),
-                    self.decompress.total_out().try_into().unwrap_or(-1)
-                );
-            }
-            tracing::trace!("capacity: {}", self.buffer.capacity());
-            Ok(Some(&mut self.buffer))
-        } else {
-            // Received a partial payload.
-            Ok(None)
+        // Check if a partial payload was received. If it was, we can just
+        // return that no decompressed message is available.
+        if length < 4 || self.compressed[(length - 4)..] != ZLIB_SUFFIX {
+            return Ok(None);
         }
+
+        let before = self.decompress.total_in();
+        let mut offset = 0;
+
+        loop {
+            self.internal_buffer.clear();
+
+            self.decompress.decompress_vec(
+                &self.compressed[offset..],
+                &mut self.internal_buffer,
+                FlushDecompress::Sync,
+            )?;
+
+            offset = (self.decompress.total_in() - before)
+                .try_into()
+                .unwrap_or_default();
+            self.buffer.extend_from_slice(&self.internal_buffer[..]);
+
+            let not_at_capacity = self.internal_buffer.len() < self.internal_buffer.capacity();
+
+            if not_at_capacity || offset > self.compressed.len() {
+                break;
+            }
+        }
+
+        tracing::trace!(
+            bytes_in = self.compressed.len(),
+            bytes_out = self.buffer.len(),
+            shard_id = self.shard[0],
+            shard_total = self.shard[1],
+            "payload lengths",
+        );
+        self.compressed.clear();
+
+        // It doesn't matter if we lose precision for logging.
+        #[allow(clippy::cast_precision_loss)]
+        let saved_percentage =
+            self.decompress.total_in() as f64 / self.decompress.total_out() as f64;
+        let saved_percentage_readable = saved_percentage * 100.0;
+
+        let saved_kib = (self.decompress.total_out() - self.decompress.total_in()) / 1_024;
+
+        #[allow(clippy::cast_precision_loss)]
+        tracing::trace!(
+            saved_kib = saved_kib,
+            saved_percentage = %saved_percentage_readable,
+            shard_id = self.shard[0],
+            shard_total = self.shard[1],
+            total_in = self.decompress.total_in(),
+            total_out = self.decompress.total_out(),
+            "data saved",
+        );
+
+        #[cfg(feature = "metrics")]
+        self.inflater_metrics();
+
+        tracing::trace!("capacity: {}", self.buffer.capacity());
+        Ok(Some(&mut self.buffer))
     }
 
-    // Clear the buffer, and shrink it if it has more space
-    // enough to grow the length more than 4 times.
+    /// Clear the buffer and shrink it if the capacity is too large.
+    ///
+    /// If the capacity is 4 times larger than the buffer length then the
+    /// capacity will be shrunk to the length.
+    #[tracing::instrument(level = "trace")]
     pub fn clear(&mut self) {
         self.countdown_to_resize -= 1;
 
-        // Only shrink capacity if it is less than 4
-        // times the size, this is to prevent too
-        // frequent shrinking.
-        let cap = self.buffer.capacity();
-        if self.countdown_to_resize == 0 && self.buffer.len() < cap * 4 {
-            // When shrink_to goes stable use that on the following line.
-            // https://github.com/rust-lang/rust/issues/56431
-            self.compressed.shrink_to_fit();
-            self.buffer.shrink_to_fit();
-            tracing::trace!("compressed: {}", self.compressed.capacity());
-            tracing::trace!("buffer: {}", self.buffer.capacity());
-            self.countdown_to_resize = u8::max_value();
-        }
+        self.shrink_if_too_large();
+
         self.compressed.clear();
         self.internal_buffer.clear();
         self.buffer.clear();
     }
 
-    // Reset the inflater
+    /// Reset the state of the inflater back to its default state.
     pub fn reset(&mut self) {
-        self.decompress.reset(true);
-        self.compressed.clear();
-        self.internal_buffer.clear();
-        self.buffer.clear();
-        self.countdown_to_resize = u8::max_value();
+        let _ = mem::replace(self, Self::new(self.shard));
+    }
+
+    /// Log metrics about the inflater.
+    #[cfg(feature = "metrics")]
+    fn inflater_metrics(&self) {
+        metrics::gauge!(
+            format!("Inflater-Capacity-{}", self.shard[0]),
+            self.buffer.capacity().try_into().unwrap_or(-1)
+        );
+        metrics::gauge!(
+            format!("Inflater-In-{}", self.shard[0]),
+            self.decompress.total_in().try_into().unwrap_or(-1)
+        );
+        metrics::gauge!(
+            format!("Inflater-Out-{}", self.shard[0]),
+            self.decompress.total_out().try_into().unwrap_or(-1)
+        );
+    }
+
+    /// Shrink the capacity of the compressed buffer and payload buffer if the
+    /// payload buffer length is less than 25% of its capacity.
+    fn shrink_if_too_large(&mut self) {
+        // Only shrink capacity if it is less than 4 times the size. Doing it
+        // all the time will cause performance issues. So, if it's greater,
+        // don't do anything.
+        if self.countdown_to_resize != u8::MIN || self.buffer.len() < self.buffer.capacity() / 4 {
+            return;
+        }
+
+        self.compressed.shrink_to_fit();
+        self.buffer.shrink_to_fit();
+
+        tracing::trace!(
+            capacity = self.compressed.capacity(),
+            shard_id = self.shard[0],
+            shard_total = self.shard[1],
+            "compressed capacity",
+        );
+        tracing::trace!(
+            capacity = self.buffer.capacity(),
+            shard_id = self.shard[0],
+            shard_total = self.shard[1],
+            "buffer capacity",
+        );
+
+        self.countdown_to_resize = u8::MAX;
     }
 }


### PR DESCRIPTION
Refactor the internals of the inflater to be clearer and to split a few more pieces of functionality into their own functions. Make the tracing logs clearer and utilise the functionality of tracing to a greater extent.

One small logic change has been applied: the logic to check if the buffer length is at least 1/4 the size of the capacity was incorrect. The math was basically `len > capacity * 4`. This can clearly never be the case, so the buffers were never being shrunk. This has instead been changed to `len > capacity / 4`.