### PR TITLE
http,model: add support for message type 19 replies

### DIFF
--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -920,6 +920,7 @@ mod tests {
             reactions: Vec::new(),
             reference: None,
             stickers: Vec::new(),
+            referenced_message: None,
             timestamp: String::new(),
             tts: false,
             webhook_id: None,

--- a/http/src/request/channel/message/allowed_mentions.rs
+++ b/http/src/request/channel/message/allowed_mentions.rs
@@ -135,7 +135,9 @@ impl<'a> Default for AllowedMentionsBuilder<'a, Unspecified, Unspecified, Unspec
 }
 
 impl<'a, E, U, R> AllowedMentionsBuilder<'a, E, U, R> {
-    /// Whether to mention users getting replied to, the default is false.
+    /// Whether to mention the user being replied to.
+    ///
+    /// Defaults to false.
     pub fn replied_user(self, reply: bool) -> AllowedMentionsBuilder<'a, E, U, R> {
         AllowedMentionsBuilder {
             create_message: self.create_message,

--- a/http/src/request/channel/message/allowed_mentions.rs
+++ b/http/src/request/channel/message/allowed_mentions.rs
@@ -34,6 +34,7 @@ pub struct AllowedMentions {
     parse: Vec<ParseTypes>,
     users: Option<Vec<UserId>>,
     roles: Option<Vec<RoleId>>,
+    replied_user: bool,
 }
 
 pub trait VisitAllowedMentionsEveryone: Sized {
@@ -101,6 +102,7 @@ pub struct AllowedMentionsBuilder<'a, E, U, R> {
     e: E,
     u: U,
     r: R,
+    reply: bool,
 }
 
 impl<'a> AllowedMentionsBuilder<'a, Unspecified, Unspecified, Unspecified> {
@@ -110,6 +112,7 @@ impl<'a> AllowedMentionsBuilder<'a, Unspecified, Unspecified, Unspecified> {
             e: Unspecified,
             u: Unspecified,
             r: Unspecified,
+            reply: false,
         }
     }
 
@@ -120,6 +123,7 @@ impl<'a> AllowedMentionsBuilder<'a, Unspecified, Unspecified, Unspecified> {
             e: Unspecified,
             u: Unspecified,
             r: Unspecified,
+            reply: false,
         }
     }
 }
@@ -127,6 +131,19 @@ impl<'a> AllowedMentionsBuilder<'a, Unspecified, Unspecified, Unspecified> {
 impl<'a> Default for AllowedMentionsBuilder<'a, Unspecified, Unspecified, Unspecified> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<'a, E, U, R> AllowedMentionsBuilder<'a, E, U, R> {
+    /// Whether to mention users getting replied to, the default is false.
+    pub fn replied_user(self, reply: bool) -> AllowedMentionsBuilder<'a, E, U, R> {
+        AllowedMentionsBuilder {
+            create_message: self.create_message,
+            e: self.e,
+            u: self.u,
+            r: self.r,
+            reply,
+        }
     }
 }
 
@@ -138,6 +155,7 @@ impl<'a, U, R> AllowedMentionsBuilder<'a, Unspecified, U, R> {
             e: Parsed,
             u: self.u,
             r: self.r,
+            reply: self.reply,
         }
     }
 }
@@ -150,6 +168,7 @@ impl<'a, E, R> AllowedMentionsBuilder<'a, E, Unspecified, R> {
             e: self.e,
             u: Parsed,
             r: self.r,
+            reply: self.reply,
         }
     }
 
@@ -164,6 +183,7 @@ impl<'a, E, R> AllowedMentionsBuilder<'a, E, Unspecified, R> {
             e: self.e,
             u: ExplicitUser(vec),
             r: self.r,
+            reply: self.reply,
         }
     }
 }
@@ -176,6 +196,7 @@ impl<'a, E, U> AllowedMentionsBuilder<'a, E, U, Unspecified> {
             e: self.e,
             u: self.u,
             r: Parsed,
+            reply: self.reply,
         }
     }
 
@@ -190,6 +211,7 @@ impl<'a, E, U> AllowedMentionsBuilder<'a, E, U, Unspecified> {
             e: self.e,
             u: self.u,
             r: ExplicitRole(vec),
+            reply: self.reply,
         }
     }
 }
@@ -206,6 +228,7 @@ impl<'a, E, U> AllowedMentionsBuilder<'a, E, U, ExplicitRole> {
             e: self.e,
             u: self.u,
             r: self.r,
+            reply: self.reply,
         }
     }
 }
@@ -222,6 +245,7 @@ impl<'a, E, R> AllowedMentionsBuilder<'a, E, ExplicitUser, R> {
             e: self.e,
             u: self.u,
             r: self.r,
+            reply: self.reply,
         }
     }
 }
@@ -243,6 +267,7 @@ impl<
                 self.e.visit(&mut m);
                 self.u.visit(&mut m);
                 self.r.visit(&mut m);
+                m.replied_user = self.reply;
                 builder.fields.allowed_mentions.replace(m);
                 builder
             }
