### PR TITLE
util: highlight features in documentation with #[doc(cfg)]

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build docs
         env:
-          RUSTDOCFLAGS: -D broken_intra_doc_links
+          RUSTDOCFLAGS: --cfg docsrs -D broken_intra_doc_links
         run: |
           cargo doc --workspace --no-deps
           cargo doc -p twilight-util --no-deps --all-features

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build docs
         env:
-          RUSTDOCFLAGS: -D broken_intra_doc_links
+          RUSTDOCFLAGS: --cfg docsrs -D broken_intra_doc_links
         run: |
           exclude_examples=($(grep -h '^name' **/examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
           cargo doc --workspace --no-deps "${exclude_examples[@]}"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -21,6 +21,7 @@ full = ["snowflake"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 twilight-model = { path = "../model", default-features = false, optional = true }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -33,6 +33,8 @@
     unused,
     warnings
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "snowflake")]
+#[cfg_attr(docsrs, doc(cfg(feature = "snowflake")))]
 pub mod snowflake;


### PR DESCRIPTION
Rustdoc will render the item with a banner explaining that the item is
only available with certain features. See [tokio docs].

This unstable feature is conditionally enabled for CI & docs.rs

[tokio docs]: https://docs.rs/tokio/0.3.1/tokio/#modules