### PR TITLE
Fix CNAME in workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,3 +49,4 @@ jobs:
           publish_branch: gh-pages
           publish_dir: target/doc
           allow_empty_commit: true
+          cname: twilight.rs

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-twilight.rs


### PR DESCRIPTION
Make it so the CNAME file gets created on the gh-pages branch.