@@ -262,6 +287,7 @@ impl<
         self.e.visit(&mut m);
         self.u.visit(&mut m);
         self.r.visit(&mut m);
+        m.replied_user = self.reply;
         m
     }
 }

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -216,7 +216,7 @@ impl<'a> CreateMessage<'a> {
         self
     }
 
-    /// Specify the id of another message to create a reply
+    /// Specify the ID of another message to create a reply to.
     pub fn reply(mut self, other: MessageId) -> Self {
         let reference = MessageReference {
             channel_id: Some(self.channel_id),

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -10,8 +10,8 @@ use std::{
     fmt::{Display, Formatter, Result as FmtResult},
 };
 use twilight_model::{
-    channel::{embed::Embed, Message},
-    id::ChannelId,
+    channel::{embed::Embed, message::MessageReference, Message},
+    id::{ChannelId, MessageId},
 };
 
 /// The error created when a messsage can not be created as configured.
@@ -64,6 +64,8 @@ pub(crate) struct CreateMessageFields {
     tts: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) allowed_mentions: Option<AllowedMentions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message_reference: Option<MessageReference>,
 }
 
 /// Send a message to a channel.
@@ -210,6 +212,18 @@ impl<'a> CreateMessage<'a> {
     /// Specify true if the message is TTS.
     pub fn tts(mut self, tts: bool) -> Self {
         self.fields.tts.replace(tts);
+
+        self
+    }
+
+    /// Specify the id of another message to create a reply
+    pub fn reply(mut self, other: MessageId) -> Self {
+        let reference = MessageReference {
+            channel_id: Some(self.channel_id),
+            guild_id: None,
+            message_id: Some(other),
+        };
+        self.fields.message_reference.replace(reference);
 
         self
     }

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -193,7 +193,6 @@ impl<'a> CreateMessage<'a> {
         Ok(self)
     }
 
-
     /// Attach a nonce to the message, for optimistic message sending.
     pub fn nonce(mut self, nonce: u64) -> Self {
         self.fields.nonce.replace(nonce);

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -218,12 +218,11 @@ impl<'a> CreateMessage<'a> {
 
     /// Specify the ID of another message to create a reply to.
     pub fn reply(mut self, other: MessageId) -> Self {
-        let reference = MessageReference {
+        self.fields.message_reference.replace(MessageReference {
             channel_id: Some(self.channel_id),
             guild_id: None,
             message_id: Some(other),
-        };
-        self.fields.message_reference.replace(reference);
+        });
 
         self
     }

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -57,15 +57,15 @@ pub(crate) struct CreateMessageFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     embed: Option<Embed>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    message_reference: Option<MessageReference>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     nonce: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payload_json: Option<Vec<u8>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tts: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) allowed_mentions: Option<AllowedMentions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    message_reference: Option<MessageReference>,
+    tts: Option<bool>,
 }
 
 /// Send a message to a channel.

--- a/model/src/channel/message/kind.rs
+++ b/model/src/channel/message/kind.rs
@@ -22,7 +22,7 @@ pub enum MessageType {
     ChannelFollowAdd = 12,
     GuildDiscoveryDisqualified = 14,
     GuildDiscoveryRequalified = 15,
-    /// Message is a inline reply
+    /// Message is an inline reply
     Reply = 19,
 }
 

--- a/model/src/channel/message/kind.rs
+++ b/model/src/channel/message/kind.rs
@@ -22,7 +22,7 @@ pub enum MessageType {
     ChannelFollowAdd = 12,
     GuildDiscoveryDisqualified = 14,
     GuildDiscoveryRequalified = 15,
-    /// Message is an inline reply
+    /// Message is an inline reply.
     Reply = 19,
 }
 

--- a/model/src/channel/message/kind.rs
+++ b/model/src/channel/message/kind.rs
@@ -22,6 +22,7 @@ pub enum MessageType {
     ChannelFollowAdd = 12,
     GuildDiscoveryDisqualified = 14,
     GuildDiscoveryRequalified = 15,
+    /// Message is a inline reply
     Reply = 19,
 }
 

--- a/model/src/channel/message/kind.rs
+++ b/model/src/channel/message/kind.rs
@@ -22,6 +22,7 @@ pub enum MessageType {
     ChannelFollowAdd = 12,
     GuildDiscoveryDisqualified = 14,
     GuildDiscoveryRequalified = 15,
+    Reply = 19,
 }
 
 impl TryFrom<u8> for MessageType {

--- a/model/src/channel/message/kind.rs
+++ b/model/src/channel/message/kind.rs
@@ -46,6 +46,7 @@ impl TryFrom<u8> for MessageType {
             12 => MessageType::ChannelFollowAdd,
             14 => MessageType::GuildDiscoveryDisqualified,
             15 => MessageType::GuildDiscoveryRequalified,
+            19 => MessageType::Reply,
             _ => return Err(ConversionError::MessageType(value)),
         };
 
@@ -76,6 +77,7 @@ mod tests {
         serde_test::assert_tokens(&MessageType::ChannelFollowAdd, &[Token::U8(12)]);
         serde_test::assert_tokens(&MessageType::GuildDiscoveryDisqualified, &[Token::U8(14)]);
         serde_test::assert_tokens(&MessageType::GuildDiscoveryRequalified, &[Token::U8(15)]);
+        serde_test::assert_tokens(&MessageType::Reply, &[Token::U8(19)]);
     }
 
     #[test]
@@ -131,6 +133,7 @@ mod tests {
             MessageType::try_from(15).unwrap(),
             MessageType::GuildDiscoveryRequalified
         );
+        assert_eq!(MessageType::try_from(19).unwrap(), MessageType::Reply);
         assert_eq!(
             MessageType::try_from(250).unwrap_err(),
             ConversionError::MessageType(250)

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -48,8 +48,13 @@ pub struct Message {
     pub pinned: bool,
     #[serde(default)]
     pub reactions: Vec<MessageReaction>,
+    /// Reference data sent with crossposted messages and replies.
     #[serde(rename = "message_reference")]
     pub reference: Option<MessageReference>,
+    /// The message associated with the [reference].
+    ///
+    /// [reference]: #structfield.reference
+    pub referenced_message: Option<Box<Message>>,
     /// Stickers within the message.
     #[serde(default)]
     pub stickers: Vec<Sticker>,

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -245,6 +245,8 @@ mod tests {
                 Token::SeqEnd,
                 Token::Str("message_reference"),
                 Token::None,
+                Token::Str("referenced_message"),
+                Token::None,
                 Token::Str("stickers"),
                 Token::Seq { len: Some(1) },
                 Token::Struct {
@@ -274,8 +276,6 @@ mod tests {
                 Token::Str("foo,bar,baz"),
                 Token::StructEnd,
                 Token::SeqEnd,
-                Token::Str("referenced_message"),
-                Token::None,
                 Token::Str("timestamp"),
                 Token::Str("2020-02-02T02:02:02.020000+00:00"),
                 Token::Str("tts"),

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -131,6 +131,7 @@ mod tests {
                 preview_asset: None,
                 tags: Some("foo,bar,baz".to_owned()),
             }],
+            referenced_message: None,
             timestamp: "2020-02-02T02:02:02.020000+00:00".to_owned(),
             tts: false,
             webhook_id: None,
@@ -141,7 +142,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Message",
-                    len: 24,
+                    len: 25,
                 },
                 Token::Str("activity"),
                 Token::None,
@@ -273,6 +274,8 @@ mod tests {
                 Token::Str("foo,bar,baz"),
                 Token::StructEnd,
                 Token::SeqEnd,
+                Token::Str("referenced_message"),
+                Token::None,
                 Token::Str("timestamp"),
                 Token::Str("2020-02-02T02:02:02.020000+00:00"),
                 Token::Str("tts"),

--- a/model/src/channel/message/reference.rs
+++ b/model/src/channel/message/reference.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct MessageReference {
-    pub channel_id: ChannelId,
+    pub channel_id: Option<ChannelId>,
     pub guild_id: Option<GuildId>,
     pub message_id: Option<MessageId>,
 }

--- a/model/src/channel/message/reference.rs
+++ b/model/src/channel/message/reference.rs
@@ -16,7 +16,7 @@ mod tests {
     #[test]
     fn test_minimal() {
         let value = MessageReference {
-            channel_id: ChannelId(1),
+            channel_id: Some(ChannelId(1)),
             guild_id: None,
             message_id: None,
         };
@@ -29,6 +29,7 @@ mod tests {
                     len: 3,
                 },
                 Token::Str("channel_id"),
+                Token::Some,
                 Token::NewtypeStruct { name: "ChannelId" },
                 Token::Str("1"),
                 Token::Str("guild_id"),
@@ -43,7 +44,7 @@ mod tests {
     #[test]
     fn test_complete() {
         let value = MessageReference {
-            channel_id: ChannelId(1),
+            channel_id: Some(ChannelId(1)),
             guild_id: Some(GuildId(2)),
             message_id: Some(MessageId(3)),
         };
@@ -56,6 +57,7 @@ mod tests {
                     len: 3,
                 },
                 Token::Str("channel_id"),
+                Token::Some,
                 Token::NewtypeStruct { name: "ChannelId" },
                 Token::Str("1"),
                 Token::Str("guild_id"),

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -924,6 +924,7 @@ mod tests {
             reactions: Vec::new(),
             reference: None,
             stickers: Vec::new(),
+            referenced_message: None,
             timestamp: String::new(),
             tts: false,
             webhook_id: None,


### PR DESCRIPTION
This changeset adds support for replies as described in the
following pr:
https://github.com/discord/discord-api-docs/pull/2118
and the subsequent commit
https://github.com/discord/discord-api-docs/commit/e2cbad6830e627721e4b2d10cf71770ab3a94fa3

The `referenced_message` field in the `Message` struct is boxed as I
think it is a good compromise instead of doubling the memory usage of
the object, I would like to hear others opinion of this.