### PR TITLE
http: replace calls to request with verify

### DIFF
--- a/http/src/request/channel/reaction/delete_all_reactions.rs
+++ b/http/src/request/channel/reaction/delete_all_reactions.rs
@@ -20,7 +20,7 @@ impl<'a> DeleteAllReactions<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
+        self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::DeleteMessageReactions {
                 channel_id: self.channel_id.0,
                 message_id: self.message_id.0,

--- a/http/src/request/guild/delete_guild.rs
+++ b/http/src/request/guild/delete_guild.rs
@@ -18,7 +18,7 @@ impl<'a> DeleteGuild<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
+        self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::DeleteGuild {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -45,7 +45,7 @@ impl<'a> DeleteEmoji<'a> {
             })
         };
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/integration/create_guild_integration.rs
+++ b/http/src/request/guild/integration/create_guild_integration.rs
@@ -66,7 +66,7 @@ impl<'a> CreateGuildIntegration<'a> {
             ))
         };
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -45,7 +45,7 @@ impl<'a> DeleteGuildIntegration<'a> {
             })
         };
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/integration/sync_guild_integration.rs
+++ b/http/src/request/guild/integration/sync_guild_integration.rs
@@ -20,7 +20,7 @@ impl<'a> SyncGuildIntegration<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
+        self.fut.replace(Box::pin(self.http.verify(Request::from(
             Route::SyncGuildIntegration {
                 guild_id: self.guild_id.0,
                 integration_id: self.integration_id.0,

--- a/http/src/request/guild/integration/update_guild_integration.rs
+++ b/http/src/request/guild/integration/update_guild_integration.rs
@@ -92,7 +92,7 @@ impl<'a> UpdateGuildIntegration<'a> {
             ))
         };
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -3,10 +3,7 @@ use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
-use twilight_model::{
-    guild::Member,
-    id::{ChannelId, GuildId, RoleId, UserId},
-};
+use twilight_model::id::{ChannelId, GuildId, RoleId, UserId};
 
 /// The error created when the member can not be updated as configured.
 #[derive(Clone, Debug)]
@@ -55,7 +52,7 @@ struct UpdateGuildMemberFields {
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild-member
 pub struct UpdateGuildMember<'a> {
     fields: UpdateGuildMemberFields,
-    fut: Option<Pending<'a, Member>>,
+    fut: Option<Pending<'a, ()>>,
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
@@ -158,10 +155,10 @@ impl<'a> UpdateGuildMember<'a> {
             ))
         };
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }
 }
 
-poll_req!(UpdateGuildMember<'_>, Member);
+poll_req!(UpdateGuildMember<'_>, ());

--- a/http/src/request/guild/update_current_user_nick.rs
+++ b/http/src/request/guild/update_current_user_nick.rs
@@ -25,7 +25,7 @@ impl<'a> UpdateCurrentUserNick<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
+        self.fut.replace(Box::pin(self.http.verify(Request::from((
             crate::json_to_vec(&self.fields)?,
             Route::UpdateNickname {
                 guild_id: self.guild_id.0,

--- a/http/src/request/guild/update_guild_channel_positions.rs
+++ b/http/src/request/guild/update_guild_channel_positions.rs
@@ -36,7 +36,7 @@ impl<'a> UpdateGuildChannelPositions<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
+        self.fut.replace(Box::pin(self.http.verify(Request::from((
             crate::json_to_vec(&self.positions)?,
             Route::UpdateGuildChannels {
                 guild_id: self.guild_id.0,


### PR DESCRIPTION
Some future implementations called `Client::request` when `start`ing, while their associated responses returned a `204 No Content` to indicate success. This PR changes those method calls to `Client::verify`.

Fixes #443. 