### PR TITLE
Fix gateway-queue standalone with sink feature

### DIFF
--- a/gateway/queue/Cargo.toml
+++ b/gateway/queue/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.1.0"
 
 [dependencies]
 futures-channel = { default-features = false, features = ["sink"], version = "0.3" }
-futures-util = { default-features = false, features = ["std"], version = "0.3" }
+futures-util = { default-features = false, features = ["std", "sink"], version = "0.3" }
 tokio = { default-features = false, features = ["net", "rt-core", "sync"], version = "0.2" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-http = { path = "../../http", default-features = false }


### PR DESCRIPTION
When I copied all the dependencies straight from gateway's Cargo.toml, it seems like some features were not specified because they were pulled in by other dependencies. This fixes compilation of twilight-gateway-queue standalone, tested on my fork of gateway-queue.

Sorry for missing that one out, I did not test the gateway-queue completely standalone without gateway until now, this definitely works now.