### PR TITLE
Add AuditLogReason trait

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -38,5 +38,5 @@ rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 serde_test = { default-features = false, version = "1" }
-static_assertions = "1.1.0"
+static_assertions = { default-features = false, version = "1.1.0" }
 tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -38,4 +38,5 @@ rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 serde_test = { default-features = false, version = "1" }
+static_assertions = "1.1.0"
 tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }

--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -1,0 +1,24 @@
+pub trait AuditLogReason {
+    fn reason(self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError>
+    where
+        Self: Sized;
+}
+
+impl AuditLogReasonError {
+    /// The maximum audit log reason length in codepoints.
+    pub const AUDIT_REASON_LENGTH: usize = 512;
+
+    pub(crate) fn validate(reason: String) -> Result<String, AuditLogReasonError> {
+        if reason.chars().count() <= Self::AUDIT_REASON_LENGTH {
+            Ok(reason)
+        } else {
+            Err(AuditLogReasonError::ReasonInvalid { reason })
+        }
+    }
+}
+
+/// The error created when a reason can not be used as configured.
+pub enum AuditLogReasonError {
+    /// Returned when the reason is over 512 UTF-16 characters.
+    ReasonInvalid { reason: String },
+}

--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -1,4 +1,7 @@
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
 
 pub trait AuditLogReason: private::Sealed {
     fn reason(self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError>
@@ -45,7 +48,7 @@ mod private {
 }
 
 impl AuditLogReasonError {
-    /// The maximum audit log reason length in codepoints.
+    /// The maximum audit log reason length in UTF-16 codepoints.
     pub const AUDIT_REASON_LENGTH: usize = 512;
 
     pub(crate) fn validate(reason: String) -> Result<String, AuditLogReasonError> {
@@ -77,12 +80,14 @@ impl Display for AuditLogReasonError {
     }
 }
 
-impl std::error::Error for AuditLogReasonError {}
+impl Error for AuditLogReasonError {}
 
 #[cfg(test)]
 mod test {
     use crate::request::prelude::*;
-    use static_assertions::assert_impl_all;
+    use static_assertions::{assert_impl_all, assert_obj_safe};
+
+    assert_obj_safe!(AuditLogReason);
 
     assert_impl_all!(CreateInvite<'_>: AuditLogReason);
     assert_impl_all!(DeleteInvite<'_>: AuditLogReason);

--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -1,7 +1,47 @@
-pub trait AuditLogReason {
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+pub trait AuditLogReason: private::Sealed {
     fn reason(self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError>
     where
         Self: Sized;
+}
+
+mod private {
+    use crate::request::prelude::*;
+
+    /// Sealed stops crates other crates implementing the trait.
+    pub trait Sealed {}
+    impl<'a> Sealed for CreateInvite<'a> {}
+    impl<'a> Sealed for DeleteInvite<'a> {}
+    impl<'a> Sealed for DeleteMessage<'a> {}
+    impl<'a> Sealed for DeleteMessages<'a> {}
+    impl<'a> Sealed for UpdateChannel<'a> {}
+    impl<'a> Sealed for CreateWebhook<'a> {}
+    impl<'a> Sealed for DeleteWebhook<'a> {}
+    impl<'a> Sealed for UpdateWebhook<'a> {}
+    impl<'a> Sealed for CreatePin<'a> {}
+    impl<'a> Sealed for DeleteChannel<'a> {}
+    impl<'a> Sealed for DeleteChannelPermissionConfigured<'a> {}
+    impl<'a> Sealed for DeletePin<'a> {}
+    impl<'a> Sealed for UpdateChannelPermissionConfigured<'a> {}
+    impl<'a> Sealed for CreateBan<'a> {}
+    impl<'a> Sealed for DeleteBan<'a> {}
+    impl<'a> Sealed for CreateGuildChannel<'a> {}
+    impl<'a> Sealed for CreateGuildPrune<'a> {}
+    impl<'a> Sealed for CreateEmoji<'a> {}
+    impl<'a> Sealed for DeleteEmoji<'a> {}
+    impl<'a> Sealed for UpdateEmoji<'a> {}
+    impl<'a> Sealed for CreateGuildIntegration<'a> {}
+    impl<'a> Sealed for DeleteGuildIntegration<'a> {}
+    impl<'a> Sealed for UpdateGuildIntegration<'a> {}
+    impl<'a> Sealed for UpdateGuildMember<'a> {}
+    impl<'a> Sealed for AddRoleToMember<'a> {}
+    impl<'a> Sealed for RemoveMember<'a> {}
+    impl<'a> Sealed for RemoveRoleFromMember<'a> {}
+    impl<'a> Sealed for CreateRole<'a> {}
+    impl<'a> Sealed for DeleteRole<'a> {}
+    impl<'a> Sealed for UpdateRole<'a> {}
+    impl<'a> Sealed for UpdateGuild<'a> {}
 }
 
 impl AuditLogReasonError {
@@ -12,13 +52,67 @@ impl AuditLogReasonError {
         if reason.chars().count() <= Self::AUDIT_REASON_LENGTH {
             Ok(reason)
         } else {
-            Err(AuditLogReasonError::ReasonInvalid { reason })
+            Err(AuditLogReasonError::TooLarge { reason })
         }
     }
 }
 
 /// The error created when a reason can not be used as configured.
+#[derive(Clone, Debug)]
 pub enum AuditLogReasonError {
     /// Returned when the reason is over 512 UTF-16 characters.
-    ReasonInvalid { reason: String },
+    TooLarge { reason: String },
+}
+
+impl Display for AuditLogReasonError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::TooLarge { reason } => write!(
+                f,
+                "the audit log reason is {} characters long, but the max is {}",
+                reason.chars().count(),
+                Self::AUDIT_REASON_LENGTH
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AuditLogReasonError {}
+
+#[cfg(test)]
+mod test {
+    use crate::request::prelude::*;
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(CreateInvite<'_>: AuditLogReason);
+    assert_impl_all!(DeleteInvite<'_>: AuditLogReason);
+    assert_impl_all!(DeleteMessage<'_>: AuditLogReason);
+    assert_impl_all!(DeleteMessages<'_>: AuditLogReason);
+    assert_impl_all!(UpdateChannel<'_>: AuditLogReason);
+    assert_impl_all!(CreateWebhook<'_>: AuditLogReason);
+    assert_impl_all!(DeleteWebhook<'_>: AuditLogReason);
+    assert_impl_all!(UpdateWebhook<'_>: AuditLogReason);
+    assert_impl_all!(CreatePin<'_>: AuditLogReason);
+    assert_impl_all!(DeleteChannel<'_>: AuditLogReason);
+    assert_impl_all!(DeleteChannelPermissionConfigured<'_>: AuditLogReason);
+    assert_impl_all!(DeletePin<'_>: AuditLogReason);
+    assert_impl_all!(UpdateChannelPermissionConfigured<'_>: AuditLogReason);
+    assert_impl_all!(CreateBan<'_>: AuditLogReason);
+    assert_impl_all!(DeleteBan<'_>: AuditLogReason);
+    assert_impl_all!(CreateGuildChannel<'_>: AuditLogReason);
+    assert_impl_all!(CreateGuildPrune<'_>: AuditLogReason);
+    assert_impl_all!(CreateEmoji<'_>: AuditLogReason);
+    assert_impl_all!(DeleteEmoji<'_>: AuditLogReason);
+    assert_impl_all!(UpdateEmoji<'_>: AuditLogReason);
+    assert_impl_all!(CreateGuildIntegration<'_>: AuditLogReason);
+    assert_impl_all!(DeleteGuildIntegration<'_>: AuditLogReason);
+    assert_impl_all!(UpdateGuildIntegration<'_>: AuditLogReason);
+    assert_impl_all!(UpdateGuildMember<'_>: AuditLogReason);
+    assert_impl_all!(AddRoleToMember<'_>: AuditLogReason);
+    assert_impl_all!(RemoveMember<'_>: AuditLogReason);
+    assert_impl_all!(RemoveRoleFromMember<'_>: AuditLogReason);
+    assert_impl_all!(CreateRole<'_>: AuditLogReason);
+    assert_impl_all!(DeleteRole<'_>: AuditLogReason);
+    assert_impl_all!(UpdateRole<'_>: AuditLogReason);
+    assert_impl_all!(UpdateGuild<'_>: AuditLogReason);
 }

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -21,6 +21,8 @@ impl<'a> CreatePin<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -48,6 +50,15 @@ impl<'a> CreatePin<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for CreatePin<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -57,8 +57,8 @@ impl<'a> CreatePin<'a> {
 
 impl<'a> AuditLogReason for CreatePin<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -21,8 +21,10 @@ impl<'a> CreatePin<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -19,6 +19,8 @@ impl<'a> DeleteChannel<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -44,6 +46,15 @@ impl<'a> DeleteChannel<'a> {
         self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for DeleteChannel<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -53,8 +53,8 @@ impl<'a> DeleteChannel<'a> {
 
 impl<'a> AuditLogReason for DeleteChannel<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -19,8 +19,10 @@ impl<'a> DeleteChannel<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/channel/delete_channel_permission_configured.rs
+++ b/http/src/request/channel/delete_channel_permission_configured.rs
@@ -59,8 +59,8 @@ impl<'a> DeleteChannelPermissionConfigured<'a> {
 
 impl<'a> AuditLogReason for DeleteChannelPermissionConfigured<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/delete_channel_permission_configured.rs
+++ b/http/src/request/channel/delete_channel_permission_configured.rs
@@ -23,8 +23,10 @@ impl<'a> DeleteChannelPermissionConfigured<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/channel/delete_channel_permission_configured.rs
+++ b/http/src/request/channel/delete_channel_permission_configured.rs
@@ -23,6 +23,8 @@ impl<'a> DeleteChannelPermissionConfigured<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -50,6 +52,15 @@ impl<'a> DeleteChannelPermissionConfigured<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for DeleteChannelPermissionConfigured<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -21,6 +21,8 @@ impl<'a> DeletePin<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -48,6 +50,15 @@ impl<'a> DeletePin<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for DeletePin<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -21,8 +21,10 @@ impl<'a> DeletePin<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -57,8 +57,8 @@ impl<'a> DeletePin<'a> {
 
 impl<'a> AuditLogReason for DeletePin<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -148,8 +148,8 @@ impl<'a> CreateInvite<'a> {
 
 impl<'a> AuditLogReason for CreateInvite<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -110,8 +110,10 @@ impl<'a> CreateInvite<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -110,6 +110,8 @@ impl<'a> CreateInvite<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -139,6 +141,15 @@ impl<'a> CreateInvite<'a> {
         self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for CreateInvite<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -18,8 +18,10 @@ impl<'a> DeleteInvite<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -52,8 +52,8 @@ impl<'a> DeleteInvite<'a> {
 
 impl<'a> AuditLogReason for DeleteInvite<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -18,6 +18,8 @@ impl<'a> DeleteInvite<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -43,6 +45,15 @@ impl<'a> DeleteInvite<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for DeleteInvite<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -24,8 +24,10 @@ impl<'a> DeleteMessage<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -24,6 +24,8 @@ impl<'a> DeleteMessage<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -51,6 +53,15 @@ impl<'a> DeleteMessage<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for DeleteMessage<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -60,8 +60,8 @@ impl<'a> DeleteMessage<'a> {
 
 impl<'a> AuditLogReason for DeleteMessage<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -78,8 +78,8 @@ impl<'a> DeleteMessages<'a> {
 
 impl<'a> AuditLogReason for DeleteMessages<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -40,8 +40,10 @@ impl<'a> DeleteMessages<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -40,6 +40,8 @@ impl<'a> DeleteMessages<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -69,6 +71,15 @@ impl<'a> DeleteMessages<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for DeleteMessages<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -296,8 +296,8 @@ impl<'a> UpdateChannel<'a> {
 
 impl<'a> AuditLogReason for UpdateChannel<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -258,8 +258,10 @@ impl<'a> UpdateChannel<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -258,6 +258,8 @@ impl<'a> UpdateChannel<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -287,6 +289,15 @@ impl<'a> UpdateChannel<'a> {
         self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for UpdateChannel<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -81,8 +81,8 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
 
 impl<'a> AuditLogReason for UpdateChannelPermissionConfigured<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -41,6 +41,8 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -72,6 +74,15 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for UpdateChannelPermissionConfigured<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -41,8 +41,10 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -61,8 +61,10 @@ impl<'a> CreateWebhook<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -61,6 +61,8 @@ impl<'a> CreateWebhook<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -90,6 +92,15 @@ impl<'a> CreateWebhook<'a> {
         self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for CreateWebhook<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -99,8 +99,8 @@ impl<'a> CreateWebhook<'a> {
 
 impl<'a> AuditLogReason for CreateWebhook<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/webhook/delete_webhook.rs
+++ b/http/src/request/channel/webhook/delete_webhook.rs
@@ -32,6 +32,8 @@ impl<'a> DeleteWebhook<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -59,6 +61,15 @@ impl<'a> DeleteWebhook<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for DeleteWebhook<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/webhook/delete_webhook.rs
+++ b/http/src/request/channel/webhook/delete_webhook.rs
@@ -68,8 +68,8 @@ impl<'a> DeleteWebhook<'a> {
 
 impl<'a> AuditLogReason for DeleteWebhook<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/webhook/delete_webhook.rs
+++ b/http/src/request/channel/webhook/delete_webhook.rs
@@ -32,8 +32,10 @@ impl<'a> DeleteWebhook<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -105,8 +105,8 @@ impl<'a> UpdateWebhook<'a> {
 
 impl<'a> AuditLogReason for UpdateWebhook<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -65,6 +65,8 @@ impl<'a> UpdateWebhook<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -96,6 +98,15 @@ impl<'a> UpdateWebhook<'a> {
         self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for UpdateWebhook<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -65,8 +65,10 @@ impl<'a> UpdateWebhook<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -124,8 +124,9 @@ impl<'a> CreateBan<'a> {
 
 impl<'a> AuditLogReason for CreateBan<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.fields.reason.replace(reason);
+        self.fields
+            .reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -97,6 +97,8 @@ impl<'a> CreateBan<'a> {
         Ok(self)
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.fields.reason.replace(reason.into());
@@ -115,6 +117,15 @@ impl<'a> CreateBan<'a> {
         ))));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for CreateBan<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.fields.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -97,8 +97,10 @@ impl<'a> CreateBan<'a> {
         Ok(self)
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.fields.reason.replace(reason.into());

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -76,8 +76,8 @@ impl<'a> DeleteBan<'a> {
 
 impl<'a> AuditLogReason for DeleteBan<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -40,6 +40,8 @@ impl<'a> DeleteBan<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -67,6 +69,15 @@ impl<'a> DeleteBan<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for DeleteBan<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -40,8 +40,10 @@ impl<'a> DeleteBan<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -248,8 +248,10 @@ impl<'a> CreateGuildChannel<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -286,8 +286,8 @@ impl<'a> CreateGuildChannel<'a> {
 
 impl<'a> AuditLogReason for CreateGuildChannel<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -248,6 +248,8 @@ impl<'a> CreateGuildChannel<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -277,6 +279,15 @@ impl<'a> CreateGuildChannel<'a> {
         self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for CreateGuildChannel<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -92,6 +92,8 @@ impl<'a> CreateGuildPrune<'a> {
         Ok(self)
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -123,6 +125,15 @@ impl<'a> CreateGuildPrune<'a> {
         self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for CreateGuildPrune<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -132,8 +132,8 @@ impl<'a> CreateGuildPrune<'a> {
 
 impl<'a> AuditLogReason for CreateGuildPrune<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -92,8 +92,10 @@ impl<'a> CreateGuildPrune<'a> {
         Ok(self)
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -96,8 +96,8 @@ impl<'a> CreateEmoji<'a> {
 
 impl<'a> AuditLogReason for CreateEmoji<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -58,8 +58,10 @@ impl<'a> CreateEmoji<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -58,6 +58,8 @@ impl<'a> CreateEmoji<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -87,6 +89,15 @@ impl<'a> CreateEmoji<'a> {
         self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for CreateEmoji<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -57,8 +57,8 @@ impl<'a> DeleteEmoji<'a> {
 
 impl<'a> AuditLogReason for DeleteEmoji<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -21,6 +21,8 @@ impl<'a> DeleteEmoji<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -48,6 +50,15 @@ impl<'a> DeleteEmoji<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for DeleteEmoji<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -21,8 +21,10 @@ impl<'a> DeleteEmoji<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -48,8 +48,10 @@ impl<'a> UpdateEmoji<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -48,6 +48,8 @@ impl<'a> UpdateEmoji<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -79,6 +81,15 @@ impl<'a> UpdateEmoji<'a> {
         self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for UpdateEmoji<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -88,8 +88,8 @@ impl<'a> UpdateEmoji<'a> {
 
 impl<'a> AuditLogReason for UpdateEmoji<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/integration/create_guild_integration.rs
+++ b/http/src/request/guild/integration/create_guild_integration.rs
@@ -40,8 +40,10 @@ impl<'a> CreateGuildIntegration<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/integration/create_guild_integration.rs
+++ b/http/src/request/guild/integration/create_guild_integration.rs
@@ -40,6 +40,8 @@ impl<'a> CreateGuildIntegration<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -69,6 +71,15 @@ impl<'a> CreateGuildIntegration<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for CreateGuildIntegration<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/integration/create_guild_integration.rs
+++ b/http/src/request/guild/integration/create_guild_integration.rs
@@ -78,8 +78,8 @@ impl<'a> CreateGuildIntegration<'a> {
 
 impl<'a> AuditLogReason for CreateGuildIntegration<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -21,8 +21,10 @@ impl<'a> DeleteGuildIntegration<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -57,8 +57,8 @@ impl<'a> DeleteGuildIntegration<'a> {
 
 impl<'a> AuditLogReason for DeleteGuildIntegration<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -21,6 +21,8 @@ impl<'a> DeleteGuildIntegration<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -48,6 +50,15 @@ impl<'a> DeleteGuildIntegration<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for DeleteGuildIntegration<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/integration/update_guild_integration.rs
+++ b/http/src/request/guild/integration/update_guild_integration.rs
@@ -64,8 +64,10 @@ impl<'a> UpdateGuildIntegration<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/integration/update_guild_integration.rs
+++ b/http/src/request/guild/integration/update_guild_integration.rs
@@ -64,6 +64,8 @@ impl<'a> UpdateGuildIntegration<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -95,6 +97,15 @@ impl<'a> UpdateGuildIntegration<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for UpdateGuildIntegration<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/integration/update_guild_integration.rs
+++ b/http/src/request/guild/integration/update_guild_integration.rs
@@ -104,8 +104,8 @@ impl<'a> UpdateGuildIntegration<'a> {
 
 impl<'a> AuditLogReason for UpdateGuildIntegration<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -48,6 +48,8 @@ impl<'a> AddRoleToMember<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -77,6 +79,15 @@ impl<'a> AddRoleToMember<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for AddRoleToMember<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -86,8 +86,8 @@ impl<'a> AddRoleToMember<'a> {
 
 impl<'a> AuditLogReason for AddRoleToMember<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -48,8 +48,10 @@ impl<'a> AddRoleToMember<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -57,8 +57,8 @@ impl<'a> RemoveMember<'a> {
 
 impl<'a> AuditLogReason for RemoveMember<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -21,6 +21,8 @@ impl<'a> RemoveMember<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -48,6 +50,15 @@ impl<'a> RemoveMember<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for RemoveMember<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -21,8 +21,10 @@ impl<'a> RemoveMember<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/member/remove_role_from_member.rs
+++ b/http/src/request/guild/member/remove_role_from_member.rs
@@ -28,8 +28,10 @@ impl<'a> RemoveRoleFromMember<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/member/remove_role_from_member.rs
+++ b/http/src/request/guild/member/remove_role_from_member.rs
@@ -28,6 +28,8 @@ impl<'a> RemoveRoleFromMember<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -57,6 +59,15 @@ impl<'a> RemoveRoleFromMember<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for RemoveRoleFromMember<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/member/remove_role_from_member.rs
+++ b/http/src/request/guild/member/remove_role_from_member.rs
@@ -66,8 +66,8 @@ impl<'a> RemoveRoleFromMember<'a> {
 
 impl<'a> AuditLogReason for RemoveRoleFromMember<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -168,8 +168,8 @@ impl<'a> UpdateGuildMember<'a> {
 
 impl<'a> AuditLogReason for UpdateGuildMember<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -128,8 +128,10 @@ impl<'a> UpdateGuildMember<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -128,6 +128,8 @@ impl<'a> UpdateGuildMember<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -159,6 +161,15 @@ impl<'a> UpdateGuildMember<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for UpdateGuildMember<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -131,8 +131,8 @@ impl<'a> CreateRole<'a> {
 
 impl<'a> AuditLogReason for CreateRole<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -93,8 +93,10 @@ impl<'a> CreateRole<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -93,6 +93,8 @@ impl<'a> CreateRole<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -122,6 +124,15 @@ impl<'a> CreateRole<'a> {
         self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for CreateRole<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -57,8 +57,8 @@ impl<'a> DeleteRole<'a> {
 
 impl<'a> AuditLogReason for DeleteRole<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -21,8 +21,10 @@ impl<'a> DeleteRole<'a> {
         }
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -21,6 +21,8 @@ impl<'a> DeleteRole<'a> {
         }
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -48,6 +50,15 @@ impl<'a> DeleteRole<'a> {
         self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for DeleteRole<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -77,6 +77,8 @@ impl<'a> UpdateRole<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -108,6 +110,15 @@ impl<'a> UpdateRole<'a> {
         self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for UpdateRole<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -77,8 +77,10 @@ impl<'a> UpdateRole<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -117,8 +117,8 @@ impl<'a> UpdateRole<'a> {
 
 impl<'a> AuditLogReason for UpdateRole<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -282,6 +282,8 @@ impl<'a> UpdateGuild<'a> {
         self
     }
 
+    #[deprecated(note = "you've used the request's reason method which is deprecated; \
+                please import the request::AuditLogReason trait")]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());
@@ -311,6 +313,15 @@ impl<'a> UpdateGuild<'a> {
         self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for UpdateGuild<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        let reason = AuditLogReasonError::validate(reason.into())?;
+        self.reason.replace(reason);
+
+        Ok(self)
     }
 }
 

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -320,8 +320,8 @@ impl<'a> UpdateGuild<'a> {
 
 impl<'a> AuditLogReason for UpdateGuild<'a> {
     fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        let reason = AuditLogReasonError::validate(reason.into())?;
-        self.reason.replace(reason);
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
 
         Ok(self)
     }

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -282,8 +282,10 @@ impl<'a> UpdateGuild<'a> {
         self
     }
 
-    #[deprecated(note = "you've used the request's reason method which is deprecated; \
-                please import the request::AuditLogReason trait")]
+    #[deprecated(
+        since = "0.1.5",
+        note = "please prefer the request::AuditLogReason trait"
+    )]
     /// Attach an audit log reason to this request.
     pub fn reason(mut self, reason: impl Into<String>) -> Self {
         self.reason.replace(reason.into());

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -67,6 +67,7 @@ pub mod guild;
 pub mod prelude;
 pub mod user;
 
+mod audit_reason;
 mod get_gateway;
 mod get_gateway_authed;
 mod get_user_application;
@@ -74,8 +75,11 @@ mod get_voice_regions;
 mod validate;
 
 pub use self::{
-    get_gateway::GetGateway, get_gateway_authed::GetGatewayAuthed,
-    get_user_application::GetUserApplicationInfo, get_voice_regions::GetVoiceRegions,
+    audit_reason::{AuditLogReason, AuditLogReasonError},
+    get_gateway::GetGateway,
+    get_gateway_authed::GetGatewayAuthed,
+    get_user_application::GetUserApplicationInfo,
+    get_voice_regions::GetVoiceRegions,
 };
 
 use crate::{

--- a/http/src/request/prelude.rs
+++ b/http/src/request/prelude.rs
@@ -1,5 +1,6 @@
 pub(super) use super::{audit_header, validate, Pending, PendingOption, Request};
 pub use super::{
+    audit_reason::{AuditLogReason, AuditLogReasonError},
     channel::{invite::*, message::*, reaction::*, webhook::*, *},
     get_gateway::GetGateway,
     get_gateway_authed::GetGatewayAuthed,


### PR DESCRIPTION
This changeset adds a AuditLogReason trait and implements the
trait for all applicable structs. It also marks the old reason
methods as depricated.

Furthermore it ads validation of the length of the reason.


----

# Open question about how the trait is formulated

How the trait is currently formulated to fit in with other similar methods:
``` rust
pub trait AuditLogReason {
    fn reason(self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError>
    where
        Self: Sized;
}
```

This gives the issue that there is no way to recover `Self` if it fails.
So a better way of formulating the trait may be to have it take `&mut self`.

This opens the question of what the return value should be:
``` rust
pub trait AuditLogReason {
    fn reason(&mut self, reason: impl Into<String>) -> Result<& mut Self, AuditLogReasonError>
}
```
or
``` rust
pub trait AuditLogReason {
    fn reason(&mut self, reason: impl Into<String>) -> Result<(), AuditLogReasonError>
}
```

There is also the alternative that we embed `Self` in the error something like 
`Result<Self, (Self, AuditLogReasonError)>` or `Result<Self, AuditLogReasonError<Self>>`.