### PR TITLE
don't set content headers when the request doesn't have a body

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1392,14 +1392,13 @@ impl Client {
 
         if let Some(form) = form {
             builder = builder.multipart(form);
-        } else if Some(bytes) = body {
+        } else if let Some(bytes) = body {
             let len = bytes.len();
-
             builder = builder.body(Body::from(bytes));
             builder = builder.header("content-length", len);
             let content_type = HeaderValue::from_static("application/json");
             builder = builder.header("Content-Type", content_type);
-        }
+        };
 
         let precision = HeaderValue::from_static("millisecond");
         let user_agent = HeaderValue::from_static(concat!(
@@ -1422,7 +1421,7 @@ impl Client {
                 return builder
                     .send()
                     .await
-                    .map_err(|source| Error::RequestError { source });
+                    .map_err(|source| Error::RequestError { source })
             }
         };
 

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1398,12 +1398,9 @@ impl Client {
 
                 builder = builder.body(Body::from(bytes));
                 builder = builder.header("content-length", len);
-            } else {
-                builder = builder.header("content-length", 0);
+                let content_type = HeaderValue::from_static("application/json");
+                builder = builder.header("Content-Type", content_type);
             }
-
-            let content_type = HeaderValue::from_static("application/json");
-            builder = builder.header("Content-Type", content_type);
         }
 
         let precision = HeaderValue::from_static("millisecond");

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1392,15 +1392,13 @@ impl Client {
 
         if let Some(form) = form {
             builder = builder.multipart(form);
-        } else {
-            if let Some(bytes) = body {
-                let len = bytes.len();
+        } else if Some(bytes) = body {
+            let len = bytes.len();
 
-                builder = builder.body(Body::from(bytes));
-                builder = builder.header("content-length", len);
-                let content_type = HeaderValue::from_static("application/json");
-                builder = builder.header("Content-Type", content_type);
-            }
+            builder = builder.body(Body::from(bytes));
+            builder = builder.header("content-length", len);
+            let content_type = HeaderValue::from_static("application/json");
+            builder = builder.header("Content-Type", content_type);
         }
 
         let precision = HeaderValue::from_static("millisecond");
@@ -1424,7 +1422,7 @@ impl Client {
                 return builder
                     .send()
                     .await
-                    .map_err(|source| Error::RequestError { source })
+                    .map_err(|source| Error::RequestError { source });
             }
         };
 


### PR DESCRIPTION
This prevents getting "400 bad request" for non get requests without a body (like DELETE)