### PR TITLE
http: take the correct type in client::reactions

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1077,7 +1077,7 @@ impl Client {
         &self,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: impl Into<String>,
+        emoji: RequestReactionType,
     ) -> GetReactions<'_> {
         GetReactions::new(self, channel_id, message_id, emoji)
     }

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -54,11 +54,11 @@ impl<'a> GetReactions<'a> {
         http: &'a Client,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: impl Into<String>,
+        emoji: RequestReactionType,
     ) -> Self {
         Self {
             channel_id,
-            emoji: emoji.into(),
+            emoji: super::format_emoji(emoji),
             fields: GetReactionsFields::default(),
             fut: None,
             http,


### PR DESCRIPTION
This route was missing `RequestReactionType`, this PR fixes that.