### PR TITLE
use zlib-ng as default

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -29,6 +29,10 @@ url = { default-features = false, version = "2" }
 # from the C-backed backend zlib, When you give it the sync argument
 # it does not seem to update the total_in of the function to have an offset
 # https://github.com/alexcrichton/flate2-rs/issues/217
+
+# if the `zlib` feature is enabled anywhere in the dependency tree it will
+# use stock zlib instead of zlib-ng.
+# https://github.com/rust-lang/libz-sys/blob/main/README.md#zlib-ng
 flate2 = { default-features = false, features = ["zlib-ng-compat"], version = "1.0" }
 dashmap = { default-features = false, version = "3" }
 

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -29,7 +29,7 @@ url = { default-features = false, version = "2" }
 # from the C-backed backend zlib, When you give it the sync argument
 # it does not seem to update the total_in of the function to have an offset
 # https://github.com/alexcrichton/flate2-rs/issues/217
-flate2 = { default-features = false, features = ["zlib"], version = "1.0" }
+flate2 = { default-features = false, features = ["zlib-ng-compat"], version = "1.0" }
 dashmap = { default-features = false, version = "3" }
 
 # optional
@@ -44,4 +44,4 @@ tokio = { default-features = false, features = ["rt-core", "macros"], version = 
 default = ["rustls"]
 native = ["twilight-http/native", "async-tungstenite/tokio-native-tls"]
 rustls = ["twilight-http/rustls", "async-tungstenite/async-tls"]
-simd-zlib = ["flate2/cloudflare_zlib"]
+stock-zlib = ["flate2/zlib"]

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -74,7 +74,7 @@ This is enabled by default.
 
 ### zlib
 
-The `stock-zlib` feature enables [`flate2`]'s [`zlib`] feature which makes
+The `stock-zlib` feature enables [`flate2`]'s `zlib` feature which makes
 [`flate2`] use system zlib instead of [`zlib-ng`].
 
 This is not enabled by default.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -74,17 +74,19 @@ This is enabled by default.
 
 ### zlib
 
-The `simd-zlib` feature enables [`flate2`]'s [`cloudflare_zlib`] feature which
-uses Cloudflares SIMD-accelerated fork of zlib.
+The `stock-zlib` feature disables [`flate2`]'s [`zlib-ng-compat`] feature which
+uses the [`zlib-ng`] fork of zlib, the system zlib will then be used instead.
+
+This is not enabled by default.
 
 [`async-tungstenite`]: https://crates.io/crates/async-tungstenite
-[`cloudflare_zlib`]: https://crates.io/crates/cloudflare-zlib
 [`flate2`]: https://crates.io/crates/flate2
 [`native-tls`]: https://crates.io/crates/native-tls
 [`rustls`]: https://crates.io/crates/rustls
 [`serde_json`]: https://crates.io/crates/serde_json
 [`simd-json`]: https://crates.io/crates/simd-json
 [`twilight-http`]: https://twilight-rs.github.io/twilight/twilight_http/index.html
+[`zlib-ng`]: https://github.com/zlib-ng/zlib-ng
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -74,8 +74,8 @@ This is enabled by default.
 
 ### zlib
 
-The `stock-zlib` feature disables [`flate2`]'s [`zlib-ng-compat`] feature which
-uses the [`zlib-ng`] fork of zlib, the system zlib will then be used instead.
+The `stock-zlib` feature enables [`flate2`]'s [`zlib`] feature which makes
+[`flate2`] use system zlib instead of [`zlib-ng`].
 
 This is not enabled by default.
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -72,8 +72,8 @@
 //!
 //! ### zlib
 //!
-//! The `stock-zlib` feature disables [`flate2`]'s [`zlib-ng-compat`] feature which
-//! uses the [`zlib-ng`] fork of zlib, the system zlib will then be used instead.
+//! The `stock-zlib` feature enables [`flate2`]'s [`zlib`] feature which makes
+//! [`flate2`] use system zlib instead of [`zlib-ng`].
 //!
 //! This is not enabled by default.
 //!

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -72,17 +72,19 @@
 //!
 //! ### zlib
 //!
-//! The `simd-zlib` feature enables [`flate2`]'s [`cloudflare_zlib`] feature which
-//! uses Cloudflares SIMD-accelerated fork of zlib.
+//! The `stock-zlib` feature disables [`flate2`]'s [`zlib-ng-compat`] feature which
+//! uses the [`zlib-ng`] fork of zlib, the system zlib will then be used instead.
+//!
+//! This is not enabled by default.
 //!
 //! [`async-tungstenite`]: https://crates.io/crates/async-tungstenite
-//! [`cloudflare_zlib`]: https://crates.io/crates/cloudflare-zlib
 //! [`flate2`]: https://crates.io/crates/flate2
 //! [`native-tls`]: https://crates.io/crates/native-tls
 //! [`rustls`]: https://crates.io/crates/rustls
 //! [`serde_json`]: https://crates.io/crates/serde_json
 //! [`simd-json`]: https://crates.io/crates/simd-json
 //! [`twilight-http`]: https://twilight-rs.github.io/twilight/twilight_http/index.html
+//! [`zlib-ng`]: https://github.com/zlib-ng/zlib-ng
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -72,7 +72,7 @@
 //!
 //! ### zlib
 //!
-//! The `stock-zlib` feature enables [`flate2`]'s [`zlib`] feature which makes
+//! The `stock-zlib` feature enables [`flate2`]'s `zlib` feature which makes
 //! [`flate2`] use system zlib instead of [`zlib-ng`].
 //!
 //! This is not enabled by default.


### PR DESCRIPTION
This changeset may look a bit strange in that the zlib-ng-compat
feature is not disabled when setting it to use stock-zlib. This is
because flate2 (through libz) will use stock zlib if it is asked for
anywhere even if zlib-ng-compat is also asked for.