### PR TITLE
Downgrade gateway warnings

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -676,7 +676,7 @@ impl ShardProcessor {
         &mut self,
         close_frame: Option<&CloseFrame<'_>>,
     ) -> Result<(), ReceivingEventError> {
-        tracing::warn!("got close code: {:?}", close_frame);
+        tracing::info!("got close code: {:?}", close_frame);
 
         self.emitter.event(Event::ShardDisconnected(Disconnected {
             code: close_frame.as_ref().map(|frame| frame.code.into()),
@@ -796,7 +796,7 @@ impl ShardProcessor {
         let id = if let Some(id) = self.session.id() {
             id
         } else {
-            tracing::warn!("session id unavailable, reconnecting");
+            tracing::info!("session id unavailable, reconnecting");
             self.reconnect().await;
             return;
         };

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -523,7 +523,7 @@ impl ShardProcessor {
             // Safe to unwrap so here as we have just checked that
             // it is some.
             let (seq, id) = self.resume.take().unwrap();
-            tracing::warn!("resuming with sequence {}, session id {}", seq, id);
+            tracing::debug!("resuming with sequence {}, session id {}", seq, id);
             let payload = Resume::new(seq, &id, self.config.token());
 
             // Set id so it is correct for next resume.


### PR DESCRIPTION
This downgrades the warnings for gateway events to debug for resumes and info for reconnects as discussed.