### PR TITLE
model: rework request guild members

### DIFF
--- a/gateway/tests/test_shard_command_ratelimit.rs
+++ b/gateway/tests/test_shard_command_ratelimit.rs
@@ -38,7 +38,7 @@ async fn test_shard_command_ratelimit() {
     assert!(matches!(events.next().await.unwrap(), Event::Ready(_)));
 
     // now that we're connected we can test sending
-    let payload = RequestGuildMembers::new_all(GuildId(644_743_296_891_224_113), None);
+    let payload = RequestGuildMembers::builder(GuildId(1)).query("", None);
     let now = Instant::now();
     shard.command(&payload).await.unwrap();
     assert!(now.elapsed() < Duration::from_millis(500));

--- a/model/src/gateway/payload/mod.rs
+++ b/model/src/gateway/payload/mod.rs
@@ -1,5 +1,6 @@
 pub mod identify;
 pub mod reaction_remove_emoji;
+pub mod request_guild_members;
 pub mod resume;
 pub mod update_status;
 
@@ -30,7 +31,6 @@ mod reaction_add;
 mod reaction_remove;
 mod reaction_remove_all;
 mod ready;
-mod request_guild_members;
 mod role_create;
 mod role_delete;
 mod role_update;

--- a/model/src/gateway/payload/request_guild_members.rs
+++ b/model/src/gateway/payload/request_guild_members.rs
@@ -1,11 +1,39 @@
 use crate::{
-    gateway::{
-        opcode::OpCode,
-        payload::request_guild_members::RequestGuildMembersInfo::{MultiUser, Query, SingleUser},
-    },
+    gateway::opcode::OpCode,
     id::{GuildId, UserId},
 };
 use serde::{Deserialize, Serialize};
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+
+/// Provided IDs is invalid for the request.
+///
+/// Returned by [`RequestGuildMembersBuilder::user_ids`].
+///
+/// [`RequestGuildMembersBuilder::user_ids`]: struct.RequestGuildMembersBuilder.html#method.user_ids
+#[derive(Clone, Debug)]
+pub enum UserIdsError {
+    /// More than 100 user IDs were provided.
+    TooMany {
+        /// Provided list of user IDs.
+        ids: Vec<UserId>,
+    },
+}
+
+impl Display for UserIdsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::TooMany { ids } => f.write_fmt(format_args!(
+                "{} user IDs were permitted when only a maximum of 100 is allowed",
+                ids.len(),
+            )),
+        }
+    }
+}
+
+impl Error for UserIdsError {}
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct RequestGuildMembers {
@@ -14,200 +42,225 @@ pub struct RequestGuildMembers {
 }
 
 impl RequestGuildMembers {
-    pub fn new_all(guild_id: impl Into<GuildId>, presences: Option<bool>) -> Self {
-        Self::new_all_with_nonce(guild_id, presences, None)
-    }
-
-    pub fn new_all_with_nonce(
-        guild_id: impl Into<GuildId>,
-        presences: Option<bool>,
-        nonce: Option<String>,
-    ) -> Self {
-        Self {
-            d: RequestGuildMembersInfo::new_all(guild_id, presences, nonce),
-            op: OpCode::RequestGuildMembers,
-        }
-    }
-
-    pub fn new(
-        guild_id: impl Into<GuildId>,
-        limit: u64,
-        query: impl Into<String>,
-        presences: Option<bool>,
-    ) -> Self {
-        Self::new_with_nonce(guild_id, limit, query, presences, None)
-    }
-
-    pub fn new_with_nonce(
-        guild_id: impl Into<GuildId>,
-        limit: u64,
-        query: impl Into<String>,
-        presences: Option<bool>,
-        nonce: Option<String>,
-    ) -> Self {
-        Self {
-            d: RequestGuildMembersInfo::new(guild_id, limit, query, presences, nonce),
-            op: OpCode::RequestGuildMembers,
-        }
-    }
-
-    pub fn new_single_user(
-        guild_id: impl Into<GuildId>,
-        user: impl Into<UserId>,
-        presence: Option<bool>,
-    ) -> Self {
-        Self::new_single_user_with_nonce(guild_id, user, presence, None)
-    }
-
-    pub fn new_single_user_with_nonce(
-        guild_id: impl Into<GuildId>,
-        user: impl Into<UserId>,
-        presence: Option<bool>,
-        nonce: Option<String>,
-    ) -> Self {
-        Self {
-            d: RequestGuildMembersInfo::new_single_user(guild_id, user, presence, nonce),
-            op: OpCode::RequestGuildMembers,
-        }
-    }
-
-    pub fn new_multi_user(
-        guild_id: impl Into<GuildId>,
-        users: Vec<UserId>,
-        presences: Option<bool>,
-    ) -> Self {
-        Self::new_multi_user_with_nonce(guild_id, users, presences, None)
-    }
-
-    pub fn new_multi_user_with_nonce(
-        guild_id: impl Into<GuildId>,
-        users: Vec<UserId>,
-        presences: Option<bool>,
-        nonce: Option<String>,
-    ) -> Self {
-        Self {
-            d: RequestGuildMembersInfo::new_multi_user(guild_id, users, presences, nonce),
-            op: OpCode::RequestGuildMembers,
-        }
+    /// Create a new builder to configure a guild members request.
+    ///
+    /// This is an alias to [`RequestGuildMembersBuilder::new`]. Refer to its
+    /// documentation for more information.
+    ///
+    /// [`RequestGuildMembersBuilder::new`]: struct.RequestGuildMembersBuilder.html#method.new
+    pub fn builder(guild_id: GuildId) -> RequestGuildMembersBuilder {
+        RequestGuildMembersBuilder::new(guild_id)
     }
 }
 
+pub struct RequestGuildMembersBuilder {
+    guild_id: GuildId,
+    nonce: Option<String>,
+    presences: Option<bool>,
+}
+
+impl RequestGuildMembersBuilder {
+    /// Create a new builder to configure and construct a
+    /// [`RequestGuildMembers`].
+    ///
+    /// [`RequestGuildMembers`]: struct.RequestGuildMembers.html
+    pub fn new(guild_id: GuildId) -> Self {
+        Self {
+            guild_id,
+            nonce: None,
+            presences: None,
+        }
+    }
+
+    /// Set the nonce to identify the member chunk response.
+    ///
+    /// By default, this uses Discord's default.
+    pub fn nonce(self, nonce: impl Into<String>) -> Self {
+        self._nonce(nonce.into())
+    }
+
+    fn _nonce(mut self, nonce: String) -> Self {
+        self.nonce.replace(nonce);
+
+        self
+    }
+
+    /// Request that guild members' presences are included in member chunks.
+    ///
+    /// By default, this uses Discord's default.
+    pub fn presences(mut self, presences: bool) -> Self {
+        self.presences.replace(presences);
+
+        self
+    }
+
+    /// Consume the builder, creating a request for users whose usernames start
+    /// with the provided string and optionally limiting the number of members
+    /// to retrieve.
+    ///
+    /// If you specify no limit, then Discord's default will be used, which will
+    /// be an unbounded number of members.
+    ///
+    /// To request the entire member list, pass in a `None` query. You must also
+    /// have the `GUILD_MEMBERS` intent enabled.
+    ///
+    /// # Examples
+    ///
+    /// Request all of the guild members that start with the letter "a" and
+    /// their presences:
+    ///
+    /// ```
+    /// use twilight_model::{gateway::payload::RequestGuildMembers, id::GuildId};
+    ///
+    /// let request = RequestGuildMembers::builder(GuildId(1))
+    ///     .presences(true)
+    ///     .query("a", None);
+    ///
+    /// assert_eq!(GuildId(1), request.d.guild_id);
+    /// assert_eq!(Some(0), request.d.limit);
+    /// assert_eq!(Some("a"), request.d.query.as_deref());
+    /// assert_eq!(Some(true), request.d.presences);
+    /// ```
+    pub fn query(self, query: impl Into<String>, limit: Option<u64>) -> RequestGuildMembers {
+        self._query(query.into(), limit)
+    }
+
+    fn _query(self, query: String, limit: Option<u64>) -> RequestGuildMembers {
+        RequestGuildMembers {
+            d: RequestGuildMembersInfo {
+                guild_id: self.guild_id,
+                limit: Some(limit.unwrap_or_default()),
+                nonce: self.nonce,
+                presences: self.presences,
+                query: Some(query),
+                user_ids: None,
+            },
+            op: OpCode::RequestGuildMembers,
+        }
+    }
+
+    /// Consume the builder, creating a request that requests the provided
+    /// member in the specified guild(s).
+    ///
+    /// # Examples
+    ///
+    /// Request a member within a guild and specify a nonce of "test":
+    ///
+    /// ```
+    /// use twilight_model::{
+    ///     gateway::payload::request_guild_members::{RequestGuildMemberId, RequestGuildMembers},
+    ///     id::{GuildId, UserId},
+    /// };
+    ///
+    /// let request = RequestGuildMembers::builder(GuildId(1))
+    ///     .nonce("test")
+    ///     .user_id(UserId(2));
+    ///
+    /// assert_eq!(Some(RequestGuildMemberId::One(UserId(2))), request.d.user_ids);
+    /// ```
+    pub fn user_id(self, user_id: UserId) -> RequestGuildMembers {
+        RequestGuildMembers {
+            d: RequestGuildMembersInfo {
+                guild_id: self.guild_id,
+                limit: None,
+                nonce: self.nonce,
+                presences: self.presences,
+                query: None,
+                user_ids: Some(RequestGuildMemberId::One(user_id)),
+            },
+            op: OpCode::RequestGuildMembers,
+        }
+    }
+
+    /// Consume the builder, creating a request that requests the provided
+    /// user(s) in the specified guild(s).
+    ///
+    /// Only up to 100 user IDs can be requested at once.
+    ///
+    /// # Examples
+    ///
+    /// Request two members within one guild and specify a nonce of "test":
+    ///
+    /// ```
+    /// use twilight_model::{
+    ///     gateway::payload::request_guild_members::{RequestGuildMemberId, RequestGuildMembers},
+    ///     id::{GuildId, UserId},
+    /// };
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let request = RequestGuildMembers::builder(GuildId(1))
+    ///     .nonce("test")
+    ///     .user_ids(vec![UserId(2), UserId(3)])?;
+    ///
+    /// assert!(matches!(request.d.user_ids, Some(RequestGuildMemberId::Multiple(ids)) if ids.len() == 2));
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UserIdsError::TooMany`] if more than 100 user IDs were
+    /// provided.
+    pub fn user_ids(
+        self,
+        user_ids: impl Into<Vec<UserId>>,
+    ) -> Result<RequestGuildMembers, UserIdsError> {
+        self._user_ids(user_ids.into())
+    }
+
+    fn _user_ids(self, user_ids: Vec<UserId>) -> Result<RequestGuildMembers, UserIdsError> {
+        if user_ids.len() > 100 {
+            return Err(UserIdsError::TooMany { ids: user_ids });
+        }
+
+        Ok(RequestGuildMembers {
+            d: RequestGuildMembersInfo {
+                guild_id: self.guild_id,
+                limit: None,
+                nonce: self.nonce,
+                presences: self.presences,
+                query: None,
+                user_ids: Some(RequestGuildMemberId::Multiple(user_ids)),
+            },
+            op: OpCode::RequestGuildMembers,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct RequestGuildMembersInfo {
+    /// Guild ID.
+    pub guild_id: GuildId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Maximum number of members to request.
+    pub limit: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presences: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_ids: Option<RequestGuildMemberId<UserId>>,
+}
+
+/// One or a list of IDs in a request.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(untagged)]
-pub enum RequestGuildMembersInfo {
-    Query {
-        guild_id: GuildId,
-        limit: u64,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        nonce: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        presences: Option<bool>,
-        query: String,
-    },
-    SingleUser {
-        guild_id: GuildId,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        nonce: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        presences: Option<bool>,
-        user_ids: UserId,
-    },
-    MultiUser {
-        guild_id: GuildId,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        nonce: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        presences: Option<bool>,
-        user_ids: Vec<UserId>,
-    },
+pub enum RequestGuildMemberId<T> {
+    /// Single ID specified.
+    One(T),
+    /// List of IDs specified.
+    Multiple(Vec<T>),
 }
 
-impl RequestGuildMembersInfo {
-    pub fn new_all(
-        guild_id: impl Into<GuildId>,
-        presences: Option<bool>,
-        nonce: Option<String>,
-    ) -> Self {
-        Self::_new_query(guild_id.into(), 0, String::from(""), presences, nonce)
-    }
-
-    pub fn new(
-        guild_id: impl Into<GuildId>,
-        limit: u64,
-        query: impl Into<String>,
-        presences: Option<bool>,
-        nonce: Option<String>,
-    ) -> Self {
-        Self::_new_query(guild_id.into(), limit, query.into(), presences, nonce)
-    }
-
-    fn _new_query(
-        guild_id: GuildId,
-        limit: u64,
-        query: String,
-        presences: Option<bool>,
-        nonce: Option<String>,
-    ) -> Self {
-        Query {
-            guild_id,
-            limit,
-            query,
-            presences,
-            nonce,
-        }
-    }
-
-    pub fn new_single_user(
-        guild_id: impl Into<GuildId>,
-        user: impl Into<UserId>,
-        presence: Option<bool>,
-        nonce: Option<String>,
-    ) -> Self {
-        Self::_new_single_user(guild_id.into(), user.into(), presence, nonce)
-    }
-
-    fn _new_single_user(
-        guild_id: GuildId,
-        user: UserId,
-        presences: Option<bool>,
-        nonce: Option<String>,
-    ) -> Self {
-        SingleUser {
-            guild_id,
-            presences,
-            user_ids: user,
-            nonce,
-        }
-    }
-
-    pub fn new_multi_user(
-        guild_id: impl Into<GuildId>,
-        users: Vec<UserId>,
-        presences: Option<bool>,
-        nonce: Option<String>,
-    ) -> Self {
-        Self::_new_multi_user(guild_id.into(), users, presences, nonce)
-    }
-
-    fn _new_multi_user(
-        guild_id: GuildId,
-        user_ids: Vec<UserId>,
-        presences: Option<bool>,
-        nonce: Option<String>,
-    ) -> Self {
-        MultiUser {
-            guild_id,
-            user_ids,
-            presences,
-            nonce,
-        }
+impl<T> From<T> for RequestGuildMemberId<T> {
+    fn from(id: T) -> Self {
+        Self::One(id)
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct RequestGuildMemberInfo {
-    pub guild_id: GuildId,
-    pub presences: bool,
-    pub query: String,
-    pub user_ids: u64,
+impl<T> From<Vec<T>> for RequestGuildMemberId<T> {
+    fn from(ids: Vec<T>) -> Self {
+        Self::Multiple(ids)
+    }
 }

--- a/model/src/gateway/payload/request_guild_members.rs
+++ b/model/src/gateway/payload/request_guild_members.rs
@@ -26,7 +26,7 @@ impl Display for UserIdsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::TooMany { ids } => f.write_fmt(format_args!(
-                "{} user IDs were permitted when only a maximum of 100 is allowed",
+                "{} user IDs were provided when only a maximum of 100 is allowed",
                 ids.len(),
             )),
         }
@@ -99,7 +99,7 @@ impl RequestGuildMembersBuilder {
     /// to retrieve.
     ///
     /// If you specify no limit, then Discord's default will be used, which will
-    /// be an unbounded number of members.
+    /// be an unbounded number of members. Specifying 0 is also equivalent.
     ///
     /// To request the entire member list, pass in a `None` query. You must also
     /// have the `GUILD_MEMBERS` intent enabled.


### PR DESCRIPTION
Rework the `twilight_model::gateway::payload::RequestGuildMembers` type by no longer using a variety of methods to construct an instance of it, and instead using a consuming builder pattern.

Previously, creating a `RequestGuildMembers` that retrieved a single user's member information and presence with a nonce looked something like:

```rust
let request = RequestGuildMembers::new_single_user_with_nonce(
    guild_id,
    user_id,
    Some(true),
    Some("nonce".to_owned()),
);
```

It's not clear what the parameters are, and booleans in long parameter lists are notoriously confusing. There were many methods like this for each possible combination: `new_with_nonce`, `new_single_user`, `new_multi_user`, and `new_multi_user_with_nonce`. These were also copied into the child payload struct of `RequestGuildMembers`, producing an untagged enum of the payload depending on the variant used.

Instead, use a consuming builder to create (and now, validated!) requests. The above looks like:

```rust
let request = RequestGuildMembers::builder(guild_id)
    .nonce("nonce")
    .presences(true)
    .user_id(user_id);
```

Requesting a list of users is similar:

```rust
let request = RequestGuildMembers::builder(guild_id)
    .nonce("nonce")
    .presences(true)
    .user_ids(vec![user_id, another_user_id])?;
```

Unlike `user_id`, `user_ids` can error if more than 100 user IDs are provided at a time, which is the API's limit.

Querying for a number of users whose names start with some characters can be done like so:

```rust
let request = RequestGuildMembers::builder(guild_id)
    .presences(true)
    .query("tw", Some(50));
```