### PR TITLE
Fix compilation and running of command and deserialization benchmarks

### DIFF
--- a/command-parser/benches/commands.rs
+++ b/command-parser/benches/commands.rs
@@ -3,6 +3,7 @@ use patricia_tree::PatriciaSet;
 use std::{
     borrow::Cow,
     collections::{BTreeSet, HashSet},
+    iter::FromIterator,
 };
 
 fn btreeset(set: &BTreeSet<Cow<'static, str>>, needle: &str) {
@@ -77,7 +78,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     ];
 
     c.bench_function("c: btreeset", |b| {
-        let mut set = BTreeSet::from_iter(commands.iter().map(Cow::from));
+        let set = BTreeSet::from_iter(commands.iter().map(|e| Cow::from(*e)));
 
         b.iter(|| {
             for command in commands.iter() {
@@ -87,7 +88,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("c: hashset", |b| {
-        let mut set = HashSet::from_iter(commands.iter().map(Cow::from));
+        let set = HashSet::from_iter(commands.iter().map(|e| Cow::from(*e)));
 
         for e in commands.iter() {
             set.insert(Cow::from(*e));

--- a/command-parser/benches/commands.rs
+++ b/command-parser/benches/commands.rs
@@ -90,10 +90,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("c: hashset", |b| {
         let set = HashSet::from_iter(commands.iter().map(|e| Cow::from(*e)));
 
-        for e in commands.iter() {
-            set.insert(Cow::from(*e));
-        }
-
         b.iter(|| {
             for command in commands.iter() {
                 hashset(&set, command);
@@ -112,7 +108,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("c: patricia_tree", |b| {
-        let mut set = PatriciaSet::from_iter(commands.iter());
+        let set = PatriciaSet::from_iter(commands.iter());
 
         b.iter(|| {
             for command in commands.iter() {

--- a/model/benches/deserialization.rs
+++ b/model/benches/deserialization.rs
@@ -151,7 +151,7 @@ fn reaction() {
             }
         },
         "message_id": "3",
-        "user_id": "4",
+        "user_id": "4"
     }"#;
 
     serde_json::from_str::<Reaction>(input).unwrap();

--- a/model/benches/deserialization.rs
+++ b/model/benches/deserialization.rs
@@ -184,11 +184,11 @@ fn typing_start() {
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("gateway event role delete", |b| {
-        b.iter(gateway_event_role_delete())
+        b.iter(gateway_event_role_delete)
     });
-    c.bench_function("member chunk", |b| b.iter(member_chunk()));
-    c.bench_function("reaction", |b| b.iter(reaction()));
-    c.bench_function("typing start", |b| b.iter(typing_start()));
+    c.bench_function("member chunk", |b| b.iter(member_chunk));
+    c.bench_function("reaction", |b| b.iter(reaction));
+    c.bench_function("typing start", |b| b.iter(typing_start));
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
Small fix of compilation of benches.

The removal of the comma is not a compilation fix, but fixed that the deserialzation would panic.