### PR TITLE
model/gateway: impl Key for UserOrId

### DIFF
--- a/model/src/gateway/presence/mod.rs
+++ b/model/src/gateway/presence/mod.rs
@@ -44,6 +44,12 @@ pub struct Presence {
     pub user: UserOrId,
 }
 
+impl Key<'_, UserId> for Presence {
+    fn key(&self) -> UserId {
+        self.user.key()
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum UserOrId {
@@ -51,9 +57,9 @@ pub enum UserOrId {
     UserId { id: UserId },
 }
 
-impl Key<'_, UserId> for Presence {
+impl Key<'_, UserId> for UserOrId {
     fn key(&self) -> UserId {
-        match self.user {
+        match *self {
             UserOrId::User(ref u) => u.id,
             UserOrId::UserId { id } => id,
         }


### PR DESCRIPTION
Allows the use of `key()` from `PresenceUpdate` events.

Not sure if you intend for the payload types to ever implement `Key`, can remove that if so. Implementing it on `UserOrId` still makes it usable within `PresenceUpdate` so I'm not torn either way.