### PR TITLE
Change default zlib backend to be system zlib.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,12 @@ jobs:
             additional: --features rustls
             rustflags: '-C target-cpu=native'
           - package: gateway
+            features: rustls
+            additional: --features stock-zlib
+          - package: gateway
+            features: native
+            additional: --features stock-zlib
+          - package: gateway
             features: simd-json
             additional: --features rustls,stock-zlib
             rustflags: '-C target-cpu=native'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
             rustflags: '-C target-cpu=native'
           - package: gateway
             features: simd-json
-            additional: --features rustls
+            additional: --features rustls,stock-zlib
             rustflags: '-C target-cpu=native'
           - package: lavalink
             additional: --features http-support

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -31,11 +31,7 @@ url = { default-features = false, version = "2" }
 # from the C-backed backend zlib, When you give it the sync argument
 # it does not seem to update the total_in of the function to have an offset
 # https://github.com/alexcrichton/flate2-rs/issues/217
-
-# if the `zlib` feature is enabled anywhere in the dependency tree it will
-# use stock zlib instead of zlib-ng.
-# https://github.com/rust-lang/libz-sys/blob/main/README.md#zlib-ng
-flate2 = { default-features = false, features = ["zlib-ng-compat"], version = "1.0" }
+flate2 = { default-features = false, version = "1.0" }
 dashmap = { default-features = false, version = "3" }
 
 # optional
@@ -47,7 +43,11 @@ futures = { default-features = false, version = "0.3" }
 tokio = { default-features = false, features = ["rt-core", "macros"], version = "0.2" }
 
 [features]
-default = ["rustls"]
+default = ["rustls", "stock-zlib"]
 native = ["twilight-http/native", "async-tungstenite/tokio-native-tls"]
 rustls = ["twilight-http/rustls", "async-tungstenite/async-tls"]
+simd-zlib = ["flate2/zlib-ng-compat"]
+# if the `zlib` feature is enabled anywhere in the dependency tree it will
+# always use stock zlib instead of zlib-ng.
+# https://github.com/rust-lang/libz-sys/blob/main/README.md#zlib-ng
 stock-zlib = ["flate2/zlib"]

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -74,13 +74,15 @@ This is enabled by default.
 
 ### zlib
 
-The `stock-zlib` feature enables [`flate2`]'s `zlib` feature which makes
-[`flate2`] use system zlib instead of [`zlib-ng`].
+There are 2 zlib features `stock-zlib` and `simd-zlib` for the library to work
+one of them has to be enabled. If both are enabled it will use `stock-zlib`
 
-This is not enabled by default.
+`stock-zlib` enabled by default.
+
+Enabling **only** `simd-zlib` will make the library use [`zlib-ng`] which is a modern
+fork of zlib that is faster and more effective, but it needs `cmake` to compile.
 
 [`async-tungstenite`]: https://crates.io/crates/async-tungstenite
-[`flate2`]: https://crates.io/crates/flate2
 [`native-tls`]: https://crates.io/crates/native-tls
 [`rustls`]: https://crates.io/crates/rustls
 [`serde_json`]: https://crates.io/crates/serde_json

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -72,13 +72,15 @@
 //!
 //! ### zlib
 //!
-//! The `stock-zlib` feature enables [`flate2`]'s `zlib` feature which makes
-//! [`flate2`] use system zlib instead of [`zlib-ng`].
+//! There are 2 zlib features `stock-zlib` and `simd-zlib` for the library to work
+//! one of them has to be enabled. If both are enabled it will use `stock-zlib`
 //!
-//! This is not enabled by default.
+//! `stock-zlib` enabled by default.
+//!
+//! Enabling **only** `simd-zlib` will make the library use [`zlib-ng`] which is a modern
+//! fork of zlib that is faster and more effective, but it needs `cmake` to compile.
 //!
 //! [`async-tungstenite`]: https://crates.io/crates/async-tungstenite
-//! [`flate2`]: https://crates.io/crates/flate2
 //! [`native-tls`]: https://crates.io/crates/native-tls
 //! [`rustls`]: https://crates.io/crates/rustls
 //! [`serde_json`]: https://crates.io/crates/serde_json


### PR DESCRIPTION
This change was made to make the library not need cmake in the
most basic case.