### PR TITLE
actions: add the util crate to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,9 @@ jobs:
           - package: lavalink
             additional: --features http-support
 
+          - package: util
+            features: full
+
         exclude:
           - package: lavalink
             features: simd-json


### PR DESCRIPTION
The util crate was not fully tested via CI and needs to be added to the `test-features` build matrix.