### PR TITLE
project: add CONTRIBUTING.md and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,9 @@
+---
+name: Bug Report
+about: Use this template to report a bug.
+---
+
+- What behavior are you experiencing and why is it unexpected?
+- What are you running your code on? Tell us your operating system, tech stack, and any other
+  pertinent information.
+- What feature flags are you using?

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug Report
 about: Use this template to report a bug.
 ---
 
-- What behavior are you experiencing and why is it unexpected?
-- What are you running your code on? Tell us your operating system, tech stack, and any other
-  pertinent information.
+- What unexpected behavior are you experiencing?
+- What are you running your code on? Tell us your operating system, tech stack, and any other pertinent information.
 - What feature flags are you using?
+- How can we reproduce the issue?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+    - name: Support Server
+      url: https://discord.gg/7jj8n7D
+      about: Ask a question here before making an issue, if possible.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,12 @@
+---
+name: Feature Request
+about: Use this template to request a feature or enhancement.
+---
+
+## What would you like implemented? What do you want that Twilight lacks?
+
+## What use case does this request address? This should be more than a single project's use case.
+
+## Are you willing to help towards contributing this feature?
+
+## Is there any other information that we should know?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,10 +3,7 @@ name: Feature Request
 about: Use this template to request a feature or enhancement.
 ---
 
-## What would you like implemented? What do you want that Twilight lacks?
-
-## What use case does this request address? This should be more than a single project's use case.
-
-## Are you willing to help towards contributing this feature?
-
-## Is there any other information that we should know?
+- What would you like implemented? What do you want that Twilight lacks?
+- What use case does this request address? This should be more than a single project's use case.
+- Are you willing to help towards contributing this feature?
+- Is there any other information that we should know?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,11 @@
 
 Issues have three types: bug, feature request, and support. When reporting a bug, you must include
 the operating system used, any relevant information about the tech stack, and the feature flags
