### PR TITLE
gateway: add shards method to the Cluster

### DIFF
--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -249,6 +249,17 @@ impl Cluster {
             .cloned()
     }
 
+    /// Return a list of all the shards.
+    pub fn shards(&self) -> Vec<Shard> {
+        self.0
+            .shards
+            .lock()
+            .expect("shards poisned")
+            .values()
+            .cloned()
+            .collect()
+    }
+
     /// Return information about all shards.
     ///
     /// # Examples


### PR DESCRIPTION
This PR adds a convenience method to the Cluster that returns all the shards