### PR TITLE
Use the correct route for `http.current_user_application()`

### DIFF
--- a/http/src/request/get_user_application.rs
+++ b/http/src/request/get_user_application.rs
@@ -13,7 +13,8 @@ impl<'a> GetUserApplicationInfo<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(
-            self.http.request(Request::from(Route::GetCurrentUserApplicationInfo)),
+            self.http
+                .request(Request::from(Route::GetCurrentUserApplicationInfo)),
         ));
 
         Ok(())

--- a/http/src/request/get_user_application.rs
+++ b/http/src/request/get_user_application.rs
@@ -13,7 +13,7 @@ impl<'a> GetUserApplicationInfo<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(
-            self.http.request(Request::from(Route::GetGatewayBot)),
+            self.http.request(Request::from(Route::GetCurrentUserApplicationInfo)),
         ));
 
         Ok(())


### PR DESCRIPTION
The method `current_user_application` used the `GetGatewayBot` routed instead of the `GetCurrentApplicationInfo` route.