### PR TITLE
http/client: take note of invalid tokens

### DIFF
--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -5,7 +5,10 @@ use crate::{
     request::channel::message::allowed_mentions::AllowedMentions,
 };
 use reqwest::{ClientBuilder as ReqwestClientBuilder, Proxy};
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{atomic::AtomicBool, Arc},
+    time::Duration,
+};
 
 #[derive(Debug)]
 /// A builder for [`Client`].
@@ -52,6 +55,7 @@ impl ClientBuilder {
                     .build()
                     .map_err(|source| Error::BuildingClient { source })?,
                 ratelimiter: self.ratelimiter,
+                token_invalid: AtomicBool::new(false),
                 token: self.token,
                 use_http: self.proxy_http,
                 default_allowed_mentions: self.default_allowed_mentions,

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1423,7 +1423,7 @@ impl Client {
     ///
     /// [`Error::Unauthorized`]: ../enum.Error.html#variant.Unauthorized
     pub async fn raw(&self, request: Request) -> Result<Response> {
-        if !self.state.token_invalid.load(Ordering::Relaxed) {
+        if self.state.token_invalid.load(Ordering::Relaxed) {
             return Err(Error::Unauthorized);
         }
 

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -21,7 +21,10 @@ use std::{
     convert::TryFrom,
     fmt::{Debug, Formatter, Result as FmtResult},
     result::Result as StdResult,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 use twilight_model::{
     guild::Permissions,
@@ -32,6 +35,7 @@ use url::Url;
 struct State {
     http: ReqwestClient,
     ratelimiter: Option<Ratelimiter>,
+    token_invalid: AtomicBool,
     token: Option<String>,
     use_http: bool,
     pub(crate) default_allowed_mentions: Option<AllowedMentions>,
@@ -52,6 +56,14 @@ impl Debug for State {
 ///
 /// Almost all of the client methods require authentication, and as such, the client must be
 /// supplied with a Discord Token. Get yours [here].
+///
+/// # Unauthorized behavior
+///
+/// When the client encounters an Unauthorized response it will take note that
+/// the configured token is invalid. This may occur when the token has been
+/// revoked or expired. When this happens, you must create a new client with the
+/// new token. The client will no longer execute requests in order to
+/// prevent API bans and will always return [`Error::Unauthorized`].
 ///
 /// # Examples
 ///
@@ -84,6 +96,7 @@ impl Debug for State {
 ///
 /// [here]: https://discord.com/developers/applications
 /// [`ClientBuilder`]: struct.ClientBuilder.html
+/// [`Error::Unauthorized`]: ../enum.Error.html#variant.Unauthorized
 #[derive(Clone, Debug)]
 pub struct Client {
     state: Arc<State>,
@@ -111,6 +124,7 @@ impl Client {
             state: Arc::new(State {
                 http: ReqwestClient::new(),
                 ratelimiter: Some(Ratelimiter::new()),
+                token_invalid: AtomicBool::new(false),
                 token: Some(token),
                 use_http: false,
                 default_allowed_mentions: None,
@@ -1400,7 +1414,19 @@ impl Client {
         Ok(self.execute_webhook(id, token.ok_or(UrlError::SegmentMissing)?))
     }
 
+    /// Execute a request, returning the response.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unauthorized`] if the configured token has become
+    /// invalid due to expiration, revokation, etc.
+    ///
+    /// [`Error::Unauthorized`]: ../enum.Error.html#variant.Unauthorized
     pub async fn raw(&self, request: Request) -> Result<Response> {
+        if !self.state.token_invalid.load(Ordering::Relaxed) {
+            return Err(Error::Unauthorized);
+        }
+
         let Request {
             body,
             form,
@@ -1471,6 +1497,13 @@ impl Client {
             .await
             .map_err(|source| Error::RequestError { source })?;
 
+        // If the API sent back an Unauthorized response, then the client's
+        // configured token is permanently invalid and future requests must be
+        // ignored to avoid API bans.
+        if resp.status() == StatusCode::UNAUTHORIZED {
+            self.state.token_invalid.store(true, Ordering::Relaxed);
+        }
+
         match RatelimitHeaders::try_from(resp.headers()) {
             Ok(v) => {
                 let _ = tx.send(Some(v));
@@ -1485,6 +1518,14 @@ impl Client {
         Ok(resp)
     }
 
+    /// Execute a request, chunking and deserializing the response.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unauthorized`] if the configured token has become
+    /// invalid due to expiration, revokation, etc.
+    ///
+    /// [`Error::Unauthorized`]: ../enum.Error.html#variant.Unauthorized
     pub async fn request<T: DeserializeOwned>(&self, request: Request) -> Result<T> {
         let resp = self.make_request(request).await?;
 
@@ -1511,6 +1552,16 @@ impl Client {
             .map_err(|source| Error::ChunkingResponse { source })
     }
 
+    /// Execute a request, checking only that the response was a success.
+    ///
+    /// This will not chunk and deserialize the body of the response.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unauthorized`] if the configured token has become
+    /// invalid due to expiration, revokation, etc.
+    ///
+    /// [`Error::Unauthorized`]: ../enum.Error.html#variant.Unauthorized
     pub async fn verify(&self, request: Request) -> Result<()> {
         self.make_request(request).await?;
 
@@ -1570,6 +1621,7 @@ impl From<ReqwestClient> for Client {
             state: Arc::new(State {
                 http: reqwest_client,
                 ratelimiter: Some(Ratelimiter::new()),
+                token_invalid: AtomicBool::new(false),
                 token: None,
                 use_http: false,
                 default_allowed_mentions: None,

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -105,6 +105,11 @@ pub enum Error {
     ServiceUnavailable {
         response: Response,
     },
+    /// Token in use has become revoked or is otherwise invalid.
+    ///
+    /// This can occur if a bot token is invalidated or an access token expires
+    /// or is revoked. Recreate the client to configure a new token.
+    Unauthorized,
 }
 
 impl From<FmtError> for Error {
@@ -154,6 +159,7 @@ impl Display for Error {
             Self::ServiceUnavailable { .. } => {
                 f.write_str("api may be temporarily unavailable (received a 503)")
             }
+            Self::Unauthorized => f.write_str("token in use is invalid, expired, or is revoked"),
         }
     }
 }
@@ -170,7 +176,7 @@ impl StdError for Error {
             Self::BuildingClient { source }
             | Self::ChunkingResponse { source }
             | Self::RequestError { source } => Some(source),
-            Self::Response { .. } | Self::ServiceUnavailable { .. } => None,
+            Self::Response { .. } | Self::ServiceUnavailable { .. } | Self::Unauthorized => None,
         }
     }
 }


### PR DESCRIPTION
In the HTTP client take note of when the configured token is invalid and prevent new requests from being executed. This will prevent potential API bans. When an unauthorized response is encountered, the `Error::Unauthorized` variant is returned, and future request executions will short-circuit it and return it as well. A new client must be configured with a new token to issue further requests.