### PR TITLE
promote `missing_docs` to a deny in all crates

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -47,6 +47,8 @@
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
 
+#![deny(missing_docs)]
+
 pub mod model;
 
 mod builder;

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -56,6 +56,7 @@
 #![deny(
     clippy::all,
     clippy::pedantic,
+    missing_docs,
     future_incompatible,
     nonstandard_style,
     rust_2018_idioms,

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -80,7 +80,8 @@
     nonstandard_style,
     rust_2018_idioms,
     unused,
-    warnings
+    warnings,
+    missing_docs
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -42,7 +42,8 @@
     nonstandard_style,
     rust_2018_idioms,
     unused,
-    warnings
+    warnings,
+    missing_docs
 )]
 #![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
 

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -125,6 +125,7 @@
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+#![deny(missing_docs)]
 
 mod futures;
 


### PR DESCRIPTION
This may be a point of much contention, but being that this project has a large amount of user facing apis and is very user-oriented, we should strive to document every public facing api. Many crates already have missing_docs as a denied lint, but many of the more core crates: `cache-inmemory`, `http`, and `model` end up with many undocumented items, many of which has documentation that can be more or less copied from the official discord API for a more central point of information versus the current need to cross reference the model types with the discord documentation.

I understand that this pull request cannot and will not be merged until all of the public apis are documented, therefore this pull request is more of a marker for an intended goal. It would probably be of our best intention to complete a few more projects such as #532, and #389 so that time is not wasted documenting items about to be removed.