### PR TITLE
http/request: remove deprecated methods

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -159,7 +159,7 @@ impl Client {
     /// In guild `1`, add role `2` to user `3`, for the reason `"test"`:
     ///
     /// ```rust,no_run
-    /// # use twilight_http::Client;
+    /// # use twilight_http::{request::AuditLogReason, Client};
     /// use twilight_model::id::{GuildId, RoleId, UserId};
     /// #
     /// # #[tokio::main]
@@ -170,7 +170,7 @@ impl Client {
     /// let role_id = RoleId(2);
     /// let user_id = UserId(3);
     ///
-    /// client.add_role(guild_id, user_id, role_id).reason("test").await?;
+    /// client.add_role(guild_id, user_id, role_id).reason("test")?.await?;
     /// # Ok(()) }
     /// ```
     pub fn add_role(
@@ -243,7 +243,7 @@ impl Client {
     /// 1 day's worth of messages, for the reason `"memes"`:
     ///
     /// ```rust,no_run
-    /// # use twilight_http::Client;
+    /// # use twilight_http::{request::AuditLogReason, Client};
     /// use twilight_model::id::{GuildId, UserId};
     /// #
     /// # #[tokio::main]
@@ -254,7 +254,7 @@ impl Client {
     /// let user_id = UserId(200);
     /// client.create_ban(guild_id, user_id)
     ///     .delete_message_days(1)?
-    ///     .reason("memes")
+    ///     .reason("memes")?
     ///     .await?;
     /// # Ok(()) }
     /// ```

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -21,17 +21,6 @@ impl<'a> CreatePin<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -19,17 +19,6 @@ impl<'a> DeleteChannel<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/channel/delete_channel_permission_configured.rs
+++ b/http/src/request/channel/delete_channel_permission_configured.rs
@@ -23,17 +23,6 @@ impl<'a> DeleteChannelPermissionConfigured<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -21,17 +21,6 @@ impl<'a> DeletePin<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -110,17 +110,6 @@ impl<'a> CreateInvite<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -18,17 +18,6 @@ impl<'a> DeleteInvite<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -24,17 +24,6 @@ impl<'a> DeleteMessage<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -40,17 +40,6 @@ impl<'a> DeleteMessages<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -258,17 +258,6 @@ impl<'a> UpdateChannel<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -41,17 +41,6 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -61,17 +61,6 @@ impl<'a> CreateWebhook<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/channel/webhook/delete_webhook.rs
+++ b/http/src/request/channel/webhook/delete_webhook.rs
@@ -32,17 +32,6 @@ impl<'a> DeleteWebhook<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -65,17 +65,6 @@ impl<'a> UpdateWebhook<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -43,7 +43,7 @@ struct CreateBanFields {
 /// 1 day's worth of messages, for the reason `"memes"`:
 ///
 /// ```rust,no_run
-/// use twilight_http::Client;
+/// use twilight_http::{request::AuditLogReason, Client};
 /// use twilight_model::id::{GuildId, UserId};
 ///
 /// # #[tokio::main]
@@ -54,7 +54,7 @@ struct CreateBanFields {
 /// let user_id = UserId(200);
 /// client.create_ban(guild_id, user_id)
 ///     .delete_message_days(1)?
-///     .reason("memes")
+///     .reason("memes")?
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -95,17 +95,6 @@ impl<'a> CreateBan<'a> {
         self.fields.delete_message_days.replace(days);
 
         Ok(self)
-    }
-
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.fields.reason.replace(reason.into());
-
-        self
     }
 
     fn start(&mut self) -> Result<()> {

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -40,17 +40,6 @@ impl<'a> DeleteBan<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -248,17 +248,6 @@ impl<'a> CreateGuildChannel<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -92,17 +92,6 @@ impl<'a> CreateGuildPrune<'a> {
         Ok(self)
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -58,17 +58,6 @@ impl<'a> CreateEmoji<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -21,17 +21,6 @@ impl<'a> DeleteEmoji<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -48,17 +48,6 @@ impl<'a> UpdateEmoji<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/integration/create_guild_integration.rs
+++ b/http/src/request/guild/integration/create_guild_integration.rs
@@ -40,17 +40,6 @@ impl<'a> CreateGuildIntegration<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -21,17 +21,6 @@ impl<'a> DeleteGuildIntegration<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/integration/update_guild_integration.rs
+++ b/http/src/request/guild/integration/update_guild_integration.rs
@@ -64,17 +64,6 @@ impl<'a> UpdateGuildIntegration<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -8,7 +8,7 @@ use twilight_model::id::{GuildId, RoleId, UserId};
 /// In guild `1`, add role `2` to user `3`, for the reason `"test"`:
 ///
 /// ```rust,no_run
-/// use twilight_http::Client;
+/// use twilight_http::{request::AuditLogReason, Client};
 /// use twilight_model::id::{GuildId, RoleId, UserId};
 ///
 /// # #[tokio::main]
@@ -19,7 +19,7 @@ use twilight_model::id::{GuildId, RoleId, UserId};
 /// let role_id = RoleId(2);
 /// let user_id = UserId(3);
 ///
-/// client.add_role(guild_id, user_id, role_id).reason("test").await?;
+/// client.add_role(guild_id, user_id, role_id).reason("test")?.await?;
 /// # Ok(()) }
 /// ```
 pub struct AddRoleToMember<'a> {
@@ -46,17 +46,6 @@ impl<'a> AddRoleToMember<'a> {
             user_id: user_id.into(),
             reason: None,
         }
-    }
-
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
     }
 
     fn start(&mut self) -> Result<()> {

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -21,17 +21,6 @@ impl<'a> RemoveMember<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/member/remove_role_from_member.rs
+++ b/http/src/request/guild/member/remove_role_from_member.rs
@@ -28,17 +28,6 @@ impl<'a> RemoveRoleFromMember<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -128,17 +128,6 @@ impl<'a> UpdateGuildMember<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -93,17 +93,6 @@ impl<'a> CreateRole<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -21,17 +21,6 @@ impl<'a> DeleteRole<'a> {
         }
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -77,17 +77,6 @@ impl<'a> UpdateRole<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -282,17 +282,6 @@ impl<'a> UpdateGuild<'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.1.5",
-        note = "please prefer the request::AuditLogReason trait"
-    )]
-    /// Attach an audit log reason to this request.
-    pub fn reason(mut self, reason: impl Into<String>) -> Self {
-        self.reason.replace(reason.into());
-
-        self
-    }
-
     fn start(&mut self) -> Result<()> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;


### PR DESCRIPTION
Remove all of the deprecated `reason` methods on requests, as users should now instead use the `request::AuditLogReason` trait.