### PR TITLE
Switch to async-tungstenite/tokio-rustls

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.2.0-beta.0"
 
 [dependencies]
-async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.8" }
+async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.9.3" }
 bitflags = { default-features = false, version = "1" }
 twilight-gateway-queue = { default-features = false, path = "./queue" }
 twilight-http = { default-features = false, path = "../http" }
@@ -47,7 +47,7 @@ tokio = { default-features = false, features = ["rt-core", "macros"], version = 
 [features]
 default = ["rustls", "stock-zlib"]
 native = ["twilight-http/native", "twilight-gateway-queue/native", "async-tungstenite/tokio-native-tls"]
-rustls = ["twilight-http/rustls", "twilight-gateway-queue/rustls", "async-tungstenite/async-tls"]
+rustls = ["twilight-http/rustls", "twilight-gateway-queue/rustls", "async-tungstenite/tokio-rustls"]
 simd-zlib = ["flate2/zlib-ng-compat"]
 # if the `zlib` feature is enabled anywhere in the dependency tree it will
 # always use stock zlib instead of zlib-ng.

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.2.0-beta.0"
 
 [dependencies]
-async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.8" }
+async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.9.3" }
 dashmap = { default-features = false, version = "3" }
 futures-channel = { default-features = false, features = ["std"], version = "0.3" }
 futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }
@@ -38,4 +38,4 @@ twilight-http = { path = "../http" }
 default = ["http-support", "rustls"]
 http-support = ["http", "percent-encoding"]
 native = ["async-tungstenite/tokio-native-tls"]
-rustls = ["async-tungstenite/async-tls"]
+rustls = ["async-tungstenite/tokio-rustls"]


### PR DESCRIPTION
New `async-tungstenite` version supports `tokio-rustls` which means less dependencies.