### PR TITLE
gateway/examples/metrics: reduce features

### DIFF
--- a/gateway/examples/metrics/Cargo.toml
+++ b/gateway/examples/metrics/Cargo.toml
@@ -5,11 +5,10 @@ name = "twilight-gateway-example-metrics"
 version = "0.1.0"
 
 [dependencies]
-twilight-gateway = { path = "../..", features = ["metrics"] }
 futures = "0.3"
-log = "0.4"
-tracing = "0.1"
-tracing-log = "0.1"
-tracing-subscriber = "0.2"
-tokio = { version = "0.2", features = ["macros", "rt-core"] }
-metrics-runtime = "0.13"
+log = { default-features = false, version = "0.4" }
+metrics-runtime = { default-features = false, features = ["metrics-exporter-log", "metrics-observer-json"], version = "0.13" }
+tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }
+tracing-log = { default-features = false, features = ["log-tracer", "std"], version = "0.1" }
+tracing-subscriber = { default-features = false, features = ["fmt"], version = "0.2" }
+twilight-gateway = { path = "../..", features = ["metrics"] }


### PR DESCRIPTION
In the gateway's "metrics" example, reduce the features of dependencies, mainly `tracing-log` and `metrics-runtime`. `metrics-runtime` in particular by default brings in all observers and exporters, such as HTTP exporters and prometheus observers.

This reduces the example's dependency count from 232 to 216 and the workspace's total dependency count in a build from 262 to 256.