### PR TITLE
model: add Option for CurrentUser::verified

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -892,7 +892,7 @@ mod tests {
             id: UserId(id),
             mfa_enabled: true,
             name: "test".to_owned(),
-            verified: true,
+            verified: Some(true),
         }
     }
 

--- a/model/src/user/current_user.rs
+++ b/model/src/user/current_user.rs
@@ -20,6 +20,12 @@ pub struct CurrentUser {
     pub mfa_enabled: bool,
     #[serde(rename = "username")]
     pub name: String,
+    /// Whether the email on this account has been verified.
+    ///
+    /// Requires the `email` oauth scope. See [Discord's documentation] for
+    /// more information.
+    ///
+    /// [Discord's documentation]: https://discord.com/developers/docs/resources/user#user-object-user-structure
     pub verified: Option<bool>,
 }
 

--- a/model/src/user/current_user.rs
+++ b/model/src/user/current_user.rs
@@ -20,7 +20,7 @@ pub struct CurrentUser {
     pub mfa_enabled: bool,
     #[serde(rename = "username")]
     pub name: String,
-    pub verified: bool,
+    pub verified: Option<bool>,
 }
 
 #[cfg(test)]

--- a/model/src/user/current_user.rs
+++ b/model/src/user/current_user.rs
@@ -51,6 +51,7 @@ mod tests {
             Token::Str("username"),
             Token::Str("test name"),
             Token::Str("verified"),
+            Token::Some,
             Token::Bool(true),
             Token::StructEnd,
         ]
@@ -66,7 +67,7 @@ mod tests {
             id: UserId(1),
             mfa_enabled: true,
             name: "test name".to_owned(),
-            verified: true,
+            verified: Some(true),
         };
 
         // Deserializing a current user with a string discriminator (which

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -1012,7 +1012,7 @@ mod tests {
                 id: UserId(1),
                 mfa_enabled: true,
                 name: "twilight".to_owned(),
-                verified: false,
+                verified: Some(false),
             },
             version: 6,
         };


### PR DESCRIPTION
The response from a current_user request (with the `identify` scope) is as follows:
```json
{
    "avatar": "a_05dcf66dd5961e3147bfdbef64282d1a",
    "discriminator": "4191",
    "flags": 768,
    "id": "168827261682843648",
    "locale": "en-US",
    "mfa_enabled": true,
    "premium_type": 2,
    "public_flags": 768,
    "username": "DusterTheFirst"
}
```
[(also discord docs for more info)](https://discord.com/developers/docs/resources/user#user-object-user-structure)
But the `CurrentUser` struct in the model requires a `verified` member which is only avaliable with the `email` scope.

I have chosen to make it an `Option<bool>` versus adding `#[serde(default)]` like with the bot bool since `verified: false` has a very different meaning than `verified: None`.