### PR TITLE
command-parser: remove 'unicode-segmentation' dependency

### DIFF
--- a/command-parser/Cargo.toml
+++ b/command-parser/Cargo.toml
@@ -16,7 +16,6 @@ version = "0.2.0"
 
 [dependencies]
 unicase = { default-features = false, version = "2" }
-unicode-segmentation = "1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/command-parser/src/arguments.rs
+++ b/command-parser/src/arguments.rs
@@ -1,11 +1,13 @@
-use std::fmt::{Debug, Formatter, Result as FmtResult};
-use unicode_segmentation::{GraphemeIndices, UnicodeSegmentation};
+use std::{
+    fmt::{Debug, Formatter, Result as FmtResult},
+    str::CharIndices,
+};
 
 /// An iterator over command arguments.
 #[derive(Clone)]
 pub struct Arguments<'a> {
     buf: &'a str,
-    indices: GraphemeIndices<'a>,
+    indices: CharIndices<'a>,
     idx: usize,
 }
 
@@ -67,7 +69,7 @@ impl<'a> From<&'a str> for Arguments<'a> {
     fn from(buf: &'a str) -> Self {
         Self {
             buf: buf.trim(),
-            indices: buf.trim().grapheme_indices(true),
+            indices: buf.trim().char_indices(),
             idx: 0,
         }
     }
@@ -97,13 +99,13 @@ impl<'a> Iterator for Arguments<'a> {
 
         while let Some((i, ch)) = self.indices.next() {
             if quoted {
-                if ch == r#"""# {
+                if ch == '"' {
                     let v = self.buf.get(start_idx..i);
                     self.idx = i + 1;
 
                     return v.map(str::trim);
                 }
-            } else if ch == " " {
+            } else if ch == ' ' {
                 if started {
                     let v = self.buf.get(start_idx..i);
                     self.idx = i + 1;
@@ -115,7 +117,7 @@ impl<'a> Iterator for Arguments<'a> {
                     started = true;
                     continue;
                 }
-            } else if ch == r#"""# {
+            } else if ch == '"' {
                 start_idx = i + 1;
                 quoted = true;
             }


### PR DESCRIPTION
Remove the `unicode-segmentation` dependency from the Command Parser. It was added in #575 to support unicode via `unicode_segmentation::GrapheneIndices`, but it's not actually required, as the `std::str::CharIndices` iterator is effectively the same with how it's used. Tests for unicode support are unchanged and continue to pass.