### PR TITLE
project: sprinkle around non_exhaustive

### DIFF
--- a/cache/in-memory/src/config.rs
+++ b/cache/in-memory/src/config.rs
@@ -2,6 +2,7 @@ use bitflags::bitflags;
 
 bitflags! {
     /// Bitflags to filter what event types to process in the cache.
+    #[non_exhaustive]
     pub struct EventType: u64 {
         const BAN_ADD = 1;
         const BAN_REMOVE = 1 << 1;

--- a/command-parser/src/casing.rs
+++ b/command-parser/src/casing.rs
@@ -1,6 +1,7 @@
 use unicase::UniCase;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum CaseSensitivity {
     Insensitive(UniCase<String>),
     Sensitive(String),

--- a/command-parser/src/casing.rs
+++ b/command-parser/src/casing.rs
@@ -1,7 +1,6 @@
 use unicase::UniCase;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[non_exhaustive]
 pub enum CaseSensitivity {
     Insensitive(UniCase<String>),
     Sensitive(String),

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -22,6 +22,7 @@ use twilight_model::gateway::event::Event;
 
 /// Sending a command to a shard failed.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ClusterCommandError {
     /// The shard exists, but sending the provided value failed.
     Sending {
@@ -57,6 +58,7 @@ impl Error for ClusterCommandError {
 
 /// Starting a cluster failed.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ClusterStartError {
     /// Retrieving the bot's gateway information via the HTTP API failed.
     ///

--- a/gateway/src/event.rs
+++ b/gateway/src/event.rs
@@ -4,6 +4,7 @@ use twilight_model::gateway::event::EventType;
 
 bitflags! {
     /// Bitflags representing all of the possible types of events.
+    #[non_exhaustive]
     pub struct EventTypeFlags: u64 {
         /// User has been banned from a guild.
         const BAN_ADD = 1;

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -14,7 +14,6 @@ use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents}
 ///
 /// [`ShardBuilder::large_threshold`]: struct.ShardBuilder.html#method.large_threshold
 #[derive(Debug)]
-#[non_exhaustive]
 pub enum LargeThresholdError {
     /// Provided large threshold value is too few in number.
     TooFew {
@@ -45,7 +44,6 @@ impl Error for LargeThresholdError {}
 ///
 /// [`ShardBuilder::shard`]: struct.ShardBuilder.html#method.shard
 #[derive(Debug)]
-#[non_exhaustive]
 pub enum ShardIdError {
     /// Provided shard ID is higher than provided total shard count.
     IdTooLarge {

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -14,6 +14,7 @@ use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents}
 ///
 /// [`ShardBuilder::large_threshold`]: struct.ShardBuilder.html#method.large_threshold
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum LargeThresholdError {
     /// Provided large threshold value is too few in number.
     TooFew {
@@ -44,6 +45,7 @@ impl Error for LargeThresholdError {}
 ///
 /// [`ShardBuilder::shard`]: struct.ShardBuilder.html#method.shard
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ShardIdError {
     /// Provided shard ID is higher than provided total shard count.
     IdTooLarge {

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -36,6 +36,7 @@ use simd_json::Error as JsonError;
 
 /// Sending a command failed.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum CommandError {
     /// Sending the payload over the WebSocket failed. This is indicative of a
     /// shutdown shard.
@@ -75,6 +76,7 @@ impl Error for CommandError {
 ///
 /// This means that the shard has not yet been started.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct SessionInactiveError;
 
 impl Display for SessionInactiveError {
@@ -87,6 +89,7 @@ impl Error for SessionInactiveError {}
 
 /// Starting a shard and connecting to the gateway failed.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ShardStartError {
     /// Establishing a connection to the gateway failed.
     Establishing {

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -45,6 +45,7 @@ use url::{ParseError as UrlParseError, Url};
 
 /// Connecting to the gateway failed.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ConnectingError {
     Establishing { source: TungsteniteError },
     ParsingUrl { source: UrlParseError, url: String },
@@ -144,6 +145,7 @@ impl Error for ProcessError {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 enum ReceivingEventError {
     /// Provided authorization token is invalid.
     AuthorizationInvalid { shard_id: u64, token: String },

--- a/gateway/src/shard/stage.rs
+++ b/gateway/src/shard/stage.rs
@@ -20,6 +20,7 @@ use std::{
 ///
 /// [`Stage`]: enum.Stage.html
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum StageConversionError {
     /// The integer isn't one that maps to a stage. For example, 7 might not map
     /// to a Stage variant.
@@ -43,6 +44,7 @@ impl Error for StageConversionError {}
 ///
 /// [`Shard`]: ../struct.Shard.html
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum Stage {
     /// Indicator that a shard is now fully connected to the gateway.

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -17,6 +17,7 @@ use simd_json::Error as JsonError;
 pub type Result<T, E = Error> = StdResult<T, E>;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum UrlError {
     UrlParsing { source: UrlParseError },
     IdParsing { source: ParseIntError },
@@ -58,6 +59,7 @@ impl From<ParseIntError> for UrlError {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     BuildingClient {
         source: ReqwestError,

--- a/http/src/ratelimiting/error.rs
+++ b/http/src/ratelimiting/error.rs
@@ -10,6 +10,7 @@ use std::{
 pub type RatelimitResult<T> = StdResult<T, RatelimitError>;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum RatelimitError {
     NoHeaders,
     HeaderMissing {

--- a/http/src/ratelimiting/headers.rs
+++ b/http/src/ratelimiting/headers.rs
@@ -3,6 +3,7 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use std::convert::TryFrom;
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum RatelimitHeaders {
     GlobalLimited {
         reset_after: u64,

--- a/http/src/request/channel/message/allowed_mentions.rs
+++ b/http/src/request/channel/message/allowed_mentions.rs
@@ -19,6 +19,7 @@ pub struct Unspecified;
 
 /// Parse types.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
+#[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum ParseTypes {
     Users,

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -16,6 +16,7 @@ use twilight_model::{
 
 /// The error created when a messsage can not be created as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum CreateMessageError {
     /// Returned when the content is over 2000 UTF-16 characters.
     ContentInvalid {

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -11,6 +11,7 @@ use twilight_model::{
 
 /// The error returned if the request can not be created as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum GetChannelMessagesError {
     /// The maximum number of messages to retrieve is either 0 or more than 100.
     LimitInvalid {

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -10,6 +10,7 @@ use twilight_model::{
 
 /// The error returned if the request can not be created as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum GetChannelMessagesConfiguredError {
     /// The maximum number of messages to retrieve is either 0 or more than 100.
     LimitInvalid {

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -10,6 +10,7 @@ use twilight_model::{
 
 /// The error created when a message can not be updated as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum UpdateMessageError {
     /// Returned when the content is over 2000 UTF-16 characters.
     ContentInvalid {

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -10,6 +10,7 @@ use twilight_model::{
 
 /// The error created if the reactions can not be retrieved as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum GetReactionsError {
     /// The number of reactions to retrieve must be between 1 and 100, inclusive.
     LimitInvalid {

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -8,8 +8,9 @@ use twilight_model::{
     id::ChannelId,
 };
 
-#[derive(Clone, Debug)]
 /// Returned when the channel can not be updated as configured.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum UpdateChannelError {
     /// The length of the name is either fewer than 2 UTF-16 characters or
     /// more than 100 UTF-16 characters.

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -7,6 +7,7 @@ use twilight_model::id::{GuildId, UserId};
 
 /// The error created when the ban can not be created as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum CreateBanError {
     /// The number of days' worth of messages to delete is greater than 7.
     DeleteMessageDaysInvalid {

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -18,6 +18,7 @@ pub use self::builder::*;
 
 /// The error returned when the guild can not be created as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum CreateGuildError {
     /// The name of the guild is either fewer than 2 UTF-16 characters or more than 100 UTF-16
     /// characters.
@@ -113,6 +114,7 @@ impl From<RoleFieldsBuilder> for RoleFields {
 ///
 /// [`GuildChannelFieldsBuilder`]: struct.GuildChannelFieldsBuilder.html
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
 #[serde(untagged)]
 pub enum GuildChannelFields {
     Category(CategoryFields),

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -8,8 +8,9 @@ use twilight_model::{
     id::{ChannelId, GuildId},
 };
 
-#[derive(Clone, Debug)]
 /// Returned when the channel can not be created as configured.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum CreateGuildChannelError {
     /// The length of the name is either fewer than 2 UTF-16 characters or
     /// more than 100 UTF-16 characters.

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -10,6 +10,7 @@ use twilight_model::{
 
 /// The error created when the guild prune can not be created as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum CreateGuildPruneError {
     /// The number of days is 0.
     DaysInvalid,

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -10,6 +10,7 @@ use twilight_model::{
 
 /// The error returned when the audit log can not be requested as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum GetAuditLogError {
     /// The limit is either 0 or more than 100.
     LimitInvalid {

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -10,6 +10,7 @@ use twilight_model::{
 
 /// The error created when the guild prune count can not be requested as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum GetGuildPruneCountError {
     /// The number of days is 0.
     DaysInvalid,

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -20,6 +20,7 @@ use simd_json::value::OwnedValue as Value;
 
 /// The error created when the members can not be fetched as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum GetGuildMembersError {
     /// The limit is either 0 or more than 1000.
     LimitInvalid {

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -7,6 +7,7 @@ use twilight_model::id::{ChannelId, GuildId, RoleId, UserId};
 
 /// The error created when the member can not be updated as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum UpdateGuildMemberError {
     /// The nickname is either empty or the length is more than 32 UTF-16 characters.
     NicknameInvalid { nickname: String },

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -12,6 +12,7 @@ use twilight_model::{
 
 /// The error returned when the guild can not be updated as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum UpdateGuildError {
     /// The name length is either fewer than 2 UTF-16 characters or more than 100 UTF-16
     /// characters.

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -7,6 +7,7 @@ use twilight_model::{guild::PartialGuild, id::GuildId};
 
 /// The error created when the current guilds can not be retrieved as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum GetCurrentUserGuildsError {
     /// The maximum number of guilds to retrieve is 0 or more than 100.
     LimitInvalid {

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -7,6 +7,7 @@ use twilight_model::user::User;
 
 /// The error created when the user can not be updated as configured.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum UpdateCurrentUserError {
     /// The length of the username is either fewer than 2 UTF-16 characters or more than 32 UTF-16
     /// characters.

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -15,6 +15,7 @@ use twilight_model::channel::embed::Embed;
 ///
 /// [docs]: https://discord.com/developers/docs/resources/channel#embed-limits
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum EmbedValidationError {
     /// The embed author's name is larger than
     /// [the maximum][`AUTHOR_NAME_LENGTH`].

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum PathParseError {
     /// The ID couldn't be parsed as an integer.
     IntegerParsing {
@@ -57,6 +58,7 @@ impl StdError for PathParseError {
 /// An enum representing a path, most useful for ratelimiting implementations.
 // If adding to this enum, be sure to add to the `TryFrom` impl.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum Path {
     /// Operating on a channel.
     ChannelsId(u64),
@@ -230,6 +232,7 @@ impl TryFrom<(Method, &str)> for Path {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum Route {
     /// Route information to add a role to guild member.
     AddMemberRole {

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -23,6 +23,7 @@ use twilight_model::{
 
 /// An error that can occur while interacting with the client.
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum ClientError {
     /// A node isn't configured, so the operation isn't possible to fulfill.
     NodesUnconfigured,

--- a/model/src/gateway/payload/request_guild_members.rs
+++ b/model/src/gateway/payload/request_guild_members.rs
@@ -14,6 +14,7 @@ use std::{
 ///
 /// [`RequestGuildMembersBuilder::user_ids`]: struct.RequestGuildMembersBuilder.html#method.user_ids
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum UserIdsError {
     /// More than 100 user IDs were provided.
     TooMany {


### PR DESCRIPTION
Sprinkle around `#[non_exhaustive]`, especially on things like validation error enums. Some types, such as `twilight_lavalink::client::VoiceStateHalf`, have remained exhaustive because what it works with can only ever have two halves by API implementation.

This is a part of #459.