### PR TITLE
Derive from Serialize for cache structs

### DIFF
--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 [dependencies]
 bitflags = { default-features = false, version = "1" }
 dashmap = { default-features = false, version = "3" }
+serde = { default-features = false, features = ["derive", "rc"], version = "1" }
 twilight-model = { default-features = false, path = "../../model" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 

--- a/cache/in-memory/src/model/emoji.rs
+++ b/cache/in-memory/src/model/emoji.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use std::sync::Arc;
 use twilight_model::{
     guild::Emoji,
@@ -5,7 +6,7 @@ use twilight_model::{
     user::User,
 };
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedEmoji {
     pub id: EmojiId,
     pub animated: bool,

--- a/cache/in-memory/src/model/guild.rs
+++ b/cache/in-memory/src/model/guild.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use twilight_model::{
     guild::{
         DefaultMessageNotificationLevel, ExplicitContentFilter, MfaLevel, Permissions, PremiumTier,
@@ -6,7 +7,7 @@ use twilight_model::{
     id::{ApplicationId, ChannelId, GuildId, UserId},
 };
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedGuild {
     pub id: GuildId,
     pub afk_channel_id: Option<ChannelId>,

--- a/cache/in-memory/src/model/member.rs
+++ b/cache/in-memory/src/model/member.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use std::sync::Arc;
 use twilight_model::{
     guild::Member,
@@ -5,7 +6,7 @@ use twilight_model::{
     user::User,
 };
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedMember {
     pub deaf: bool,
     pub guild_id: GuildId,

--- a/cache/in-memory/src/model/message.rs
+++ b/cache/in-memory/src/model/message.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use twilight_model::{
     channel::{
         embed::Embed,
@@ -11,7 +12,7 @@ use twilight_model::{
     id::{ChannelId, GuildId, MessageId, RoleId, UserId, WebhookId},
 };
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedMessage {
     pub id: MessageId,
     pub activity: Option<MessageActivity>,

--- a/cache/in-memory/src/model/presence.rs
+++ b/cache/in-memory/src/model/presence.rs
@@ -1,9 +1,10 @@
+use serde::Serialize;
 use twilight_model::{
     gateway::presence::{Activity, ClientStatus, Presence, Status, UserOrId},
     id::{GuildId, UserId},
 };
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedPresence {
     pub activities: Vec<Activity>,
     pub client_status: ClientStatus,

--- a/cache/in-memory/src/model/voice_state.rs
+++ b/cache/in-memory/src/model/voice_state.rs
@@ -1,9 +1,10 @@
+use serde::Serialize;
 use twilight_model::{
     id::{ChannelId, GuildId, UserId},
     voice::VoiceState,
 };
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedVoiceState {
     pub channel_id: Option<ChannelId>,
     pub deaf: bool,


### PR DESCRIPTION
This makes the cache struct derive Serialize, allowing for them to be serialized as JSON to e.g. expose the cache to the outside world in any way.

All tests pass, I hope I did not miss out any struct.