### PR TITLE
gateway: conditionally deserialize received events

### DIFF
--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -320,6 +320,15 @@ impl Cluster {
     ///
     /// Each item in the stream contains both the shard's ID and the event
     /// itself.
+    ///
+    /// **Note** that we *highly* recommend specifying only the events that you
+    /// need via [`some_events`], especially if performance is a concern. This
+    /// will ensure that events you don't care about aren't deserialized from
+    /// received websocket messages. Gateway intents only allow specifying
+    /// categories of events, but using [`some_events`] will filter it further
+    /// on the client side.
+    ///
+    /// [`some_events`]: #method.some_events
     pub fn events<'a>(&'a self) -> impl Stream<Item = (u64, Event)> + 'a {
         self.some_events(EventTypeFlags::default())
     }

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -121,15 +121,5 @@ pub use self::{
 #[doc(no_inline)]
 pub use twilight_model::gateway::event::{Event, EventType};
 
-#[cfg(not(feature = "simd-json"))]
-pub(crate) use serde_json::to_vec as json_to_vec;
-#[cfg(feature = "simd-json")]
-pub(crate) use simd_json::to_vec as json_to_vec;
-
-#[cfg(not(feature = "simd-json"))]
-pub(crate) use serde_json::to_string as json_to_string;
-#[cfg(feature = "simd-json")]
-pub(crate) use simd_json::to_string as json_to_string;
-
 #[cfg(not(any(feature = "native", feature = "rustls")))]
 compile_error!("Either the `native` or `rustls` feature must be enabled");

--- a/gateway/src/listener.rs
+++ b/gateway/src/listener.rs
@@ -21,6 +21,11 @@ impl<T> Listener<T> {
 
 #[derive(Debug)]
 struct ListenersRef<T> {
+    // Bitflags of the event types that all listeners combined want.
+    //
+    // If listener 1 wants message creates and listener 2 wants message deletes,
+    // then this will contain the bits of both.
+    event_types: AtomicU64,
     id: AtomicU64,
     listeners: DashMap<u64, Listener<T>>,
 }
@@ -28,6 +33,7 @@ struct ListenersRef<T> {
 impl<T> Default for ListenersRef<T> {
     fn default() -> Self {
         Self {
+            event_types: AtomicU64::new(0),
             id: AtomicU64::new(0),
             listeners: DashMap::new(),
         }
@@ -43,12 +49,23 @@ impl<T> Listeners<T> {
         let (tx, rx) = mpsc::unbounded();
 
         self.0.listeners.insert(id, Listener { events, tx });
+        self.recalculate_event_types();
 
         rx
     }
 
     pub fn all(&self) -> &DashMap<u64, Listener<T>> {
         &self.0.listeners
+    }
+
+    /// Return all of the event types that are being requested by listeners.
+    ///
+    /// If listener 1 has requested message creates and listener 2 has requested
+    /// message deletes, then this returns bitflags with both flipped on.
+    pub fn event_types(&self) -> EventTypeFlags {
+        let bits = self.0.event_types.load(Ordering::SeqCst);
+
+        EventTypeFlags::from_bits_truncate(bits)
     }
 
     /// Return the length of the listeners map.
@@ -58,11 +75,45 @@ impl<T> Listeners<T> {
 
     pub fn remove_all(&self) {
         self.0.listeners.clear();
+        self.recalculate_event_types();
+    }
+
+    fn recalculate_event_types(&self) {
+        let flags = self
+            .0
+            .listeners
+            .iter()
+            .fold(EventTypeFlags::empty(), |mut acc, r| {
+                acc.insert(r.events);
+
+                acc
+            });
+
+        self.0.event_types.store(flags.bits(), Ordering::SeqCst);
     }
 }
 
 impl<T> Default for Listeners<T> {
     fn default() -> Self {
         Self(Arc::new(ListenersRef::default()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EventTypeFlags, Listeners};
+
+    #[test]
+    fn test_total_event_types() {
+        let listeners: Listeners<()> = Listeners::default();
+        listeners.add(EventTypeFlags::MESSAGE_CREATE);
+        assert_eq!(EventTypeFlags::MESSAGE_CREATE, listeners.event_types());
+        listeners.add(EventTypeFlags::MESSAGE_DELETE);
+        assert_eq!(
+            EventTypeFlags::MESSAGE_CREATE | EventTypeFlags::MESSAGE_DELETE,
+            listeners.event_types(),
+        );
+        listeners.remove_all();
+        assert!(listeners.event_types().is_empty());
     }
 }

--- a/gateway/src/shard/json.rs
+++ b/gateway/src/shard/json.rs
@@ -1,0 +1,124 @@
+#[cfg(feature = "simd-json")]
+pub use serde_json::{from_slice, from_str, to_string, to_vec, Error as JsonError};
+#[cfg(not(feature = "simd-json"))]
+pub use serde_json::{from_slice, from_str, to_string, to_vec, Error as JsonError};
+
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+use twilight_model::gateway::event::GatewayEvent;
+
+#[derive(Debug)]
+pub enum GatewayEventParsingError {
+    /// Deserializing the GatewayEvent payload from JSON failed.
+    Deserializing {
+        /// Reason for the error.
+        source: JsonError,
+    },
+    /// The payload received from Discord was an unrecognized or invalid
+    /// structure.
+    ///
+    /// The payload was either invalid JSON or did not contain the necessary
+    /// "op" key in the object.
+    PayloadInvalid,
+}
+
+impl Display for GatewayEventParsingError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::Deserializing { source } => Display::fmt(source, f),
+            Self::PayloadInvalid => f.write_str("payload is an invalid json structure"),
+        }
+    }
+}
+
+impl Error for GatewayEventParsingError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Deserializing { source } => Some(source),
+            Self::PayloadInvalid => None,
+        }
+    }
+}
+
+/// Parse a gateway event from a string using `serde_json` with headers.
+///
+/// # Errors
+///
+/// Returns [`Error::PayloadInvalid`] if the payload wasn't a valid
+/// `GatewayEvent` data structure.
+///
+/// Returns [`Error::PayloadSerialization`] if the payload failed to
+/// deserialize.
+///
+/// [`Error::PayloadInvalid`]: ../enum.Error.html#variant.PayloadInvalid
+/// [`Error::PayloadSerialization`]: ../enum.Error.html#variant.PayloadSerialization
+#[cfg(not(feature = "simd-json"))]
+#[allow(dead_code)]
+pub fn parse_gateway_event(
+    op: u8,
+    sequence: Option<u64>,
+    event_type: Option<&str>,
+    json: &mut str,
+) -> Result<GatewayEvent, GatewayEventParsingError> {
+    use serde::de::DeserializeSeed;
+    use serde_json::Deserializer;
+    use twilight_model::gateway::event::GatewayEventDeserializer;
+
+    let gateway_deserializer = GatewayEventDeserializer::new(op, sequence, event_type);
+    let mut json_deserializer = Deserializer::from_str(json);
+
+    gateway_deserializer
+        .deserialize(&mut json_deserializer)
+        .map_err(|source| {
+            tracing::debug!("invalid JSON: {}", json);
+
+            GatewayEventParsingError::Deserializing { source }
+        })
+}
+
+/// Parse a gateway event from a string using `simd-json` with headers.
+///
+/// # Errors
+///
+/// Returns [`Error::PayloadInvalid`] if the payload wasn't a valid
+/// `GatewayEvent` data structure.
+///
+/// Returns [`Error::PayloadSerialization`] if the payload failed to
+/// deserialize.
+///
+/// [`Error::PayloadInvalid`]: ../enum.Error.html#variant.PayloadInvalid
+/// [`Error::PayloadSerialization`]: ../enum.Error.html#variant.PayloadSerialization
+#[allow(unsafe_code)]
+#[cfg(feature = "simd-json")]
+#[allow(dead_code)]
+pub fn parse_gateway_event(
+    op: u8,
+    sequence: Option<u64>,
+    event_type: Option<&str>,
+    json: &mut str,
+) -> Result<GatewayEvent, GatewayEventParsingError> {
+    use serde::de::DeserializeSeed;
+    use simd_json::Deserializer;
+    use twilight_model::gateway::event::gateway::GatewayEventDeserializer;
+
+    let gateway_deserializer = GatewayEventDeserializer::new(op, sequence, event_type);
+
+    // # Safety
+    //
+    // The SIMD deserializer may change the string in ways that aren't
+    // UTF-8 valid, but that's fine because it won't be used again.
+    let json_bytes = unsafe { json.as_bytes_mut() };
+
+    let mut json_deserializer = Deserializer::from_slice(json_bytes)
+        .map_err(|_| GatewayEventParsingError::PayloadInvalid)?;
+
+    gateway_deserializer
+        .deserialize(&mut json_deserializer)
+        .map_err(|source| {
+            tracing::debug!("invalid JSON: {}", json);
+
+            GatewayEventParsingError::Deserializing { source }
+        })
+}

--- a/gateway/src/shard/json.rs
+++ b/gateway/src/shard/json.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "simd-json")]
-pub use simd_json::{from_slice, from_str, to_string, to_vec, Error as JsonError};
 #[cfg(not(feature = "simd-json"))]
 pub use serde_json::{from_slice, from_str, to_string, to_vec, Error as JsonError};
