### PR TITLE
gateway: add {cluster,shard}::command_raw

### DIFF
--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -302,12 +302,7 @@ impl Cluster {
         value: &impl serde::Serialize,
     ) -> Result<(), ClusterCommandError> {
         let shard = self
-            .0
-            .shards
-            .lock()
-            .expect("shards poisoned")
-            .get(&id)
-            .cloned()
+            .shard(id)
             .ok_or(ClusterCommandError::ShardNonexistent { id })?;
 
         shard
@@ -328,18 +323,13 @@ impl Cluster {
     ///
     /// [`ClusterCommandError::Sending`]: enum.ClusterCommandError.html#variant.Sending
     /// [`ClusterCommandError::ShardNonexistent`]: enum.ClusterCommandError.html#variant.ShardNonexistent
-    pub async fn raw_command(&self, id: u64, value: String) -> Result<(), ClusterCommandError> {
+    pub async fn command_raw(&self, id: u64, value: Vec<u8>) -> Result<(), ClusterCommandError> {
         let shard = self
-            .0
-            .shards
-            .lock()
-            .expect("shards poisoned")
-            .get(&id)
-            .cloned()
+            .shard(id)
             .ok_or(ClusterCommandError::ShardNonexistent { id })?;
 
         shard
-            .raw_command(value)
+            .command_raw(value)
             .await
             .map_err(|source| ClusterCommandError::Sending { source })
     }


### PR DESCRIPTION
This adds a method `raw_command` to Shard and Cluster.

I have a usecase for this as I receive bytes from a different source that I need to relay over the gateway, and deserializing just for twilight to serialize it again is unnecessary overhead. This allows for sending the raw JSON as a string (and therefore bytes with `String::from_utf8`).