### PR TITLE
utils/embed-builder: test with static_assertions

### DIFF
--- a/utils/embed-builder/Cargo.toml
+++ b/utils/embed-builder/Cargo.toml
@@ -14,3 +14,6 @@ version = "0.1.0"
 
 [dependencies]
 twilight-model = { path = "../../model", default-features = false }
+
+[dev-dependencies]
+static_assertions = { default-features = false, version = "1" }

--- a/utils/embed-builder/src/author.rs
+++ b/utils/embed-builder/src/author.rs
@@ -145,8 +145,32 @@ impl From<EmbedAuthorBuilder> for EmbedAuthor {
 mod tests {
     use super::{EmbedAuthorBuilder, EmbedAuthorNameError};
     use crate::ImageSource;
-    use std::error::Error;
+    use static_assertions::{assert_fields, assert_impl_all, const_assert};
+    use std::{error::Error, fmt::Debug};
     use twilight_model::channel::embed::EmbedAuthor;
+
+    assert_impl_all!(
+        EmbedAuthorNameError: Clone,
+        Debug,
+        Error,
+        Eq,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_fields!(EmbedAuthorNameError::Empty: name);
+    assert_fields!(EmbedAuthorNameError::TooLong: name);
+    assert_impl_all!(
+        EmbedAuthorBuilder: Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        Send,
+        Sync
+    );
+    const_assert!(EmbedAuthorBuilder::NAME_LENGTH_LIMIT == 256);
+    assert_impl_all!(EmbedAuthor: From<EmbedAuthorBuilder>);
 
     #[test]
     fn test_defaults() {

--- a/utils/embed-builder/src/builder.rs
+++ b/utils/embed-builder/src/builder.rs
@@ -610,10 +610,72 @@ impl TryFrom<EmbedBuilder> for Embed {
 
 #[cfg(test)]
 mod tests {
-    use super::{EmbedBuilder, EmbedColorError, EmbedDescriptionError, EmbedTitleError};
+    use super::{
+        EmbedBuildError, EmbedBuilder, EmbedColorError, EmbedDescriptionError, EmbedTitleError,
+    };
     use crate::{field::EmbedFieldBuilder, footer::EmbedFooterBuilder, image_source::ImageSource};
-    use std::error::Error;
+    use static_assertions::{assert_fields, assert_impl_all, const_assert};
+    use std::{convert::TryFrom, error::Error, fmt::Debug};
     use twilight_model::channel::embed::{Embed, EmbedField, EmbedFooter};
+
+    assert_impl_all!(
+        EmbedBuildError: Clone,
+        Debug,
+        Error,
+        Eq,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_fields!(EmbedBuildError::ContentTooLarge: length);
+    assert_fields!(EmbedBuildError::TooManyFields: fields);
+    assert_impl_all!(
+        EmbedColorError: Clone,
+        Debug,
+        Error,
+        Eq,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_fields!(EmbedColorError::NotRgb: color);
+    assert_impl_all!(
+        EmbedDescriptionError: Clone,
+        Debug,
+        Error,
+        Eq,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_fields!(EmbedDescriptionError::Empty: description);
+    assert_fields!(EmbedDescriptionError::TooLong: description);
+    assert_impl_all!(
+        EmbedTitleError: Clone,
+        Debug,
+        Error,
+        Eq,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_fields!(EmbedTitleError::Empty: title);
+    assert_fields!(EmbedTitleError::TooLong: title);
+    assert_impl_all!(
+        EmbedBuilder: Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        Send,
+        Sync
+    );
+    const_assert!(EmbedBuilder::COLOR_MAXIMUM == 0xff_ff_ff);
+    const_assert!(EmbedBuilder::DESCRIPTION_LENGTH_LIMIT == 2048);
+    const_assert!(EmbedBuilder::EMBED_FIELD_LIMIT == 25);
+    const_assert!(EmbedBuilder::EMBED_LENGTH_LIMIT == 6000);
+    const_assert!(EmbedBuilder::TITLE_LENGTH_LIMIT == 256);
+    assert_impl_all!(Embed: TryFrom<EmbedBuilder>);
 
     #[test]
     fn test_color_error() -> Result<(), Box<dyn Error>> {

--- a/utils/embed-builder/src/field.rs
+++ b/utils/embed-builder/src/field.rs
@@ -179,8 +179,27 @@ impl From<EmbedFieldBuilder> for EmbedField {
 #[cfg(test)]
 mod tests {
     use super::{EmbedFieldBuilder, EmbedFieldError};
-    use std::error::Error;
+    use static_assertions::{assert_fields, assert_impl_all, const_assert};
+    use std::{error::Error, fmt::Debug};
     use twilight_model::channel::embed::EmbedField;
+
+    assert_impl_all!(
+        EmbedFieldError: Clone,
+        Debug,
+        Error,
+        Eq,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_fields!(EmbedFieldError::NameEmpty: name, value);
+    assert_fields!(EmbedFieldError::NameTooLong: name, value);
+    assert_fields!(EmbedFieldError::ValueEmpty: name, value);
+    assert_fields!(EmbedFieldError::ValueTooLong: name, value);
+    assert_impl_all!(EmbedFieldBuilder: Clone, Debug, Eq, PartialEq, Send, Sync);
+    const_assert!(EmbedFieldBuilder::NAME_LENGTH_LIMIT == 256);
+    const_assert!(EmbedFieldBuilder::VALUE_LENGTH_LIMIT == 1024);
+    assert_impl_all!(EmbedField: From<EmbedFieldBuilder>);
 
     #[test]
     fn test_new_errors() {

--- a/utils/embed-builder/src/footer.rs
+++ b/utils/embed-builder/src/footer.rs
@@ -132,8 +132,24 @@ impl From<EmbedFooterBuilder> for EmbedFooter {
 mod tests {
     use super::{EmbedFooterBuilder, EmbedFooterTextError};
     use crate::ImageSource;
-    use std::error::Error;
+    use static_assertions::{assert_fields, assert_impl_all, const_assert};
+    use std::{error::Error, fmt::Debug};
     use twilight_model::channel::embed::EmbedFooter;
+
+    assert_impl_all!(
+        EmbedFooterTextError: Clone,
+        Debug,
+        Error,
+        Eq,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_fields!(EmbedFooterTextError::Empty: text);
+    assert_fields!(EmbedFooterTextError::TooLong: text);
+    assert_impl_all!(EmbedFooterBuilder: Clone, Debug, Eq, PartialEq, Send, Sync);
+    const_assert!(EmbedFooterBuilder::TEXT_LENGTH_LIMIT == 2048);
+    assert_impl_all!(EmbedFooter: From<EmbedFooterBuilder>);
 
     #[test]
     fn test_text() -> Result<(), Box<dyn Error>> {

--- a/utils/embed-builder/src/image_source.rs
+++ b/utils/embed-builder/src/image_source.rs
@@ -122,7 +122,29 @@ impl ImageSource {
 #[cfg(test)]
 mod tests {
     use super::{ImageSource, ImageSourceAttachmentError, ImageSourceUrlError};
-    use std::error::Error;
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{error::Error, fmt::Debug};
+
+    assert_impl_all!(
+        ImageSourceAttachmentError: Clone,
+        Debug,
+        Error,
+        Eq,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_impl_all!(
+        ImageSourceUrlError: Clone,
+        Debug,
+        Error,
+        Eq,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_fields!(ImageSourceUrlError::ProtocolUnsupported: url);
+    assert_impl_all!(ImageSource: Clone, Debug, Eq, PartialEq, Send, Sync);
 
     #[test]
     fn test_attachment() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
In the `twilight-embed-builder` crate, test implementations with `static_assertions`.