+#[cfg(feature = "simd-json")]
+pub use simd_json::{from_slice, from_str, to_string, to_vec, Error as JsonError};
 
 use std::{
     error::Error,

--- a/gateway/src/shard/json.rs
+++ b/gateway/src/shard/json.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "simd-json")]
-pub use serde_json::{from_slice, from_str, to_string, to_vec, Error as JsonError};
+pub use simd_json::{from_slice, from_str, to_string, to_vec, Error as JsonError};
 #[cfg(not(feature = "simd-json"))]
 pub use serde_json::{from_slice, from_str, to_string, to_vec, Error as JsonError};
 

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -28,6 +28,7 @@ mod builder;
 mod config;
 mod event;
 mod r#impl;
+mod json;
 mod processor;
 mod sink;
 

--- a/gateway/src/shard/processor/heartbeat.rs
+++ b/gateway/src/shard/processor/heartbeat.rs
@@ -1,4 +1,4 @@
-use super::session::SessionSendError;
+use super::{super::json, session::SessionSendError};
 use async_tungstenite::tungstenite::Message as TungsteniteMessage;
 use futures_channel::mpsc::UnboundedSender;
 use std::{
@@ -225,7 +225,7 @@ impl Heartbeater {
 
             let seq = self.seq.load(Ordering::Acquire);
             let heartbeat = Heartbeat::new(seq);
-            let bytes = crate::json_to_vec(&heartbeat)
+            let bytes = json::to_vec(&heartbeat)
                 .map_err(|source| SessionSendError::Serializing { source })?;
 
             tracing::debug!(seq, "sending heartbeat");

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -441,12 +441,12 @@ impl ShardProcessor {
             })
     }
 
