### PR TITLE
Remove Copy and Ordering derives from ShardScheme

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -49,7 +49,7 @@ impl Error for ShardSchemeRangeError {}
 /// By default this is [`Auto`].
 ///
 /// [`Auto`]: #variant.Auto
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum ShardScheme {
     /// Specifies to retrieve the amount of shards recommended by Discord and

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -39,13 +39,13 @@ impl Config {
         &self.shard_config
     }
 
-    /// Return the shard scheme used to start shards.
+    /// Return a immutable reference to the shard scheme used to start shards.
     ///
     /// Refer to [`ClusterBuilder::shard_scheme`] for the default value.
     ///
     /// [`ClusterBuilder::shard_scheme`]: struct.ClusterBuilder.html#method.shard_scheme
-    pub fn shard_scheme(&self) -> ShardScheme {
-        self.shard_scheme
+    pub fn shard_scheme(&self) -> &ShardScheme {
+        &self.shard_scheme
     }
 
     /// Return an immutable reference to the queue used for initiating shard

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -39,7 +39,7 @@ impl Config {
         &self.shard_config
     }
 
-    /// Return a immutable reference to the shard scheme used to start shards.
+    /// Return an immutable reference to the shard scheme used to start shards.
     ///
     /// Refer to [`ClusterBuilder::shard_scheme`] for the default value.
     ///

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -137,7 +137,7 @@ impl Cluster {
 
                 [0, gateway.shards - 1, gateway.shards]
             }
-            ShardScheme::Range { from, to, total } => [from, to, total],
+            ShardScheme::Range { from, to, total } => [*from, *to, *total],
         };
 
         #[cfg(feature = "metrics")]


### PR DESCRIPTION
Copy: We want to be able to add non-copy variants in the future.

Ordering: It does not make much sense to have a order for
ShardSchemes.