### PR TITLE
http: fix ClientBuilder ignoring reqwest_client

### DIFF
--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -84,7 +84,7 @@ impl ClientBuilder {
         self
     }
 
-    /// Set a pre-configured reqwest client builder to build off of
+    /// Set a pre-configured reqwest client builder to build off of.
     ///
     /// The proxy and timeout settings in the reqwest client will be overridden by
     /// those in this builder

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -89,7 +89,7 @@ impl ClientBuilder {
     /// The proxy and timeout settings in the reqwest client will be overridden by
     /// those in this builder.
     ///
-    /// The default client is a RusTLS-backed client.
+    /// The default client uses Rustls as its TLS backend.
     pub fn reqwest_client(mut self, client: ReqwestClientBuilder) -> Self {
         self.reqwest_client.replace(client);
 

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -87,7 +87,7 @@ impl ClientBuilder {
     /// Set a pre-configured reqwest client builder to build off of.
     ///
     /// The proxy and timeout settings in the reqwest client will be overridden by
-    /// those in this builder
+    /// those in this builder.
     ///
     /// The default client is a RusTLS-backed client.
     pub fn reqwest_client(mut self, client: ReqwestClientBuilder) -> Self {

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -37,8 +37,9 @@ impl ClientBuilder {
     ///
     /// [`Client`]: struct.Client.html
     pub fn build(self) -> Result<Client> {
-        let mut builder = self.reqwest_client
-            .unwrap_or_else(|| ReqwestClientBuilder::new())
+        let mut builder = self
+            .reqwest_client
+            .unwrap_or_else(ReqwestClientBuilder::new)
             .timeout(self.timeout);
 
         if let Some(proxy) = self.proxy {


### PR DESCRIPTION
There was an oversight in the design of the `ClientBuilder` that caused the given `reqwest_client` to be ignored. My change may not be the right one, so I expect discussion on how we should fix the problem since it is not so easy as just a new line. I chose to replace the input in the `reqwest_client` function from a `ReqwestClient` to a `ReqwestClientBuilder` so that the user can configure the client on their own and the `ClientBuilder` can configure the builder with its defaults (timeout/proxy).

This does remove the `Clone` implementation from the `ClientBuilder` struct since `ReqwestClientBuilder` does not implement `Clone`

Closes #561