### PR TITLE
command-parser: add unicode support to the Arguments struct

### DIFF
--- a/command-parser/Cargo.toml
+++ b/command-parser/Cargo.toml
@@ -16,6 +16,7 @@ version = "0.2.0-beta.0"
 
 [dependencies]
 unicase = { default-features = false, version = "2" }
+unicode-segmentation = "1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/command-parser/src/arguments.rs
+++ b/command-parser/src/arguments.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{Debug, Formatter, Result as FmtResult};
 use unicode_segmentation::{GraphemeIndices, UnicodeSegmentation};
 
 /// An iterator over command arguments.
@@ -73,8 +73,8 @@ impl<'a> From<&'a str> for Arguments<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Arguments<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl<'a> Debug for Arguments<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.debug_struct("Arguments")
             .field("buf", &self.buf)
             .field("idx", &self.idx)

--- a/command-parser/src/arguments.rs
+++ b/command-parser/src/arguments.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use unicode_segmentation::{UnicodeSegmentation, GraphemeIndices};
+use unicode_segmentation::{GraphemeIndices, UnicodeSegmentation};
 
 /// An iterator over command arguments.
 #[derive(Clone)]
@@ -75,8 +75,7 @@ impl<'a> From<&'a str> for Arguments<'a> {
 
 impl<'a> fmt::Debug for Arguments<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f
-            .debug_struct("Arguments")
+        f.debug_struct("Arguments")
             .field("buf", &self.buf)
             .field("idx", &self.idx)
             .finish()
@@ -134,6 +133,7 @@ impl<'a> Iterator for Arguments<'a> {
     }
 }
 
+#[allow(clippy::non_ascii_literal)]
 #[cfg(test)]
 mod tests {
     use super::Arguments;

--- a/command-parser/src/arguments.rs
+++ b/command-parser/src/arguments.rs
@@ -1,7 +1,10 @@
+use unicode_segmentation::UnicodeSegmentation;
+
 /// An iterator over command arguments.
 #[derive(Clone, Debug)]
 pub struct Arguments<'a> {
     buf: &'a str,
+    indices: Vec<usize>,
     idx: usize,
 }
 
@@ -63,6 +66,7 @@ impl<'a> From<&'a str> for Arguments<'a> {
     fn from(buf: &'a str) -> Self {
         Self {
             buf: buf.trim(),
+            indices: buf.trim().grapheme_indices(true).map(|ch| ch.0).collect::<Vec<usize>>(),
             idx: 0,
         }
     }
@@ -73,7 +77,7 @@ impl<'a> Iterator for Arguments<'a> {
 
     // todo: clean this up
     fn next(&mut self) -> Option<Self::Item> {
-        if self.idx > self.buf.len() {
+        if self.idx > self.indices.len() {
             return None;
         }
 
@@ -81,24 +85,24 @@ impl<'a> Iterator for Arguments<'a> {
         let mut quoted = false;
         let mut started = false;
 
-        if let Some(r#"""#) = self.buf.get(idx..=idx) {
+        if let Some(r#"""#) = self.indices.get(idx).and_then(|i| self.buf.get(*i..=*i)) {
             idx += 1;
             quoted = true;
             started = true;
             self.idx += 1;
         }
 
-        while let Some(ch) = self.buf.get(idx..=idx) {
+        while let Some(i) = self.indices.get(idx) {
             if quoted {
-                if ch == r#"""# {
-                    let v = self.buf.get(self.idx..idx);
+                if let Some(r#"""#) = self.buf.get(*i..=*i) {
+                    let v = self.indices.get(self.idx).and_then(|start| self.buf.get(*start..*i));
                     self.idx = idx + 1;
 
                     return v.map(str::trim);
                 }
-            } else if ch == " " {
+            } else if let Some(" ") = self.buf.get(*i..=*i) {
                 if started {
-                    let v = self.buf.get(self.idx..idx);
+                    let v = self.indices.get(self.idx).and_then(|start| self.buf.get(*start..*i));
                     self.idx = idx + 1;
 
                     return v.map(str::trim);
@@ -117,7 +121,7 @@ impl<'a> Iterator for Arguments<'a> {
         let idx = self.idx;
         self.idx = usize::max_value();
 
-        match self.buf.get(idx..) {
+        match self.indices.get(idx).and_then(|start| self.buf.get(*start..)) {
             Some("") | None => None,
             Some(v) => Some(v.trim()),
         }
@@ -161,6 +165,52 @@ mod tests {
         let mut args = Arguments::new(r#""kind of weird""but okay"#);
         assert_eq!(Some("kind of weird"), args.next());
         assert_eq!(Some("but okay"), args.next());
+        assert_eq!(None, args.next());
+    }
+
+    #[test]
+    fn test_unicode_chars_1() {
+        let mut args = Arguments::new("𝓒𝓢𝓐 nice try");
+        assert_eq!(Some("𝓒𝓢𝓐"), args.next());
+        assert_eq!(Some("nice"), args.next());
+        assert_eq!(Some("try"), args.next());
+        assert_eq!(None, args.next());
+    }
+
+    #[test]
+    fn test_unicode_chars_2() {
+        let mut args = Arguments::new("Saighdiúr réalta what even");
+        assert_eq!(Some("Saighdiúr"), args.next());
+        assert_eq!(Some("réalta"), args.next());
+        assert_eq!(Some("what"), args.next());
+        assert_eq!(Some("even"), args.next());
+        assert_eq!(None, args.next());
+    }
+
+    #[test]
+    fn test_quoted_unicode_chars() {
+        let mut args = Arguments::new(r#""𝓒𝓢𝓐 | CSA" amazing try"#);
+        assert_eq!(Some("𝓒𝓢𝓐 | CSA"), args.next());
+        assert_eq!(Some("amazing"), args.next());
+        assert_eq!(Some("try"), args.next());
+        assert_eq!(None, args.next());
+    }
+
+    #[test]
+    fn test_emote() {
+        let mut args = Arguments::new("why an emote 🙃");
+        assert_eq!(Some("why"), args.next());
+        assert_eq!(Some("an"), args.next());
+        assert_eq!(Some("emote"), args.next());
+        assert_eq!(Some("🙃"), args.next());
+        assert_eq!(None, args.next());
+    }
+
+    #[test]
+    fn test_quoted_emote() {
+        let mut args = Arguments::new(r#"omg "😕 - 😟"#);
+        assert_eq!(Some("omg"), args.next());
+        assert_eq!(Some("😕 - 😟"), args.next());
         assert_eq!(None, args.next());
     }
 }


### PR DESCRIPTION
This PR adds Unicode support to the Arguments struct along with quoted support. The previous version was unable to parse them properly, giving a false count. The PR also adds 5 new tests each containing various forms of unicode. It also switches

This also adds in a new dependency: `unicode-segmentation`