### PR TITLE
project: fix all broken links

### DIFF
--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -32,9 +32,9 @@ impl Config {
     /// Return an immutable reference to the configuration used to create
     /// shards.
     ///
-    /// Refer to [`shard::config::ClusterBuilder`]'s methods for the default values.
+    /// Refer to [`ShardBuilder`]'s methods for the default values.
     ///
-    /// [`shard::config::ClusterBuilder`]: ../../shard/config/struct.ShardConfigBuilder.html#methods
+    /// [`ShardBuilder`]: ../shard/struct.ShardBuilder.html#methods
     pub fn shard_config(&self) -> &ShardConfig {
         &self.shard_config
     }

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -64,7 +64,7 @@ pub enum ClusterStartError {
     /// number of recommended number of shards to start fails, which can happen
     /// due to something like a network or response parsing issue.
     ///
-    /// [automatic sharding]: config/enum.ShardScheme.html#variant.Auto
+    /// [automatic sharding]: enum.ShardScheme.html#variant.Auto
     RetrievingGatewayInfo {
         /// Reason for the error.
         source: HttpError,

--- a/gateway/src/queue/mod.rs
+++ b/gateway/src/queue/mod.rs
@@ -34,7 +34,7 @@
 //! [`Cluster`]: ../cluster/struct.Cluster.html
 //! [`LargeBotQueue`]: struct.LargeBotQueue.html
 //! [`LocalQueue`]: struct.LocalQueue.html
-//! [`ShardBuilder::queue`]: ../Shard/struct.ShardBuilder.html#method.queue
+//! [`ShardBuilder::queue`]: ../shard/struct.ShardBuilder.html#method.queue
 //! [`Shard`]: ../shard/struct.Shard.html
 //! [Sharding for Very Large Bots]: https://discord.com/developers/docs/topics/gateway#sharding-for-very-large-bots
 

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -10,9 +10,9 @@ use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, GatewayI
 
 /// Large threshold configuration is invalid.
 ///
-/// Returned by [`ShardConfigBuilder::large_threshold`].
+/// Returned by [`ShardBuilder::large_threshold`].
 ///
-/// [`ShardConfigBuilder::large_threshold`]: struct.ShardConfigBuilder.html#method.large_threshold
+/// [`ShardBuilder::large_threshold`]: struct.ShardBuilder.html#method.large_threshold
 #[derive(Debug)]
 pub enum LargeThresholdError {
     /// Provided large threshold value is too few in number.
@@ -40,9 +40,9 @@ impl Error for LargeThresholdError {}
 
 /// Shard ID configuration is invalid.
 ///
-/// Returned by [`ShardConfigBuilder::shard`].
+/// Returned by [`ShardBuilder::shard`].
 ///
-/// [`ShardConfigBuilder::shard`]: struct.ShardConfigBuilder.html#method.shard
+/// [`ShardBuilder::shard`]: struct.ShardBuilder.html#method.shard
 #[derive(Debug)]
 pub enum ShardIdError {
     /// Provided shard ID is higher than provided total shard count.

--- a/gateway/src/shard/event.rs
+++ b/gateway/src/shard/event.rs
@@ -36,7 +36,7 @@ use twilight_model::gateway::event::Event;
 /// Refer to [`Shard::some_events`] for an example of how to use this.
 ///
 /// [`Events::event_types`]: #method.event_types
-/// [`Shard`]: ../struct.Shard.html
+/// [`Shard`]: struct.Shard.html
 /// [`Shard::some_events`]: struct.Shard.html#method.some_events
 /// [`futures::stream::Stream`]: https://docs.rs/futures/*/futures/stream/trait.Stream.html
 pub struct Events {

--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -477,8 +477,8 @@ impl Display for MessageApiError {
 
 /// Field within a [`MessageApiError`] [embed] list.
 ///
-/// [`MessageApiError`]: enum.MessageApiError.html
-/// [embed]: enum.MessageApiError.html#structfield.embed
+/// [`MessageApiError`]: struct.MessageApiError.html
+/// [embed]: struct.MessageApiError.html#structfield.embed
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -145,7 +145,7 @@ impl<'a> CreateMessage<'a> {
     /// Returns [`CreateMessageError::EmbedTooLarge`] if the embed is too large.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#embed-limits
-    /// [`EmbedBuilder`]: ../../../../../twilight_builders/embed/struct.EmbedBuilder.html
+    /// [`EmbedBuilder`]: ../../../../../twilight_embed_builder/builder/struct.EmbedBuilder.html
     /// [`CreateMessageError::EmbedTooLarge`]: enum.CreateMessageError.html#variant.EmbedTooLarge
     pub fn embed(mut self, embed: Embed) -> Result<Self, CreateMessageError> {
         if let Err(source) = validate::embed(&embed) {

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -81,7 +81,7 @@ struct LavalinkRef {
 /// information about the active playing information of a guild and allows you to send events to the
 /// connected node, such as [`Play`] events.
 ///
-/// [`Play`]: ../model/struct.Play.html
+/// [`Play`]: ../model/outgoing/struct.Play.html
 /// [`player`]: #method.player
 /// [`process`]: #method.process
 #[derive(Clone, Debug)]

--- a/lavalink/src/http.rs
+++ b/lavalink/src/http.rs
@@ -35,7 +35,7 @@ pub struct Track {
     pub info: TrackInfo,
     /// The base64 track string that you use in the [`Play`] event.
     ///
-    /// [`Play`]: ../model/struct.Play.html
+    /// [`Play`]: ../model/outgoing/struct.Play.html
     pub track: String,
 }
 

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -3,7 +3,7 @@
 //! Using nodes, you can send events to a server and receive events.
 //!
 //! This is a bit more low level than using the [`Lavalink`] client because you
-//! will need to provide your own [`VoiceUpdate`] events when your bot joins
+//! will need to provide your own `VoiceUpdate` events when your bot joins
 //! channels, meaning you will have to accumulate and combine voice state update
 //! and voice server update events from the Discord gateway to send them to
 //! a node.
@@ -17,7 +17,6 @@
 //!
 //! [`Lavalink`]: ../client/struct.Lavalink.html
 //! [`PlayerManager`]: ../player/struct.PlayerManager.html
-//! [`VoiceUpdate`]: ../model/struct.VoiceUpdate.html
 
 use crate::{
     model::{IncomingEvent, Opcode, OutgoingEvent, PlayerUpdate, Stats, StatsCpu, StatsMemory},

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -114,8 +114,8 @@ impl Player {
     /// # Ok(()) }
     /// ```
     ///
-    /// [`Pause`]: ../model/struct.Pause.html
-    /// [`Play`]: ../model/struct.Play.html
+    /// [`Pause`]: ../model/outgoing/struct.Pause.html
+    /// [`Play`]: ../model/outgoing/struct.Play.html
     pub fn send(&self, event: impl Into<OutgoingEvent>) -> Result<(), TrySendError<OutgoingEvent>> {
         self._send(event.into())
     }

--- a/utils/embed-builder/src/author.rs
+++ b/utils/embed-builder/src/author.rs
@@ -43,7 +43,7 @@ impl Error for EmbedAuthorNameError {}
 ///
 /// This can be passed into [`EmbedBuilder::author`].
 ///
-/// [`EmbedBuilder::author`]: struct.EmbedBuilder.html#method.author
+/// [`EmbedBuilder::author`]: ../builder/struct.EmbedBuilder.html#method.author
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[must_use = "must be built into an embed author"]
 pub struct EmbedAuthorBuilder(EmbedAuthor);

--- a/utils/embed-builder/src/builder.rs
+++ b/utils/embed-builder/src/builder.rs
@@ -321,8 +321,8 @@ impl EmbedBuilder {
     /// an acceptable value.
     ///
     /// [`COLOR_MAXIMUM`]: #const.COLOR_MAXIMUM
-    /// [`EmbedError::NotRgb`]: enum.EmbedError.html#variant.NotRgb
-    /// [`EmbedError::Zero`]: enum.EmbedError.html#variant.Zero
+    /// [`EmbedError::NotRgb`]: enum.EmbedColorError.html#variant.NotRgb
+    /// [`EmbedError::Zero`]: enum.EmbedColorError.html#variant.Zero
     pub fn color(mut self, color: u32) -> Result<Self, EmbedColorError> {
         if color == 0 {
             return Err(EmbedColorError::Zero);

--- a/utils/embed-builder/src/field.rs
+++ b/utils/embed-builder/src/field.rs
@@ -65,7 +65,7 @@ impl Error for EmbedFieldError {}
 ///
 /// Fields are not inlined by default. Use [`inline`] to inline a field.
 ///
-/// [`EmbedBuilder::field`]: struct.EmbedBuilder.html#method.field
+/// [`EmbedBuilder::field`]: ../builder/struct.EmbedBuilder.html#method.field
 /// [`inline`]: #method.inline
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[must_use = "must be built into an embed field"]

--- a/utils/embed-builder/src/footer.rs
+++ b/utils/embed-builder/src/footer.rs
@@ -43,7 +43,7 @@ impl Error for EmbedFooterTextError {}
 ///
 /// This can be passed into [`EmbedBuilder::footer`].
 ///
-/// [`EmbedBuilder::footer`]: struct.EmbedBuilder.html#method.footer
+/// [`EmbedBuilder::footer`]: ../builder/struct.EmbedBuilder.html#method.footer
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[must_use = "must be built into an embed footer"]
 pub struct EmbedFooterBuilder(EmbedFooter);
@@ -66,8 +66,8 @@ impl EmbedFooterBuilder {
     /// longer than the limit defined at [`TEXT_LENGTH_LIMIT`].
     ///
     /// [`TEXT_LENGTH_LIMIT`]: #const.TEXT_LENGTH_LIMIT
-    /// [`EmbedFooterTextError::Empty`]: enum.EmbedFooterTextError.variant.Empty
-    /// [`EmbedFooterTextError::TooLong`]: enum.EmbedFooterTextError.variant.TooLong
+    /// [`EmbedFooterTextError::Empty`]: enum.EmbedFooterTextError.html#variant.Empty
+    /// [`EmbedFooterTextError::TooLong`]: enum.EmbedFooterTextError.html#variant.TooLong
     pub fn new(text: impl Into<String>) -> Result<Self, EmbedFooterTextError> {
         Self::_new(text.into())
     }


### PR DESCRIPTION
Fix all broken links via `cargo deadlinks`. This fixes links in the following crates:

- embed-builder
- gateway
- http
- lavalink

Part of #459.