### PR TITLE
gateway: make 'intents' methods non-optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let cluster = Cluster::builder(&token)
         .shard_scheme(scheme)
         // Use intents to only receive guild message events.
-        .intents(Some(Intents::GUILD_MESSAGES))
+        .intents(Intents::GUILD_MESSAGES)
         .build()
         .await?;
 

--- a/gateway/examples/intents/src/main.rs
+++ b/gateway/examples/intents/src/main.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt::init();
 
     let mut shard = Shard::builder(env::var("DISCORD_TOKEN")?)
-        .intents(Some(Intents::GUILD_MESSAGES | Intents::DIRECT_MESSAGES))
+        .intents(Intents::GUILD_MESSAGES | Intents::DIRECT_MESSAGES)
         .build();
 
     shard.start().await?;

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -225,7 +225,7 @@ impl ClusterBuilder {
     /// Refer to the shard's [`ShardBuilder::intents`] for more information.
     ///
     /// [`ShardBuilder::intents`]: ../shard/struct.ShardBuilder.html#method.intents
-    pub fn intents(mut self, intents: Option<Intents>) -> Self {
+    pub fn intents(mut self, intents: Intents) -> Self {
         self.1 = self.1.intents(intents);
 
         self

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -135,7 +135,7 @@ impl<T: RangeBounds<u64>> TryFrom<(T, u64)> for ShardScheme {
 ///
 /// let intents = Intents::GUILD_MESSAGES;
 /// let cluster = Cluster::builder(token)
-///     .intents(Some(intents))
+///     .intents(intents)
 ///     .large_threshold(100)?
 ///     .build()
 ///     .await?;

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -141,8 +141,8 @@ impl ShardBuilder {
     /// Set the gateway intents.
     ///
     /// Default is Discord's default.
-    pub fn intents(mut self, intents: Option<Intents>) -> Self {
-        self.0.intents = intents;
+    pub fn intents(mut self, intents: Intents) -> Self {
+        self.0.intents.replace(intents);
 
         self
     }

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -124,7 +124,7 @@
 //!     let cluster = Cluster::builder(&token)
 //!         .shard_scheme(scheme)
 //!         // Use intents to only receive guild message events.
-//!         .intents(Some(Intents::GUILD_MESSAGES))
+//!         .intents(Intents::GUILD_MESSAGES)
 //!         .build()
 //!         .await?;
 //!


### PR DESCRIPTION
Make the cluster and shard builders' `intents` methods take an `Intents` instead of an `Option<Intents>`. Taking an option is redundant since there are none by default.