### PR TITLE
Add dynamic prefixes to the command parser

### DIFF
--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    collections::HashSet,
+    collections::{HashMap, HashSet},
 };
 
 use crate::CaseSensitivity;
@@ -11,7 +11,7 @@ use crate::CaseSensitivity;
 #[derive(Clone, Debug, Default)]
 pub struct CommandParserConfig<'a> {
     commands: HashSet<CaseSensitivity>,
-    prefixes: HashSet<Cow<'a, str>>,
+    prefixes: HashMap<Cow<'a, str>, Cow<'a, str>>,
 }
 
 impl<'a> CommandParserConfig<'a> {
@@ -43,12 +43,12 @@ impl<'a> CommandParserConfig<'a> {
     ///
     /// [`add_prefix`]: #method.add_prefix
     /// [`remove_prefix`]: #method.remove_prefix
-    pub fn prefixes(&self) -> &HashSet<Cow<'_, str>> {
+    pub fn prefixes(&self) -> &HashMap<Cow<'_, str>, Cow<'_, str>> {
         &self.prefixes
     }
 
     /// Returns a mutable reference to the prefixes.
-    pub fn prefixes_mut(&mut self) -> &mut HashSet<Cow<'a, str>> {
+    pub fn prefixes_mut(&mut self) -> &mut HashMap<Cow<'a, str>, Cow<'a, str>> {
         &mut self.prefixes
     }
 
@@ -114,7 +114,7 @@ impl<'a> CommandParserConfig<'a> {
     /// assert_eq!(1, config.prefixes().len());
     /// ```
     pub fn add_prefix(&mut self, prefix: impl Into<Cow<'a, str>>) {
-        self.prefixes.insert(prefix.into());
+        self.prefixes.insert(prefix.into(), Cow::Borrowed(""));
     }
 
     /// Removes a prefix from the list of prefixes.
@@ -130,10 +130,10 @@ impl<'a> CommandParserConfig<'a> {
     /// assert_eq!(2, config.prefixes().len());
     ///
     /// // Now remove one and verify that there is only 1 prefix.
-    /// assert!(config.remove_prefix("!"));
+    /// config.remove_prefix("!");
     /// assert_eq!(1, config.prefixes().len());
     /// ```
-    pub fn remove_prefix(&mut self, prefix: impl Into<Cow<'a, str>>) -> bool {
+    pub fn remove_prefix(&mut self, prefix: impl Into<Cow<'a, str>>) -> Option<Cow<'a, str>> {
         self.prefixes.remove(&prefix.into())
     }
 }

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    collections::{HashMap, HashSet},
+    collections::HashSet,
 };
 
 use crate::CaseSensitivity;
@@ -11,7 +11,7 @@ use crate::CaseSensitivity;
 #[derive(Clone, Debug, Default)]
 pub struct CommandParserConfig<'a> {
     commands: HashSet<CaseSensitivity>,
-    prefixes: HashMap<Cow<'a, str>, Cow<'a, str>>,
+    prefixes: HashSet<Cow<'a, str>>,
 }
 
 impl<'a> CommandParserConfig<'a> {
@@ -43,12 +43,12 @@ impl<'a> CommandParserConfig<'a> {
     ///
     /// [`add_prefix`]: #method.add_prefix
     /// [`remove_prefix`]: #method.remove_prefix
-    pub fn prefixes(&self) -> &HashMap<Cow<'_, str>, Cow<'_, str>> {
+    pub fn prefixes(&self) -> &HashSet<Cow<'_, str>> {
         &self.prefixes
     }
 
     /// Returns a mutable reference to the prefixes.
-    pub fn prefixes_mut(&mut self) -> &mut HashMap<Cow<'a, str>, Cow<'a, str>> {
+    pub fn prefixes_mut(&mut self) -> &mut HashSet<Cow<'a, str>> {
         &mut self.prefixes
     }
 
@@ -114,7 +114,7 @@ impl<'a> CommandParserConfig<'a> {
     /// assert_eq!(1, config.prefixes().len());
     /// ```
     pub fn add_prefix(&mut self, prefix: impl Into<Cow<'a, str>>) {
-        self.prefixes.insert(prefix.into(), Cow::Borrowed(""));
+        self.prefixes.insert(prefix.into());
     }
 
     /// Removes a prefix from the list of prefixes.
@@ -130,10 +130,10 @@ impl<'a> CommandParserConfig<'a> {
     /// assert_eq!(2, config.prefixes().len());
     ///
     /// // Now remove one and verify that there is only 1 prefix.
-    /// config.remove_prefix("!");
+    /// assert!(config.remove_prefix("!"));
     /// assert_eq!(1, config.prefixes().len());
     /// ```
-    pub fn remove_prefix(&mut self, prefix: impl Into<Cow<'a, str>>) -> Option<Cow<'a, str>> {
+    pub fn remove_prefix(&mut self, prefix: impl Into<Cow<'a, str>>) -> bool {
         self.prefixes.remove(&prefix.into())
     }
 }

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -120,13 +120,11 @@ impl<'a> Parser<'a> {
     /// ```
     ///
     /// [`Command`]: struct.Command.html
-    pub fn parse_with_prefix(
-        &'a self,
-        prefix: &'a str,
-        buf: &'a str,
-    ) -> Option<Command<'a>> {
-        if !buf.starts_with(prefix) { return None }
-        
+    pub fn parse_with_prefix(&'a self, prefix: &'a str, buf: &'a str) -> Option<Command<'a>> {
+        if !buf.starts_with(prefix) {
+            return None;
+        }
+
         let mut idx = prefix.len();
         let command_buf = buf.get(idx..)?;
         let command = self.find_command(command_buf)?;
@@ -150,7 +148,6 @@ impl<'a> Parser<'a> {
             }
         })
     }
-
 
     fn find_prefix(&self, buf: &str) -> Option<(&str, &str)> {
         self.config.prefixes().iter().find_map(|(prefix, padding)| {
@@ -282,11 +279,9 @@ mod tests {
     #[test]
     fn test_dynamic_prefix() {
         let parser = simple_config();
-        
-        let command = parser.parse_with_prefix("=", "=echo foo");
-        
-        assert!(command.is_some());
-        let command = command.unwrap();
+
+        let command = parser.parse_with_prefix("=", "=echo foo").unwrap();
+
         assert_eq!("=", command.prefix);
         assert_eq!("echo", command.name);
     }

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -90,19 +90,8 @@ impl<'a> Parser<'a> {
     ///
     /// [`Command`]: struct.Command.html
     pub fn parse(&'a self, buf: &'a str) -> Option<Command<'a>> {
-        let prefix = self.find_prefix(buf)?;
-        let mut idx = prefix.len();
-
-        let command_buf = buf.get(idx..)?;
-        let command = self.find_command(command_buf)?;
-
-        idx += command.len();
-
-        Some(Command {
-            arguments: Arguments::new(buf.get(idx..)?),
-            name: command,
-            prefix,
-        })
+        let (prefix, _) = self.find_prefix(buf)?;
+        self.parse_with_prefix(prefix, buf)
     }
 
     /// Parse a command out of a buffer with a specific prefix.
@@ -162,10 +151,11 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn find_prefix(&self, buf: &str) -> Option<&str> {
-        self.config.prefixes().iter().find_map(|prefix| {
+
+    fn find_prefix(&self, buf: &str) -> Option<(&str, &str)> {
+        self.config.prefixes().iter().find_map(|(prefix, padding)| {
             if buf.starts_with(prefix.as_ref()) {
-                Some(prefix.as_ref())
+                Some((prefix.as_ref(), padding.as_ref()))
             } else {
                 None
             }

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -128,7 +128,7 @@ impl<'a> Parser<'a> {
     ///
     /// let parser = Parser::new(config);
     ///
-    /// let prefix_fn = |buf: &str| if buf.starts_with("=") { Some(1) } else { None };
+    /// let prefix_fn = |buf: &str| if buf.starts_with('=') { Some(1) } else { None };
     ///
     /// let command = parser.parse_dynamic_prefix("=echo foo", prefix_fn);
     /// assert!(command.is_some());
@@ -302,7 +302,7 @@ mod tests {
     #[test]
     fn test_dynamic_prefix() {
         let parser = simple_config();
-        let prefix_fn = |buf: &str| if buf.starts_with("=") { Some(1) } else { None };
+        let prefix_fn = |buf: &str| if buf.starts_with('=') { Some(1) } else { None };
 
         let command = parser.parse_dynamic_prefix("=echo foo", prefix_fn);
         assert!(command.is_some());

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -112,11 +112,11 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parses a command out of a buffer.
+    /// Parses a command out of a buffer with a dynamic prefix.
     ///
-    /// Instead of using the list of set prefixes can you here define a
-    /// function that returns the index at which the prefix ends if it
-    /// matches, or return none if there is no prefix that matches.
+    /// Instead of using the list of set prefixes, define a function that
+    /// manually tests for a prefix. The function must return an option,
+    /// with the Some value being the first index of the name of the command.
     ///
     /// # Example
     ///
@@ -302,6 +302,7 @@ mod tests {
     #[test]
     fn test_dynamic_prefix() {
         let parser = simple_config();
+
         let prefix_fn = |buf: &str| if buf.starts_with('=') { Some(1) } else { None };
 
         let command = parser.parse_dynamic_prefix("=echo foo", prefix_fn);

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -1,5 +1,6 @@
 use crate::{Arguments, CommandParserConfig};
 
+
 /// Indicator that a command was used.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -120,7 +121,7 @@ impl<'a> Parser<'a> {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```rust,skip
     /// # use twilight_command_parser::{Command, CommandParserConfig, Parser};
     /// let mut config = CommandParserConfig::new();
     /// config.add_prefix("!");
@@ -128,7 +129,7 @@ impl<'a> Parser<'a> {
     ///
     /// let parser = Parser::new(config);
     ///
-    /// let prefix_fn = |buf: &str| if buf.starts_with('=') { Some(1) } else { None };
+    /// let prefix_fn = |buf: &str| if buf.starts_with('=') { buf.get(..1) } else { None };
     ///
     /// let command = parser.parse_dynamic_prefix("=echo foo", prefix_fn);
     /// assert!(command.is_some());
@@ -141,12 +142,11 @@ impl<'a> Parser<'a> {
     pub fn parse_dynamic_prefix(
         &'a self,
         buf: &'a str,
-        prefix_fn: impl FnOnce(&'a str) -> Option<usize>,
+        prefix_fn: impl FnOnce(&'a str) -> Option<&'a str>,
     ) -> Option<Command<'a>> {
-        if let Some(mut idx) = prefix_fn(buf) {
-            let prefix = buf.get(0..idx)?;
-
-            let command_buf = buf.get((idx as usize)..)?;
+        if let Some(prefix) = prefix_fn(buf) {
+            let mut idx = prefix.len();
+            let command_buf = buf.get(idx..)?;
             let command = self.find_command(command_buf)?;
 
             idx += command.len();
@@ -303,7 +303,7 @@ mod tests {
     fn test_dynamic_prefix() {
         let parser = simple_config();
 
-        let prefix_fn = |buf: &str| if buf.starts_with('=') { Some(1) } else { None };
+        let prefix_fn = |buf: &str| if buf.starts_with('=') { buf.get(..1) } else { None };
 
         let command = parser.parse_dynamic_prefix("=echo foo", prefix_fn);
         assert!(command.is_some());


### PR DESCRIPTION
Instead of using the list of set prefixes can you here define a
function that returns the index at which the prefix ends if it
matches, or return none if there is no prefix that matches.

# Example

```rust
use twilight_command_parser::{Command, CommandParserConfig, Parser};
let mut config = CommandParserConfig::new();
config.add_prefix("!");
config.add_command("echo", false);

let parser = Parser::new(config);

let prefix_fn = |buf: &str| if buf.starts_with("=") { Some(1) } else { None };

let command = parser.parse_dynamic_prefix("=echo foo", prefix_fn);
 assert!(command.is_some());
let command = command.unwrap();
assert_eq!("=", command.prefix);
assert_eq!("echo", command.name);
 ```

Related to #389 