### PR TITLE
http: add bucket remaining time estimation method

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -142,6 +142,11 @@ impl Client {
         self.state.default_allowed_mentions.clone()
     }
 
+    /// Get the Ratelimiter used by the client internally.
+    pub fn ratelimiter(&self) -> Option<Ratelimiter> {
+        self.state.ratelimiter.clone()
+    }
+
     /// Add a role to a member in a guild.
     ///
     /// # Examples

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -143,6 +143,11 @@ impl Client {
     }
 
     /// Get the Ratelimiter used by the client internally.
+    ///
+    /// This will return `None` only if ratelimit handling
+    /// has been explicitly disabled in the [`ClientBuilder`].
+    ///
+    /// [`ClientBuilder`]: struct.ClientBuilder.html
     pub fn ratelimiter(&self) -> Option<Ratelimiter> {
         self.state.ratelimiter.clone()
     }


### PR DESCRIPTION
This adds a method to http::Client that will expose the internal Ratelimiter and one to the Ratelimiter to provide estimates for times on buckets for a path.