### PR TITLE
Implement application integrations

### DIFF
--- a/http/src/request/guild/integration/get_guild_integrations.rs
+++ b/http/src/request/guild/integration/get_guild_integrations.rs
@@ -6,6 +6,7 @@ pub struct GetGuildIntegrations<'a> {
     fut: Option<Pending<'a, Vec<GuildIntegration>>>,
     guild_id: GuildId,
     http: &'a Client,
+    include_applications: bool,
 }
 
 impl<'a> GetGuildIntegrations<'a> {
@@ -14,13 +15,23 @@ impl<'a> GetGuildIntegrations<'a> {
             fut: None,
             guild_id,
             http,
+            include_applications: false,
         }
+    }
+
+    /// Sets if you want to receive bot and OAuth2 webhook integrations,
+    /// otherwise it will only include Twitch and YouTube.
+    pub fn include_applications(mut self, include: bool) -> Self {
+        self.include_applications = include;
+
+        self
     }
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from(
             Route::GetGuildIntegrations {
                 guild_id: self.guild_id.0,
+                include_applications: self.include_applications,
             },
         ))));
 

--- a/http/src/request/guild/integration/get_guild_integrations.rs
+++ b/http/src/request/guild/integration/get_guild_integrations.rs
@@ -21,6 +21,7 @@ impl<'a> GetGuildIntegrations<'a> {
 
     /// Sets if you want to receive bot and OAuth2 webhook integrations,
     /// otherwise it will only include Twitch and YouTube.
+    #[allow(clippy::doc_markdown)]
     pub fn include_applications(mut self, include: bool) -> Self {
         self.include_applications = include;
 

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -513,6 +513,8 @@ pub enum Route {
     GetGuildIntegrations {
         /// The ID of the guild.
         guild_id: u64,
+        /// Whether to include applications.
+        include_applications: bool,
     },
     /// Route information to get a guild's invites.
     GetGuildInvites {
@@ -1115,11 +1117,16 @@ impl Route {
                 Path::GuildsIdWidget(guild_id),
                 format!("guilds/{}/widget", guild_id).into(),
             ),
-            Self::GetGuildIntegrations { guild_id } => (
-                Method::GET,
-                Path::GuildsIdIntegrations(guild_id),
-                format!("guilds/{}/integrations", guild_id).into(),
-            ),
+            Self::GetGuildIntegrations {
+                guild_id,
+                include_applications,
+            } => (Method::GET, Path::GuildsIdIntegrations(guild_id), {
+                if include_applications {
+                    format!("guilds/{}/integrations?include_applications=true", guild_id).into()
+                } else {
+                    format!("guilds/{}/integrations", guild_id).into()
+                }
+            }),
             Self::GetGuildInvites { guild_id } => (
                 Method::GET,
                 Path::GuildsIdInvites(guild_id),

--- a/model/src/guild/integration.rs
+++ b/model/src/guild/integration.rs
@@ -1,4 +1,4 @@
-use super::{IntegrationAccount, IntegrationExpireBehavior};
+use super::{IntegrationAccount, IntegrationApplication, IntegrationExpireBehavior};
 use crate::{
     id::{IntegrationId, RoleId},
     user::User,
@@ -9,6 +9,7 @@ use serde_mappable_seq::Key;
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct GuildIntegration {
     pub account: IntegrationAccount,
+    pub application: Option<IntegrationApplication>,
     pub enable_emoticons: Option<bool>,
     pub enabled: bool,
     pub expire_behavior: IntegrationExpireBehavior,
@@ -17,7 +18,9 @@ pub struct GuildIntegration {
     #[serde(rename = "type")]
     pub kind: String,
     pub name: String,
+    pub revoked: bool,
     pub role_id: RoleId,
+    pub subscriber_count: u64,
     pub synced_at: String,
     pub syncing: bool,
     pub user: User,
@@ -45,6 +48,7 @@ mod tests {
                 id: "abcd".to_owned(),
                 name: "account name".to_owned(),
             },
+            application: None,
             enable_emoticons: Some(true),
             enabled: true,
             expire_behavior: IntegrationExpireBehavior::Kick,
@@ -52,7 +56,9 @@ mod tests {
             id: IntegrationId(2),
             kind: "a".to_owned(),
             name: "integration name".to_owned(),
+            revoked: false,
             role_id: RoleId(3),
+            subscriber_count: 1337,
             synced_at: "timestamp".to_owned(),
             syncing: false,
             user: User {
@@ -77,7 +83,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "GuildIntegration",
-                    len: 12,
+                    len: 15,
                 },
                 Token::Str("account"),
                 Token::Struct {
@@ -89,6 +95,8 @@ mod tests {
                 Token::Str("name"),
                 Token::Str("account name"),
                 Token::StructEnd,
+                Token::Str("application"),
+                Token::None,
                 Token::Str("enable_emoticons"),
                 Token::Some,
                 Token::Bool(true),
@@ -107,9 +115,13 @@ mod tests {
                 Token::Str("a"),
                 Token::Str("name"),
                 Token::Str("integration name"),
+                Token::Str("revoked"),
+                Token::Bool(false),
                 Token::Str("role_id"),
                 Token::NewtypeStruct { name: "RoleId" },
                 Token::Str("3"),
+                Token::Str("subscriber_count"),
+                Token::U64(1337),
                 Token::Str("synced_at"),
                 Token::Str("timestamp"),
                 Token::Str("syncing"),

--- a/model/src/guild/integration_application.rs
+++ b/model/src/guild/integration_application.rs
@@ -1,0 +1,58 @@
+use crate::{id::ApplicationId, user::User};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct IntegrationApplication {
+    pub bot: Option<User>,
+    pub description: String,
+    pub icon: Option<String>,
+    pub id: ApplicationId,
+    pub name: String,
+    pub summary: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IntegrationApplication;
+    use crate::id::ApplicationId;
+    use serde_test::Token;
+
+    #[test]
+    fn test_integration_account() {
+        let value = IntegrationApplication {
+            bot: None,
+            description: "Friendship is Magic".to_string(),
+            icon: None,
+            id: ApplicationId(123),
+            name: "Twilight".to_string(),
+            summary: "A cool pony".to_string(),
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "IntegrationApplication",
+                    len: 6,
+                },
+                Token::Str("bot"),
+                Token::None,
+                Token::Str("description"),
+                Token::Str("Friendship is Magic"),
+                Token::Str("icon"),
+                Token::None,
+                Token::Str("id"),
+                Token::NewtypeStruct {
+                    name: "ApplicationId",
+                },
+                Token::Str("123"),
+                Token::Str("name"),
+                Token::Str("Twilight"),
+                Token::Str("summary"),
+                Token::Str("A cool pony"),
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -8,6 +8,7 @@ mod explicit_content_filter;
 mod info;
 mod integration;
 mod integration_account;
+mod integration_application;
 mod integration_expire_behavior;
 mod mfa_level;
 mod partial_guild;
@@ -26,7 +27,7 @@ mod widget;
 pub use self::{
     ban::Ban, default_message_notification_level::DefaultMessageNotificationLevel, emoji::Emoji,
     explicit_content_filter::ExplicitContentFilter, info::GuildInfo, integration::GuildIntegration,
-    integration_account::IntegrationAccount,
+    integration_account::IntegrationAccount, integration_application::IntegrationApplication,
     integration_expire_behavior::IntegrationExpireBehavior, member::Member, mfa_level::MfaLevel,
     partial_guild::PartialGuild, partial_member::PartialMember, permissions::Permissions,
     premium_tier::PremiumTier, preview::GuildPreview, prune::GuildPrune, role::Role,


### PR DESCRIPTION
This changeset implements the application integrations
as described in https://github.com/discord/discord-api-docs/pull/1886.


----

**Note to reviewers**: This changeset cannot be tested on Discord as they have
begun to return 403 for it even if the bot have the manage guild permission.