-    fn process_ready(&self) -> Result<(), ProcessError> {
+    fn process_ready(&mut self) -> Result<(), ProcessError> {
         #[cfg(feature = "metrics")]
         metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "Dispatch");
 
         let ready =
-            json::from_slice::<ReadyMinimal<'_>>(self.inflater.buffer_ref()).map_err(|source| {
+            json::from_slice::<ReadyMinimal<'_>>(self.inflater.buffer_mut()).map_err(|source| {
                 ProcessError::ParsingPayload {
                     source: GatewayEventParsingError::Deserializing { source },
                 }

--- a/gateway/src/shard/processor/inflater.rs
+++ b/gateway/src/shard/processor/inflater.rs
@@ -27,6 +27,16 @@ impl Inflater {
         }
     }
 
+    /// Return an immutable reference to the buffer.
+    pub fn buffer_ref(&self) -> &[u8] {
+        self.buffer.as_slice()
+    }
+
+    /// Return a mutable reference to the buffer.
+    pub fn buffer_mut(&mut self) -> &mut [u8] {
+        self.buffer.as_mut_slice()
+    }
+
     /// Extend the internal compressed buffer with bytes.
     pub fn extend(&mut self, slice: &[u8]) {
         self.compressed.extend_from_slice(&slice);

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::stage::Stage,
+    super::{json, stage::Stage},
     heartbeat::{Heartbeater, Heartbeats},
 };
 use async_tungstenite::tungstenite::{protocol::CloseFrame, Message as TungsteniteMessage};
