### PR TITLE
command-parser: refactor config prefixes

### DIFF
--- a/command-parser/Cargo.toml
+++ b/command-parser/Cargo.toml
@@ -17,8 +17,12 @@ unicase = { default-features = false, version = "2" }
 
 [dev-dependencies]
 criterion = "0.3"
-
+patricia_tree = "0.2"
 
 [[bench]]
 name = "prefix"
+harness = false
+
+[[bench]]
+name = "commands"
 harness = false

--- a/command-parser/Cargo.toml
+++ b/command-parser/Cargo.toml
@@ -14,3 +14,11 @@ version = "0.1.0"
 
 [dependencies]
 unicase = { default-features = false, version = "2" }
+
+[dev-dependencies]
+criterion = "0.3"
+
+
+[[bench]]
+name = "prefix"
+harness = false

--- a/command-parser/benches/commands.rs
+++ b/command-parser/benches/commands.rs
@@ -77,11 +77,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     ];
 
     c.bench_function("c: btreeset", |b| {
-        let mut set = BTreeSet::new();
-
-        for e in commands.iter() {
-            set.insert(Cow::from(*e));
-        }
+        let mut set = BTreeSet::from_iter(commands.iter().map(Cow::from));
 
         b.iter(|| {
             for command in commands.iter() {
@@ -91,7 +87,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("c: hashset", |b| {
-        let mut set = HashSet::new();
+        let mut set = HashSet::from_iter(commands.iter().map(Cow::from));
 
         for e in commands.iter() {
             set.insert(Cow::from(*e));
@@ -115,10 +111,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("c: patricia_tree", |b| {
-        let mut set = PatriciaSet::new();
-        for e in commands.iter() {
-            set.insert(e);
-        }
+        let mut set = PatriciaSet::from_iter(commands.iter());
 
         b.iter(|| {
             for command in commands.iter() {

--- a/command-parser/benches/commands.rs
+++ b/command-parser/benches/commands.rs
@@ -5,7 +5,6 @@ use std::{
     collections::{BTreeSet, HashSet},
 };
 
-
 fn btreeset(set: &BTreeSet<Cow<'static, str>>, needle: &str) {
     let start = needle.get(0..1).unwrap();
     set.range(Cow::from(start)..)
@@ -97,7 +96,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         for e in commands.iter() {
             set.insert(Cow::from(*e));
         }
-        
+
         b.iter(|| {
             for command in commands.iter() {
                 hashset(&set, command);

--- a/command-parser/benches/commands.rs
+++ b/command-parser/benches/commands.rs
@@ -1,0 +1,133 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use patricia_tree::PatriciaSet;
+use std::{
+    borrow::Cow,
+    collections::{BTreeSet, HashSet},
+};
+
+
+fn btreeset(set: &BTreeSet<Cow<'static, str>>, needle: &str) {
+    let start = needle.get(0..1).unwrap();
+    set.range(Cow::from(start)..)
+        .find(|item| needle.starts_with(item.as_ref()))
+        .unwrap();
+}
+
+fn hashset(set: &HashSet<Cow<'static, str>>, needle: &str) {
+    set.iter()
+        .find(|item| needle.starts_with(item.as_ref()))
+        .unwrap();
+}
+
+fn vec(items: &[Cow<'static, str>], needle: &str) {
+    items
+        .iter()
+        .find(|item| needle.starts_with(item.as_ref()))
+        .unwrap();
+}
+
+fn patricia_tree(items: &PatriciaSet, needle: &str) {
+    items.get_longest_common_prefix(needle).unwrap();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let commands = [
+        "about",
+        "coinflip",
+        "help",
+        "ping",
+        "quote",
+        "self_role",
+        "uid",
+        "commands",
+        "emoji",
+        "apexstats",
+        "cat",
+        "dog",
+        "jumbo",
+        "inf",
+        "mwarn",
+        "warn",
+        "archive",
+        "ban",
+        "bean",
+        "clean",
+        "cleanban",
+        "cleankick",
+        "forceban",
+        "kick",
+        "mban",
+        "mcleanban",
+        "mkick",
+        "munban",
+        "mute",
+        "nickname",
+        "purge",
+        "roles",
+        "seen",
+        "serverinfo",
+        "slowmode",
+        "tempban",
+        "unban",
+        "unmute",
+        "userinfo",
+        "verification",
+        "remind",
+        "configure",
+        "disable",
+    ];
+
+    c.bench_function("c: btreeset", |b| {
+        let mut set = BTreeSet::new();
+
+        for e in commands.iter() {
+            set.insert(Cow::from(*e));
+        }
+
+        b.iter(|| {
+            for command in commands.iter() {
+                btreeset(&set, command);
+            }
+        })
+    });
+
+    c.bench_function("c: hashset", |b| {
+        let mut set = HashSet::new();
+
+        for e in commands.iter() {
+            set.insert(Cow::from(*e));
+        }
+        
+        b.iter(|| {
+            for command in commands.iter() {
+                hashset(&set, command);
+            }
+        })
+    });
+
+    c.bench_function("c: vec", |b| {
+        let items = commands.iter().map(|e| Cow::from(*e)).collect::<Vec<_>>();
+
+        b.iter(|| {
+            for command in commands.iter() {
+                vec(&items, command);
+            }
+        });
+    });
+
+    c.bench_function("c: patricia_tree", |b| {
+        let mut set = PatriciaSet::new();
+        for e in commands.iter() {
+            set.insert(e);
+        }
+
+        b.iter(|| {
+            for command in commands.iter() {
+                patricia_tree(&set, command);
+            }
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/command-parser/benches/prefix.rs
+++ b/command-parser/benches/prefix.rs
@@ -1,0 +1,57 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::{borrow::Cow, collections::{BTreeSet, HashSet}};
+
+fn btreeset(set: &BTreeSet<Cow<'static, str>>) {
+    set.get("!").unwrap();
+}
+
+fn hashset(set: &HashSet<Cow<'static, str>>) {
+    set.get("!").unwrap();
+}
+
+fn vec(items: &[Cow<'static, str>]) {
+    items.iter().find(|item| item.as_ref() == "!").unwrap();
+}
+
+fn vec_worst_case(items: &[Cow<'static, str>]) {
+    items.iter().find(|item| item.as_ref() == "botname").unwrap();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("btreeset", |b| {
+        let mut set = BTreeSet::new();
+        set.insert(Cow::from("!"));
+        set.insert(Cow::from("botname"));
+
+        b.iter(|| {
+            btreeset(&set);
+        })
+    });
+    c.bench_function("hashset", |b| {
+        let mut set = HashSet::new();
+        set.insert(Cow::from("!"));
+        set.insert(Cow::from("botname"));
+
+        b.iter(|| {
+            hashset(&set);
+        })
+    });
+    c.bench_function("vec", |b| {
+        let items = vec![Cow::from("!"), Cow::from("botname")];
+
+        b.iter(|| {
+            vec(&items);
+        });
+    });
+
+    c.bench_function("vec_worst_case", |b| {
+        let items = vec![Cow::from("!"), Cow::from("botname")];
+
+        b.iter(|| {
+            vec_worst_case(&items);
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/command-parser/benches/prefix.rs
+++ b/command-parser/benches/prefix.rs
@@ -1,24 +1,29 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::{borrow::Cow, collections::{BTreeSet, HashSet}};
+use patricia_tree::PatriciaSet;
 
 fn btreeset(set: &BTreeSet<Cow<'static, str>>) {
-    set.get("!").unwrap();
+    set.iter().find(|item| ("!command").starts_with(item.as_ref())).unwrap();
 }
 
 fn hashset(set: &HashSet<Cow<'static, str>>) {
-    set.get("!").unwrap();
+    set.iter().find(|item| ("!command").starts_with(item.as_ref())).unwrap();
 }
 
 fn vec(items: &[Cow<'static, str>]) {
-    items.iter().find(|item| item.as_ref() == "!").unwrap();
+    items.iter().find(|item| ("!command").starts_with(item.as_ref())).unwrap();
 }
 
 fn vec_worst_case(items: &[Cow<'static, str>]) {
-    items.iter().find(|item| item.as_ref() == "botname").unwrap();
+    items.iter().find(|item| ("!command").starts_with(item.as_ref())).unwrap();
+}
+
+fn patricia_tree(items: &PatriciaSet) {
+    let _ = items.get_longest_common_prefix("!command").is_some();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("btreeset", |b| {
+    c.bench_function("p: btreeset", |b| {
         let mut set = BTreeSet::new();
         set.insert(Cow::from("!"));
         set.insert(Cow::from("botname"));
@@ -27,7 +32,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             btreeset(&set);
         })
     });
-    c.bench_function("hashset", |b| {
+    c.bench_function("p: hashset", |b| {
         let mut set = HashSet::new();
         set.insert(Cow::from("!"));
         set.insert(Cow::from("botname"));
@@ -36,7 +41,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             hashset(&set);
         })
     });
-    c.bench_function("vec", |b| {
+    c.bench_function("p: vec", |b| {
         let items = vec![Cow::from("!"), Cow::from("botname")];
 
         b.iter(|| {
@@ -44,11 +49,21 @@ fn criterion_benchmark(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("vec_worst_case", |b| {
+    c.bench_function("p: vec_worst_case", |b| {
         let items = vec![Cow::from("!"), Cow::from("botname")];
 
         b.iter(|| {
             vec_worst_case(&items);
+        });
+    });
+
+    c.bench_function("p: patricia_tree", |b| {
+        let mut set = PatriciaSet::new();
+        set.insert("!");
+        set.insert("botname");
+
+        b.iter(|| {
+            patricia_tree(&set);
         });
     });
 }

--- a/command-parser/benches/prefix.rs
+++ b/command-parser/benches/prefix.rs
@@ -1,21 +1,34 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use std::{borrow::Cow, collections::{BTreeSet, HashSet}};
 use patricia_tree::PatriciaSet;
+use std::{
+    borrow::Cow,
+    collections::{BTreeSet, HashSet},
+};
 
 fn btreeset(set: &BTreeSet<Cow<'static, str>>) {
-    set.iter().find(|item| ("!command").starts_with(item.as_ref())).unwrap();
+    set.iter()
+        .find(|item| ("!command").starts_with(item.as_ref()))
+        .unwrap();
 }
 
 fn hashset(set: &HashSet<Cow<'static, str>>) {
-    set.iter().find(|item| ("!command").starts_with(item.as_ref())).unwrap();
+    set.iter()
+        .find(|item| ("!command").starts_with(item.as_ref()))
+        .unwrap();
 }
 
 fn vec(items: &[Cow<'static, str>]) {
-    items.iter().find(|item| ("!command").starts_with(item.as_ref())).unwrap();
+    items
+        .iter()
+        .find(|item| ("!command").starts_with(item.as_ref()))
+        .unwrap();
 }
 
 fn vec_worst_case(items: &[Cow<'static, str>]) {
-    items.iter().find(|item| ("!command").starts_with(item.as_ref())).unwrap();
+    items
+        .iter()
+        .find(|item| ("!command").starts_with(item.as_ref()))
+        .unwrap();
 }
 
 fn patricia_tree(items: &PatriciaSet) {

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -18,14 +18,14 @@ impl<'a> CommandParserConfig<'a> {
         Self::default()
     }
 
-    /// Returns an immutable iterator for the commands.
+    /// Returns an iterator of immutable references to the commands.
     pub fn commands(&self) -> Commands<'_> {
         Commands {
             iter: self.commands.iter(),
         }
     }
 
-    /// Returns a mutable iterator of the commands.
+    /// Returns an iterator of mutable references to the commands.
     ///
     /// Use the [`command`] and [`remove_command`] methods for an easier way to
     /// manage commands.
@@ -38,7 +38,7 @@ impl<'a> CommandParserConfig<'a> {
         }
     }
 
-    /// Returns an immutable iterator of the prefixes.
+    /// Returns an iterator of immutable references to the prefixes.
     ///
     /// Use the [`add_prefix`] and [`remove_prefix`] methods for an easier way
     /// to manage prefixes.
@@ -51,7 +51,7 @@ impl<'a> CommandParserConfig<'a> {
         }
     }
 
-    /// Returns a mutable iterator for the prefixes.
+    /// Returns an iterator of mutable references to the prefixes.
     pub fn prefixes_mut(&'a mut self) -> PrefixesMut<'a> {
         PrefixesMut {
             iter: self.prefixes.iter_mut(),

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -116,7 +116,7 @@ impl<'a> CommandParserConfig<'a> {
 
     /// Removes a prefix from the list of prefixes.
     ///
-    /// Returns true when a prefix with the name was removed.
+    /// Returns whether a prefix with the name was removed.
     ///
     /// # Examples
     ///

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -25,7 +25,7 @@ impl<'a> CommandParserConfig<'a> {
         }
     }
 
-    /// Returns a mutable iterator for the commands.
+    /// Returns a mutable iterator of the commands.
     ///
     /// Use the [`command`] and [`remove_command`] methods for an easier way to
     /// manage commands.
@@ -38,7 +38,7 @@ impl<'a> CommandParserConfig<'a> {
         }
     }
 
-    /// Returns an immutable iterator for the prefixes.
+    /// Returns an immutable iterator of the prefixes.
     ///
     /// Use the [`add_prefix`] and [`remove_prefix`] methods for an easier way
     /// to manage prefixes.

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -83,11 +83,11 @@ impl<'a> CommandParserConfig<'a> {
         } else {
             CaseSensitivity::Insensitive(name.into())
         };
-        if !self.commands.contains(&command) {
+        if self.commands.contains(&command) {
+            false
+        } else {
             self.commands.push(command);
             true
-        } else {
-            false
         }
     }
 
@@ -126,11 +126,11 @@ impl<'a> CommandParserConfig<'a> {
     /// ```
     pub fn add_prefix(&mut self, prefix: impl Into<Cow<'a, str>>) -> bool {
         let prefix = prefix.into();
-        if !self.prefixes.contains(&prefix) {
+        if self.prefixes.contains(&prefix) {
+            false
+        } else {
             self.prefixes.push(prefix);
             true
-        } else {
-            false
         }
     }
 

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -1,7 +1,4 @@
-use std::{
-    borrow::Cow,
-    collections::{HashMap, HashSet},
-};
+use std::{borrow::Cow, collections::HashSet};
 
 use crate::CaseSensitivity;
 
@@ -11,7 +8,7 @@ use crate::CaseSensitivity;
 #[derive(Clone, Debug, Default)]
 pub struct CommandParserConfig<'a> {
     commands: HashSet<CaseSensitivity>,
-    prefixes: HashMap<Cow<'a, str>, Cow<'a, str>>,
+    prefixes: HashSet<Cow<'a, str>>,
 }
 
 impl<'a> CommandParserConfig<'a> {
@@ -43,12 +40,12 @@ impl<'a> CommandParserConfig<'a> {
     ///
     /// [`add_prefix`]: #method.add_prefix
     /// [`remove_prefix`]: #method.remove_prefix
-    pub fn prefixes(&self) -> &HashMap<Cow<'_, str>, Cow<'_, str>> {
+    pub fn prefixes(&self) -> &HashSet<Cow<'_, str>> {
         &self.prefixes
     }
 
     /// Returns a mutable reference to the prefixes.
-    pub fn prefixes_mut(&mut self) -> &mut HashMap<Cow<'a, str>, Cow<'a, str>> {
+    pub fn prefixes_mut(&mut self) -> &mut HashSet<Cow<'a, str>> {
         &mut self.prefixes
     }
 
@@ -114,10 +111,12 @@ impl<'a> CommandParserConfig<'a> {
     /// assert_eq!(1, config.prefixes().len());
     /// ```
     pub fn add_prefix(&mut self, prefix: impl Into<Cow<'a, str>>) {
-        self.prefixes.insert(prefix.into(), Cow::Borrowed(""));
+        self.prefixes.insert(prefix.into());
     }
 
     /// Removes a prefix from the list of prefixes.
+    ///
+    /// Returns true when a prefix with the name was removed.
     ///
     /// # Examples
     ///
@@ -133,7 +132,7 @@ impl<'a> CommandParserConfig<'a> {
     /// config.remove_prefix("!");
     /// assert_eq!(1, config.prefixes().len());
     /// ```
-    pub fn remove_prefix(&mut self, prefix: impl Into<Cow<'a, str>>) -> Option<Cow<'a, str>> {
+    pub fn remove_prefix(&mut self, prefix: impl Into<Cow<'a, str>>) -> bool {
         self.prefixes.remove(&prefix.into())
     }
 }

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -173,65 +173,6 @@ impl<'a> Iterator for Commands<'a> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
-
-    fn count(self) -> usize {
-        self.iter.count()
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth(n)
-    }
-
-    fn last(self) -> Option<Self::Item> {
-        self.iter.last()
-    }
-
-    fn for_each<F>(self, f: F)
-    where
-        F: FnMut(Self::Item),
-    {
-        self.iter.for_each(f)
-    }
-
-    fn all<F>(&mut self, f: F) -> bool
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> bool,
-    {
-        self.iter.all(f)
-    }
-
-    fn any<F>(&mut self, f: F) -> bool
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> bool,
-    {
-        self.iter.any(f)
-    }
-
-    fn find<P>(&mut self, predicate: P) -> Option<Self::Item>
-    where
-        Self: Sized,
-        P: FnMut(&Self::Item) -> bool,
-    {
-        self.iter.find(predicate)
-    }
-
-    fn find_map<B, F>(&mut self, f: F) -> Option<B>
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> Option<B>,
-    {
-        self.iter.find_map(f)
-    }
-
-    fn position<P>(&mut self, predicate: P) -> Option<usize>
-    where
-        Self: Sized,
-        P: FnMut(Self::Item) -> bool,
-    {
-        self.iter.position(predicate)
-    }
 }
 
 impl<'a> ExactSizeIterator for Commands<'a> {}
@@ -249,65 +190,6 @@ impl<'a> Iterator for CommandsMut<'a> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
-    }
-
-    fn count(self) -> usize {
-        self.iter.count()
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth(n)
-    }
-
-    fn last(self) -> Option<Self::Item> {
-        self.iter.last()
-    }
-
-    fn for_each<F>(self, f: F)
-    where
-        F: FnMut(Self::Item),
-    {
-        self.iter.for_each(f)
-    }
-
-    fn all<F>(&mut self, f: F) -> bool
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> bool,
-    {
-        self.iter.all(f)
-    }
-
-    fn any<F>(&mut self, f: F) -> bool
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> bool,
-    {
-        self.iter.any(f)
-    }
-
-    fn find<P>(&mut self, predicate: P) -> Option<Self::Item>
-    where
-        Self: Sized,
-        P: FnMut(&Self::Item) -> bool,
-    {
-        self.iter.find(predicate)
-    }
-
-    fn find_map<B, F>(&mut self, f: F) -> Option<B>
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> Option<B>,
-    {
-        self.iter.find_map(f)
-    }
-
-    fn position<P>(&mut self, predicate: P) -> Option<usize>
-    where
-        Self: Sized,
-        P: FnMut(Self::Item) -> bool,
-    {
-        self.iter.position(predicate)
     }
 }
 
@@ -327,65 +209,6 @@ impl<'a> Iterator for Prefixes<'a> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
-
-    fn count(self) -> usize {
-        self.iter.count()
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth(n)
-    }
-
-    fn last(self) -> Option<Self::Item> {
-        self.iter.last()
-    }
-
-    fn for_each<F>(self, f: F)
-    where
-        F: FnMut(Self::Item),
-    {
-        self.iter.for_each(f)
-    }
-
-    fn all<F>(&mut self, f: F) -> bool
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> bool,
-    {
-        self.iter.all(f)
-    }
-
-    fn any<F>(&mut self, f: F) -> bool
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> bool,
-    {
-        self.iter.any(f)
-    }
-
-    fn find<P>(&mut self, predicate: P) -> Option<Self::Item>
-    where
-        Self: Sized,
-        P: FnMut(&Self::Item) -> bool,
-    {
-        self.iter.find(predicate)
-    }
-
-    fn find_map<B, F>(&mut self, f: F) -> Option<B>
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> Option<B>,
-    {
-        self.iter.find_map(f)
-    }
-
-    fn position<P>(&mut self, predicate: P) -> Option<usize>
-    where
-        Self: Sized,
-        P: FnMut(Self::Item) -> bool,
-    {
-        self.iter.position(predicate)
-    }
 }
 
 impl<'a> ExactSizeIterator for Prefixes<'a> {}
@@ -403,65 +226,6 @@ impl<'a> Iterator for PrefixesMut<'a> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
-    }
-
-    fn count(self) -> usize {
-        self.iter.count()
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.iter.nth(n)
-    }
-
-    fn last(self) -> Option<Self::Item> {
-        self.iter.last()
-    }
-
-    fn for_each<F>(self, f: F)
-    where
-        F: FnMut(Self::Item),
-    {
-        self.iter.for_each(f)
-    }
-
-    fn all<F>(&mut self, f: F) -> bool
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> bool,
-    {
-        self.iter.all(f)
-    }
-
-    fn any<F>(&mut self, f: F) -> bool
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> bool,
-    {
-        self.iter.any(f)
-    }
-
-    fn find<P>(&mut self, predicate: P) -> Option<Self::Item>
-    where
-        Self: Sized,
-        P: FnMut(&Self::Item) -> bool,
-    {
-        self.iter.find(predicate)
-    }
-
-    fn find_map<B, F>(&mut self, f: F) -> Option<B>
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> Option<B>,
-    {
-        self.iter.find_map(f)
-    }
-
-    fn position<P>(&mut self, predicate: P) -> Option<usize>
-    where
-        Self: Sized,
-        P: FnMut(Self::Item) -> bool,
-    {
-        self.iter.position(predicate)
     }
 }
 

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -140,7 +140,7 @@ impl<'a> Parser<'a> {
 
     fn find_command(&'a self, buf: &'a str) -> Option<&'a str> {
         let buf = buf.split_whitespace().next()?;
-        self.config.commands().iter().find_map(|command| {
+        self.config.commands.iter().find_map(|command| {
             if command == buf {
                 Some(command.as_ref())
             } else {
@@ -150,7 +150,7 @@ impl<'a> Parser<'a> {
     }
 
     fn find_prefix(&self, buf: &str) -> Option<&str> {
-        self.config.prefixes().iter().find_map(|prefix| {
+        self.config.prefixes.iter().find_map(|prefix| {
             if buf.starts_with(prefix.as_ref()) {
                 Some(prefix.as_ref())
             } else {
@@ -223,7 +223,7 @@ mod tests {
 
         // Case sensitive
         let config = parser.config_mut();
-        config.commands_mut().clear();
+        config.commands.clear();
         config.add_command("echo", true);
         config.add_command("wei\u{df}", true);
         config.add_command("\u{394}", true);

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -90,7 +90,7 @@ impl<'a> Parser<'a> {
     ///
     /// [`Command`]: struct.Command.html
     pub fn parse(&'a self, buf: &'a str) -> Option<Command<'a>> {
-        let (prefix, _) = self.find_prefix(buf)?;
+        let prefix = self.find_prefix(buf)?;
         self.parse_with_prefix(prefix, buf)
     }
 
@@ -149,10 +149,10 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn find_prefix(&self, buf: &str) -> Option<(&str, &str)> {
-        self.config.prefixes().iter().find_map(|(prefix, padding)| {
+    fn find_prefix(&self, buf: &str) -> Option<&str> {
+        self.config.prefixes().iter().find_map(|prefix| {
             if buf.starts_with(prefix.as_ref()) {
-                Some((prefix.as_ref(), padding.as_ref()))
+                Some(prefix.as_ref())
             } else {
                 None
             }


### PR DESCRIPTION
Refactor the command-parser to change a HashMap into a HashSet.