### PR TITLE
gateway-queue: remove cross-crate links

### DIFF
--- a/gateway/queue/src/lib.rs
+++ b/gateway/queue/src/lib.rs
@@ -18,8 +18,8 @@
 //! single-process [Sharding for Very Large Bots] through the use of bucket
 //! releasing.
 //!
-//! By default, the [`Cluster`] and [`Shard`]s use the [`LocalQueue`]. You can
-//! override this in the [`ClusterBuilder::queue`] and [`ShardBuilder::queue`]
+//! By default, the gateway's `Cluster` and `Shard`s use the [`LocalQueue`]. You
+//! can override this in the `ClusterBuilder::queue` and `ShardBuilder::queue`
 //! configuration methods.
 //!
 //! # Advanced use cases
@@ -30,12 +30,8 @@
 //! all so a [`Queue`] trait is provided that shards can use to make requests to
 //! create sessions.
 //!
-//! [`ClusterBuilder::queue`]: ../cluster/struct.ClusterBuilder.html#method.queue
-//! [`Cluster`]: ../cluster/struct.Cluster.html
 //! [`LargeBotQueue`]: struct.LargeBotQueue.html
 //! [`LocalQueue`]: struct.LocalQueue.html
-//! [`ShardBuilder::queue`]: ../shard/struct.ShardBuilder.html#method.queue
-//! [`Shard`]: ../shard/struct.Shard.html
 //! [Sharding for Very Large Bots]: https://discord.com/developers/docs/topics/gateway#sharding-for-very-large-bots
 
 mod day_limiter;
@@ -70,13 +66,13 @@ pub trait Queue: Debug + Send + Sync {
 }
 
 /// A local, in-process implementation of a [`Queue`] which manages the
-/// connection attempts of one or more [`Shard`]s.
+/// connection attempts of one or more shards.
 ///
 /// The queue will take incoming requests and then queue them, releasing one of
 /// the requests every 6 seconds. The queue is necessary because there's a
 /// ratelimit on how often shards can initiate sessions.
 ///
-/// You usually won't need to handle this yourself, because the [`Cluster`] will
+/// You usually won't need to handle this yourself, because the `Cluster` will
 /// do that for you when managing multiple shards.
 ///
 /// # When not to use this
@@ -94,9 +90,7 @@ pub trait Queue: Debug + Send + Sync {
 /// [`Queue`], such as the [`gateway-queue`] broker.
 ///
 /// [`LargeBotQueue`]: ./struct.LargeBotQueue.html
-/// [`Cluster`]: ../cluster/struct.Cluster.html
 /// [`Queue`]: trait.Queue.html
-/// [`Shard`]: ../shard/struct.Shard.html
 /// [`gateway-queue`]: https://github.com/twilight-rs/gateway-queue
 #[derive(Clone, Debug)]
 pub struct LocalQueue(UnboundedSender<Sender<()>>);


### PR DESCRIPTION
Remove cross-crate links, causing broken links in rendered documentation.

Closes #559.