### PR TITLE
model/gateway/event_type: add error enums

### DIFF
--- a/gateway/src/event.rs
+++ b/gateway/src/event.rs
@@ -189,7 +189,8 @@ impl<'a> TryFrom<(u8, Option<&'a str>)> for EventTypeFlags {
             (10, _) => Ok(EventTypeFlags::GATEWAY_HELLO),
             (11, _) => Ok(EventTypeFlags::GATEWAY_HEARTBEAT_ACK),
             (_, Some(event_type)) => {
-                let flag = EventType::try_from(event_type).map_err(|kind| (op, Some(kind)))?;
+                let flag = EventType::try_from(event_type)
+                    .map_err(|kind| (op, Some(kind.into_event_type())))?;
 
                 Ok(Self::from(flag))
             }

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -26,6 +26,7 @@ tracing = { default-features = false, version = "0.1" }
 criterion = "0.3"
 serde_json = { default-features = false, features = ["alloc"], version = "1" }
 serde_test = { default-features = false, version = "1" }
+static_assertions = { default-features = false, version = "1.1" }
 
 [[bench]]
 name = "deserialization"

--- a/model/src/gateway/event/mod.rs
+++ b/model/src/gateway/event/mod.rs
@@ -9,7 +9,7 @@ mod kind;
 pub use self::{
     dispatch::{DispatchEvent, DispatchEventWithTypeDeserializer},
     gateway::{GatewayEvent, GatewayEventDeserializer, GatewayEventDeserializerOwned},
-    kind::EventType,
+    kind::{EventType, EventTypeConversionError, EventTypeConversionErrorOwned},
 };
 
 use self::shard::*;


### PR DESCRIPTION
Add error enums to use when `EventType`'s `TryFrom<&str>` implementation fails. Instead of returning the source string, return an error wrapping it that implements `Error` (and thus `Display`).