### PR TITLE
gateway: add option of gateway url to shard config

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -313,6 +313,12 @@ impl ClusterBuilder {
     }
 }
 
+impl<T: Into<String>> From<(T, Intents)> for ClusterBuilder {
+    fn from((token, intents): (T, Intents)) -> Self {
+        Self::new(token, intents)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{ClusterBuilder, ShardScheme, ShardSchemeRangeError};

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -180,7 +180,7 @@ impl ClusterBuilder {
     /// [`ClusterStartError::RetrievingGatewayInfo`]: enum.ClusterStartError.html#variant.RetrievingGatewayInfo
     pub async fn build(mut self) -> Result<Cluster, ClusterStartError> {
         if self.0.shard_config.gateway_url.is_none() {
-            let gateway_url = self
+            let gateway_url = (self.1)
                 .0
                 .http_client
                 .gateway()
@@ -188,12 +188,20 @@ impl ClusterBuilder {
                 .await
                 .ok()
                 .map(|s| s.url);
-            self.0.shard_config = (self.1).gateway_url(gateway_url).0;
-        } else {
-            self.0.shard_config = (self.1).0;
+
+            self = self.gateway_url(gateway_url);
         }
 
+        self.0.shard_config = (self.1).0;
+
         Cluster::new_with_config(self.0).await
+    }
+
+    /// Set the URL that will be used to connect to the gateway.
+    pub fn gateway_url(mut self, gateway_url: Option<String>) -> Self {
+        self.1 = self.1.gateway_url(gateway_url);
+
+        self
     }
 
     /// Set the `twilight_http` Client used by the cluster and the shards it

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -111,6 +111,7 @@ impl ShardBuilder {
         }
 
         Self(Config {
+            gateway_url: None,
             http_client: HttpClient::new(token.clone()),
             intents,
             large_threshold: 250,
@@ -126,6 +127,13 @@ impl ShardBuilder {
     /// Consume the builder, constructing a shard.
     pub fn build(self) -> Shard {
         Shard::new_with_config(self.0)
+    }
+
+    /// Set the URL used for connecting to Discord's gateway
+    pub fn gateway_url(mut self, gateway_url: Option<String>) -> Self {
+        self.0.gateway_url = gateway_url;
+
+        self
     }
 
     /// Set the HTTP client to be used by the shard for getting gateway

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -11,6 +11,7 @@ use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents}
 /// [`Shard::builder`]: struct.Shard.html#method.builder
 #[derive(Clone, Debug)]
 pub struct Config {
+    pub(crate) gateway_url: Option<String>,
     pub(super) http_client: Client,
     pub(super) intents: Intents,
     pub(super) large_threshold: u64,
@@ -23,6 +24,11 @@ pub struct Config {
 }
 
 impl Config {
+    /// Return an immutable reference to the url used to connect to the gateway.
+    pub fn gateway_url(&self) -> Option<&str> {
+        self.gateway_url.as_deref()
+    }
+
     /// Return an immutable reference to the `twilight_http` client to be used
     /// by the shard.
     pub fn http_client(&self) -> &Client {

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -12,7 +12,7 @@ use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents}
 #[derive(Clone, Debug)]
 pub struct Config {
     pub(crate) gateway_url: Option<String>,
-    pub(super) http_client: Client,
+    pub(crate) http_client: Client,
     pub(super) intents: Intents,
     pub(super) large_threshold: u64,
     pub(super) presence: Option<UpdateStatusInfo>,

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -335,15 +335,18 @@ impl Shard {
     /// [`ShardStartError::ParsingGatewayUrl`]: enum.ShardStartError.html#variant.ParsingGatewayUrl
     /// [`ShardStartError::RetrievingGatewayUrl`]: enum.ShardStartError.html#variant.RetrievingGatewayUrl
     pub async fn start(&mut self) -> Result<(), ShardStartError> {
-        let url = self
-            .0
-            .config
-            .http_client()
-            .gateway()
-            .authed()
-            .await
-            .map_err(|source| ShardStartError::RetrievingGatewayUrl { source })?
-            .url;
+        let url = if let Some(u) = self.0.config.gateway_url.clone() {
+            u
+        } else {
+            self.0
+                .config
+                .http_client()
+                .gateway()
+                .authed()
+                .await
+                .map_err(|source| ShardStartError::RetrievingGatewayUrl { source })?
+                .url
+        };
 
         let config = Arc::clone(&self.0.config);
         let listeners = self.0.listeners.clone();


### PR DESCRIPTION
Twilight currently gets the gateway url for each shard when starting
up, this is not reccomended by Discord and leads to ratelimiting and
therefore a slower startup for larger bots.

This change set adds a new option to the shard builder `gateway_url`
that if set will be used instead of making a request to Discord.

This is also built into the Cluster so it will only make a single
request for all the shards it is set to start up.