### PR TITLE
feat(http): Crossposting and channel following

### DIFF
--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -87,6 +87,8 @@ pub enum ErrorCode {
     FeatureTemporarilyDisabled,
     /// The user is banned from this guild
     UserBannedFromGuild,
+    /// This message has already been crossposted
+    MessageAlreadyCrossposted,
     /// Missing access
     Missingaccess,
     /// Invalid account type
@@ -188,6 +190,7 @@ impl ErrorCode {
             Self::RequestEntityTooLarge => 40005,
             Self::FeatureTemporarilyDisabled => 40006,
             Self::UserBannedFromGuild => 40007,
+            Self::MessageAlreadyCrossposted => 40033,
             Self::Missingaccess => 50001,
             Self::InvalidAccountType => 50002,
             Self::InvalidDMChannelAction => 50003,
@@ -262,6 +265,7 @@ impl From<u64> for ErrorCode {
             40005 => Self::RequestEntityTooLarge,
             40006 => Self::FeatureTemporarilyDisabled,
             40007 => Self::UserBannedFromGuild,
+            40033 => Self::MessageAlreadyCrossposted,
             50001 => Self::Missingaccess,
             50002 => Self::InvalidAccountType,
             50003 => Self::InvalidDMChannelAction,
@@ -336,6 +340,7 @@ impl Display for ErrorCode {
             Self::RequestEntityTooLarge => f.write_str("Request entity too large. Try sending something smaller in size"),
             Self::FeatureTemporarilyDisabled => f.write_str("This feature has been temporarily disabled server-side"),
             Self::UserBannedFromGuild => f.write_str("The user is banned from this guild"),
+            Self::MessageAlreadyCrossposted => f.write_str("This message has already been crossposted"),
             Self::Missingaccess => f.write_str("Missing access"),
             Self::InvalidAccountType => f.write_str("Invalid account type"),
             Self::InvalidDMChannelAction => f.write_str("Cannot execute action on a DM channel"),

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -327,6 +327,20 @@ impl Client {
         UpdateChannel::new(self, channel_id)
     }
 
+    /// Follows a news channel by [`ChannelId`].
+    ///
+    /// The type returned is [`FollowedChannel`].
+    ///
+    /// [`ChannelId`]: ../../twilight_model/id/struct.ChannelId.html
+    /// [`FollowedChannel`]: ../../twilight_model/channel/followed_channel.html#struct.FollowedChannel
+    pub fn follow_news_channel(
+        &self,
+        channel_id: ChannelId,
+        webhook_channel_id: ChannelId,
+    ) -> FollowNewsChannel<'_> {
+        FollowNewsChannel::new(self, channel_id, webhook_channel_id)
+    }
+
     /// Get the invites for a guild channel.
     ///
     /// This method only works if the channel is of type `GuildChannel`.
@@ -1052,6 +1066,18 @@ impl Client {
         message_id: MessageId,
     ) -> UpdateMessage<'_> {
         UpdateMessage::new(self, channel_id, message_id)
+    }
+
+    /// Crosspost a message by [`ChannelId`] and [`MessageId`].
+    ///
+    /// [`ChannelId`]: ../../twilight_model/id/struct.ChannelId.html
+    /// [`MessageId`]: ../../twilight_model/id/struct.MessageId.html
+    pub fn crosspost_message(
+        &self,
+        channel_id: ChannelId,
+        message_id: MessageId,
+    ) -> CrosspostMessage<'_> {
+        CrosspostMessage::new(self, channel_id, message_id)
     }
 
     /// Get the pins of a channel.

--- a/http/src/request/channel/follow_news_channel.rs
+++ b/http/src/request/channel/follow_news_channel.rs
@@ -1,0 +1,48 @@
+use crate::request::prelude::*;
+use serde::Serialize;
+use twilight_model::{channel::FollowedChannel, id::ChannelId};
+
+#[derive(Default, Serialize)]
+struct FollowNewsChannelFields {
+    webhook_channel_id: ChannelId,
+}
+
+/// Follow a news channel by [`ChannelId`]s.
+///
+/// [`ChannelId`]: ../../../twilight_model/id/struct.ChannelId.html
+pub struct FollowNewsChannel<'a> {
+    channel_id: ChannelId,
+    fields: FollowNewsChannelFields,
+    fut: Option<Pending<'a, FollowedChannel>>,
+    http: &'a Client,
+}
+
+impl<'a> FollowNewsChannel<'a> {
+    pub(crate) fn new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        webhook_channel_id: ChannelId,
+    ) -> Self {
+        Self {
+            channel_id,
+            fut: None,
+            http,
+            fields: FollowNewsChannelFields { webhook_channel_id },
+        }
+    }
+
+    fn start(&mut self) -> Result<()> {
+        let request = Request::from((
+            crate::json_to_vec(&self.fields)?,
+            Route::FollowNewsChannel {
+                channel_id: self.channel_id.0,
+            },
+        ));
+
+        self.fut.replace(Box::pin(self.http.request(request)));
+
+        Ok(())
+    }
+}
+
+poll_req!(FollowNewsChannel<'_>, FollowedChannel);

--- a/http/src/request/channel/message/crosspost_message.rs
+++ b/http/src/request/channel/message/crosspost_message.rs
@@ -1,0 +1,40 @@
+use crate::request::prelude::*;
+use twilight_model::{
+    channel::Message,
+    id::{ChannelId, MessageId},
+};
+
+/// Crosspost a message by [`ChannelId`] and [`MessageId`].
+///
+/// [`ChannelId`]: ../../../../twilight_model/id/struct.ChannelId.html
+/// [`MessageId`]: ../../../../twilight_model/id/struct.MessageId.html
+pub struct CrosspostMessage<'a> {
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, Message>>,
+    http: &'a Client,
+    message_id: MessageId,
+}
+
+impl<'a> CrosspostMessage<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId, message_id: MessageId) -> Self {
+        Self {
+            channel_id,
+            fut: None,
+            http,
+            message_id,
+        }
+    }
+
+    fn start(&mut self) -> Result<()> {
+        let request = Request::from(Route::CrosspostMessage {
+            channel_id: self.channel_id.0,
+            message_id: self.message_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
+
+        Ok(())
+    }
+}
+
+poll_req!(CrosspostMessage<'_>, Message);

--- a/http/src/request/channel/message/mod.rs
+++ b/http/src/request/channel/message/mod.rs
@@ -1,5 +1,6 @@
 pub mod allowed_mentions;
 pub mod create_message;
+pub mod crosspost_message;
 pub mod get_channel_messages;
 pub mod get_channel_messages_configured;
 pub mod update_message;
@@ -9,7 +10,8 @@ mod delete_messages;
 mod get_message;
 
 pub use self::{
-    create_message::CreateMessage, delete_message::DeleteMessage, delete_messages::DeleteMessages,
+    create_message::CreateMessage, crosspost_message::CrosspostMessage,
+    delete_message::DeleteMessage, delete_messages::DeleteMessages,
     get_channel_messages::GetChannelMessages,
     get_channel_messages_configured::GetChannelMessagesConfigured, get_message::GetMessage,
     update_message::UpdateMessage,

--- a/http/src/request/channel/mod.rs
+++ b/http/src/request/channel/mod.rs
@@ -10,6 +10,7 @@ mod delete_channel;
 mod delete_channel_permission;
 mod delete_channel_permission_configured;
 mod delete_pin;
+mod follow_news_channel;
 mod get_channel;
 mod get_pins;
 mod update_channel_permission;
@@ -19,7 +20,7 @@ pub use self::{
     create_pin::CreatePin, create_typing_trigger::CreateTypingTrigger,
     delete_channel::DeleteChannel, delete_channel_permission::DeleteChannelPermission,
     delete_channel_permission_configured::DeleteChannelPermissionConfigured, delete_pin::DeletePin,
-    get_channel::GetChannel, get_pins::GetPins, update_channel::UpdateChannel,
-    update_channel_permission::UpdateChannelPermission,
+    follow_news_channel::FollowNewsChannel, get_channel::GetChannel, get_pins::GetPins,
+    update_channel::UpdateChannel, update_channel_permission::UpdateChannelPermission,
     update_channel_permission_configured::UpdateChannelPermissionConfigured,
 };

--- a/model/src/channel/followed_channel.rs
+++ b/model/src/channel/followed_channel.rs
@@ -1,0 +1,39 @@
+use crate::id::{ChannelId, WebhookId};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct FollowedChannel {
+    pub channel_id: ChannelId,
+    pub webhook_id: WebhookId,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ChannelId, FollowedChannel, WebhookId};
+    use serde_test::Token;
+
+    #[test]
+    fn test_followed_channel() {
+        let value = FollowedChannel {
+            channel_id: ChannelId(1),
+            webhook_id: WebhookId(2),
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "FollowedChannel",
+                    len: 2,
+                },
+                Token::Str("channel_id"),
+                Token::NewtypeStruct { name: "ChannelId" },
+                Token::Str("1"),
+                Token::Str("webhook_id"),
+                Token::NewtypeStruct { name: "WebhookId" },
+                Token::Str("2"),
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -6,6 +6,7 @@ mod attachment;
 mod category_channel;
 mod channel_mention;
 mod channel_type;
+mod followed_channel;
 mod group;
 mod private_channel;
 mod reaction;
@@ -17,9 +18,10 @@ mod webhook_type;
 
 pub use self::{
     attachment::Attachment, category_channel::CategoryChannel, channel_mention::ChannelMention,
-    channel_type::ChannelType, group::Group, message::Message, private_channel::PrivateChannel,
-    reaction::Reaction, reaction_type::ReactionType, text_channel::TextChannel,
-    voice_channel::VoiceChannel, webhook::Webhook, webhook_type::WebhookType,
+    channel_type::ChannelType, followed_channel::FollowedChannel, group::Group, message::Message,
+    private_channel::PrivateChannel, reaction::Reaction, reaction_type::ReactionType,
+    text_channel::TextChannel, voice_channel::VoiceChannel, webhook::Webhook,
+    webhook_type::WebhookType,
 };
 
 use crate::id::{ChannelId, GuildId, MessageId};


### PR DESCRIPTION
Closes #545 

This adds support for following news channels and crossposting messages.

Tested both the following and crossposting and they work fine and return the according types.