### PR TITLE
cache, model: document gateway intents

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -161,6 +161,9 @@ struct InMemoryCacheRef {
 /// This is an implementation of a cache designed to be used by only the
 /// current process.
 ///
+/// Events will only be processed if they are properly expressed with
+/// [`Intents`]; refer to function-level documentation for more details.
+///
 /// # Design and Performance
 ///
 /// The defining characteristic of this cache is that returned types (such as a
@@ -183,6 +186,8 @@ struct InMemoryCacheRef {
 /// its state at that *point in time* or maybe across the lifetime of an
 /// operation. If you need the guild to always be up-to-date between operations,
 /// then the intent is that you keep getting it from the cache.
+///
+/// [`Intents`]: ../twilight_model/gateway/struct.Intents.html
 #[derive(Clone, Debug, Default)]
 pub struct InMemoryCache(Arc<InMemoryCacheRef>);
 
@@ -421,8 +426,7 @@ impl InMemoryCache {
 
     /// Gets the voice states within a voice channel.
     ///
-    /// This requires the [`GUILDS`] intent for the initial set of voice states, and further
-    /// requires the [`GUILD_VOICE_STATES`] intent for updates.
+    /// This requires both the [`GUILDS`] and [`GUILD_VOICE_STATES`] intents for updates.
     ///
     /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     /// [`GUILD_VOICE_STATES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_VOICE_STATES
@@ -439,9 +443,8 @@ impl InMemoryCache {
 
     /// Gets a voice state by user ID and Guild ID.
     ///
-    /// This is an O(1) operation. This requires the [`GUILDS`] intent for the
-    /// initial set of voice states, and further requires the [`GUILD_VOICE_STATES`] intent for
-    /// updates.
+    /// This is an O(1) operation. This requires the [`GUILDS`] and [`GUILD_VOICE_STATES`] intents
+    /// for updates.
     ///
     /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     /// [`GUILD_VOICE_STATES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_VOICE_STATES

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -298,8 +298,7 @@ impl InMemoryCache {
     /// Gets the set of emojis in a guild.
     ///
     /// This is a O(m) operation, where m is the amount of emojis in the guild.
-    /// This requires the [`GUILDS`] intent for the initial set of emojis, and
-    /// further requires the [`GUILD_EMOJIS`] intent for updates.
+    /// This requires both the [`GUILDS`] and [`GUILD_EMOJIS`] intents.
     ///
     /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     /// [`GUILD_EMOJIS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_EMOJIS
@@ -426,8 +425,7 @@ impl InMemoryCache {
 
     /// Gets the voice states within a voice channel.
     ///
-    /// This requires both the [`GUILDS`] and [`GUILD_VOICE_STATES`] intents for
-    /// updates.
+    /// This requires both the [`GUILDS`] and [`GUILD_VOICE_STATES`] intents.
     ///
     /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     /// [`GUILD_VOICE_STATES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_VOICE_STATES
@@ -444,8 +442,8 @@ impl InMemoryCache {
 
     /// Gets a voice state by user ID and Guild ID.
     ///
-    /// This is an O(1) operation. This requires the [`GUILDS`] and
-    /// [`GUILD_VOICE_STATES`] intents for updates.
+    /// This is an O(1) operation. This requires both the [`GUILDS`] and
+    /// [`GUILD_VOICE_STATES`] intents.
     ///
     /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     /// [`GUILD_VOICE_STATES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_VOICE_STATES

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -284,8 +284,8 @@ impl InMemoryCache {
 
     /// Gets the set of channels in a guild.
     ///
-    /// This is a O(m) operation, where m is the amount of channels in the guild. This requires the
-    /// [`GUILDS`] intent.
+    /// This is a O(m) operation, where m is the amount of channels in the
+    /// guild. This requires the [`GUILDS`] intent.
     ///
     /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     pub fn guild_channels(&self, guild_id: GuildId) -> Option<HashSet<ChannelId>> {
@@ -297,9 +297,9 @@ impl InMemoryCache {
 
     /// Gets the set of emojis in a guild.
     ///
-    /// This is a O(m) operation, where m is the amount of emojis in the guild. This requires the
-    /// [`GUILDS`] intent for the initial set of emojis, and further requires the [`GUILD_EMOJIS`]
-    /// intent for updates.
+    /// This is a O(m) operation, where m is the amount of emojis in the guild.
+    /// This requires the [`GUILDS`] intent for the initial set of emojis, and
+    /// further requires the [`GUILD_EMOJIS`] intent for updates.
     ///
     /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     /// [`GUILD_EMOJIS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_EMOJIS
@@ -314,8 +314,8 @@ impl InMemoryCache {
     ///
     /// This list may be incomplete if not all members have been cached.
     ///
-    /// This is a O(m) operation, where m is the amount of members in the guild. This requires the
-    /// [`GUILD_MEMBERS`] intent.
+    /// This is a O(m) operation, where m is the amount of members in the guild.
+    /// This requires the [`GUILD_MEMBERS`] intent.
     ///
     /// [`GUILD_MEMBERS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_MEMBERS
     pub fn guild_members(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
@@ -329,8 +329,8 @@ impl InMemoryCache {
     ///
     /// This list may be incomplete if not all members have been cached.
     ///
-    /// This is a O(m) operation, where m is the amount of members in the guild. This requires the
-    /// [`GUILD_PRESENCES`] intent.
+    /// This is a O(m) operation, where m is the amount of members in the guild.
+    /// This requires the [`GUILD_PRESENCES`] intent.
     ///
     /// [`GUILD_PRESENCES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_PRESENCES
     pub fn guild_presences(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
@@ -342,8 +342,8 @@ impl InMemoryCache {
 
     /// Gets the set of roles in a guild.
     ///
-    /// This is a O(m) operation, where m is the amount of roles in the guild. This requires the
-    /// [`GUILDS`] intent.
+    /// This is a O(m) operation, where m is the amount of roles in the guild.
+    /// This requires the [`GUILDS`] intent.
     ///
     /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     pub fn guild_roles(&self, guild_id: GuildId) -> Option<HashSet<RoleId>> {
@@ -364,8 +364,8 @@ impl InMemoryCache {
 
     /// Gets a message by channel ID and message ID.
     ///
-    /// This is an O(log n) operation. This requires one or both of the [`GUILD_MESSAGES`] or
-    /// [`DIRECT_MESSAGES`] intents.
+    /// This is an O(log n) operation. This requires one or both of the
+    /// [`GUILD_MESSAGES`] or [`DIRECT_MESSAGES`] intents.
     ///
     /// [`GUILD_MESSAGES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_MESSAGES
     /// [`DIRECT_MESSAGES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.DIRECT_MESSAGES
@@ -426,7 +426,8 @@ impl InMemoryCache {
 
     /// Gets the voice states within a voice channel.
     ///
-    /// This requires both the [`GUILDS`] and [`GUILD_VOICE_STATES`] intents for updates.
+    /// This requires both the [`GUILDS`] and [`GUILD_VOICE_STATES`] intents for
+    /// updates.
     ///
     /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     /// [`GUILD_VOICE_STATES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_VOICE_STATES
@@ -443,8 +444,8 @@ impl InMemoryCache {
 
     /// Gets a voice state by user ID and Guild ID.
     ///
-    /// This is an O(1) operation. This requires the [`GUILDS`] and [`GUILD_VOICE_STATES`] intents
-    /// for updates.
+    /// This is an O(1) operation. This requires the [`GUILDS`] and
+    /// [`GUILD_VOICE_STATES`] intents for updates.
     ///
     /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     /// [`GUILD_VOICE_STATES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_VOICE_STATES

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -228,7 +228,9 @@ impl InMemoryCache {
 
     /// Gets a channel by ID.
     ///
-    /// This is an O(1) operation.
+    /// This is an O(1) operation. This requires the [`GUILDS`] intent.
+    ///
+    /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     pub fn guild_channel(&self, channel_id: ChannelId) -> Option<Arc<GuildChannel>> {
         self.0
             .channels_guild
@@ -249,7 +251,9 @@ impl InMemoryCache {
 
     /// Gets an emoji by ID.
     ///
-    /// This is an O(1) operation.
+    /// This is an O(1) operation. This requires the [`GUILD_EMOJIS`] intent.
+    ///
+    /// [`GUILD_EMOJIS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_EMOJIS
     pub fn emoji(&self, emoji_id: EmojiId) -> Option<Arc<CachedEmoji>> {
         self.0.emojis.get(&emoji_id).map(|x| Arc::clone(&x.data))
     }
@@ -266,14 +270,19 @@ impl InMemoryCache {
 
     /// Gets a guild by ID.
     ///
-    /// This is an O(1) operation.
+    /// This is an O(1) operation. This requires the [`GUILDS`] intent.
+    ///
+    /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     pub fn guild(&self, guild_id: GuildId) -> Option<Arc<CachedGuild>> {
         self.0.guilds.get(&guild_id).map(|r| Arc::clone(r.value()))
     }
 
     /// Gets the set of channels in a guild.
     ///
-    /// This is a O(m) operation, where m is the amount of channels in the guild.
+    /// This is a O(m) operation, where m is the amount of channels in the guild. This requires the
+    /// [`GUILDS`] intent.
+    ///
+    /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     pub fn guild_channels(&self, guild_id: GuildId) -> Option<HashSet<ChannelId>> {
         self.0
             .guild_channels
@@ -283,7 +292,12 @@ impl InMemoryCache {
 
     /// Gets the set of emojis in a guild.
     ///
-    /// This is a O(m) operation, where m is the amount of emojis in the guild.
+    /// This is a O(m) operation, where m is the amount of emojis in the guild. This requires the
+    /// [`GUILDS`] intent for the initial set of emojis, and further requires the [`GUILD_EMOJIS`]
+    /// intent for updates.
+    ///
+    /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
+    /// [`GUILD_EMOJIS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_EMOJIS
     pub fn guild_emojis(&self, guild_id: GuildId) -> Option<HashSet<EmojiId>> {
         self.0
             .guild_emojis
@@ -295,7 +309,10 @@ impl InMemoryCache {
     ///
     /// This list may be incomplete if not all members have been cached.
     ///
-    /// This is a O(m) operation, where m is the amount of members in the guild.
+    /// This is a O(m) operation, where m is the amount of members in the guild. This requires the
+    /// [`GUILD_MEMBERS`] intent.
+    ///
+    /// [`GUILD_MEMBERS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_MEMBERS
     pub fn guild_members(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
         self.0
             .guild_members
@@ -307,7 +324,10 @@ impl InMemoryCache {
     ///
     /// This list may be incomplete if not all members have been cached.
     ///
-    /// This is a O(m) operation, where m is the amount of members in the guild.
+    /// This is a O(m) operation, where m is the amount of members in the guild. This requires the
+    /// [`GUILD_PRESENCES`] intent.
+    ///
+    /// [`GUILD_PRESENCES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_PRESENCES
     pub fn guild_presences(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
         self.0
             .guild_presences
@@ -317,14 +337,19 @@ impl InMemoryCache {
 
     /// Gets the set of roles in a guild.
     ///
-    /// This is a O(m) operation, where m is the amount of roles in the guild.
+    /// This is a O(m) operation, where m is the amount of roles in the guild. This requires the
+    /// [`GUILDS`] intent.
+    ///
+    /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     pub fn guild_roles(&self, guild_id: GuildId) -> Option<HashSet<RoleId>> {
         self.0.guild_roles.get(&guild_id).map(|r| r.value().clone())
     }
 
     /// Gets a member by guild ID and user ID.
     ///
-    /// This is an O(1) operation.
+    /// This is an O(1) operation. This requires the [`GUILD_MEMBERS`] intent.
+    ///
+    /// [`GUILD_MEMBERS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_MEMBERS
     pub fn member(&self, guild_id: GuildId, user_id: UserId) -> Option<Arc<CachedMember>> {
         self.0
             .members
@@ -334,7 +359,11 @@ impl InMemoryCache {
 
     /// Gets a message by channel ID and message ID.
     ///
-    /// This is an O(log n) operation.
+    /// This is an O(log n) operation. This requires one or both of the [`GUILD_MESSAGES`] and
+    /// [`DIRECT_MESSAGES`] intents.
+    ///
+    /// [`GUILD_MESSAGES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_MESSAGES
+    /// [`DIRECT_MESSAGES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.DIRECT_MESSAGES
     pub fn message(
         &self,
         channel_id: ChannelId,
@@ -347,7 +376,9 @@ impl InMemoryCache {
 
     /// Gets a presence by, optionally, guild ID, and user ID.
     ///
-    /// This is an O(1) operation.
+    /// This is an O(1) operation. This requires the [`GUILD_PRESENCES`] intent.
+    ///
+    /// [`GUILD_PRESENCES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_PRESENCES
     pub fn presence(&self, guild_id: GuildId, user_id: UserId) -> Option<Arc<CachedPresence>> {
         self.0
             .presences
@@ -357,7 +388,9 @@ impl InMemoryCache {
 
     /// Gets a private channel by ID.
     ///
-    /// This is an O(1) operation.
+    /// This is an O(1) operation. This requires the [`DIRECT_MESSAGES`] intent.
+    ///
+    /// [`DIRECT_MESSAGES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.DIRECT_MESSAGES
     pub fn private_channel(&self, channel_id: ChannelId) -> Option<Arc<PrivateChannel>> {
         self.0
             .channels_private
@@ -367,7 +400,9 @@ impl InMemoryCache {
 
     /// Gets a role by ID.
     ///
-    /// This is an O(1) operation.
+    /// This is an O(1) operation. This requires the [`GUILDS`] intent.
+    ///
+    /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
     pub fn role(&self, role_id: RoleId) -> Option<Arc<Role>> {
         self.0
             .roles
@@ -377,12 +412,20 @@ impl InMemoryCache {
 
     /// Gets a user by ID.
     ///
-    /// This is an O(1) operation.
+    /// This is an O(1) operation. This requires the [`GUILD_MEMBERS`] intent.
+    ///
+    /// [`GUILD_MEMBERS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_MEMBERS
     pub fn user(&self, user_id: UserId) -> Option<Arc<User>> {
         self.0.users.get(&user_id).map(|r| Arc::clone(&r.0))
     }
 
     /// Gets the voice states within a voice channel.
+    ///
+    /// This requires the [`GUILDS`] intent for the initial set of voice states, and further
+    /// requires the [`GUILD_VOICE_STATES`] intent for updates.
+    ///
+    /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
+    /// [`GUILD_VOICE_STATES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_VOICE_STATES
     pub fn voice_channel_states(&self, channel_id: ChannelId) -> Option<Vec<Arc<VoiceState>>> {
         let user_ids = self.0.voice_state_channels.get(&channel_id)?;
 
@@ -396,7 +439,12 @@ impl InMemoryCache {
 
     /// Gets a voice state by user ID and Guild ID.
     ///
-    /// This is an O(1) operation.
+    /// This is an O(1) operation. This requires the [`GUILDS`] intent for the
+    /// initial set of voice states, and further requires the [`GUILD_VOICE_STATES`] intent for
+    /// updates.
+    ///
+    /// [`GUILDS`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILDS
+    /// [`GUILD_VOICE_STATES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_VOICE_STATES
     pub fn voice_state(&self, user_id: UserId, guild_id: GuildId) -> Option<Arc<VoiceState>> {
         self.0
             .voice_states

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -359,7 +359,7 @@ impl InMemoryCache {
 
     /// Gets a message by channel ID and message ID.
     ///
-    /// This is an O(log n) operation. This requires one or both of the [`GUILD_MESSAGES`] and
+    /// This is an O(log n) operation. This requires one or both of the [`GUILD_MESSAGES`] or
     /// [`DIRECT_MESSAGES`] intents.
     ///
     /// [`GUILD_MESSAGES`]: ../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_MESSAGES

--- a/model/src/gateway/intents.rs
+++ b/model/src/gateway/intents.rs
@@ -7,9 +7,10 @@ use serde::{
 bitflags! {
     /// Gateway intents.
     ///
-    /// Developers must specify intents when connecting to the gateway. The intents specified
-    /// correspond with the events received. To specify multiple intents, create a union using the
-    /// `|` operator. See [the discord docs] for more information.
+    /// Developers must specify intents when connecting to the gateway. The
+    /// intents specified correspond with the events received. To specify
+    /// multiple intents, create a union using the `|` operator. See [the
+    /// discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/topics/gateway#gateway-intents
     pub struct Intents: u64 {
@@ -149,8 +150,8 @@ bitflags! {
         ///  - [`MESSAGE_DELETE`]
         ///  - [`MESSAGE_DELETE_BULK`]
         ///
-        /// This is different from the [`GUILD_MESSAGES`] intent in that the bot will receive
-        /// message events from locations other than guilds.
+        /// This is different from the [`GUILD_MESSAGES`] intent in that the bot
+        /// will receive message events from locations other than guilds.
         ///
         /// [`MESSAGE_CREATE`]: ./event/enum.Event.html#variant.MessageCreate
         /// [`MESSAGE_UPDATE`]: ./event/enum.Event.html#variant.MessageUpdate
@@ -166,8 +167,9 @@ bitflags! {
         ///  - [`MESSAGE_REACTION_REMOVE_ALL`]
         ///  - [`MESSAGE_REACTION_REMOVE_EMOJI`]
         ///
-        /// This is different from the [`GUILD_MESSAGE_REACTIONS`] event in that the bot will
-        /// receive message reaction events from locations other than guilds.
+        /// This is different from the [`GUILD_MESSAGE_REACTIONS`] event in that
+        /// the bot will receive message reaction events from locations other
+        /// than guilds.
         ///
         /// [`MESSAGE_REACTION_ADD`]: ./event/enum.Event.html#variant.ReactionAdd
         /// [`MESSAGE_REACTION_REMOVE`]: ./event/enum.Event.html#variant.ReactionRemove
@@ -180,8 +182,9 @@ bitflags! {
         /// Event(s) received:
         ///  - [`TYPING_START`]
         ///
-        /// This is different from the [`GUILD_MESSAGE_TYPING`] intent in that the bot will receive
-        /// typing start events from locations other than guilds.
+        /// This is different from the [`GUILD_MESSAGE_TYPING`] intent in that
+        /// the bot will receive typing start events from locations other than
+        /// guilds.
         ///
         /// [`TYPING_START`]: ./event/enum.Event.html#variant.TypingStart
         /// [`GUILD_MESSAGE_TYPING`]: #associatedconstant.GUILD_MESSAGE_TYPING

--- a/model/src/gateway/intents.rs
+++ b/model/src/gateway/intents.rs
@@ -8,14 +8,14 @@ bitflags! {
     /// Gateway intents.
     ///
     /// Developers must specify intents when connecting to the gateway. The intents specified
-    /// correspond with the events recieved. To specify multiple intents, create a union using the
+    /// correspond with the events received. To specify multiple intents, create a union using the
     /// `|` operator. See [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/topics/gateway#gateway-intents
     pub struct Intents: u64 {
         /// Guilds intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`GUILD_CREATE`]
         ///  - [`GUILD_UPDATE`]
         ///  - [`GUILD_DELETE`]
@@ -40,9 +40,9 @@ bitflags! {
         const GUILDS = 1;
         /// Guild members intent.
         ///
-        /// This intent is priveleged. See [`the discord docs`] for more information.
+        /// This intent is privileged. See [`the discord docs`] for more information.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`GUILD_MEMBER_ADD`]
         ///  - [`GUILD_MEMBER_UPDATE`]
         ///  - [`GUILD_MEMBER_REMOVE`]
@@ -54,7 +54,7 @@ bitflags! {
         const GUILD_MEMBERS = 1 << 1;
         /// Guild bans intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`GUILD_BAN_ADD`]
         ///  - [`GUILD_BAN_REMOVE`]
         ///
@@ -63,28 +63,28 @@ bitflags! {
         const GUILD_BANS = 1 << 2;
         /// Guild emojis intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`GUILD_EMOJIS_UPDATE`]
         ///
         /// [`GUILD_EMOJIS_UPDATE`]: ./event/enum.Event.html#variant.GuildEmojisUpdate
         const GUILD_EMOJIS = 1 << 3;
         /// Guild integrations intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`GUILD_INTEGRATIONS_UPDATE`]
         ///
         /// [`GUILD_INTEGRATIONS_UPDATE`]: ./event/enum.Event.html#variant.GuildIntegrationsUpdate
         const GUILD_INTEGRATIONS = 1 << 4;
         /// Guild webhooks intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`WEBHOOKS_UPDATE`]
         ///
         /// [`WEBHOOKS_UPDATE`]: ./event/enum.Event.html#variant.WebhooksUpdate
         const GUILD_WEBHOOKS = 1 << 5;
         /// Guild invites intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`INVITE_CREATE`]
         ///  - [`INVITE_DELETE`]
         ///
@@ -93,16 +93,16 @@ bitflags! {
         const GUILD_INVITES = 1 << 6;
         /// Guild voice states intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`VOICE_STATE_UPDATE`]
         ///
         /// [`VOICE_STATE_UPDATE`]: ./event/enum.Event.html#variant.VoiceStateUpdate
         const GUILD_VOICE_STATES = 1 << 7;
         /// Guild presences intent.
         ///
-        /// This intent is priveleged. See [`the discord docs`] for more information.
+        /// This intent is privileged. See [`the discord docs`] for more information.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`PRESENCE_UPDATE`]
         ///
         /// [the discord docs]: https://discord.com/developers/docs/topics/gateway#privileged-intents
@@ -110,7 +110,7 @@ bitflags! {
         const GUILD_PRESENCES = 1 << 8;
         /// Guild messages intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`MESSAGE_CREATE`]
         ///  - [`MESSAGE_UPDATE`]
         ///  - [`MESSAGE_DELETE`]
@@ -123,7 +123,7 @@ bitflags! {
         const GUILD_MESSAGES = 1 << 9;
         /// Guild message reactions intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`MESSAGE_REACTION_ADD`]
         ///  - [`MESSAGE_REACTION_REMOVE`]
         ///  - [`MESSAGE_REACTION_REMOVE_ALL`]
@@ -136,21 +136,21 @@ bitflags! {
         const GUILD_MESSAGE_REACTIONS = 1 << 10;
         /// Guild message typing intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`TYPING_START`]
         ///
         /// [`TYPING_START`]: ./event/enum.Event.html#variant.TypingStart
         const GUILD_MESSAGE_TYPING = 1 << 11;
         /// Direct messages intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`MESSAGE_CREATE`]
         ///  - [`MESSAGE_UPDATE`]
         ///  - [`MESSAGE_DELETE`]
         ///  - [`MESSAGE_DELETE_BULK`]
         ///
-        /// This is different from the [`GUILD_MESSAGES`] intent in that the bot will recieve
-        /// non-guild message events.
+        /// This is different from the [`GUILD_MESSAGES`] intent in that the bot will receive
+        /// message events from locations other than guilds.
         ///
         /// [`MESSAGE_CREATE`]: ./event/enum.Event.html#variant.MessageCreate
         /// [`MESSAGE_UPDATE`]: ./event/enum.Event.html#variant.MessageUpdate
@@ -160,14 +160,14 @@ bitflags! {
         const DIRECT_MESSAGES = 1 << 12;
         /// Direct message reactions intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`MESSAGE_REACTION_ADD`]
         ///  - [`MESSAGE_REACTION_REMOVE`]
         ///  - [`MESSAGE_REACTION_REMOVE_ALL`]
         ///  - [`MESSAGE_REACTION_REMOVE_EMOJI`]
         ///
         /// This is different from the [`GUILD_MESSAGE_REACTIONS`] event in that the bot will
-        /// recieve non-guild message reaction events.
+        /// receive message reaction events from locations other than guilds.
         ///
         /// [`MESSAGE_REACTION_ADD`]: ./event/enum.Event.html#variant.ReactionAdd
         /// [`MESSAGE_REACTION_REMOVE`]: ./event/enum.Event.html#variant.ReactionRemove
@@ -177,11 +177,11 @@ bitflags! {
         const DIRECT_MESSAGE_REACTIONS = 1 << 13;
         /// Direct message typing intent.
         ///
-        /// Event(s) recieved:
+        /// Event(s) received:
         ///  - [`TYPING_START`]
         ///
-        /// This is different from the [`GUILD_MESSAGE_TYPING`] intent in that the bot will recieve
-        /// non-guild typing start events.
+        /// This is different from the [`GUILD_MESSAGE_TYPING`] intent in that the bot will receive
+        /// typing start events from locations other than guilds.
         ///
         /// [`TYPING_START`]: ./event/enum.Event.html#variant.TypingStart
         /// [`GUILD_MESSAGE_TYPING`]: #associatedconstant.GUILD_MESSAGE_TYPING

--- a/model/src/gateway/intents.rs
+++ b/model/src/gateway/intents.rs
@@ -41,7 +41,7 @@ bitflags! {
         const GUILDS = 1;
         /// Guild members intent.
         ///
-        /// This intent is privileged. See [`the discord docs`] for more information.
+        /// This intent is privileged. See [the discord docs] for more information.
         ///
         /// Event(s) received:
         ///  - [`GUILD_MEMBER_ADD`]
@@ -101,7 +101,7 @@ bitflags! {
         const GUILD_VOICE_STATES = 1 << 7;
         /// Guild presences intent.
         ///
-        /// This intent is privileged. See [`the discord docs`] for more information.
+        /// This intent is privileged. See [the discord docs] for more information.
         ///
         /// Event(s) received:
         ///  - [`PRESENCE_UPDATE`]

--- a/model/src/gateway/intents.rs
+++ b/model/src/gateway/intents.rs
@@ -5,21 +5,186 @@ use serde::{
 };
 
 bitflags! {
+    /// Gateway intents.
+    ///
+    /// Developers must specify intents when connecting to the gateway. The intents specified
+    /// correspond with the events recieved. To specify multiple intents, create a union using the
+    /// `|` operator. See [the discord docs] for more information.
+    ///
+    /// [the discord docs]: https://discord.com/developers/docs/topics/gateway#gateway-intents
     pub struct Intents: u64 {
+        /// Guilds intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`GUILD_CREATE`]
+        ///  - [`GUILD_UPDATE`]
+        ///  - [`GUILD_DELETE`]
+        ///  - [`GUILD_ROLE_CREATE`]
+        ///  - [`GUILD_ROLE_UPDATE`]
+        ///  - [`GUILD_ROLE_DELETE`]
+        ///  - [`CHANNEL_CREATE`]
+        ///  - [`CHANNEL_UPDATE`]
+        ///  - [`CHANNEL_DELETE`]
+        ///  - [`CHANNEL_PINS_UPDATE`]
+        ///
+        /// [`GUILD_CREATE`]: ./event/enum.Event.html#variant.GuildCreate
+        /// [`GUILD_UPDATE`]: ./event/enum.Event.html#variant.GuildUpdate
+        /// [`GUILD_DELETE`]: ./event/enum.Event.html#variant.GuildDelete
+        /// [`GUILD_ROLE_CREATE`]: ./event/enum.Event.html#variant.RoleCreate
+        /// [`GUILD_ROLE_UPDATE`]: ./event/enum.Event.html#variant.RoleUpdate
+        /// [`GUILD_ROLE_DELETE`]: ./event/enum.Event.html#variant.RoleDelete
+        /// [`CHANNEL_CREATE`]: ./event/enum.Event.html#variant.ChannelCreate
+        /// [`CHANNEL_UPDATE`]: ./event/enum.Event.html#variant.ChannelUpdate
+        /// [`CHANNEL_DELETE`]: ./event/enum.Event.html#variant.ChannelDelete
+        /// [`CHANNEL_PINS_UPDATE`]: ./event/enum.Event.html#variant.ChannelPinsUpdate
         const GUILDS = 1;
+        /// Guild members intent.
+        ///
+        /// This intent is priveleged. See [`the discord docs`] for more information.
+        ///
+        /// Event(s) recieved:
+        ///  - [`GUILD_MEMBER_ADD`]
+        ///  - [`GUILD_MEMBER_UPDATE`]
+        ///  - [`GUILD_MEMBER_REMOVE`]
+        ///
+        /// [the discord docs]: https://discord.com/developers/docs/topics/gateway#privileged-intents
+        /// [`GUILD_MEMBER_ADD`]: ./event/enum.Event.html#variant.MemberAdd
+        /// [`GUILD_MEMBER_UPDATE`]: ./event/enum.Event.html#variant.MemberUpdate
+        /// [`GUILD_MEMBER_REMOVE`]: ./event/enum.Event.html#variant.MemberRemove
         const GUILD_MEMBERS = 1 << 1;
+        /// Guild bans intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`GUILD_BAN_ADD`]
+        ///  - [`GUILD_BAN_REMOVE`]
+        ///
+        /// [`GUILD_BAN_ADD`]: ./event/enum.Event.html#variant.BanAdd
+        /// [`GUILD_BAN_REMOVE`]: ./event/enum.Event.html#variant.BanRemove
         const GUILD_BANS = 1 << 2;
+        /// Guild emojis intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`GUILD_EMOJIS_UPDATE`]
+        ///
+        /// [`GUILD_EMOJIS_UPDATE`]: ./event/enum.Event.html#variant.GuildEmojisUpdate
         const GUILD_EMOJIS = 1 << 3;
+        /// Guild integrations intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`GUILD_INTEGRATIONS_UPDATE`]
+        ///
+        /// [`GUILD_INTEGRATIONS_UPDATE`]: ./event/enum.Event.html#variant.GuildIntegrationsUpdate
         const GUILD_INTEGRATIONS = 1 << 4;
+        /// Guild webhooks intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`WEBHOOKS_UPDATE`]
+        ///
+        /// [`WEBHOOKS_UPDATE`]: ./event/enum.Event.html#variant.WebhooksUpdate
         const GUILD_WEBHOOKS = 1 << 5;
+        /// Guild invites intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`INVITE_CREATE`]
+        ///  - [`INVITE_DELETE`]
+        ///
+        /// [`INVITE_CREATE`]: ./event/enum.Event.html#variant.InviteCreate
+        /// [`INVITE_DELETE`]: ./event/enum.Event.html#variant.InviteDelete
         const GUILD_INVITES = 1 << 6;
+        /// Guild voice states intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`VOICE_STATE_UPDATE`]
+        ///
+        /// [`VOICE_STATE_UPDATE`]: ./event/enum.Event.html#variant.VoiceStateUpdate
         const GUILD_VOICE_STATES = 1 << 7;
+        /// Guild presences intent.
+        ///
+        /// This intent is priveleged. See [`the discord docs`] for more information.
+        ///
+        /// Event(s) recieved:
+        ///  - [`PRESENCE_UPDATE`]
+        ///
+        /// [the discord docs]: https://discord.com/developers/docs/topics/gateway#privileged-intents
+        /// [`PRESENCE_UPDATE`]: ./event/enum.Event.html#variant.PresenceUpdate
         const GUILD_PRESENCES = 1 << 8;
+        /// Guild messages intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`MESSAGE_CREATE`]
+        ///  - [`MESSAGE_UPDATE`]
+        ///  - [`MESSAGE_DELETE`]
+        ///  - [`MESSAGE_DELETE_BULK`]
+        ///
+        /// [`MESSAGE_CREATE`]: ./event/enum.Event.html#variant.MessageCreate
+        /// [`MESSAGE_UPDATE`]: ./event/enum.Event.html#variant.MessageUpdate
+        /// [`MESSAGE_DELETE`]: ./event/enum.Event.html#variant.MessageDelete
+        /// [`MESSAGE_DELETE_BULK`]: ./event/enum.Event.html#variant.MessageDeleteBulk
         const GUILD_MESSAGES = 1 << 9;
+        /// Guild message reactions intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`MESSAGE_REACTION_ADD`]
+        ///  - [`MESSAGE_REACTION_REMOVE`]
+        ///  - [`MESSAGE_REACTION_REMOVE_ALL`]
+        ///  - [`MESSAGE_REACTION_REMOVE_EMOJI`]
+        ///
+        /// [`MESSAGE_REACTION_ADD`]: ./event/enum.Event.html#variant.ReactionAdd
+        /// [`MESSAGE_REACTION_REMOVE`]: ./event/enum.Event.html#variant.ReactionRemove
+        /// [`MESSAGE_REACTION_REMOVE_ALL`]: ./event/enum.Event.html#variant.ReactionRemoveAll
+        /// [`MESSAGE_REACTION_REMOVE_EMOJI`]: ./event/enum.Event.html#variant.ReactionRemoveEmoji
         const GUILD_MESSAGE_REACTIONS = 1 << 10;
+        /// Guild message typing intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`TYPING_START`]
+        ///
+        /// [`TYPING_START`]: ./event/enum.Event.html#variant.TypingStart
         const GUILD_MESSAGE_TYPING = 1 << 11;
+        /// Direct messages intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`MESSAGE_CREATE`]
+        ///  - [`MESSAGE_UPDATE`]
+        ///  - [`MESSAGE_DELETE`]
+        ///  - [`MESSAGE_DELETE_BULK`]
+        ///
+        /// This is different from the [`GUILD_MESSAGES`] intent in that the bot will recieve
+        /// non-guild message events.
+        ///
+        /// [`MESSAGE_CREATE`]: ./event/enum.Event.html#variant.MessageCreate
+        /// [`MESSAGE_UPDATE`]: ./event/enum.Event.html#variant.MessageUpdate
+        /// [`MESSAGE_DELETE`]: ./event/enum.Event.html#variant.MessageDelete
+        /// [`MESSAGE_DELETE_BULK`]: ./event/enum.Event.html#variant.MessageDeleteBulk
+        /// [`GUILD_MESSAGES`]: #associatedconstant.GUILD_MESSAGES
         const DIRECT_MESSAGES = 1 << 12;
+        /// Direct message reactions intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`MESSAGE_REACTION_ADD`]
+        ///  - [`MESSAGE_REACTION_REMOVE`]
+        ///  - [`MESSAGE_REACTION_REMOVE_ALL`]
+        ///  - [`MESSAGE_REACTION_REMOVE_EMOJI`]
+        ///
+        /// This is different from the [`GUILD_MESSAGE_REACTIONS`] event in that the bot will
+        /// recieve non-guild message reaction events.
+        ///
+        /// [`MESSAGE_REACTION_ADD`]: ./event/enum.Event.html#variant.ReactionAdd
+        /// [`MESSAGE_REACTION_REMOVE`]: ./event/enum.Event.html#variant.ReactionRemove
+        /// [`MESSAGE_REACTION_REMOVE_ALL`]: ./event/enum.Event.html#variant.ReactionRemoveAll
+        /// [`MESSAGE_REACTION_REMOVE_EMOJI`]: ./event/enum.Event.html#variant.ReactionRemoveEmoji
+        /// [`GUILD_MESSAGE_REACTIONS`]: #associatedconstant.GUILD_MESSAGE_REACTIONS
         const DIRECT_MESSAGE_REACTIONS = 1 << 13;
+        /// Direct message typing intent.
+        ///
+        /// Event(s) recieved:
+        ///  - [`TYPING_START`]
+        ///
+        /// This is different from the [`GUILD_MESSAGE_TYPING`] intent in that the bot will recieve
+        /// non-guild typing start events.
+        ///
+        /// [`TYPING_START`]: ./event/enum.Event.html#variant.TypingStart
+        /// [`GUILD_MESSAGE_TYPING`]: #associatedconstant.GUILD_MESSAGE_TYPING
         const DIRECT_MESSAGE_TYPING = 1 << 14;
     }
 }


### PR DESCRIPTION
This documents gateway intents in the model crate, and also specifies in
each cache method the intents required for the method to act as
expected.

Fixes #577.

Signed-off-by: Cassandra McCarthy <cassie@7596ff.com>
