### PR TITLE
model: add bench path to cargo.toml

### DIFF
--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -30,3 +30,4 @@ serde_test = { default-features = false, version = "1" }
 [[bench]]
 name = "deserialization"
 harness = false
+path = "benches/deserialization.rs"


### PR DESCRIPTION
Add the path for the benchmark to the model crate's Cargo.toml bench entries.

If this isn't present then Cargo complains about it missing when packaging the crate.