### PR TITLE
CNAME fix 2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,4 +49,4 @@ jobs:
           publish_branch: gh-pages
           publish_dir: target/doc
           allow_empty_commit: true
-          cname: twilight.rs
+          cname: api.twilight.rs


### PR DESCRIPTION
Point the cname at api.twilight.rs so it does take over the book.