### PR TITLE
mention: update docs link and description

### DIFF
--- a/utils/mention/Cargo.toml
+++ b/utils/mention/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 authors = ["Twilight Contributors"]
 categories = []
-description = "Create mentions for resources in the Twilight ecosystem."
-documentation = "https://twilight.cascadia.cafe/twilight_mention/index.html"
+description = "Create and parse mentions for resources in the Twilight ecosystem."
+documentation = "https://docs.rs/twilight-mention"
 edition = "2018"
 homepage = "https://twilight.rs/chapter_1_crates/section_8_first_party/section_2_mention.html"
 include = ["src/**/*.rs", "Cargo.toml", "README.md"]

--- a/utils/mention/Cargo.toml
+++ b/utils/mention/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Twilight Contributors"]
 categories = []
-description = "Create and parse mentions for resources in the Twilight ecosystem."
+description = "Utilities for working with mentions in the Twilight ecosystem."
 documentation = "https://docs.rs/twilight-mention"
 edition = "2018"
 homepage = "https://twilight.rs/chapter_1_crates/section_8_first_party/section_2_mention.html"

--- a/utils/mention/src/lib.rs
+++ b/utils/mention/src/lib.rs
@@ -3,7 +3,7 @@
 //! [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! `twilight-mention` is a utility crate for the Discord [`twilight-rs`]
-//! ecosystem to mention its model types.
+//! ecosystem to mention its model types and parse those mentions.
 //!
 //! With this library, you can create mentions for various types, such as users,
 //! emojis, roles, members, or channels.


### PR DESCRIPTION
Update the documentation link to accurately reflect the current link and update the description to mention the capability of parsing mentions.