### PR TITLE
http: handle service unavailability errors

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1525,15 +1525,16 @@ impl Client {
             return Ok(resp);
         }
 
-        if status == StatusCode::IM_A_TEAPOT {
-            tracing::warn!(
+        match status {
+            StatusCode::IM_A_TEAPOT => tracing::warn!(
                 "discord's api now runs off of teapots -- proceed to panic: {:?}",
                 resp,
-            );
-        }
-
-        if status == StatusCode::TOO_MANY_REQUESTS {
-            tracing::warn!("429 response: {:?}", resp);
+            ),
+            StatusCode::TOO_MANY_REQUESTS => tracing::warn!("429 response: {:?}", resp),
+            StatusCode::SERVICE_UNAVAILABLE => {
+                return Err(Error::ServiceUnavailable { response: resp })
+            }
+            _ => {}
         }
 
         let bytes = resp


### PR DESCRIPTION
When handling HTTP responses, check if the status code is a 503 (Service Unavailable). If so, return a new `twilight_http::Error` variant of `ServiceUnavailable` containing the response.

This fixes deserialization of the response body failing.