### PR TITLE
project: update readme installation version to 0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ We recommend that most users start out with these crates added to your
 `Cargo.toml`'s `[dependencies]` section:
 
 ```toml
-twilight-cache-inmemory = "0.1"
-twilight-gateway = "0.1"
-twilight-http = "0.1"
-twilight-model = "0.1"
+twilight-cache-inmemory = "0.2"
+twilight-gateway = "0.2"
+twilight-http = "0.2"
+twilight-model = "0.2"
 ```
 
 If you need any other functionality that Twilight provides, you can just add

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -43,7 +43,7 @@ you can also use this environment variable `RUSTFLAGS="-C target-cpu=native"`.
 
 ```toml
 [dependencies]
-twilight-gateway = { default-features = false, features = ["rustls", "simd-json"], version = "0.1" }
+twilight-gateway = { default-features = false, features = ["rustls", "simd-json"], version = "0.2" }
 ```
 
 ### TLS
@@ -62,7 +62,7 @@ To enable `native`, do something like this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-twilight-gateway = { default-features = false, features = ["native"], version = "0.1" }
+twilight-gateway = { default-features = false, features = ["native"], version = "0.2" }
 ```
 
 #### `rustls`

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-gateway = { default-features = false, features = ["rustls", "simd-json"], version = "0.1" }
+//! twilight-gateway = { default-features = false, features = ["rustls", "simd-json"], version = "0.2" }
 //! ```
 //!
 //! ### TLS
@@ -60,7 +60,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-gateway = { default-features = false, features = ["native"], version = "0.1" }
+//! twilight-gateway = { default-features = false, features = ["native"], version = "0.2" }
 //! ```
 //!
 //! #### `rustls`

--- a/http/README.md
+++ b/http/README.md
@@ -35,7 +35,7 @@ To enable `simd-json`, do something like this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-twilight-http = { default-features = false, features = ["rustls", "simd-json"], version = "0.1" }
+twilight-http = { default-features = false, features = ["rustls", "simd-json"], version = "0.2" }
 ```
 
 ### TLS
@@ -52,7 +52,7 @@ To enable `native`, do something like this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-twilight-http = { default-features = false, features = ["native"], version = "0.1" }
+twilight-http = { default-features = false, features = ["native"], version = "0.2" }
 ```
 
 #### `rustls`

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-http = { default-features = false, features = ["rustls", "simd-json"], version = "0.1" }
+//! twilight-http = { default-features = false, features = ["rustls", "simd-json"], version = "0.2" }
 //! ```
 //!
 //! ### TLS
@@ -50,7 +50,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-http = { default-features = false, features = ["native"], version = "0.1" }
+//! twilight-http = { default-features = false, features = ["native"], version = "0.2" }
 //! ```
 //!
 //! #### `rustls`

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -37,7 +37,7 @@ To enable `native`, do something like this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-twilight-lavalink = { default-features = false, features = ["native"], version = "0.1" }
+twilight-lavalink = { default-features = false, features = ["native"], version = "0.2" }
 ```
 
 #### `rustls`

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! twilight-lavalink = { default-features = false, features = ["native"], version = "0.1" }
+//! twilight-lavalink = { default-features = false, features = ["native"], version = "0.2" }
 //! ```
 //!
 //! #### `rustls`

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -22,10 +22,10 @@
 //! `Cargo.toml`'s `[dependencies]` section:
 //!
 //! ```toml
-//! twilight-cache-inmemory = "0.1"
-//! twilight-gateway = "0.1"
-//! twilight-http = "0.1"
-//! twilight-model = "0.1"
+//! twilight-cache-inmemory = "0.2"
+//! twilight-gateway = "0.2"
+//! twilight-http = "0.2"
+//! twilight-model = "0.2"
 //! ```
 //!
 //! If you need any other functionality that Twilight provides, you can just add


### PR DESCRIPTION
Update the READMEs of the gateway, http, lavalink, and advertisement crates to mention version `0.2` in the installation instructions.