-used. Feature request issues should answer these questions: 
-
-```
-- What would you like implemented? What do you want that Twilight lacks?
-- What use case does this request address? This should be more than a single project's use case.
-- Are you willing to help towards contributing this feature?
-- Is there any other information that we should know?
-```
-
-Before making a support issue or bug report, be sure to consider joining the
-[Discord](https://discord.gg/7jj8n7D) and bringing up your topic in the #support channel.
+used, as specified in the issue template. Feature requests also have an issue template, containing
+questions that should be answered in the issue. We aim for 100% coverage of the Discord API; we will
+wait until a new feature is supported in the [Discord API documentation] before adding its support
+to Twilight. Before making an issue, be sure to consider joining the [Twilight Discord] and bringing
+up your topic in the `#support` channel.
 
 # Pull Requests
 
@@ -28,7 +22,9 @@ Contributors should add tests and documentation that reflects their changes.
 
 ## Tests
 
-// TODO
+Contributors should write tests to ensure soundness in present and future code. Alongside regular
+test, when `model` structs are involved, you can use `serde_test`. To ensure structs implement the
+correct traits, use `static_assertions`.
 
 ## Documentation
 
@@ -75,5 +71,12 @@ correctness.
 
 # Merging
 
-Pull requests require two approvals before merging. The commit must be named with the format
-`{pr name} (#{pr number})`. The only possible merge option is squash and merge.
+Pull requests require two approvals before merging. The only possible merge option is squash and
+merge. The commit must be named with the format `{pr name} (#{pr number})`. When merging, add
+headers to the commit message that show who approved, merge, and authored the commit. The header
+`Signed-off-by` is used to specify the author. Refer to [this example commit] for proper formatting.
+Contributors can use the `-s` flag on `git commit` to automatically sign off their commits.
+
+[Discord API documentation]: https://github.com/discord/discord-api-docs
+[Twilight Discord]: https://discord.gg/7jj8n7D
+[this example commit]: https://github.com/twilight-rs/twilight/commit/bbab4a39769eac9f7f2d3878184f518a95645966

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,4 @@ correctness.
 
 Pull requests require two approvals before merging. They must be merged with the same name as the
 pull request, and as such must follow the naming rules for pull requests. The only possible merge
-option is squash and merge. Add the headers `Approved-by`, `Merged-by`, and `Signed-off-by` (the
-author of the pull request) to the end of the merge description. These headers must contain data in
-the format `Name <email@example.com>`, unless that data is not present.
+option is squash and merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,20 @@
 
 Issues have three types: bug, feature request, and support. When reporting a bug, you must include
 the operating system used, any relevant information about the tech stack, and the feature flags
-used. 
+used. Feature request issues should answer these questions: 
+
+```
+## What would you like implemented? What do you want that Twilight lacks?
+
+## What use case does this request address? This should be more than a single project's use case.
+
+## Are you willing to help towards contributing this feature?
+
+## Is there any other information that we should know?
+```
+
+Before making a support issue or bug report, be sure to consider joining the
+[Discord](https://discord.gg/7jj8n7D) and bringing up your topic in the #support channel.
 
 # Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,8 +74,9 @@ correctness.
 Pull requests require two approvals before merging. The only possible merge option is squash and
 merge. The commit must be named with the format `{pr name} (#{pr number})`. When merging, add
 headers to the commit message that show who approved, merge, and authored the commit. The header
-`Signed-off-by` is used to specify the author. Refer to [this example commit] for proper formatting.
-Contributors can use the `-s` flag on `git commit` to automatically sign off their commits.
+`Signed-off-by` is used to specify the commit author. Refer to [this example commit] for proper
+formatting.  Contributors can use the `-s` flag on `git commit` to automatically sign off their
+commits.
 
 [Discord API documentation]: https://github.com/discord/discord-api-docs
 [Twilight Discord]: https://discord.gg/7jj8n7D

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,10 @@ the operating system used, any relevant information about the tech stack, and th
 used. Feature request issues should answer these questions: 
 
 ```
-## What would you like implemented? What do you want that Twilight lacks?
-
-## What use case does this request address? This should be more than a single project's use case.
-
-## Are you willing to help towards contributing this feature?
-
-## Is there any other information that we should know?
+- What would you like implemented? What do you want that Twilight lacks?
+- What use case does this request address? This should be more than a single project's use case.
+- Are you willing to help towards contributing this feature?
+- Is there any other information that we should know?
 ```
 
 Before making a support issue or bug report, be sure to consider joining the
@@ -19,25 +16,64 @@ Before making a support issue or bug report, be sure to consider joining the
 
 # Pull Requests
 
-Pull requests must be named with the format `crate: short description of change`, and should use
+Pull requests must be named with the format `{crate}: {short description of change}`, and should use
 lower case letters. If the change spans more than one crate, separate the crate names with a comma
-and a space: `crate1, crate2: short description of change`. Pull requests must be made from a new
-branch. If a PR is made from the `trunk` branch, it will be denied. If adding a feature or
+and a space: `{crate1}, {crate2}: {short description of change}`. Pull requests must be made from a
+new branch. Please avoid making pull requests from the `trunk` branch. If adding a feature or
 enhancement, use the term `add` or something sufficiently similar. If fixing a bug, use the term
 `fix`, or something sufficiently similar. Avoid force-pushing to a pull request branch, as this
 erases review comment history.
+
+Contributors should add tests and documentation that reflects their changes.
+
+## Tests
+
+// TODO
+
+## Documentation
+
+Structs are to be documented as follows:
+```rust
+/// Short description of the struct.
+///
+/// Some more information about the struct, specifying all behavior. This can be more than one
+/// sentence, and can span multiple lines. It can also contain [named anchors], which should be
+/// specified below.
+///
+/// When documenting struct fields, don't prefix with "The", otherwise most documentation lines
+/// would start with "the".
+///
+/// [named anchors]: https://api.twilight.rs
+struct Structy {
+    /// Something.
+    pub some: String,
+    /// Something else.
+    pub stuff: String,
+}
+```
+
+Methods are to be documented as follows:
+```rust
+impl Structy {
+    /// Short decription of the method.
+    ///
+    /// More important information or clarification.
+    pub fn method(&self) -> Option<Something> {
+
+    }
+}
+```
 
 # Labeling
 
 If you are able, you must label your issues and pull requests appropriately. This includes adding a
 label for each applicable crate, or if the issue/change is project-wide, using `c-all`. `feature`s
 are new additions, and they are distinct from `enhancement`s, which are improvements on existing
-features.  `bugfix`es are self-evident. Any change relating to documentation must use the `docs`
+features. `bugfix`es are self-evident. Any change relating to documentation must use the `docs`
 label. The `discord api` label is used for changes that must be verified against the Discord API for
 correctness.
 
 # Merging
 
-Pull requests require two approvals before merging. They must be merged with the same name as the
-pull request, and as such must follow the naming rules for pull requests. The only possible merge
-option is squash and merge.
+Pull requests require two approvals before merging. The commit must be named with the format
+`{pr name} (#{pr number})`. The only possible merge option is squash and merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,11 @@ similar. Avoid force-pushing to a pull request branch, as this erases review com
 
 # Labeling
 
-If you can, you must label your issues and pull requests appropriately. This includes adding a label
-for each applicable crate, or if the issue/change is project-wide, using `c-all`. `feature`s are new
-additions, and they are distinct from `enhancement`s, which are improvements on existing features.
-`bugfix`es are self-evident. Any change relating to documentation must use the `docs` label. The
-`discord api` label is used for changes that must be verified against the Discord API for
+If you are able, you must label your issues and pull requests appropriately. This includes adding a
+label for each applicable crate, or if the issue/change is project-wide, using `c-all`. `feature`s
+are new additions, and they are distinct from `enhancement`s, which are improvements on existing
+features.  `bugfix`es are self-evident. Any change relating to documentation must use the `docs`
+label. The `discord api` label is used for changes that must be verified against the Discord API for
 correctness.
 
 # Merging

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Issues
+
+Issues have three types: bug, feature request, and support. When reporting a bug, you must include
+the operating system used, any relevant information about the tech stack, and the feature flags
+used. 
+
+# Pull Requests
+
+Pull requests should be named with the format `crate: short description of change`, and should use
+lower case letters. Always make a pull request from a new branch, that is named similarly, but with
+only a few words: `crate-short-description`. If adding a feature or enhancement, use the term `add`
+or something sufficiently similar. If fixing a bug, use the term `fix`, or something sufficiently
+similar. Avoid force-pushing to a pull request branch, as this erases review comment history.
+
+# Labeling
+
+If you can, you must label your issues and pull requests appropriately. This includes adding a label
+for each applicable crate, or if the issue/change is project-wide, using `c-all`. `feature`s are new
+additions, and they are distinct from `enhancement`s, which are improvements on existing features.
+`bugfix`es are self-evident. Any change relating to documentation must use the `docs` label. The
+`discord api` label is used for changes that must be verified against the Discord API for
+correctness.
+
+# Merging
+
+Pull requests require two approvals before merging. They must be merged with the name format `crate:
+short description of change`, and they should use lower case letters. The only possible merge option
+is squash and merge. Add the headers `Approved-by`, `Merged-by`, and `Signed-off-by` (the author of
+the pull request) to the end of the merge description. These headers must contain data in the format
+`Name <email@example.com>`, unless that data is not present.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,43 @@ Contributors should add tests and documentation that reflects their changes.
 
 ## Tests
 
-Contributors should write tests to ensure soundness in present and future code. Alongside regular
-test, when `model` structs are involved, you can use `serde_test`. To ensure structs implement the
-correct traits, use `static_assertions`.
+Feature and bugfix commits must always include unit tests to ensure the correctness of the relevant
+feature and prevent breakage. Enhancements to existing features without tests should include new
+unit tests, especially when the implementation of something is being modified.
+
+Public API types must be tested with the [`static_assertions`] crate.  `static_assertion`'s
+`assert_fields`, `assert_impl_all`, and `assert_obj_safe` functionality are notable. Asserting the
+implementation of `Send` and `Sync` are of particular importance.
+
+An example of assertions on an Enum may look like this:
+
+```rust
+#[derive(Clone, Copy, Debug)]
+pub enum PublicEnumType {
+    Foo {
+        bar: u64,
+    },
+    Baz {
+        qux: i64,
+        quz: bool,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PublicEnumType;
+    use static_assertions::{assert_fields, assert_impl_all};
+
+    assert_fields!(PublicEnumType::Foo: bar);
+    assert_fields!(PublicEnumType::Baz: qux, quz);
+    assert_impl_all!(PublicEnumType: Clone, Copy, Debug, Send, Sync);
+}
+```
+
+Tests should be concise and non-repetitive: a function doesn't need to be tested with different
+inputs multiple times if variance in the input doesn't affect the functionality. The logic of a code
+path only needs to be uniquely tested once; testing the same conditions multiple times has no
+benefit.
 
 ## Documentation
 
@@ -60,6 +94,9 @@ impl Structy {
 }
 ```
 
+Examples of other documentation can be found throughout the project. There isn't an exact standard,
+but changes that are needed will be requested, on a path towards eventual consistency.
+
 # Labeling
 
 If you are able, you must label your issues and pull requests appropriately. This includes adding a
@@ -73,10 +110,10 @@ correctness.
 
 Pull requests require two approvals before merging. The only possible merge option is squash and
 merge. The commit must be named with the format `{pr name} (#{pr number})`. When merging, add
-headers to the commit message that show who approved, merge, and authored the commit. The header
-`Signed-off-by` is used to specify the commit author. Refer to [this example commit] for proper
-formatting.  Contributors can use the `-s` flag on `git commit` to automatically sign off their
-commits.
+headers to the commit message that show who approved, merge, and authored the commit. The
+`Approved-by` and `Merged-by` headers are self-evident. The header `Signed-off-by` is used to
+specify the commit author. Refer to [this example commit] for proper formatting.  Contributors can
+use the `-s` flag on `git commit` to automatically sign off their commits.
 
 [Discord API documentation]: https://github.com/discord/discord-api-docs
 [Twilight Discord]: https://discord.gg/7jj8n7D

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,12 @@ used.
 
 # Pull Requests
 
-Pull requests should be named with the format `crate: short description of change`, and should use
-lower case letters. Always make a pull request from a new branch, that is named similarly, but with
-only a few words: `crate-short-description`. If adding a feature or enhancement, use the term `add`
-or something sufficiently similar. If fixing a bug, use the term `fix`, or something sufficiently
+Pull requests must be named with the format `crate: short description of change`, and should use
+lower case letters. If the change spans more than one crate, separate the crate names with a comma
+and a space: `crate1, crate2: short description of change`. Always make a pull request from a new
+branch, that is named similarly, but with only a few words: `crate-short-description`, or
+`crate1-crate2-short-description`. If adding a feature or enhancement, use the term `add` or
+something sufficiently similar. If fixing a bug, use the term `fix`, or something sufficiently
 similar. Avoid force-pushing to a pull request branch, as this erases review comment history.
 
 # Labeling
@@ -23,8 +25,8 @@ correctness.
 
 # Merging
 
-Pull requests require two approvals before merging. They must be merged with the name format `crate:
-short description of change`, and they should use lower case letters. The only possible merge option
-is squash and merge. Add the headers `Approved-by`, `Merged-by`, and `Signed-off-by` (the author of
-the pull request) to the end of the merge description. These headers must contain data in the format
-`Name <email@example.com>`, unless that data is not present.
+Pull requests require two approvals before merging. They must be merged with the same name as the
+pull request, and as such must follow the naming rules for pull requests. The only possible merge
+option is squash and merge. Add the headers `Approved-by`, `Merged-by`, and `Signed-off-by` (the
+author of the pull request) to the end of the merge description. These headers must contain data in
+the format `Name <email@example.com>`, unless that data is not present.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,11 @@ used.
 
 Pull requests must be named with the format `crate: short description of change`, and should use
 lower case letters. If the change spans more than one crate, separate the crate names with a comma
-and a space: `crate1, crate2: short description of change`. Always make a pull request from a new
-branch, that is named similarly, but with only a few words: `crate-short-description`, or
-`crate1-crate2-short-description`. If adding a feature or enhancement, use the term `add` or
-something sufficiently similar. If fixing a bug, use the term `fix`, or something sufficiently
-similar. Avoid force-pushing to a pull request branch, as this erases review comment history.
+and a space: `crate1, crate2: short description of change`. Pull requests must be made from a new
+branch. If a PR is made from the `trunk` branch, it will be denied. If adding a feature or
+enhancement, use the term `add` or something sufficiently similar. If fixing a bug, use the term
+`fix`, or something sufficiently similar. Avoid force-pushing to a pull request branch, as this
+erases review comment history.
 
 # Labeling
 


### PR DESCRIPTION
This adds guidelines for contributing issues and pull requests to Twilight. This PR should be approved by a majority of contributors. Please discuss and suggest changes.