### PR TITLE
model/gateway: rename 'gatewayintents'

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ use tokio::stream::StreamExt;
 use twilight_cache_inmemory::{EventType, InMemoryCache};
 use twilight_gateway::{cluster::{Cluster, ShardScheme}, Event};
 use twilight_http::Client as HttpClient;
-use twilight_model::gateway::GatewayIntents;
+use twilight_model::gateway::Intents;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -123,7 +123,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let cluster = Cluster::builder(&token)
         .shard_scheme(scheme)
         // Use intents to only receive guild message events.
-        .intents(Some(GatewayIntents::GUILD_MESSAGES))
+        .intents(Some(Intents::GUILD_MESSAGES))
         .build()
         .await?;
 

--- a/gateway/examples/intents/src/main.rs
+++ b/gateway/examples/intents/src/main.rs
@@ -1,7 +1,7 @@
 use futures::StreamExt;
 use std::{env, error::Error};
 use twilight_gateway::Shard;
-use twilight_model::gateway::GatewayIntents;
+use twilight_model::gateway::Intents;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let mut shard = Shard::builder(env::var("DISCORD_TOKEN")?)
         .intents(Some(
-            GatewayIntents::GUILD_MESSAGES | GatewayIntents::DIRECT_MESSAGES,
+            Intents::GUILD_MESSAGES | Intents::DIRECT_MESSAGES,
         ))
         .build();
 

--- a/gateway/examples/intents/src/main.rs
+++ b/gateway/examples/intents/src/main.rs
@@ -9,9 +9,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt::init();
 
     let mut shard = Shard::builder(env::var("DISCORD_TOKEN")?)
-        .intents(Some(
-            Intents::GUILD_MESSAGES | Intents::DIRECT_MESSAGES,
-        ))
+        .intents(Some(Intents::GUILD_MESSAGES | Intents::DIRECT_MESSAGES))
         .build();
 
     shard.start().await?;

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -15,7 +15,7 @@ use std::{
     sync::Arc,
 };
 use twilight_http::Client;
-use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, GatewayIntents};
+use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents};
 
 /// Starting a cluster failed.
 #[derive(Debug)]
