### PR TITLE
model: implement 3 new integration related events

### DIFF
--- a/gateway/src/event.rs
+++ b/gateway/src/event.rs
@@ -43,6 +43,12 @@ bitflags! {
         const GUILD_INTEGRATIONS_UPDATE = 1 << 13;
         /// A guild has been updated.
         const GUILD_UPDATE = 1 << 14;
+        /// ?1
+        const INTEGRATION_CREATE = 1 << 49;
+        /// ?2
+        const INTEGRATION_DELETE = 1 << 50;
+        /// ?3
+        const INTEGRATION_UPDATE = 1 << 51;
         /// Invite for a channel has been created.
         const INVITE_CREATE = 1 << 46;
         /// Invite for a channel has been deleted.
@@ -140,6 +146,9 @@ impl From<EventType> for EventTypeFlags {
             EventType::GuildEmojisUpdate => EventTypeFlags::GUILD_EMOJIS_UPDATE,
             EventType::GuildIntegrationsUpdate => EventTypeFlags::GUILD_INTEGRATIONS_UPDATE,
             EventType::GuildUpdate => EventTypeFlags::GUILD_UPDATE,
+            EventType::IntegrationCreate => EventTypeFlags::INTEGRATION_CREATE,
+            EventType::IntegrationDelete => EventTypeFlags::INTEGRATION_DELETE,
+            EventType::IntegrationUpdate => EventTypeFlags::INTEGRATION_UPDATE,
             EventType::InviteCreate => EventTypeFlags::INVITE_CREATE,
             EventType::InviteDelete => EventTypeFlags::INVITE_DELETE,
             EventType::MemberAdd => EventTypeFlags::MEMBER_ADD,

--- a/model/src/gateway/event/dispatch.rs
+++ b/model/src/gateway/event/dispatch.rs
@@ -29,6 +29,9 @@ pub enum DispatchEvent {
     GuildEmojisUpdate(GuildEmojisUpdate),
     GuildIntegrationsUpdate(GuildIntegrationsUpdate),
     GuildUpdate(Box<GuildUpdate>),
+    IntegrationCreate(IntegrationCreate),
+    IntegrationDelete(IntegrationDelete),
+    IntegrationUpdate(IntegrationUpdate),
     InviteCreate(Box<InviteCreate>),
     InviteDelete(InviteDelete),
     MemberAdd(Box<MemberAdd>),
@@ -74,6 +77,9 @@ impl DispatchEvent {
             Self::GuildEmojisUpdate(_) => EventType::GuildEmojisUpdate,
             Self::GuildIntegrationsUpdate(_) => EventType::GuildIntegrationsUpdate,
             Self::GuildUpdate(_) => EventType::GuildUpdate,
+            Self::IntegrationCreate(_) => EventType::IntegrationCreate,
+            Self::IntegrationDelete(_) => EventType::IntegrationDelete,
+            Self::IntegrationUpdate(_) => EventType::IntegrationUpdate,
             Self::InviteCreate(_) => EventType::InviteCreate,
             Self::InviteDelete(_) => EventType::InviteDelete,
             Self::MemberAdd(_) => EventType::MemberAdd,
@@ -230,6 +236,15 @@ impl<'de, 'a> DeserializeSeed<'de> for DispatchEventWithTypeDeserializer<'a> {
             }
             "GUILD_UPDATE" => {
                 DispatchEvent::GuildUpdate(Box::new(GuildUpdate::deserialize(deserializer)?))
+            }
+            "INTEGRATION_CREATE" => {
+                DispatchEvent::IntegrationCreate(IntegrationCreate::deserialize(deserializer)?)
+            }
+            "INTEGRATION_DELETE" => {
+                DispatchEvent::IntegrationDelete(IntegrationDelete::deserialize(deserializer)?)
+            }
+            "INTEGRATION_UPDATE" => {
+                DispatchEvent::IntegrationUpdate(IntegrationUpdate::deserialize(deserializer)?)
             }
             "INVITE_CREATE" => {
                 DispatchEvent::InviteCreate(Box::new(InviteCreate::deserialize(deserializer)?))

--- a/model/src/gateway/event/kind.rs
+++ b/model/src/gateway/event/kind.rs
@@ -24,6 +24,9 @@ pub enum EventType {
     GuildEmojisUpdate,
     GuildIntegrationsUpdate,
     GuildUpdate,
+    IntegrationCreate,
+    IntegrationDelete,
+    IntegrationUpdate,
     InviteCreate,
     InviteDelete,
     #[serde(rename = "GUILD_MEMBER_ADD")]
@@ -86,6 +89,9 @@ impl EventType {
             Self::GuildEmojisUpdate => Some("GUILD_EMOJIS_UPDATE"),
             Self::GuildIntegrationsUpdate => Some("GUILD_INTEGRATIONS_UPDATE"),
             Self::GuildUpdate => Some("GUILD_UPDATE"),
+            Self::IntegrationCreate => Some("INTEGRATION_CREATE"),
+            Self::IntegrationDelete => Some("INTEGRATION_DELETE"),
+            Self::IntegrationUpdate => Some("INTEGRATION_UPDATE"),
             Self::InviteCreate => Some("INVITE_CREATE"),
             Self::InviteDelete => Some("INVITE_DELETE"),
             Self::MemberAdd => Some("GUILD_MEMBER_ADD"),
@@ -146,6 +152,9 @@ impl<'a> TryFrom<&'a str> for EventType {
             "GUILD_EMOJIS_UPDATE" => Ok(Self::GuildEmojisUpdate),
             "GUILD_INTEGRATIONS_UPDATE" => Ok(Self::GuildIntegrationsUpdate),
             "GUILD_UPDATE" => Ok(Self::GuildUpdate),
+            "INTEGRATION_CREATE" => Ok(Self::IntegrationCreate),
+            "INTEGRATION_DELETE" => Ok(Self::IntegrationDelete),
+            "INTEGRATION_UPDAETE" => Ok(Self::IntegrationUpdate),
             "INVITE_CREATE" => Ok(Self::InviteCreate),
             "INVITE_DELETE" => Ok(Self::InviteDelete),
             "GUILD_MEMBER_ADD" => Ok(Self::MemberAdd),
@@ -218,6 +227,9 @@ mod tests {
             "GUILD_INTEGRATIONS_UPDATE",
         );
         assert_variant(EventType::GuildUpdate, "GUILD_UPDATE");
+        assert_variant(EventType::IntegrationCreate, "INTEGRATION_CREATE");
+        assert_variant(EventType::IntegrationDelete, "INTEGRATION_DELETE");
+        assert_variant(EventType::IntegrationUpdate, "INTEGRATION_UPDATE");
         assert_variant(EventType::InviteCreate, "INVITE_CREATE");
         assert_variant(EventType::InviteDelete, "INVITE_DELETE");
         assert_variant(EventType::MemberAdd, "GUILD_MEMBER_ADD");

--- a/model/src/gateway/event/mod.rs
+++ b/model/src/gateway/event/mod.rs
@@ -63,6 +63,9 @@ pub enum Event {
     GuildIntegrationsUpdate(GuildIntegrationsUpdate),
     /// A guild was updated.
     GuildUpdate(Box<GuildUpdate>),
+    IntegrationCreate(IntegrationCreate),
+    IntegrationDelete(IntegrationDelete),
+    IntegrationUpdate(IntegrationUpdate),
     /// A invite was made.
     InviteCreate(Box<InviteCreate>),
     /// A invite was deleted.
@@ -159,6 +162,9 @@ impl Event {
             Self::GuildEmojisUpdate(_) => EventType::GuildEmojisUpdate,
             Self::GuildIntegrationsUpdate(_) => EventType::GuildIntegrationsUpdate,
             Self::GuildUpdate(_) => EventType::GuildUpdate,
+            Self::IntegrationCreate(_) => EventType::IntegrationCreate,
+            Self::IntegrationDelete(_) => EventType::IntegrationDelete,
+            Self::IntegrationUpdate(_) => EventType::IntegrationUpdate,
             Self::InviteCreate(_) => EventType::InviteCreate,
             Self::InviteDelete(_) => EventType::InviteDelete,
             Self::MemberAdd(_) => EventType::MemberAdd,
@@ -211,6 +217,9 @@ impl From<Box<DispatchEvent>> for Event {
             DispatchEvent::GuildDelete(v) => Self::GuildDelete(v),
             DispatchEvent::GuildEmojisUpdate(v) => Self::GuildEmojisUpdate(v),
             DispatchEvent::GuildIntegrationsUpdate(v) => Self::GuildIntegrationsUpdate(v),
+            DispatchEvent::IntegrationCreate(v) => Self::IntegrationCreate(v),
+            DispatchEvent::IntegrationDelete(v) => Self::IntegrationDelete(v),
+            DispatchEvent::IntegrationUpdate(v) => Self::IntegrationUpdate(v),
             DispatchEvent::InviteCreate(v) => Self::InviteCreate(v),
             DispatchEvent::InviteDelete(v) => Self::InviteDelete(v),
             DispatchEvent::MemberAdd(v) => Self::MemberAdd(v),

--- a/model/src/gateway/payload/integration_create.rs
+++ b/model/src/gateway/payload/integration_create.rs
@@ -1,0 +1,18 @@
+use crate::guild::IntegrationAccount;
+use crate::guild::IntegrationApplication;
+use crate::id::{GuildId, IntegrationId};
+use crate::user::User;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct IntegrationCreate {
+    user: User,
+    #[serde(rename = "type")]
+    kind: String,
+    name: String,
+    id: IntegrationId,
+    enabled: bool,
+    application: IntegrationApplication,
+    account: IntegrationAccount,
+    guild_id: GuildId,
+}

--- a/model/src/gateway/payload/integration_delete.rs
+++ b/model/src/gateway/payload/integration_delete.rs
@@ -1,0 +1,9 @@
+use crate::id::{ApplicationId, GuildId, IntegrationId};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct IntegrationDelete {
+    application_id: ApplicationId,
+    guild_id: GuildId,
+    id: IntegrationId,
+}

--- a/model/src/gateway/payload/integration_update.rs
+++ b/model/src/gateway/payload/integration_update.rs
@@ -1,0 +1,5 @@
+use crate::guild::GuildIntegration;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct IntegrationUpdate(pub GuildIntegration);

--- a/model/src/gateway/payload/mod.rs
+++ b/model/src/gateway/payload/mod.rs
@@ -16,6 +16,9 @@ mod guild_emojis_update;
 mod guild_integrations_update;
 mod guild_update;
 mod heartbeat;
+mod integration_create;
+mod integration_delete;
+mod integration_update;
 mod invite_create;
 mod invite_delete;
 mod member_add;
@@ -47,16 +50,18 @@ pub use self::{
     channel_delete::ChannelDelete, channel_pins_update::ChannelPinsUpdate,
     channel_update::ChannelUpdate, guild_create::GuildCreate, guild_delete::GuildDelete,
     guild_emojis_update::GuildEmojisUpdate, guild_integrations_update::GuildIntegrationsUpdate,
-    guild_update::GuildUpdate, heartbeat::Heartbeat, invite_create::InviteCreate,
-    invite_delete::InviteDelete, member_add::MemberAdd, member_chunk::MemberChunk,
-    member_remove::MemberRemove, member_update::MemberUpdate, message_create::MessageCreate,
-    message_delete::MessageDelete, message_delete_bulk::MessageDeleteBulk,
-    message_update::MessageUpdate, presence_update::PresenceUpdate, reaction_add::ReactionAdd,
-    reaction_remove::ReactionRemove, reaction_remove_all::ReactionRemoveAll,
-    reaction_remove_emoji::ReactionRemoveEmoji, ready::Ready,
-    request_guild_members::RequestGuildMembers, role_create::RoleCreate, role_delete::RoleDelete,
-    role_update::RoleUpdate, typing_start::TypingStart, unavailable_guild::UnavailableGuild,
-    update_status::UpdateStatus, update_voice_state::UpdateVoiceState, user_update::UserUpdate,
+    guild_update::GuildUpdate, heartbeat::Heartbeat, integration_create::IntegrationCreate,
+    integration_delete::IntegrationDelete, integration_update::IntegrationUpdate,
+    invite_create::InviteCreate, invite_delete::InviteDelete, member_add::MemberAdd,
+    member_chunk::MemberChunk, member_remove::MemberRemove, member_update::MemberUpdate,
+    message_create::MessageCreate, message_delete::MessageDelete,
+    message_delete_bulk::MessageDeleteBulk, message_update::MessageUpdate,
+    presence_update::PresenceUpdate, reaction_add::ReactionAdd, reaction_remove::ReactionRemove,
+    reaction_remove_all::ReactionRemoveAll, reaction_remove_emoji::ReactionRemoveEmoji,
+    ready::Ready, request_guild_members::RequestGuildMembers, role_create::RoleCreate,
+    role_delete::RoleDelete, role_update::RoleUpdate, typing_start::TypingStart,
+    unavailable_guild::UnavailableGuild, update_status::UpdateStatus,
+    update_voice_state::UpdateVoiceState, user_update::UserUpdate,
     voice_server_update::VoiceServerUpdate, voice_state_update::VoiceStateUpdate,
     webhooks_update::WebhooksUpdate,
 };


### PR DESCRIPTION
This changeset implements INTEGRATION_CREATE,
INTEGRATION_DELETE and INTEGRATION_UPDATE.

The events were first described in
https://github.com/discord/discord-api-docs/issues/2121

None of the events are officially supported by Discord yet so this
PR will be marked as WIP until then.