### PR TITLE
model: bump to v0.1.1

### DIFF
--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog for `twilight-model`.
 
 ### Fixes
 
-- Handle webhooks with tokens in path parsing ([#499] - [@vivian])
+- support deserializing IDs from integers ([#499] - [@vivian])
 
 ## [0.1.0] - 2020-09-13
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+Changelog for `twilight-model`.
+
+## [0.1.1] - 2020-09-14
+
+### Fixes
+
+- Handle webhooks with tokens in path parsing ([#499] - [@vivian])
+
+## [0.1.0] - 2020-09-13
+
+Initial release.
+
+[@vivian]: https://github.com/vivian
+
+[#499]: https://github.com/twilight-rs/twilight/pull/499
+
+[0.1.1]: https://github.com/twilight-rs/twilight/releases/tag/model-v0.1.1
+[0.1.0]: https://github.com/twilight-rs/twilight/releases/tag/v0.1.0

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -12,7 +12,7 @@ name = "twilight-model"
 publish = false
 readme = "README.md"
 repository = "https://github.com/twilight-rs/twilight.git"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 bitflags = { default-features = false, version = "1" }


### PR DESCRIPTION
Changelog:

Fixes

- Handle webhooks with tokens in path parsing ([#499] - [@vivian])

[@vivian]: https://github.com/vivian
[#499]: https://github.com/twilight-rs/twilight/pull/499