### PR TITLE
model/oauth: make team membership state a repr

### DIFF
--- a/model/src/oauth/team/membership_state.rs
+++ b/model/src/oauth/team/membership_state.rs
@@ -1,8 +1,22 @@
-use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
+)]
 #[repr(u8)]
 pub enum TeamMembershipState {
     Invited = 1,
     Accepted = 2,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TeamMembershipState;
+    use serde_test::Token;
+
+    #[test]
+    fn test_variants() {
+        serde_test::assert_tokens(&TeamMembershipState::Invited, &[Token::U8(1)]);
+        serde_test::assert_tokens(&TeamMembershipState::Accepted, &[Token::U8(2)]);
+    }
 }


### PR DESCRIPTION
Make the `oauth::team::MembershipState` enum (de)serialize as a repr enum via `serde_repr` instead of via `serde`'s `Deserialize` and `Serialize`s.

A test is included.