### PR TITLE
http: move api version to a public const

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -3,12 +3,18 @@ mod builder;
 pub use self::builder::ClientBuilder;
 pub use reqwest::Proxy;
 
-use crate::{api_error::{ApiError, ErrorCode}, error::{Error, Result, UrlError}, ratelimiting::{RatelimitHeaders, Ratelimiter}, request::{
-    channel::message::allowed_mentions::AllowedMentions,
-    guild::{create_guild::CreateGuildError, create_guild_channel::CreateGuildChannelError},
-    prelude::*,
-    GetUserApplicationInfo, Request,
-}, API_VERSION};
+use crate::{
+    api_error::{ApiError, ErrorCode},
+    error::{Error, Result, UrlError},
+    ratelimiting::{RatelimitHeaders, Ratelimiter},
+    request::{
+        channel::message::allowed_mentions::AllowedMentions,
+        guild::{create_guild::CreateGuildError, create_guild_channel::CreateGuildChannelError},
+        prelude::*,
+        GetUserApplicationInfo, Request,
+    },
+    API_VERSION,
+};
 use bytes::Bytes;
 use reqwest::{header::HeaderValue, Body, Client as ReqwestClient, Method, Response, StatusCode};
 use serde::de::DeserializeOwned;

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -3,17 +3,12 @@ mod builder;
 pub use self::builder::ClientBuilder;
 pub use reqwest::Proxy;
 
-use crate::{
-    api_error::{ApiError, ErrorCode},
-    error::{Error, Result, UrlError},
-    ratelimiting::{RatelimitHeaders, Ratelimiter},
-    request::{
-        channel::message::allowed_mentions::AllowedMentions,
-        guild::{create_guild::CreateGuildError, create_guild_channel::CreateGuildChannelError},
-        prelude::*,
-        GetUserApplicationInfo, Request,
-    },
-};
+use crate::{api_error::{ApiError, ErrorCode}, error::{Error, Result, UrlError}, ratelimiting::{RatelimitHeaders, Ratelimiter}, request::{
+    channel::message::allowed_mentions::AllowedMentions,
+    guild::{create_guild::CreateGuildError, create_guild_channel::CreateGuildChannelError},
+    prelude::*,
+    GetUserApplicationInfo, Request,
+}, API_VERSION};
 use bytes::Bytes;
 use reqwest::{header::HeaderValue, Body, Client as ReqwestClient, Method, Response, StatusCode};
 use serde::de::DeserializeOwned;
@@ -1411,8 +1406,7 @@ impl Client {
         } = request;
 
         let protocol = if self.state.use_http { "http" } else { "https" };
-        let url = format!("{}://discord.com/api/v8/{}", protocol, path);
-
+        let url = format!("{}://discord.com/api/v{}/{}", protocol, API_VERSION, path);
         tracing::debug!("URL: {:?}", url);
 
         let mut builder = self.state.http.request(method.clone(), &url);

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -96,6 +96,9 @@ pub mod ratelimiting;
 pub mod request;
 pub mod routing;
 
+/// The discord api version used by this crate
+pub const API_VERSION: u8 = 8;
+
 pub use crate::{
     client::Client,
     error::{Error, Result},

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -96,7 +96,7 @@ pub mod ratelimiting;
 pub mod request;
 pub mod routing;
 
-/// Discord API version used by this crate
+/// Discord API version used by this crate.
 pub const API_VERSION: u8 = 8;
 
 pub use crate::{

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -96,7 +96,7 @@ pub mod ratelimiting;
 pub mod request;
 pub mod routing;
 
-/// The discord api version used by this crate
+/// Discord API version used by this crate
 pub const API_VERSION: u8 = 8;
 
 pub use crate::{


### PR DESCRIPTION
exposes the api version the crate uses, allows for the proxy crate to stay in sync with this