### PR TITLE
model/user: support discrim deser from integers

### DIFF
--- a/model/src/user/current_user.rs
+++ b/model/src/user/current_user.rs
@@ -6,6 +6,14 @@ pub struct CurrentUser {
     pub avatar: Option<String>,
     #[serde(default)]
     pub bot: bool,
+    /// Discriminator used to differentiate people with the same username.
+    ///
+    /// # serde
+    ///
+    /// The discriminator field can be deserialized from either a string or an
+    /// integer. The field will always serialize into a string due to that being
+    /// the type Discord's API uses.
+    #[serde(with = "super::discriminator")]
     pub discriminator: String,
     pub email: Option<String>,
     pub id: UserId,
@@ -20,6 +28,34 @@ mod tests {
     use super::{CurrentUser, UserId};
     use serde_test::Token;
 
+    fn user_tokens(discriminator_token: Token) -> Vec<Token> {
+        vec![
+            Token::Struct {
+                name: "CurrentUser",
+                len: 8,
+            },
+            Token::Str("avatar"),
+            Token::Some,
+            Token::Str("avatar hash"),
+            Token::Str("bot"),
+            Token::Bool(true),
+            Token::Str("discriminator"),
+            discriminator_token,
+            Token::Str("email"),
+            Token::None,
+            Token::Str("id"),
+            Token::NewtypeStruct { name: "UserId" },
+            Token::Str("1"),
+            Token::Str("mfa_enabled"),
+            Token::Bool(true),
+            Token::Str("username"),
+            Token::Str("test name"),
+            Token::Str("verified"),
+            Token::Bool(true),
+            Token::StructEnd,
+        ]
+    }
+
     #[test]
     fn test_current_user() {
         let value = CurrentUser {
@@ -33,33 +69,13 @@ mod tests {
             verified: true,
         };
 
-        serde_test::assert_tokens(
-            &value,
-            &[
-                Token::Struct {
-                    name: "CurrentUser",
-                    len: 8,
-                },
-                Token::Str("avatar"),
-                Token::Some,
-                Token::Str("avatar hash"),
-                Token::Str("bot"),
-                Token::Bool(true),
-                Token::Str("discriminator"),
-                Token::Str("9999"),
-                Token::Str("email"),
-                Token::None,
-                Token::Str("id"),
-                Token::NewtypeStruct { name: "UserId" },
-                Token::Str("1"),
-                Token::Str("mfa_enabled"),
-                Token::Bool(true),
-                Token::Str("username"),
-                Token::Str("test name"),
-                Token::Str("verified"),
-                Token::Bool(true),
-                Token::StructEnd,
-            ],
-        );
+        // Deserializing a current user with a string discriminator (which
+        // Discord provides)
+        serde_test::assert_tokens(&value, &user_tokens(Token::Str("9999")));
+
+        // Deserializing a current user with an integer discriminator. Userland
+        // code may have this due to being a more compact memory representation
+        // of a discriminator.
+        serde_test::assert_de_tokens(&value, &user_tokens(Token::U64(9999)));
     }
 }

--- a/model/src/user/mod.rs
+++ b/model/src/user/mod.rs
@@ -14,11 +14,53 @@ use crate::id::UserId;
 use serde::{Deserialize, Serialize};
 use serde_mappable_seq::Key;
 
+mod discriminator {
+    use serde::{
+        de::{Deserializer, Error as DeError, Visitor},
+        ser::Serializer,
+    };
+    use std::fmt::{Formatter, Result as FmtResult};
+
+    struct DiscriminatorVisitor;
+
+    impl<'de> Visitor<'de> for DiscriminatorVisitor {
+        type Value = String;
+
+        fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+            f.write_str("string or integer discriminator")
+        }
+
+        fn visit_u64<E: DeError>(self, value: u64) -> Result<Self::Value, E> {
+            Ok(format!("{:04}", value))
+        }
+
+        fn visit_str<E: DeError>(self, value: &str) -> Result<Self::Value, E> {
+            Ok(value.to_owned())
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<String, D::Error> {
+        deserializer.deserialize_any(DiscriminatorVisitor)
+    }
+
+    pub fn serialize<S: Serializer>(value: &str, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(value)
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct User {
     pub avatar: Option<String>,
     #[serde(default)]
     pub bot: bool,
+    /// Discriminator used to differentiate people with the same username.
+    ///
+    /// # serde
+    ///
+    /// The discriminator field can be deserialized from either a string or an
+    /// integer. The field will always serialize into a string due to that being
+    /// the type Discord's API uses.
+    #[serde(with = "discriminator")]
     pub discriminator: String,
     pub email: Option<String>,
     pub flags: Option<UserFlags>,
@@ -44,6 +86,51 @@ mod tests {
     use super::{PremiumType, User, UserFlags, UserId};
     use serde_test::Token;
 
+    fn user_tokens(discriminator_token: Token) -> Vec<Token> {
+        vec![
+            Token::Struct {
+                name: "User",
+                len: 13,
+            },
+            Token::Str("avatar"),
+            Token::Some,
+            Token::Str("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            Token::Str("bot"),
+            Token::Bool(false),
+            Token::Str("discriminator"),
+            discriminator_token,
+            Token::Str("email"),
+            Token::Some,
+            Token::Str("address@example.com"),
+            Token::Str("flags"),
+            Token::Some,
+            Token::U64(131_584),
+            Token::Str("id"),
+            Token::NewtypeStruct { name: "UserId" },
+            Token::Str("1"),
+            Token::Str("locale"),
+            Token::Some,
+            Token::Str("en-us"),
+            Token::Str("mfa_enabled"),
+            Token::Some,
+            Token::Bool(true),
+            Token::Str("username"),
+            Token::Str("test"),
+            Token::Str("premium_type"),
+            Token::Some,
+            Token::U8(2),
+            Token::Str("public_flags"),
+            Token::Some,
+            Token::U64(131_584),
+            Token::Str("system"),
+            Token::None,
+            Token::Str("verified"),
+            Token::Some,
+            Token::Bool(true),
+            Token::StructEnd,
+        ]
+    }
+
     #[test]
     fn test_user() {
         let value = User {
@@ -62,50 +149,13 @@ mod tests {
             verified: Some(true),
         };
 
-        serde_test::assert_tokens(
-            &value,
-            &[
-                Token::Struct {
-                    name: "User",
-                    len: 13,
-                },
-                Token::Str("avatar"),
-                Token::Some,
-                Token::Str("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-                Token::Str("bot"),
-                Token::Bool(false),
-                Token::Str("discriminator"),
-                Token::Str("0001"),
-                Token::Str("email"),
-                Token::Some,
-                Token::Str("address@example.com"),
-                Token::Str("flags"),
-                Token::Some,
-                Token::U64(131_584),
-                Token::Str("id"),
-                Token::NewtypeStruct { name: "UserId" },
-                Token::Str("1"),
-                Token::Str("locale"),
-                Token::Some,
-                Token::Str("en-us"),
-                Token::Str("mfa_enabled"),
-                Token::Some,
-                Token::Bool(true),
-                Token::Str("username"),
-                Token::Str("test"),
-                Token::Str("premium_type"),
-                Token::Some,
-                Token::U8(2),
-                Token::Str("public_flags"),
-                Token::Some,
-                Token::U64(131_584),
-                Token::Str("system"),
-                Token::None,
-                Token::Str("verified"),
-                Token::Some,
-                Token::Bool(true),
-                Token::StructEnd,
-            ],
-        );
+        // Deserializing a user with a string discriminator (which Discord
+        // provides)
+        serde_test::assert_tokens(&value, &user_tokens(Token::Str("0001")));
+
+        // Deserializing a user with an integer discriminator. Userland code
+        // may have this due to being a more compact memory representation of a
+        // discriminator.
+        serde_test::assert_de_tokens(&value, &user_tokens(Token::U64(1)));
     }
 }


### PR DESCRIPTION
For the `CurrentUser`, `UserProfile`, and `User` model types, support deserializing discriminators from integers because some userland may have objects with them due to being a more efficient representation. Discriminators will continue to serialize back into strings because this is what Discord provides.

Tests and documentation about the behaviour on the fields have been provided.

Closes #525.