### PR TITLE
model: remove old permission fields

### DIFF
--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -12,7 +12,7 @@ mod integration_expire_behavior;
 mod mfa_level;
 mod partial_guild;
 mod partial_member;
-pub(crate) mod permissions;
+mod permissions;
 mod premium_tier;
 mod preview;
 mod prune;

--- a/model/src/guild/permissions.rs
+++ b/model/src/guild/permissions.rs
@@ -1,12 +1,9 @@
 use bitflags::bitflags;
 use serde::{
     de::{Deserialize, Deserializer, Error as DeError, Visitor},
-    ser::{Error as SerError, Serialize, Serializer},
+    ser::{Serialize, Serializer},
 };
-use std::{
-    convert::TryInto,
-    fmt::{Formatter, Result as FmtResult},
-};
+use std::fmt::{Formatter, Result as FmtResult};
 
 bitflags! {
     pub struct Permissions: u128 {
@@ -42,18 +39,6 @@ bitflags! {
         const MANAGE_WEBHOOKS = 0x2000_0000;
         const MANAGE_EMOJIS = 0x4000_0000;
     }
-}
-
-pub(crate) fn serialize_u64<S: Serializer>(
-    permissions: &Permissions,
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    let bits = permissions
-        .bits()
-        .try_into()
-        .map_err(|_| SerError::custom("permission bits can't be a u64"))?;
-
-    serializer.serialize_u64(bits)
 }
 
 struct PermissionsVisitor;

--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -1,7 +1,4 @@
-use crate::{
-    guild::permissions::{self, Permissions},
-    id::RoleId,
-};
+use crate::{guild::Permissions, id::RoleId};
 use serde::{
     de::{DeserializeSeed, Deserializer, SeqAccess, Visitor},
     Deserialize, Serialize,
@@ -20,8 +17,6 @@ pub struct Role {
     pub managed: bool,
     pub mentionable: bool,
     pub name: String,
-    #[serde(rename = "permissions", serialize_with = "permissions::serialize_u64")]
-    pub permissions_old: Permissions,
     #[serde(rename = "permissions_new")]
     pub permissions: Permissions,
     pub position: i64,
@@ -85,7 +80,6 @@ mod tests {
             managed: false,
             mentionable: true,
             name: "test".to_owned(),
-            permissions_old: Permissions::ADMINISTRATOR,
             permissions: Permissions::ADMINISTRATOR,
             position: 12,
         };
@@ -95,7 +89,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Role",
-                    len: 9,
+                    len: 8,
                 },
                 Token::Str("color"),
                 Token::U32(0),
@@ -110,8 +104,6 @@ mod tests {
                 Token::Bool(true),
                 Token::Str("name"),
                 Token::Str("test"),
-                Token::Str("permissions"),
-                Token::U64(8),
                 Token::Str("permissions_new"),
                 Token::Str("8"),
                 Token::Str("position"),


### PR DESCRIPTION
Remove the old permission fields from `PermissionOverwrite`s and `Role`s. It's not really necessary to support both, and just makes constructing instances of these structs a bit difficult and weird.

Related to #385.