### PR TITLE
http/requestreactiontype: impl eq, from, partialeq

### DIFF
--- a/http/src/request/channel/reaction/mod.rs
+++ b/http/src/request/channel/reaction/mod.rs
@@ -11,11 +11,21 @@ pub use self::{
     get_reactions::GetReactions,
 };
 use std::fmt::Write;
-use twilight_model::id::EmojiId;
+use twilight_model::{channel::ReactionType, id::EmojiId};
 
+#[derive(Eq, PartialEq)]
 pub enum RequestReactionType {
-    Unicode { name: String },
     Custom { id: EmojiId, name: Option<String> },
+    Unicode { name: String },
+}
+
+impl From<ReactionType> for RequestReactionType {
+    fn from(other: ReactionType) -> Self {
+        match other {
+            ReactionType::Custom { id, name, .. } => Self::Custom { id, name },
+            ReactionType::Unicode { name } => Self::Unicode { name },
+        }
+    }
 }
 
 fn format_emoji(emoji: RequestReactionType) -> String {


### PR DESCRIPTION
This PR implements a simple one-way `From<ReactionType>` conversion for `RequestReactionType`. It also derives `Eq` and `PartialEq`. Manually implementing `PartialEq<ReactionType> for RequestReactionType` would require changes in `model`, and would require `model` to depend on `http`, so convert-and-compare is the simplest way to do this. 

Fixes #505. 