### PR TITLE
command-parser: add bench paths to cargo.toml

### DIFF
--- a/command-parser/Cargo.toml
+++ b/command-parser/Cargo.toml
@@ -24,7 +24,9 @@ patricia_tree = "0.2"
 [[bench]]
 name = "prefix"
 harness = false
+path = "benches/prefix.rs"
 
 [[bench]]
 name = "commands"
 harness = false
+path = "benches/commands.rs"


### PR DESCRIPTION
Add the paths for the benchmarks to the command parser's `Cargo.toml` bench entries.

If this isn't present then Cargo complains about it missing when packaging the crate.