### PR TITLE
cache: Fix missing guild specific insert in cache_emoji(s)

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -511,6 +511,12 @@ impl InMemoryCache {
             },
         );
 
+        self.0
+            .guild_emojis
+            .entry(guild_id)
+            .or_default()
+            .insert(emoji.id);
+
         cached
     }
 
@@ -1424,7 +1430,7 @@ mod tests {
 
         // Bulk inserts
         {
-            let guild_2_emoji_ids = (10..=20).map(EmojiId).collect::<Vec<_>>();
+            let guild_2_emoji_ids = (11..=20).map(EmojiId).collect::<Vec<_>>();
             let guild_2_emojis = guild_2_emoji_ids
                 .iter()
                 .copied()

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -874,9 +874,8 @@ mod tests {
     use twilight_model::{
         channel::{ChannelType, GuildChannel, TextChannel},
         gateway::payload::{MemberRemove, RoleDelete},
-        guild::Emoji,
         guild::{
-            DefaultMessageNotificationLevel, ExplicitContentFilter, Guild, Member, MfaLevel,
+            DefaultMessageNotificationLevel, Emoji, ExplicitContentFilter, Guild, Member, MfaLevel,
             Permissions, PremiumTier, Role, SystemChannelFlags, VerificationLevel,
         },
         id::{ChannelId, EmojiId, GuildId, RoleId, UserId},
@@ -1413,17 +1412,17 @@ mod tests {
                 cache.cache_emoji(GuildId(1), emoji);
             }
 
-            // Check for the emoji in the global cache
             for id in guild_1_emoji_ids.iter().cloned() {
                 let global_emoji = cache.emoji(id);
                 assert!(global_emoji.is_some());
             }
 
-            // Check for the emoji in the per-guild cache
+            // Ensure the emoji has been added to the per-guild lookup map to prevent
+            // issues like #551 from returning
             let guild_emojis = cache.guild_emojis(GuildId(1));
-
             assert!(guild_emojis.is_some());
             let guild_emojis = guild_emojis.unwrap();
+
             assert_eq!(guild_1_emoji_ids.len(), guild_emojis.len());
             assert!(guild_1_emoji_ids.iter().all(|id| guild_emojis.contains(id)));
         }
@@ -1438,13 +1437,11 @@ mod tests {
                 .collect::<Vec<_>>();
             cache.cache_emojis(GuildId(2), guild_2_emojis);
 
-            // Check for the emoji in the global cache
             for id in guild_2_emoji_ids.iter().cloned() {
                 let global_emoji = cache.emoji(id);
                 assert!(global_emoji.is_some());
             }
 
-            // Check for the emoji in the per-guild cache
             let guild_emojis = cache.guild_emojis(GuildId(2));
 
             assert!(guild_emojis.is_some());


### PR DESCRIPTION
Same problem as in #540. Just an oversight in the development of the cache. I have added tests to prevent regressions for `cache_emoji` and `cache_emojis`. The tests were proven failing before the fix and are now passing after the fix.