### PR TITLE
gateway/shard: use configured large threshold

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -372,7 +372,7 @@ impl ShardProcessor {
         let identify = Identify::new(IdentifyInfo {
             compression: false,
             intents,
-            large_threshold: 250,
+            large_threshold: self.config.large_threshold(),
             properties: self.properties.clone(),
             shard: Some(self.config.shard()),
             presence: self.config.presence().cloned(),


### PR DESCRIPTION
In the gateway's `ShardProcessor`, actually use the configured `large_threshold` value. It wasn't being used and forced a value of 250.