### PR TITLE
command-parser: add static-assertions tests

### DIFF
--- a/command-parser/Cargo.toml
+++ b/command-parser/Cargo.toml
@@ -20,6 +20,7 @@ unicase = { default-features = false, version = "2" }
 [dev-dependencies]
 criterion = "0.3"
 patricia_tree = "0.2"
+static_assertions = { default-features = false, version = "1" }
 
 [[bench]]
 name = "prefix"

--- a/command-parser/src/arguments.rs
+++ b/command-parser/src/arguments.rs
@@ -127,6 +127,10 @@ impl<'a> Iterator for Arguments<'a> {
 #[cfg(test)]
 mod tests {
     use super::Arguments;
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(Arguments<'_>: Clone, Debug, From<&'static str>, Iterator, Send, Sync);
 
     #[test]
     fn test_as_str() {

--- a/command-parser/src/casing.rs
+++ b/command-parser/src/casing.rs
@@ -23,3 +23,22 @@ impl PartialEq<str> for CaseSensitivity {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CaseSensitivity;
+    use static_assertions::assert_impl_all;
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_impl_all!(
+        CaseSensitivity: AsRef<str>,
+        Clone,
+        Debug,
+        Eq,
+        Hash,
+        PartialEq,
+        PartialEq<str>,
+        Send,
+        Sync
+    );
+}

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -233,7 +233,15 @@ impl<'a> ExactSizeIterator for PrefixesMut<'a> {}
 
 #[cfg(test)]
 mod tests {
-    use super::CommandParserConfig;
+    use super::{CommandParserConfig, Commands, CommandsMut, Prefixes, PrefixesMut};
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(CommandParserConfig<'_>: Clone, Debug, Default, Send, Sync);
+    assert_impl_all!(CommandsMut<'_>: ExactSizeIterator, Iterator, Send, Sync);
+    assert_impl_all!(Commands<'_>: ExactSizeIterator, Iterator, Send, Sync);
+    assert_impl_all!(PrefixesMut<'_>: ExactSizeIterator, Iterator, Send, Sync);
+    assert_impl_all!(Prefixes<'_>: ExactSizeIterator, Iterator, Send, Sync);
 
     #[test]
     fn test_getters() {

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -169,6 +169,12 @@ impl<'a, T: Into<CommandParserConfig<'a>>> From<T> for Parser<'a> {
 #[cfg(test)]
 mod tests {
     use crate::{Command, CommandParserConfig, Parser};
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::fmt::Debug;
+
+    assert_fields!(Command<'_>: arguments, name, prefix);
+    assert_impl_all!(Command<'_>: Clone, Debug, Send, Sync);
+    assert_impl_all!(Parser<'_>: Clone, Debug, Send, Sync);
 
     fn simple_config() -> Parser<'static> {
         let mut config = CommandParserConfig::new();


### PR DESCRIPTION
Add tests for all types in the command parser crate via the `static-assertions` crate.