### PR TITLE
command-parser: handle whitespace after prefix

### DIFF
--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -311,5 +311,6 @@ mod tests {
         assert_eq!("foo", prefix);
         assert_eq!("dump", name);
         assert_eq!(Some("test"), arguments.next());
+        assert!(arguments.next().is_none());
     }
 }

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -131,6 +131,10 @@ impl<'a> Parser<'a> {
 
         idx += command.len();
 
+        // Advance from the amount of whitespace that was between the prefix and
+        // the command name.
+        idx += command_buf.len() - command_buf.trim_start().len();
+
         Some(Command {
             arguments: Arguments::new(buf.get(idx..)?),
             name: command,
@@ -290,5 +294,22 @@ mod tests {
 
         assert_eq!("=", command.prefix);
         assert_eq!("echo", command.name);
+    }
+
+    #[test]
+    fn test_prefix_mention() {
+        let mut config = CommandParserConfig::new();
+        config.add_prefix("foo");
+        config.add_command("dump", false);
+        let parser = Parser::new(config);
+
+        let Command {
+            mut arguments,
+            name,
+            prefix,
+        } = parser.parse("foo dump test").unwrap();
+        assert_eq!("foo", prefix);
+        assert_eq!("dump", name);
+        assert_eq!(Some("test"), arguments.next());
     }
 }


### PR DESCRIPTION
Handle whitespace after the prefix. While the buffer `!bar baz` parses into the prefix `!`, command `bar`, and argument `baz` fine, the buffer `foo bar baz` parses incorrectly as the prefix `foo`, the command `bar`, and the argument buffer `r baz`.

By advancing the starting index of the Arguments iterator by the amount of the whitespace before the command name, this will properly parse. In the listed example, the iterator would be advanced by 1, due to there being 1 byte of whitespace.

A test is included.