### PR TITLE
model: add missing fields to CurrentUser

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -895,6 +895,8 @@ mod tests {
             verified: true,
             premium_type: None,
             public_flags: None,
+            flags: None,
+            locale: None,
         }
     }
 

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -893,6 +893,8 @@ mod tests {
             mfa_enabled: true,
             name: "test".to_owned(),
             verified: true,
+            premium_type: None,
+            public_flags: None,
         }
     }
 

--- a/model/src/user/current_user.rs
+++ b/model/src/user/current_user.rs
@@ -4,7 +4,14 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct CurrentUser {
+    /// User's avatar hash
+    ///
+    /// To retrieve the url to the avatar, you can follow [Discord's documentation] on
+    /// Image formatting
+    ///
+    /// [Discord's documentation]: https://discord.com/developers/docs/reference#image-formatting
     pub avatar: Option<String>,
+    /// Whether the user belongs to an OAuth2 application
     #[serde(default)]
     pub bot: bool,
     /// Discriminator used to differentiate people with the same username.
@@ -16,14 +23,27 @@ pub struct CurrentUser {
     /// the type Discord's API uses.
     #[serde(with = "super::discriminator")]
     pub discriminator: String,
+    /// User's email address associated to the account
+    ///
+    /// Requires the `email` oauth scope. See [Discord's documentation] for
+    /// more information
+    ///
+    /// [Discord's documentation]: https://discord.com/developers/docs/resources/user#user-object-user-structure
     pub email: Option<String>,
+    /// All flags on a user's account
+    pub flags: Option<UserFlags>,
+    /// User's id
     pub id: UserId,
+    /// User's chosen language option.
+    pub locale: Option<String>,
+    /// Whether the user has two factor enabled on their account
     pub mfa_enabled: bool,
+    /// User's username, not unique across the platform
     #[serde(rename = "username")]
     pub name: String,
-    /// Type of Nitro subscription on a user's account
+    /// Type of Nitro subscription on a user's account.
     pub premium_type: Option<PremiumType>,
-    /// Public flags on a user's account
+    /// Public flags on a user's account.
     pub public_flags: Option<UserFlags>,
     pub verified: bool,
 }
@@ -37,7 +57,7 @@ mod tests {
         vec![
             Token::Struct {
                 name: "CurrentUser",
-                len: 10,
+                len: 12,
             },
             Token::Str("avatar"),
             Token::Some,
@@ -48,9 +68,14 @@ mod tests {
             discriminator_token,
             Token::Str("email"),
             Token::None,
+            Token::Str("flags"),
+            Token::None,
             Token::Str("id"),
             Token::NewtypeStruct { name: "UserId" },
             Token::Str("1"),
+            Token::Str("locale"),
+            Token::Some,
+            Token::Str("test locale"),
             Token::Str("mfa_enabled"),
             Token::Bool(true),
             Token::Str("username"),
@@ -80,6 +105,8 @@ mod tests {
             verified: true,
             premium_type: Some(PremiumType::NitroClassic),
             public_flags: Some(UserFlags::DISCORD_EMPLOYEE),
+            flags: None,
+            locale: Some("test locale".to_owned()),
         };
 
         // Deserializing a current user with a string discriminator (which

--- a/model/src/user/current_user.rs
+++ b/model/src/user/current_user.rs
@@ -1,3 +1,4 @@
+use super::{PremiumType, UserFlags};
 use crate::id::UserId;
 use serde::{Deserialize, Serialize};
 
@@ -20,19 +21,23 @@ pub struct CurrentUser {
     pub mfa_enabled: bool,
     #[serde(rename = "username")]
     pub name: String,
+    /// Type of Nitro subscription on a user's account
+    pub premium_type: Option<PremiumType>,
+    /// Public flags on a user's account
+    pub public_flags: Option<UserFlags>,
     pub verified: bool,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{CurrentUser, UserId};
+    use super::{CurrentUser, PremiumType, UserFlags, UserId};
     use serde_test::Token;
 
     fn user_tokens(discriminator_token: Token) -> Vec<Token> {
         vec![
             Token::Struct {
                 name: "CurrentUser",
-                len: 8,
+                len: 10,
             },
             Token::Str("avatar"),
             Token::Some,
@@ -50,6 +55,12 @@ mod tests {
             Token::Bool(true),
             Token::Str("username"),
             Token::Str("test name"),
+            Token::Str("premium_type"),
+            Token::Some,
+            Token::U8(1),
+            Token::Str("public_flags"),
+            Token::Some,
+            Token::U64(1),
             Token::Str("verified"),
             Token::Bool(true),
             Token::StructEnd,
@@ -67,6 +78,8 @@ mod tests {
             mfa_enabled: true,
             name: "test name".to_owned(),
             verified: true,
+            premium_type: Some(PremiumType::NitroClassic),
+            public_flags: Some(UserFlags::DISCORD_EMPLOYEE),
         };
 
         // Deserializing a current user with a string discriminator (which

--- a/model/src/user/current_user.rs
+++ b/model/src/user/current_user.rs
@@ -11,7 +11,7 @@ pub struct CurrentUser {
     ///
     /// [Discord's documentation]: https://discord.com/developers/docs/reference#image-formatting
     pub avatar: Option<String>,
-    /// Whether the user belongs to an OAuth2 application
+    /// Whether the user belongs to an OAuth2 application.
     #[serde(default)]
     pub bot: bool,
     /// Discriminator used to differentiate people with the same username.

--- a/model/src/user/current_user.rs
+++ b/model/src/user/current_user.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct CurrentUser {
-    /// User's avatar hash
+    /// User's avatar hash.
     ///
     /// To retrieve the url to the avatar, you can follow [Discord's documentation] on
-    /// Image formatting
+    /// Image formatting.
     ///
     /// [Discord's documentation]: https://discord.com/developers/docs/reference#image-formatting
     pub avatar: Option<String>,
@@ -23,22 +23,22 @@ pub struct CurrentUser {
     /// the type Discord's API uses.
     #[serde(with = "super::discriminator")]
     pub discriminator: String,
-    /// User's email address associated to the account
+    /// User's email address associated to the account.
     ///
     /// Requires the `email` oauth scope. See [Discord's documentation] for
-    /// more information
+    /// more information.
     ///
     /// [Discord's documentation]: https://discord.com/developers/docs/resources/user#user-object-user-structure
     pub email: Option<String>,
-    /// All flags on a user's account
+    /// All flags on a user's account.
     pub flags: Option<UserFlags>,
-    /// User's id
+    /// User's id.
     pub id: UserId,
     /// User's chosen language option.
     pub locale: Option<String>,
-    /// Whether the user has two factor enabled on their account
+    /// Whether the user has two factor enabled on their account.
     pub mfa_enabled: bool,
-    /// User's username, not unique across the platform
+    /// User's username, not unique across the platform.
     #[serde(rename = "username")]
     pub name: String,
     /// Type of Nitro subscription on a user's account.

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -1013,6 +1013,8 @@ mod tests {
                 mfa_enabled: true,
                 name: "twilight".to_owned(),
                 verified: false,
+                premium_type: None,
+                public_flags: None,
             },
             version: 6,
         };

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -1015,6 +1015,8 @@ mod tests {
                 verified: false,
                 premium_type: None,
                 public_flags: None,
+                flags: None,
+                locale: None,
             },
             version: 6,
         };


### PR DESCRIPTION
The fields `public_flags` and `premium_type` were both missing off of the `CurrentUser` struct. These are both optional, so the serialization was not affected by their absence. This does constitute as a breaking change since any de-structuring of the `CurrentUser` will no longer work, unless the rest syntax is used