@@ -102,8 +102,8 @@ impl Session {
     /// [`Error::PayloadSerialization`]: ../enum.Error.html#variant.PayloadSerialization
     /// [`Error::SendingMessage`]: ../enum.Error.html#variant.SendingMessage
     pub fn send(&self, payload: impl Serialize) -> Result<(), SessionSendError> {
-        let bytes = crate::json_to_vec(&payload)
-            .map_err(|source| SessionSendError::Serializing { source })?;
+        let bytes =
+            json::to_vec(&payload).map_err(|source| SessionSendError::Serializing { source })?;
 
         self.tx
             .unbounded_send(TungsteniteMessage::Binary(bytes))

--- a/model/src/gateway/event/kind.rs
+++ b/model/src/gateway/event/kind.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 
 /// The type of an event.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -68,6 +69,113 @@ pub enum EventType {
     VoiceServerUpdate,
     VoiceStateUpdate,
     WebhooksUpdate,
+}
+
+impl EventType {
+    pub fn name(self) -> Option<&'static str> {
+        match self {
+            Self::BanAdd => Some("GUILD_BAN_ADD"),
+            Self::BanRemove => Some("GUILD_BAN_REMOVE"),
+            Self::ChannelCreate => Some("CHANNEL_CREATE"),
+            Self::ChannelDelete => Some("CHANNEL_DELETE"),
+            Self::ChannelPinsUpdate => Some("CHANNEL_PINS_UPDATE"),
+            Self::ChannelUpdate => Some("CHANNEL_UPDATE"),
+            Self::GiftCodeUpdate => Some("GIFT_CODE_UPDATE"),
+            Self::GuildCreate => Some("GUILD_CREATE"),
+            Self::GuildDelete => Some("GUILD_DELETE"),
+            Self::GuildEmojisUpdate => Some("GUILD_EMOJIS_UPDATE"),
+            Self::GuildIntegrationsUpdate => Some("GUILD_INTEGRATIONS_UPDATE"),
+            Self::GuildUpdate => Some("GUILD_UPDATE"),
+            Self::InviteCreate => Some("INVITE_CREATE"),
+            Self::InviteDelete => Some("INVITE_DELETE"),
+            Self::MemberAdd => Some("GUILD_MEMBER_ADD"),
+            Self::MemberRemove => Some("GUILD_MEMBER_REMOVE"),
+            Self::MemberUpdate => Some("GUILD_MEMBER_UPDATE"),
+            Self::MemberChunk => Some("GUILD_MEMBERS_CHUNK"),
+            Self::MessageCreate => Some("MESSAGE_CREATE"),
+            Self::MessageDelete => Some("MESSAGE_DELETE"),
+            Self::MessageDeleteBulk => Some("MESSAGE_DELETE_BULK"),
+            Self::MessageUpdate => Some("MESSAGE_UPDATE"),
+            Self::PresenceUpdate => Some("PRESENCE_UPDATE"),
+            Self::PresencesReplace => Some("PRESENCES_REPLACE"),
+            Self::ReactionAdd => Some("MESSAGE_REACTION_ADD"),
+            Self::ReactionRemove => Some("MESSAGE_REACTION_REMOVE"),
+            Self::ReactionRemoveAll => Some("MESSAGE_REACTION_REMOVE_ALL"),
+            Self::ReactionRemoveEmoji => Some("MESSAGE_REACTION_REMOVE_EMOJI"),
+            Self::Ready => Some("READY"),
+            Self::Resumed => Some("RESUMED"),
+            Self::RoleCreate => Some("GUILD_ROLE_CREATE"),
+            Self::RoleDelete => Some("GUILD_ROLE_DELETE"),
+            Self::RoleUpdate => Some("GUILD_ROLE_UPDATE"),
+            Self::TypingStart => Some("TYPING_START"),
+            Self::UnavailableGuild => Some("UNAVAILABLE_GUILD"),
+            Self::UserUpdate => Some("USER_UPDATE"),
+            Self::VoiceServerUpdate => Some("VOICE_SERVER_UPDATE"),
+            Self::VoiceStateUpdate => Some("VOICE_STATE_UPDATE"),
+            Self::WebhooksUpdate => Some("WEBHOOKS_UPDATE"),
+            Self::GatewayHeartbeat
+            | Self::GatewayHeartbeatAck
+            | Self::GatewayHello
+            | Self::GatewayInvalidateSession
+            | Self::GatewayReconnect
+            | Self::ShardConnected
+            | Self::ShardConnecting
+            | Self::ShardDisconnected
+            | Self::ShardIdentifying
+            | Self::ShardReconnecting
+            | Self::ShardPayload
+            | Self::ShardResuming => None,
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a str> for EventType {
+    type Error = &'a str;
+
+    fn try_from(event_type: &'a str) -> Result<Self, Self::Error> {
+        match event_type {
+            "GUILD_BAN_ADD" => Ok(Self::BanAdd),
+            "GUILD_BAN_REMOVE" => Ok(Self::BanRemove),
+            "CHANNEL_CREATE" => Ok(Self::ChannelCreate),
+            "CHANNEL_DELETE" => Ok(Self::ChannelDelete),
+            "CHANNEL_PINS_UPDATE" => Ok(Self::ChannelPinsUpdate),
+            "CHANNEL_UPDATE" => Ok(Self::ChannelUpdate),
+            "GIFT_CODE_UPDATE" => Ok(Self::GiftCodeUpdate),
+            "GUILD_CREATE" => Ok(Self::GuildCreate),
+            "GUILD_DELETE" => Ok(Self::GuildDelete),
+            "GUILD_EMOJIS_UPDATE" => Ok(Self::GuildEmojisUpdate),
+            "GUILD_INTEGRATIONS_UPDATE" => Ok(Self::GuildIntegrationsUpdate),
+            "GUILD_UPDATE" => Ok(Self::GuildUpdate),
+            "INVITE_CREATE" => Ok(Self::InviteCreate),
+            "INVITE_DELETE" => Ok(Self::InviteDelete),
+            "GUILD_MEMBER_ADD" => Ok(Self::MemberAdd),
+            "GUILD_MEMBER_REMOVE" => Ok(Self::MemberRemove),
+            "GUILD_MEMBER_UPDATE" => Ok(Self::MemberUpdate),
+            "GUILD_MEMBERS_CHUNK" => Ok(Self::MemberChunk),
+            "MESSAGE_CREATE" => Ok(Self::MessageCreate),
+            "MESSAGE_DELETE" => Ok(Self::MessageDelete),
+            "MESSAGE_DELETE_BULK" => Ok(Self::MessageDeleteBulk),
+            "MESSAGE_UPDATE" => Ok(Self::MessageUpdate),
+            "PRESENCE_UPDATE" => Ok(Self::PresenceUpdate),
+            "PRESENCES_REPLACE" => Ok(Self::PresencesReplace),
+            "MESSAGE_REACTION_ADD" => Ok(Self::ReactionAdd),
+            "MESSAGE_REACTION_REMOVE" => Ok(Self::ReactionRemove),
+            "MESSAGE_REACTION_REMOVE_ALL" => Ok(Self::ReactionRemoveAll),
+            "MESSAGE_REACTION_REMOVE_EMOJI" => Ok(Self::ReactionRemoveEmoji),
+            "READY" => Ok(Self::Ready),
+            "RESUMED" => Ok(Self::Resumed),
+            "GUILD_ROLE_CREATE" => Ok(Self::RoleCreate),
+            "GUILD_ROLE_DELETE" => Ok(Self::RoleDelete),
+            "GUILD_ROLE_UPDATE" => Ok(Self::RoleUpdate),
+            "TYPING_START" => Ok(Self::TypingStart),
+            "UNAVAILABLE_GUILD" => Ok(Self::UnavailableGuild),
+            "USER_UPDATE" => Ok(Self::UserUpdate),
+            "VOICE_SERVER_UPDATE" => Ok(Self::VoiceServerUpdate),
+            "VOICE_STATE_UPDATE" => Ok(Self::VoiceStateUpdate),
+            "WEBHOOKS_UPDATE" => Ok(Self::WebhooksUpdate),
+            _ => Err(event_type),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/model/src/gateway/event/mod.rs
+++ b/model/src/gateway/event/mod.rs
@@ -8,7 +8,7 @@ mod kind;
 
 pub use self::{
     dispatch::{DispatchEvent, DispatchEventWithTypeDeserializer},
-    gateway::{GatewayEvent, GatewayEventDeserializer},
+    gateway::{GatewayEvent, GatewayEventDeserializer, GatewayEventDeserializerOwned},
     kind::EventType,
 };
 


### PR DESCRIPTION
In the gateway's shard processor, conditionally deserialize received events if the user has specified that they want them.

Intents are a good way of filtering events that a user wants, but it only filters by category. If a user selects the `GUILD_MESSAGES` event then they will receive `MESSAGE_CREATE`s, `MESSAGE_DELETE`s, `MESSAGE_UPDATE`s, and so on. Intents are especially good at reducing network usage, but can cause users to still receive and deserialize more events than they actually use.

Say that a user wants to handle `MESSAGE_CREATE`s but not `MESSAGE_DELETE`s. They don't care if message deletes are deserialized or not since they don't use them. Coincidentally, shards don't use most dispatch events either, such as message deletes. We can utilize event filtering through the `Cluster::some_events` and `Shard::some_events` methods to determine whether a payload should be deserialized or not. If not, then we can just receive the payload over the websocket and immediately forget about it.

Shards care about only a specific handful of events: the Ready and Resumed dispatch events and other non-dispatch gateway events. For the Resumed event, we don't actually need to go through a serde context to deserialize it and can construct it and process it. This is the same for the Heartbeat Acknowledgement gateway event. The Ready event is another that shards need to process and contains a lot of information. We can easily use serde to deserialize the only field of Ready events that we need.

For some use cases this may only see a few percentage points in performance difference, but for others this may be up to 50% or more depending on what the application does. Notes have been added to `Cluster::events` and `Shard::events` that it is highly recommended users use their `some_events` counterpart to utilize this new event deserialization efficiency.