### PR TITLE
cache/in-memory: cache MessageCreate's user & member

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -704,6 +704,7 @@ impl InMemoryCache {
             user,
         });
         self.0.members.insert(id, Arc::clone(&cached));
+
         cached
     }
 

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -62,6 +62,7 @@ pub use self::{
 use self::model::*;
 use dashmap::{mapref::entry::Entry, DashMap, DashSet};
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashSet},
     hash::Hash,
     sync::{Arc, Mutex},
@@ -535,7 +536,7 @@ impl InMemoryCache {
         }
 
         let user = match emoji.user {
-            Some(u) => Some(self.cache_user(u, guild_id)),
+            Some(u) => Some(self.cache_user(Cow::Owned(u), Some(guild_id))),
             None => None,
         };
 
@@ -654,7 +655,7 @@ impl InMemoryCache {
             Some(_) | None => {}
         }
 
-        let user = self.cache_user(member.user, guild_id);
+        let user = self.cache_user(Cow::Owned(member.user), Some(guild_id));
         let cached = Arc::new(CachedMember {
             deaf: member.deaf,
             guild_id,
@@ -674,18 +675,23 @@ impl InMemoryCache {
         cached
     }
 
-    fn cache_ref_partial_member(
+    fn cache_borrowed_partial_member(
         &self,
         guild_id: GuildId,
         member: &PartialMember,
         user: Arc<User>,
     ) -> Arc<CachedMember> {
-        let member_id = user.id;
-        let id = (guild_id, member_id);
+        let id = (guild_id, user.id);
         match self.0.members.get(&id) {
             Some(m) if **m == member => return Arc::clone(&m),
             Some(_) | None => {}
         }
+
+        self.0
+            .guild_members
+            .entry(guild_id)
+            .or_default()
+            .insert(user.id);
 
         let cached = Arc::new(CachedMember {
             deaf: member.deaf,
@@ -698,11 +704,6 @@ impl InMemoryCache {
             user,
         });
         self.0.members.insert(id, Arc::clone(&cached));
-        self.0
-            .guild_members
-            .entry(guild_id)
-            .or_default()
-            .insert(member_id);
         cached
     }
 
@@ -795,28 +796,9 @@ impl InMemoryCache {
         upsert_guild_item(&self.0.roles, guild_id, role.id, role)
     }
 
-    fn cache_user(&self, user: User, guild_id: GuildId) -> Arc<User> {
+    fn cache_user(&self, user: Cow<User>, guild_id: Option<GuildId>) -> Arc<User> {
         match self.0.users.get_mut(&user.id) {
-            Some(mut u) if *u.0 == user => {
-                u.1.insert(guild_id);
-
-                return Arc::clone(&u.value().0);
-            }
-            Some(_) | None => {}
-        }
-        let user = Arc::new(user);
-        let mut guild_id_set = BTreeSet::new();
-        guild_id_set.insert(guild_id);
-        self.0
-            .users
-            .insert(user.id, (Arc::clone(&user), guild_id_set));
-
-        user
-    }
-
-    fn cache_ref_user(&self, user: &User, guild_id: Option<GuildId>) -> Arc<User> {
-        match self.0.users.get_mut(&user.id) {
-            Some(mut u) if &*u.0 == user => {
+            Some(mut u) if *u.0 == *user => {
                 if let Some(guild_id) = guild_id {
                     u.1.insert(guild_id);
                 }
@@ -825,14 +807,14 @@ impl InMemoryCache {
             }
             Some(_) | None => {}
         }
-        let user = Arc::new(user.to_owned());
-        let mut guild_id_set = BTreeSet::new();
+        let user = Arc::new(user.into_owned());
         if let Some(guild_id) = guild_id {
+            let mut guild_id_set = BTreeSet::new();
             guild_id_set.insert(guild_id);
+            self.0
+                .users
+                .insert(user.id, (Arc::clone(&user), guild_id_set));
         }
-        self.0
-            .users
-            .insert(user.id, (Arc::clone(&user), guild_id_set));
 
         user
     }
@@ -972,7 +954,7 @@ fn presence_user_id(presence: &Presence) -> UserId {
 #[cfg(test)]
 mod tests {
     use crate::InMemoryCache;
-    use std::collections::HashMap;
+    use std::{borrow::Cow, collections::HashMap};
     use twilight_model::{
         channel::{ChannelType, GuildChannel, TextChannel},
         gateway::payload::{MemberRemove, RoleDelete},
@@ -1190,7 +1172,7 @@ mod tests {
     fn test_cache_user_guild_state() {
         let user_id = UserId(2);
         let cache = InMemoryCache::new();
-        cache.cache_user(user(user_id), GuildId(1));
+        cache.cache_user(Cow::Owned(user(user_id)), Some(GuildId(1)));
 
         // Test the guild's ID is the only one in the user's set of guilds.
         {
@@ -1200,7 +1182,7 @@ mod tests {
         }
 
         // Test that a second guild will cause 2 in the set.
-        cache.cache_user(user(user_id), GuildId(3));
+        cache.cache_user(Cow::Owned(user(user_id)), Some(GuildId(3)));
 
         {
             let user = cache.0.users.get(&user_id).unwrap();

--- a/cache/in-memory/src/model/member.rs
+++ b/cache/in-memory/src/model/member.rs
@@ -55,3 +55,96 @@ impl PartialEq<&PartialMember> for CachedMember {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CachedMember;
+    use std::sync::Arc;
+    use twilight_model::{
+        guild::{Member, PartialMember},
+        id::{GuildId, RoleId, UserId},
+        user::User,
+    };
+
+    #[test]
+    fn test_eq_member() {
+        let user = User {
+            avatar: None,
+            bot: false,
+            discriminator: "0001".to_owned(),
+            email: None,
+            flags: None,
+            id: UserId(1),
+            locale: None,
+            mfa_enabled: None,
+            name: "bar".to_owned(),
+            premium_type: None,
+            public_flags: None,
+            system: None,
+            verified: None,
+        };
+
+        let member = Member {
+            deaf: false,
+            guild_id: GuildId(3),
+            hoisted_role: Some(RoleId(4)),
+            joined_at: None,
+            mute: true,
+            nick: Some("member nick".to_owned()),
+            premium_since: None,
+            roles: vec![],
+            user: user.clone(),
+        };
+        let cached = CachedMember {
+            deaf: false,
+            guild_id: GuildId(3),
+            joined_at: None,
+            mute: true,
+            nick: Some("member nick".to_owned()),
+            premium_since: None,
+            roles: vec![],
+            user: Arc::new(user),
+        };
+
+        assert_eq!(cached, member);
+    }
+
+    #[test]
+    fn test_eq_partial_member() {
+        let user = User {
+            avatar: None,
+            bot: false,
+            discriminator: "0001".to_owned(),
+            email: None,
+            flags: None,
+            id: UserId(1),
+            locale: None,
+            mfa_enabled: None,
+            name: "bar".to_owned(),
+            premium_type: None,
+            public_flags: None,
+            system: None,
+            verified: None,
+        };
+
+        let member = PartialMember {
+            deaf: false,
+            joined_at: None,
+            mute: true,
+            nick: Some("member nick".to_owned()),
+            roles: vec![],
+        };
+        let cached = CachedMember {
+            deaf: false,
+            guild_id: GuildId(3),
+            joined_at: None,
+            mute: true,
+            nick: Some("member nick".to_owned()),
+            premium_since: None,
+            roles: vec![],
+            user: Arc::new(user),
+        };
+
+        assert_eq!(cached, &member);
+    }
+}

--- a/cache/in-memory/src/model/member.rs
+++ b/cache/in-memory/src/model/member.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use std::sync::Arc;
 use twilight_model::{
-    guild::Member,
+    guild::{Member, PartialMember},
     id::{GuildId, RoleId},
     user::User,
 };
@@ -33,6 +33,24 @@ impl PartialEq<Member> for CachedMember {
             other.mute,
             &other.nick,
             other.premium_since.as_ref(),
+            &other.roles,
+        )
+    }
+}
+
+impl PartialEq<&PartialMember> for CachedMember {
+    fn eq(&self, other: &&PartialMember) -> bool {
+        (
+            self.deaf,
+            self.joined_at.as_ref(),
+            self.mute,
+            &self.nick,
+            &self.roles,
+        ) == (
+            other.deaf,
+            other.joined_at.as_ref(),
+            other.mute,
+            &other.nick,
             &other.roles,
         )
     }

--- a/cache/in-memory/src/model/member.rs
+++ b/cache/in-memory/src/model/member.rs
@@ -66,9 +66,21 @@ mod tests {
         user::User,
     };
 
-    #[test]
-    fn test_eq_member() {
-        let user = User {
+    fn cached_member() -> CachedMember {
+        CachedMember {
+            deaf: false,
+            guild_id: GuildId(3),
+            joined_at: None,
+            mute: true,
+            nick: Some("member nick".to_owned()),
+            premium_since: None,
+            roles: Vec::new(),
+            user: Arc::new(user()),
+        }
+    }
+
+    fn user() -> User {
+        User {
             avatar: None,
             bot: false,
             discriminator: "0001".to_owned(),
@@ -82,8 +94,11 @@ mod tests {
             public_flags: None,
             system: None,
             verified: None,
-        };
+        }
+    }
 
+    #[test]
+    fn test_eq_member() {
         let member = Member {
             deaf: false,
             guild_id: GuildId(3),
@@ -92,59 +107,23 @@ mod tests {
             mute: true,
             nick: Some("member nick".to_owned()),
             premium_since: None,
-            roles: vec![],
-            user: user.clone(),
-        };
-        let cached = CachedMember {
-            deaf: false,
-            guild_id: GuildId(3),
-            joined_at: None,
-            mute: true,
-            nick: Some("member nick".to_owned()),
-            premium_since: None,
-            roles: vec![],
-            user: Arc::new(user),
+            roles: Vec::new(),
+            user: user(),
         };
 
-        assert_eq!(cached, member);
+        assert_eq!(cached_member(), member);
     }
 
     #[test]
     fn test_eq_partial_member() {
-        let user = User {
-            avatar: None,
-            bot: false,
-            discriminator: "0001".to_owned(),
-            email: None,
-            flags: None,
-            id: UserId(1),
-            locale: None,
-            mfa_enabled: None,
-            name: "bar".to_owned(),
-            premium_type: None,
-            public_flags: None,
-            system: None,
-            verified: None,
-        };
-
         let member = PartialMember {
             deaf: false,
             joined_at: None,
             mute: true,
             nick: Some("member nick".to_owned()),
-            roles: vec![],
-        };
-        let cached = CachedMember {
-            deaf: false,
-            guild_id: GuildId(3),
-            joined_at: None,
-            mute: true,
-            nick: Some("member nick".to_owned()),
-            premium_since: None,
-            roles: vec![],
-            user: Arc::new(user),
+            roles: Vec::new(),
         };
 
-        assert_eq!(cached, &member);
+        assert_eq!(cached_member(), &member);
     }
 }

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -376,6 +376,7 @@ impl UpdateCache for MessageCreate {
         channel.insert(self.0.id, Arc::new(From::from(self.0.clone())));
 
         let user = cache.cache_user(Cow::Borrowed(&self.author), self.guild_id);
+
         if let (Some(member), Some(guild_id)) = (&self.member, self.guild_id) {
             cache.cache_borrowed_partial_member(guild_id, member, user);
         }

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -672,6 +672,7 @@ impl UpdateCache for WebhooksUpdate {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::EventType;
     use std::collections::HashMap;
     use twilight_model::{
         channel::{ChannelType, GuildChannel, TextChannel},
@@ -873,7 +874,7 @@ mod tests {
         };
 
         let cache = InMemoryCache::builder()
-            .event_types(crate::config::EventType::MESSAGE_CREATE)
+            .event_types(EventType::MESSAGE_CREATE)
             .message_cache_size(1)
             .build();
         let msg = Message {
@@ -917,7 +918,7 @@ mod tests {
             pinned: false,
             reactions: Vec::new(),
             reference: None,
-            timestamp: "".to_owned(),
+            timestamp: String::new(),
             tts: false,
             webhook_id: None,
         };


### PR DESCRIPTION
Since `MessageCreate` events contain a `Message` which in turn contains an author `User` and a potential `PartialMember`, one might aswell cache these two.

To avoid cloning them on each event unnecessarily if they're already in the cache, I added new user/member cache functions to handle the values as references.

Also added a test case for a `MessageCreate` event.