@@ -127,12 +127,12 @@ impl<T: RangeBounds<u64>> TryFrom<(T, u64)> for ShardScheme {
 /// ```rust,no_run
 /// use std::env;
 /// use twilight_gateway::Cluster;
-/// use twilight_model::gateway::GatewayIntents;
+/// use twilight_model::gateway::Intents;
 ///
 /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let token = env::var("DISCORD_TOKEN")?;
 ///
-/// let intents = GatewayIntents::GUILD_MESSAGES;
+/// let intents = Intents::GUILD_MESSAGES;
 /// let cluster = Cluster::builder(token)
 ///     .intents(Some(intents))
 ///     .large_threshold(100)?
@@ -224,7 +224,7 @@ impl ClusterBuilder {
     /// Refer to the shard's [`ShardBuilder::intents`] for more information.
     ///
     /// [`ShardBuilder::intents`]: ../shard/struct.ShardBuilder.html#method.intents
-    pub fn intents(mut self, intents: Option<GatewayIntents>) -> Self {
+    pub fn intents(mut self, intents: Option<Intents>) -> Self {
         self.1 = self.1.intents(intents);
 
         self

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -6,7 +6,7 @@ use std::{
     sync::Arc,
 };
 use twilight_http::Client as HttpClient;
-use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, GatewayIntents};
+use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents};
 
 /// Large threshold configuration is invalid.
 ///
@@ -141,7 +141,7 @@ impl ShardBuilder {
     /// Set the gateway intents.
     ///
     /// Default is Discord's default.
-    pub fn intents(mut self, intents: Option<GatewayIntents>) -> Self {
+    pub fn intents(mut self, intents: Option<Intents>) -> Self {
         self.0.intents = intents;
 
         self

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -1,7 +1,7 @@
 use crate::queue::Queue;
 use std::sync::Arc;
 use twilight_http::Client;
-use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, GatewayIntents};
+use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents};
 
 /// The configuration used by the shard to identify with the gateway and
 /// operate.
@@ -12,7 +12,7 @@ use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, GatewayI
 #[derive(Clone, Debug)]
 pub struct Config {
     pub(super) http_client: Client,
-    pub(super) intents: Option<GatewayIntents>,
+    pub(super) intents: Option<Intents>,
     pub(super) large_threshold: u64,
     pub(super) presence: Option<UpdateStatusInfo>,
     pub(super) queue: Arc<Box<dyn Queue>>,
@@ -30,7 +30,7 @@ impl Config {
     }
 
     /// Return an immutable reference to the intents that the gateway is using.
-    pub fn intents(&self) -> Option<&GatewayIntents> {
+    pub fn intents(&self) -> Option<&Intents> {
         self.intents.as_ref()
     }
 

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -39,7 +39,7 @@ use twilight_model::gateway::{
         identify::{Identify, IdentifyInfo, IdentifyProperties},
         resume::Resume,
     },
-    GatewayIntents, OpCode,
+    Intents, OpCode,
 };
 use url::{ParseError as UrlParseError, Url};
 
@@ -160,7 +160,7 @@ enum ReceivingEventError {
     /// The intents are provided.
     IntentsDisallowed {
         /// The configured intents for the shard.
-        intents: Option<GatewayIntents>,
+        intents: Option<Intents>,
         /// The ID of the shard.
         shard_id: u64,
     },
@@ -169,7 +169,7 @@ enum ReceivingEventError {
     /// The intents are provided.
     IntentsInvalid {
         /// Configured intents for the shard.
-        intents: Option<GatewayIntents>,
+        intents: Option<Intents>,
         /// ID of the shard.
         shard_id: u64,
     },

--- a/model/src/gateway/intents.rs
+++ b/model/src/gateway/intents.rs
@@ -5,7 +5,7 @@ use serde::{
 };
 
 bitflags! {
-    pub struct GatewayIntents: u64 {
+    pub struct Intents: u64 {
         const GUILDS = 1;
         const GUILD_MEMBERS = 1 << 1;
         const GUILD_BANS = 1 << 2;
@@ -24,13 +24,13 @@ bitflags! {
     }
 }
 
-impl<'de> Deserialize<'de> for GatewayIntents {
+impl<'de> Deserialize<'de> for Intents {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Ok(Self::from_bits_truncate(u64::deserialize(deserializer)?))
     }
 }
 
-impl Serialize for GatewayIntents {
+impl Serialize for Intents {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -41,36 +41,36 @@ impl Serialize for GatewayIntents {
 
 #[cfg(test)]
 mod tests {
-    use super::GatewayIntents;
+    use super::Intents;
     use serde_test::Token;
 
     #[test]
     fn test_variants() {
-        serde_test::assert_tokens(&GatewayIntents::GUILDS, &[Token::U64(1)]);
-        serde_test::assert_tokens(&GatewayIntents::GUILD_MEMBERS, &[Token::U64(1 << 1)]);
-        serde_test::assert_tokens(&GatewayIntents::GUILD_BANS, &[Token::U64(1 << 2)]);
-        serde_test::assert_tokens(&GatewayIntents::GUILD_EMOJIS, &[Token::U64(1 << 3)]);
-        serde_test::assert_tokens(&GatewayIntents::GUILD_INTEGRATIONS, &[Token::U64(1 << 4)]);
-        serde_test::assert_tokens(&GatewayIntents::GUILD_WEBHOOKS, &[Token::U64(1 << 5)]);
-        serde_test::assert_tokens(&GatewayIntents::GUILD_INVITES, &[Token::U64(1 << 6)]);
-        serde_test::assert_tokens(&GatewayIntents::GUILD_VOICE_STATES, &[Token::U64(1 << 7)]);
-        serde_test::assert_tokens(&GatewayIntents::GUILD_PRESENCES, &[Token::U64(1 << 8)]);
-        serde_test::assert_tokens(&GatewayIntents::GUILD_MESSAGES, &[Token::U64(1 << 9)]);
+        serde_test::assert_tokens(&Intents::GUILDS, &[Token::U64(1)]);
+        serde_test::assert_tokens(&Intents::GUILD_MEMBERS, &[Token::U64(1 << 1)]);
+        serde_test::assert_tokens(&Intents::GUILD_BANS, &[Token::U64(1 << 2)]);
+        serde_test::assert_tokens(&Intents::GUILD_EMOJIS, &[Token::U64(1 << 3)]);
+        serde_test::assert_tokens(&Intents::GUILD_INTEGRATIONS, &[Token::U64(1 << 4)]);
+        serde_test::assert_tokens(&Intents::GUILD_WEBHOOKS, &[Token::U64(1 << 5)]);
+        serde_test::assert_tokens(&Intents::GUILD_INVITES, &[Token::U64(1 << 6)]);
+        serde_test::assert_tokens(&Intents::GUILD_VOICE_STATES, &[Token::U64(1 << 7)]);
+        serde_test::assert_tokens(&Intents::GUILD_PRESENCES, &[Token::U64(1 << 8)]);
+        serde_test::assert_tokens(&Intents::GUILD_MESSAGES, &[Token::U64(1 << 9)]);
         serde_test::assert_tokens(
-            &GatewayIntents::GUILD_MESSAGE_REACTIONS,
+            &Intents::GUILD_MESSAGE_REACTIONS,
             &[Token::U64(1 << 10)],
         );
         serde_test::assert_tokens(
-            &GatewayIntents::GUILD_MESSAGE_TYPING,
+            &Intents::GUILD_MESSAGE_TYPING,
             &[Token::U64(1 << 11)],
         );
-        serde_test::assert_tokens(&GatewayIntents::DIRECT_MESSAGES, &[Token::U64(1 << 12)]);
+        serde_test::assert_tokens(&Intents::DIRECT_MESSAGES, &[Token::U64(1 << 12)]);
         serde_test::assert_tokens(
-            &GatewayIntents::DIRECT_MESSAGE_REACTIONS,
+            &Intents::DIRECT_MESSAGE_REACTIONS,
             &[Token::U64(1 << 13)],
         );
         serde_test::assert_tokens(
-            &GatewayIntents::DIRECT_MESSAGE_TYPING,
+            &Intents::DIRECT_MESSAGE_TYPING,
             &[Token::U64(1 << 14)],
         );
     }

--- a/model/src/gateway/intents.rs
+++ b/model/src/gateway/intents.rs
@@ -56,22 +56,10 @@ mod tests {
         serde_test::assert_tokens(&Intents::GUILD_VOICE_STATES, &[Token::U64(1 << 7)]);
         serde_test::assert_tokens(&Intents::GUILD_PRESENCES, &[Token::U64(1 << 8)]);
         serde_test::assert_tokens(&Intents::GUILD_MESSAGES, &[Token::U64(1 << 9)]);
-        serde_test::assert_tokens(
-            &Intents::GUILD_MESSAGE_REACTIONS,
-            &[Token::U64(1 << 10)],
-        );
-        serde_test::assert_tokens(
-            &Intents::GUILD_MESSAGE_TYPING,
-            &[Token::U64(1 << 11)],
-        );
+        serde_test::assert_tokens(&Intents::GUILD_MESSAGE_REACTIONS, &[Token::U64(1 << 10)]);
+        serde_test::assert_tokens(&Intents::GUILD_MESSAGE_TYPING, &[Token::U64(1 << 11)]);
         serde_test::assert_tokens(&Intents::DIRECT_MESSAGES, &[Token::U64(1 << 12)]);
-        serde_test::assert_tokens(
-            &Intents::DIRECT_MESSAGE_REACTIONS,
-            &[Token::U64(1 << 13)],
-        );
-        serde_test::assert_tokens(
-            &Intents::DIRECT_MESSAGE_TYPING,
-            &[Token::U64(1 << 14)],
-        );
+        serde_test::assert_tokens(&Intents::DIRECT_MESSAGE_REACTIONS, &[Token::U64(1 << 13)]);
+        serde_test::assert_tokens(&Intents::DIRECT_MESSAGE_TYPING, &[Token::U64(1 << 14)]);
     }
 }

--- a/model/src/gateway/mod.rs
+++ b/model/src/gateway/mod.rs
@@ -7,4 +7,4 @@ mod intents;
 mod opcode;
 mod session_start_limit;
 
-pub use self::{intents::GatewayIntents, opcode::OpCode, session_start_limit::SessionStartLimit};
+pub use self::{intents::Intents, opcode::OpCode, session_start_limit::SessionStartLimit};

--- a/model/src/gateway/payload/identify.rs
+++ b/model/src/gateway/payload/identify.rs
@@ -1,5 +1,5 @@
 use super::update_status::UpdateStatusInfo;
-use crate::gateway::{intents::GatewayIntents, opcode::OpCode};
+use crate::gateway::{intents::Intents, opcode::OpCode};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -20,7 +20,7 @@ impl Identify {
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct IdentifyInfo {
     pub compression: bool,
-    pub intents: Option<GatewayIntents>,
+    pub intents: Option<Intents>,
     pub large_threshold: u64,
     pub presence: Option<UpdateStatusInfo>,
     pub properties: IdentifyProperties,

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -108,7 +108,7 @@
 //! use twilight_cache_inmemory::{EventType, InMemoryCache};
 //! use twilight_gateway::{cluster::{Cluster, ShardScheme}, Event};
 //! use twilight_http::Client as HttpClient;
-//! use twilight_model::gateway::GatewayIntents;
+//! use twilight_model::gateway::Intents;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -121,7 +121,7 @@
 //!     let cluster = Cluster::builder(&token)
 //!         .shard_scheme(scheme)
 //!         // Use intents to only receive guild message events.
-//!         .intents(Some(GatewayIntents::GUILD_MESSAGES))
+//!         .intents(Some(Intents::GUILD_MESSAGES))
 //!         .build()
 //!         .await?;
 //!


### PR DESCRIPTION
Rename `twilight_model::gateway::GatewayIntents` to just `Intents`. It's not necessary to repeat `Gateway` in the name and `Intents` is more concise.