### PR TITLE
command-parser,embed-builder,gateway,http: fix typos in links

### DIFF
--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -27,10 +27,10 @@ impl<'a> CommandParserConfig<'a> {
 
     /// Returns an iterator of mutable references to the commands.
     ///
-    /// Use the [`command`] and [`remove_command`] methods for an easier way to
+    /// Use the [`add_command`] and [`remove_command`] methods for an easier way to
     /// manage commands.
     ///
-    /// [`command`]: #method.command
+    /// [`add_command`]: #method.add_command
     /// [`remove_command`]: #method.remove_command
     pub fn commands_mut(&mut self) -> CommandsMut<'_> {
         CommandsMut {

--- a/gateway/src/shard/json.rs
+++ b/gateway/src/shard/json.rs
@@ -46,14 +46,14 @@ impl Error for GatewayEventParsingError {
 ///
 /// # Errors
 ///
-/// Returns [`Error::PayloadInvalid`] if the payload wasn't a valid
+/// Returns [`GatewayEventParsingError::PayloadInvalid`] if the payload wasn't a valid
 /// `GatewayEvent` data structure.
 ///
-/// Returns [`Error::PayloadSerialization`] if the payload failed to
+/// Returns [`GatewayEventParsingError::Deserializing`] if the payload failed to
 /// deserialize.
 ///
-/// [`Error::PayloadInvalid`]: ../enum.Error.html#variant.PayloadInvalid
-/// [`Error::PayloadSerialization`]: ../enum.Error.html#variant.PayloadSerialization
+/// [`GatewayEventParsingError::PayloadInvalid`]: enum.GatewayEventParsingError.html#variant.PayloadInvalid
+/// [`GatewayEventParsingError::Deserializing`]: enum.GatewayEventParsingError.html#variant.Deserializing
 #[cfg(not(feature = "simd-json"))]
 #[allow(dead_code)]
 pub fn parse_gateway_event(
@@ -82,14 +82,14 @@ pub fn parse_gateway_event(
 ///
 /// # Errors
 ///
-/// Returns [`Error::PayloadInvalid`] if the payload wasn't a valid
+/// Returns [`GatewayEventParsingError::PayloadInvalid`] if the payload wasn't a valid
 /// `GatewayEvent` data structure.
 ///
-/// Returns [`Error::PayloadSerialization`] if the payload failed to
+/// Returns [`GatewayEventParsingError::Deserializing`] if the payload failed to
 /// deserialize.
 ///
-/// [`Error::PayloadInvalid`]: ../enum.Error.html#variant.PayloadInvalid
-/// [`Error::PayloadSerialization`]: ../enum.Error.html#variant.PayloadSerialization
+/// [`GatewayEventParsingError::PayloadInvalid`]: enum.GatewayEventParsingError.html#variant.PayloadInvalid
+/// [`GatewayEventParsingError::Deserializing`]: enum.GatewayEventParsingError.html#variant.Deserializing
 #[allow(unsafe_code)]
 #[cfg(feature = "simd-json")]
 #[allow(dead_code)]

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -613,10 +613,10 @@ impl ShardProcessor {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::AuthorizationInvalid`] if the provided authorization
+    /// Returns [`ReceivingEventError::AuthorizationInvalid`] if the provided authorization
     /// is invalid.
     ///
-    /// [`Error::AuthorizationInvalid`]: ../../error/enum.Error.html#variant.AuthorizationInvalid
+    /// [`ReceivingEventError::AuthorizationInvalid`]: enum.ReceivingEventError.html#variant.AuthorizationInvalid
     async fn next_payload(&mut self) -> Result<(), ReceivingEventError> {
         self.inflater.clear();
 

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -92,15 +92,15 @@ impl Session {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::PayloadSerialization`] when there is an error
+    /// Returns [`SessionSendError::Serializing`] when there is an error
     /// serializing the payload into an acceptable format.
     ///
-    /// Returns [`Error::SendingMessage`] when the receiving channel has hung
+    /// Returns [`SessionSendError::Sending`] when the receiving channel has hung
     /// up. This will only happen when the shard has either not started or has
     /// already shutdown.
     ///
-    /// [`Error::PayloadSerialization`]: ../enum.Error.html#variant.PayloadSerialization
-    /// [`Error::SendingMessage`]: ../enum.Error.html#variant.SendingMessage
+    /// [`SessionSendError::Serializing`]: enum.SessionSendError.html#variant.Serializing
+    /// [`SessionSendError::Sending`]: enum.SessionSendError.html#variant.Sending
     pub fn send(&self, payload: impl Serialize) -> Result<(), SessionSendError> {
         let bytes =
             json::to_vec(&payload).map_err(|source| SessionSendError::Serializing { source })?;

--- a/gateway/src/shard/stage.rs
+++ b/gateway/src/shard/stage.rs
@@ -1,12 +1,12 @@
 //! Utilities for knowing and parsing the current connection stage of a shard.
 //!
 //! Included is the [`Stage`], which is an enum representing the connection
-//! stage with variants such as [`Connecting`] or [`Disconnected`].
+//! stage with variants such as [`Connected`] or [`Disconnected`].
 //!
 //! The [`Stage`] also has some parsing capability, so an error type for
 //! conversion reasons is included.
 //!
-//! [`Connecting`]: enum.Stage.html#variant.Connecting
+//! [`Connected`]: enum.Stage.html#variant.Connected
 //! [`Disconnected`]: enum.Stage.html#variant.Disconnected
 //! [`Stage`]: enum.Stage.html
 

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -365,7 +365,7 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns [`GetChannelMessages::LimitInvalid`] if the amount is less than 1 or greater than 100.
+    /// Returns [`GetChannelMessagesError::LimitInvalid`] if the amount is less than 1 or greater than 100.
     ///
     /// [`ChannelId`]: ../../twilight_model/id/struct.ChannelId.html
     /// [`after`]: ../request/channel/message/get_channel_messages/struct.GetChannelMessages.html#method.after
@@ -373,7 +373,7 @@ impl Client {
     /// [`before`]: ../request/channel/message/get_channel_messages/struct.GetChannelMessages.html#method.before
     /// [`GetChannelMessagesConfigured`]: ../request/channel/message/get_channel_messages_configured/struct.GetChannelMessagesConfigured.html
     /// [`limit`]: ../request/channel/message/get_channel_messages/struct.GetChannelMessages.html#method.limit
-    /// [`GetChannelMessages::LimitInvalid`]: ../request/channel/message/get_channel_messages/enum.GetChannelMessagesError.html#variant.LimitInvalid
+    /// [`GetChannelMessagesError::LimitInvalid`]: ../request/channel/message/get_channel_messages/enum.GetChannelMessagesError.html#variant.LimitInvalid
     pub fn channel_messages(&self, channel_id: ChannelId) -> GetChannelMessages<'_> {
         GetChannelMessages::new(self, channel_id)
     }

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -65,7 +65,7 @@ struct GetChannelMessagesFields {
 ///
 /// # Errors
 ///
-/// Returns [`GetChannelMessages::LimitInvalid`] if the amount is less than 1 or greater than 100.
+/// Returns [`GetChannelMessagesError::LimitInvalid`] if the amount is less than 1 or greater than 100.
 ///
 /// [`ChannelId`]: ../../../../../twilight_model/id/struct.ChannelId.html
 /// [`after`]: #method.after
@@ -74,7 +74,7 @@ struct GetChannelMessagesFields {
 /// [`GetChannelMessagesConfigured`]:
 /// ../get_channel_messages_configured/struct.GetChannelMessagesConfigured.html
 /// [`limit`]: #method.limit
-/// [`GetChannelMessages::LimitInvalid`]: enum.GetChannelMessagesError.html#variant.LimitInvalid
+/// [`GetChannelMessagesError::LimitInvalid`]: enum.GetChannelMessagesError.html#variant.LimitInvalid
 pub struct GetChannelMessages<'a> {
     channel_id: ChannelId,
     fields: GetChannelMessagesFields,
@@ -131,10 +131,10 @@ impl<'a> GetChannelMessages<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`GetChannelMessages::LimitInvalid`] if the amount is less than 1 or greater than
+    /// Returns [`GetChannelMessagesError::LimitInvalid`] if the amount is less than 1 or greater than
     /// 100.
     ///
-    /// [`GetChannelMessages::LimitInvalid`]: enum.GetChannelMessagesError.html#variant.LimitInvalid
+    /// [`GetChannelMessagesError::LimitInvalid`]: enum.GetChannelMessagesError.html#variant.LimitInvalid
     pub fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesError> {
         if !validate::get_channel_messages_limit(limit) {
             return Err(GetChannelMessagesError::LimitInvalid { limit });

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -214,11 +214,11 @@ impl<'a> UpdateChannel<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`UpdateGuildChannel::TopicInvalid`] if the topic length is
+    /// Returns [`UpdateChannelError::TopicInvalid`] if the topic length is
     /// too long.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure
-    /// [`UpdateGuildChannel::TopicInvalid`]: enum.UpdateChannelError.html#variant.TopicInvalid
+    /// [`UpdateChannelError::TopicInvalid`]: enum.UpdateChannelError.html#variant.TopicInvalid
     pub fn topic(self, topic: impl Into<String>) -> Result<Self, UpdateChannelError> {
         self._topic(topic.into())
     }

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -191,11 +191,11 @@ impl<'a> CreateGuildChannel<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`GetGuildPruneCountError::RateLimitPerUserInvalid`] if the amount is greater than
+    /// Returns [`CreateGuildChannelError::RateLimitPerUserInvalid`] if the amount is greater than
     /// 21600.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure
-    /// [`GetGuildPruneCountError::RateLimitPerUserInvalid`]: ../get_guild_prune_count/enum.GetGuildPruneCountError.html#variant.RateLimitPerUserInvalid
+    /// [`CreateGuildChannelError::RateLimitPerUserInvalid`]: enum.CreateGuildChannelError.html#variant.RateLimitPerUserInvalid
     pub fn rate_limit_per_user(
         mut self,
         rate_limit_per_user: u64,

--- a/utils/embed-builder/src/builder.rs
+++ b/utils/embed-builder/src/builder.rs
@@ -313,16 +313,16 @@ impl EmbedBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`EmbedError::NotRgb`] if the provided color is not a valid
+    /// Returns [`EmbedColorError::NotRgb`] if the provided color is not a valid
     /// RGB integer. Refer to [`COLOR_MAXIMUM`] to know what the maximum
     /// accepted value is.
     ///
-    /// Returns [`EmbedError::Zero`] if the provided color is 0, which is not
+    /// Returns [`EmbedColorError::Zero`] if the provided color is 0, which is not
     /// an acceptable value.
     ///
     /// [`COLOR_MAXIMUM`]: #const.COLOR_MAXIMUM
-    /// [`EmbedError::NotRgb`]: enum.EmbedColorError.html#variant.NotRgb
-    /// [`EmbedError::Zero`]: enum.EmbedColorError.html#variant.Zero
+    /// [`EmbedColorError::NotRgb`]: enum.EmbedColorError.html#variant.NotRgb
+    /// [`EmbedColorError::Zero`]: enum.EmbedColorError.html#variant.Zero
     pub fn color(mut self, color: u32) -> Result<Self, EmbedColorError> {
         if color == 0 {
             return Err(EmbedColorError::Zero);
@@ -354,11 +354,11 @@ impl EmbedBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`EmbedDescriptionError::DescriptionTooLong`] if the provided
+    /// Returns [`EmbedDescriptionError::TooLong`] if the provided
     /// description is longer than the maximum number of code points.
     ///
     /// [`DESCRIPTION_LENGTH_LIMIT`]: #const.DESCRIPTION_LENGTH_LIMIT
-    /// [`EmbedDescriptionError::DescriptionTooLong`]: enum.EmbedDescriptionError.html#variant.DescriptionTooLong
+    /// [`EmbedDescriptionError::TooLong`]: enum.EmbedDescriptionError.html#variant.TooLong
     pub fn description(
         self,
         description: impl Into<String>,

--- a/utils/embed-builder/src/image_source.rs
+++ b/utils/embed-builder/src/image_source.rs
@@ -65,14 +65,14 @@ impl ImageSource {
     ///
     /// # Errors
     ///
-    /// Returns [`ImageSourceUrlError::ExtensionEmpty`] if an extension exists
+    /// Returns [`ImageSourceAttachmentError::ExtensionEmpty`] if an extension exists
     /// but is empty.
     ///
-    /// Returns [`ImageSourceUrlError::ExtensionMissing`] if an extension is
+    /// Returns [`ImageSourceAttachmentError::ExtensionMissing`] if an extension is
     /// missing.
     ///
-    /// [`ImageSourceUrlError::ExtensionEmpty`]: enum.ImageSourceUrlError.html#variant.ExtensionEmpty
-    /// [`ImageSourceUrlError::ExtensionMissing`]: enum.ImageSourceUrlError.html#variant.ExtensionMissing
+    /// [`ImageSourceAttachmentError::ExtensionEmpty`]: enum.ImageSourceAttachmentError.html#variant.ExtensionEmpty
+    /// [`ImageSourceAttachmentError::ExtensionMissing`]: enum.ImageSourceAttachmentError.html#variant.ExtensionMissing
     pub fn attachment(filename: impl AsRef<str>) -> Result<Self, ImageSourceAttachmentError> {
         Self::_attachment(filename.as_ref())
     }


### PR DESCRIPTION
I found several broken/wrong links while changing them to intra-doc links