### PR TITLE
lavalink: add additional static-assertions tests

### DIFF
--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -374,12 +374,12 @@ impl Lavalink {
 
 #[cfg(test)]
 mod tests {
-    use super::{ClientError, Lavalink, LavalinkRef, VoiceStateHalf};
-    use static_assertions::assert_impl_all;
-    use std::fmt::Debug;
+    use super::{ClientError, Lavalink, VoiceStateHalf};
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{error::Error, fmt::Debug};
 
-    assert_impl_all!(ClientError: Clone, Debug, PartialEq);
-    assert_impl_all!(LavalinkRef: Debug, Default);
-    assert_impl_all!(Lavalink: Clone, Debug);
-    assert_impl_all!(VoiceStateHalf: Debug);
+    assert_fields!(ClientError::SendingVoiceUpdate: source);
+    assert_impl_all!(ClientError: Clone, Debug, Error, PartialEq, Send, Sync);
+    assert_impl_all!(Lavalink: Clone, Debug, Send, Sync);
+    assert_impl_all!(VoiceStateHalf: Debug, Send, Sync);
 }

--- a/lavalink/src/http.rs
+++ b/lavalink/src/http.rs
@@ -302,21 +302,25 @@ pub fn unmark_failed_address(
 #[cfg(test)]
 mod tests {
     use super::{
-        FailingAddress, IpBlock, IpBlockType, NanoIpDetails, NanoIpRoutePlanner, RotatingIpDetails,
-        RotatingIpRoutePlanner, RotatingNanoIpDetails, RotatingNanoIpRoutePlanner, RoutePlanner,
-        RoutePlannerType,
+        FailingAddress, IpBlock, IpBlockType, LoadType, LoadedTracks, NanoIpDetails,
+        NanoIpRoutePlanner, PlaylistInfo, RotatingIpDetails, RotatingIpRoutePlanner,
+        RotatingNanoIpDetails, RotatingNanoIpRoutePlanner, RoutePlanner, RoutePlannerType, Track,
+        TrackInfo,
     };
     use serde::{Deserialize, Serialize};
-    use static_assertions::assert_impl_all;
+    use static_assertions::{assert_fields, assert_impl_all};
     use std::fmt::Debug;
 
+    assert_fields!(FailingAddress: address, failing_timestamp, failing_time);
     assert_impl_all!(
         FailingAddress: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
     assert_impl_all!(
         IpBlockType: Clone,
@@ -324,15 +328,46 @@ mod tests {
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(IpBlock: kind, size);
     assert_impl_all!(
         IpBlock: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
+    );
+    assert_impl_all!(
+        LoadType: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync,
+    );
+    assert_fields!(LoadedTracks: load_type, playlist_info, tracks);
+    assert_impl_all!(
+        LoadedTracks: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync,
+    );
+    assert_fields!(
+        NanoIpDetails: current_address_index,
+        failing_addresses,
+        ip_block
     );
     assert_impl_all!(
         NanoIpDetails: Clone,
@@ -340,15 +375,38 @@ mod tests {
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(NanoIpRoutePlanner: class, details);
     assert_impl_all!(
         NanoIpRoutePlanner: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
+    );
+    assert_fields!(PlaylistInfo: name, selected_track);
+    assert_impl_all!(
+        PlaylistInfo: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync,
+    );
+    assert_fields!(
+        RotatingIpDetails: current_address,
+        failing_addresses,
+        ip_block,
+        ip_index,
+        rotate_index
     );
     assert_impl_all!(
         RotatingIpDetails: Clone,
@@ -356,15 +414,26 @@ mod tests {
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(RotatingIpRoutePlanner: class, details);
     assert_impl_all!(
         RotatingIpRoutePlanner: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
+    );
+    assert_fields!(
+        RotatingNanoIpDetails: block_index,
+        current_address_index,
+        failing_addresses,
+        ip_block
     );
     assert_impl_all!(
         RotatingNanoIpDetails: Clone,
@@ -372,15 +441,20 @@ mod tests {
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(RotatingNanoIpRoutePlanner: class, details);
     assert_impl_all!(
         RotatingNanoIpRoutePlanner: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
     assert_impl_all!(
         RoutePlannerType: Clone,
@@ -388,7 +462,9 @@ mod tests {
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
     assert_impl_all!(
         RoutePlanner: Clone,
@@ -396,6 +472,39 @@ mod tests {
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
+    );
+    assert_fields!(
+        TrackInfo: author,
+        identifier,
+        is_seekable,
+        is_stream,
+        length,
+        position,
+        title,
+        uri
+    );
+    assert_impl_all!(
+        TrackInfo: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync
+    );
+    assert_fields!(Track: info, track);
+    assert_impl_all!(
+        Track: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync
     );
 }

--- a/lavalink/src/model.rs
+++ b/lavalink/src/model.rs
@@ -655,135 +655,220 @@ mod tests {
     };
     use serde::{Deserialize, Serialize};
     use serde_test::Token;
-    use static_assertions::assert_impl_all;
+    use static_assertions::{assert_fields, assert_impl_all};
     use std::fmt::Debug;
+    use twilight_model::id::GuildId;
 
+    assert_fields!(Destroy: guild_id, op);
     assert_impl_all!(
         Destroy: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
+        From<GuildId>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(EqualizerBand: band, gain);
     assert_impl_all!(
         EqualizerBand: Clone,
         Debug,
         Deserialize<'static>,
+        From<(i64, f64)>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(Equalizer: bands, guild_id, op);
     assert_impl_all!(
         Equalizer: Clone,
         Debug,
         Deserialize<'static>,
+        From<(GuildId, Vec<EqualizerBand>)>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
     assert_impl_all!(
         IncomingEvent: Clone,
         Debug,
         Deserialize<'static>,
+        From<PlayerUpdate>,
+        From<Stats>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
     assert_impl_all!(
         OutgoingEvent: Clone,
         Debug,
         Deserialize<'static>,
+        From<Destroy>,
+        From<Equalizer>,
+        From<Pause>,
+        From<Play>,
+        From<Seek>,
+        From<Stop>,
+        From<VoiceUpdate>,
+        From<Volume>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(Pause: guild_id, op, pause);
     assert_impl_all!(
         Pause: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
+        From<(GuildId, bool)>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(PlayerUpdateState: position, time);
     assert_impl_all!(
         PlayerUpdateState: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(PlayerUpdate: guild_id, op, state);
     assert_impl_all!(
         PlayerUpdate: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(Play: end_time, guild_id, no_replace, op, start_time, track);
     assert_impl_all!(
         Play: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
+        From<(GuildId, String)>,
+        From<(GuildId, String, Option<u64>)>,
+        From<(GuildId, String, u64)>,
+        From<(GuildId, String, Option<u64>, Option<u64>)>,
+        From<(GuildId, String, Option<u64>, u64)>,
+        From<(GuildId, String, u64, Option<u64>)>,
+        From<(GuildId, String, u64, u64)>,
+        From<(GuildId, String, Option<u64>, Option<u64>, bool)>,
+        From<(GuildId, String, Option<u64>, u64, bool)>,
+        From<(GuildId, String, u64, Option<u64>, bool)>,
+        From<(GuildId, String, u64, u64, bool)>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(Seek: guild_id, op, position);
     assert_impl_all!(
         Seek: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
+        From<(GuildId, i64)>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(SlimVoiceServerUpdate: endpoint, guild_id, token);
     assert_impl_all!(
         SlimVoiceServerUpdate: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
+    );
+    assert_fields!(
+        Stats: cpu,
+        frames,
+        memory,
+        players,
+        playing_players,
+        op,
+        uptime
     );
     assert_impl_all!(
         Stats: Clone,
         Debug,
         Deserialize<'static>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(StatsCpu: cores, lavalink_load, system_load);
     assert_impl_all!(
         StatsCpu: Clone,
         Debug,
         Deserialize<'static>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(StatsFrames: deficit, nulled, sent);
     assert_impl_all!(
         StatsFrames: Clone,
         Debug,
         Deserialize<'static>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(StatsMemory: allocated, free, reservable, used);
     assert_impl_all!(
         StatsMemory: Clone,
         Debug,
         Deserialize<'static>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(Stop: guild_id, op);
     assert_impl_all!(
         Stop: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
+        From<GuildId>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(TrackEnd: guild_id, kind, op, reason, track);
     assert_impl_all!(
         TrackEnd: Clone,
         Debug,
         Deserialize<'static>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
     assert_impl_all!(
         TrackEventType: Clone,
@@ -791,30 +876,42 @@ mod tests {
         Debug,
         Deserialize<'static>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(TrackStart: guild_id, kind, op, track);
     assert_impl_all!(
         TrackStart: Clone,
         Debug,
         Deserialize<'static>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(VoiceUpdate: event, guild_id, op, session_id);
     assert_impl_all!(
         VoiceUpdate: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
+        From<(GuildId, String, SlimVoiceServerUpdate)>,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
+    assert_fields!(Volume: guild_id, op, volume);
     assert_impl_all!(
         Volume: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
 
     #[test]

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -567,12 +567,24 @@ async fn backoff(
 
 #[cfg(test)]
 mod tests {
-    use super::{Node, NodeConfig, NodeError, NodeRef};
-    use static_assertions::assert_impl_all;
-    use std::fmt::Debug;
+    use super::{Node, NodeConfig, NodeError, Resume};
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{error::Error, fmt::Debug};
 
+    assert_fields!(
+        NodeConfig: address,
+        authorization,
+        resume,
+        shard_count,
+        user_id
+    );
     assert_impl_all!(NodeConfig: Clone, Debug, Send, Sync);
-    assert_impl_all!(NodeError: Debug, Send, Sync);
-    assert_impl_all!(NodeRef: Debug, Send, Sync);
+    assert_fields!(NodeError::BuildingConnectionRequest: source);
+    assert_fields!(NodeError::Connecting: source);
+    assert_fields!(NodeError::SerializingMessage: message, source);
+    assert_fields!(NodeError::Unauthorized: address, authorization);
+    assert_impl_all!(NodeError: Debug, Error, Send, Sync);
     assert_impl_all!(Node: Clone, Debug, Send, Sync);
+    assert_fields!(Resume: timeout);
+    assert_impl_all!(Resume: Clone, Debug, Default, Eq, PartialEq, Send, Sync);
 }


### PR DESCRIPTION
Add additional tests for types in the lavalink crate via the `static-assertions`. Many types were missing assertions for fields and Send + Sync bounds.