### PR TITLE
Make almost all InMemoryCache methods non-async and not return results

### DIFF
--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 async-trait = { default-features = false, version = "0.1" }
 bitflags = { default-features = false, version = "1" }
 dashmap = { default-features = false, version = "3" }
-futures-util = { default-features = false, features = ["std"], version = "0.3" }
 twilight-cache-trait = { default-features = false, path = "../trait" }
 twilight-model = { default-features = false, path = "../../model" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }


### PR DESCRIPTION
In the InMemoryCache, make all of the async functions non-async except for the CacheUpdate implementations due to trait requirements. Since we layer over DashMap, we don't need these to be async.

The only other logic change is the current user: instead of using a futures-util Mutex to store the current user, just use a Mutex from the stdlib. So long as the lock isn't held across await points and no panic points are accessible during the guards' lifetime the lock won't poison.

Additionally, make all of the `InMemoryCache` methods not return results. The methods can never return an error, so there's no point to doing this.