### PR TITLE
workflows/doc: fix lint to broken_intra_doc_links

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build docs
         env:
-          RUSTDOCFLAGS: -D intra_doc_link_resolution_failure
+          RUSTDOCFLAGS: -D broken_intra_doc_links
         run: cargo doc --no-deps
 
   sync-readme:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build docs
         env:
-          RUSTDOCFLAGS: -D intra_doc_link_resolution_failure
+          RUSTDOCFLAGS: -D broken_intra_doc_links
         run: |
           exclude_examples=($(grep -h '^name' **/examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
           cargo doc --workspace --no-deps "${exclude_examples[@]}"


### PR DESCRIPTION
The CI is throwing a warning that the `intra_doc_link_resolution_failure` lint has been renamed to `broken_intra_doc_links`.

Warnings:

```
warning: lint `intra_doc_link_resolution_failure` has been renamed to `broken_intra_doc_links`
  |
  = note: requested on the command line with `-D intra_doc_link_resolution_failure`

warning: 1 warning emitted

 Documenting twilight-cache-inmemory v0.1.0 (/home/runner/work/twilight/twilight/cache/in-memory)
 Documenting twilight-mention v0.1.0 (/home/runner/work/twilight/twilight/utils/mention)
warning: lint `intra_doc_link_resolution_failure` has been renamed to `broken_intra_doc_links`
  |
  = note: requested on the command line with `-D intra_doc_link_resolution_failure`

warning: lint `intra_doc_link_resolution_failure` has been renamed to `broken_intra_doc_links`
  |
  = note: requested on the command line with `-D intra_doc_link_resolution_failure`

warning: 1 warning emitted
```