### PR TITLE
cache,model: make presence guild id required

### DIFF
--- a/cache/in-memory/src/model/presence.rs
+++ b/cache/in-memory/src/model/presence.rs
@@ -8,7 +8,7 @@ pub struct CachedPresence {
     pub activities: Vec<Activity>,
     pub client_status: ClientStatus,
     pub game: Option<Activity>,
-    pub guild_id: Option<GuildId>,
+    pub guild_id: GuildId,
     pub status: Status,
     pub user_id: UserId,
 }

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -221,7 +221,7 @@ impl UpdateCache for GuildDelete {
 
         if let Some((_, ids)) = cache.0.guild_presences.remove(&id) {
             for user_id in ids {
-                cache.0.presences.remove(&(Some(id), user_id));
+                cache.0.presences.remove(&(id, user_id));
             }
         }
     }
@@ -478,13 +478,13 @@ impl UpdateCache for PresenceUpdate {
             activities: self.activities.clone(),
             client_status: self.client_status.clone(),
             game: self.game.clone(),
-            guild_id: Some(self.guild_id),
+            guild_id: self.guild_id,
             nick: self.nick.clone(),
             status: self.status,
             user: self.user.clone(),
         };
 
-        cache.cache_presence(Some(self.guild_id), presence);
+        cache.cache_presence(self.guild_id, presence);
     }
 }
 

--- a/model/src/gateway/payload/member_chunk.rs
+++ b/model/src/gateway/payload/member_chunk.rs
@@ -162,7 +162,7 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
         }
 
         for presence in presences.values_mut() {
-            presence.guild_id.replace(guild_id);
+            presence.guild_id = guild_id;
         }
 
         Ok(MemberChunk {
@@ -276,6 +276,7 @@ mod tests {
                     "web": "online",
                 },
                 "game": null,
+                "guild_id": "1",
                 "status": "online",
                 "user": {
                     "id": "2",
@@ -286,6 +287,7 @@ mod tests {
                     "web": "online",
                 },
                 "game": null,
+                "guild_id": "1",
                 "status": "online",
                 "user": {
                     "id": "3",
@@ -296,6 +298,7 @@ mod tests {
                     "desktop": "dnd",
                 },
                 "game": null,
+                "guild_id": "1",
                 "status": "dnd",
                 "user": {
                     "id": "5",
@@ -438,7 +441,7 @@ mod tests {
                             web: Some(Status::Online),
                         },
                         game: None,
-                        guild_id: Some(GuildId(1)),
+                        guild_id: GuildId(1),
                         nick: None,
                         status: Status::Online,
                         user: UserOrId::UserId { id: UserId(2) },
@@ -454,7 +457,7 @@ mod tests {
                             web: Some(Status::Online),
                         },
                         game: None,
-                        guild_id: Some(GuildId(1)),
+                        guild_id: GuildId(1),
                         nick: None,
                         status: Status::Online,
                         user: UserOrId::UserId { id: UserId(3) },
@@ -470,7 +473,7 @@ mod tests {
                             web: None,
                         },
                         game: None,
-                        guild_id: Some(GuildId(1)),
+                        guild_id: GuildId(1),
                         nick: None,
                         status: Status::DoNotDisturb,
                         user: UserOrId::UserId { id: UserId(5) },

--- a/model/src/gateway/presence/mod.rs
+++ b/model/src/gateway/presence/mod.rs
@@ -36,7 +36,7 @@ pub struct Presence {
     pub activities: Vec<Activity>,
     pub client_status: ClientStatus,
     pub game: Option<Activity>,
-    pub guild_id: Option<GuildId>,
+    pub guild_id: GuildId,
     pub nick: Option<String>,
     pub status: Status,
     pub user: UserOrId,
@@ -107,7 +107,7 @@ impl<'de> DeserializeSeed<'de> for PresenceMapDeserializer {
 #[cfg(test)]
 mod tests {
     use super::{Activity, ActivityEmoji, ActivityType, ClientStatus, Presence, Status, UserOrId};
-    use crate::id::UserId;
+    use crate::id::{GuildId, UserId};
     use serde_test::Token;
 
     #[test]
@@ -142,7 +142,7 @@ mod tests {
                 web: None,
             },
             game: Some(activity),
-            guild_id: None,
+            guild_id: GuildId(2),
             nick: None,
             status: Status::Online,
             user: UserOrId::UserId { id: UserId(1) },
@@ -163,6 +163,9 @@ mod tests {
                 Token::Str("id"),
                 Token::Str("1"),
                 Token::StructEnd,
+                Token::Str("guild_id"),
+                Token::NewtypeStruct { name: "GuildId" },
+                Token::Str("2"),
                 Token::Str("status"),
                 Token::Enum { name: "Status" },
                 Token::Str("online"),

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -706,7 +706,7 @@ impl<'de> Deserialize<'de> for Guild {
                 }
 
                 for presence in presences.values_mut() {
-                    presence.guild_id.replace(id);
+                    presence.guild_id = id;
                 }
 
                 for voice_state in voice_states.values_mut() {


### PR DESCRIPTION
Make `twilight_model::gateway::Presence::guild_id` a non-Optional field. Also make `twilight_model::gateway::payload::PresenceUpdate::guild_id` non-Optional to match it. Since bots can only receive presences from guilds the guild ID will always be present.

To go along with this, update the cache to no longer handle optional guild IDs. The `twilight_cache_inmemory::models::CachedPresence::guild_id` field is now non-Optional, and methods that work with presences now require a `GuildId` parameter.