### PR TITLE
command-parser,model,twilight: correct readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ![project logo][logo]
 
-`twilight` is an asynchronous, simple, and extensible set of libraries which can
-be used separately or in combination for the Discord API.
+`twilight` is a powerful asynchronous, flexible, and scalable ecosystem of
+Rust libraries for the Discord API.
 
 The ecosystem of first-class crates includes `twilight-cache-inmemory`,
 `twilight-command-parser`, `twilight-gateway`, `twilight-http`,
@@ -18,7 +18,7 @@ non-vendor-specific crates in the `twilight` ecosystem.
 
 ## Installation
 
-Most of Twilight requires at least 1.40+ (rust stable).
+Twilight requires the latest Rust version.
 
 Add this to your `Cargo.toml`'s `[dependencies]` section:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ non-vendor-specific crates in the `twilight` ecosystem.
 
 ## Installation
 
-Twilight requires the latest Rust version.
+Twilight requires the latest stable Rust version.
 
 Add this to your `Cargo.toml`'s `[dependencies]` section:
 

--- a/command-parser/README.md
+++ b/command-parser/README.md
@@ -13,8 +13,6 @@ command and prefix and provides the command arguments to you.
 
 # Installation
 
-`twilight-command-parser` requires at least Rust 1.36.0.
-
 Add the following to your Cargo.toml:
 
 ```toml

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -11,8 +11,6 @@
 //!
 //! # Installation
 //!
-//! `twilight-command-parser` requires at least Rust 1.36.0.
-//!
 //! Add the following to your Cargo.toml:
 //!
 //! ```toml

--- a/model/README.md
+++ b/model/README.md
@@ -25,8 +25,6 @@ or extended by other crates.
 
 ### Installation
 
-This crate requires Rust 1.31+.
-
 Add the following to your `Cargo.toml`:
 
 ```toml

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -23,8 +23,6 @@
 //!
 //! ### Installation
 //!
-//! This crate requires Rust 1.31+.
-//!
 //! Add the following to your `Cargo.toml`:
 //!
 //! ```toml

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -4,8 +4,8 @@
 //!
 //! ![project logo][logo]
 //!
-//! `twilight` is an asynchronous, simple, and extensible set of libraries which can
-//! be used separately or in combination for the Discord API.
+//! `twilight` is a powerful asynchronous, flexible, and scalable ecosystem of
+//! Rust libraries for the Discord API.
 //!
 //! The ecosystem of first-class crates includes `twilight-cache-inmemory`,
 //! `twilight-command-parser`, `twilight-gateway`, `twilight-http`,
@@ -16,7 +16,7 @@
 //!
 //! ## Installation
 //!
-//! Most of Twilight requires at least 1.40+ (rust stable).
+//! Twilight requires the latest Rust version.
 //!
 //! Add this to your `Cargo.toml`'s `[dependencies]` section:
 //!

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Installation
 //!
-//! Twilight requires the latest Rust version.
+//! Twilight requires the latest stable Rust version.
 //!
 //! Add this to your `Cargo.toml`'s `[dependencies]` section:
 //!


### PR DESCRIPTION
Correct the readmes in the command-parser, model, and twilight crates by specifying that the latest Rust version is required.