### PR TITLE
model/gateway/opcode: make non-exhaustive

### DIFF
--- a/model/src/gateway/opcode.rs
+++ b/model/src/gateway/opcode.rs
@@ -3,6 +3,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 #[derive(
     Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
 )]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum OpCode {
     Event = 0,


### PR DESCRIPTION
Make the `twilight_model::gateway::OpCode` enum non-exhaustive, allowing us to add variants to it in the future without needing a breaking change.