### PR TITLE
docs: clarify cloning behavior

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -167,6 +167,11 @@ struct InMemoryCacheRef {
 /// Events will only be processed if they are properly expressed with
 /// [`Intents`]; refer to function-level documentation for more details.
 ///
+/// # Cloning
+///
+/// The cache internally wraps its data within an Arc. This means that the cache
+/// can be cloned and passed around tasks and threads cheaply.
+///
 /// # Design and Performance
 ///
 /// The defining characteristic of this cache is that returned types (such as a

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -104,6 +104,11 @@ struct ClusterRef {
 /// The Cluster can be cloned and will point to the same cluster, so you can
 /// pass it around as needed.
 ///
+/// # Cloning
+///
+/// The cluster internally wraps its data within an Arc. This means that the
+/// cluster can be cloned and passed around tasks and threads cheaply.
+///
 /// # Examples
 ///
 /// Refer to the module-level documentation for examples.

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -217,6 +217,11 @@ struct ShardRef {
 /// sessions with the ratelimit. Refer to Discord's [documentation][docs:shards]
 /// on shards to have a better understanding of what they are.
 ///
+/// # Cloning
+///
+/// The shard internally wraps its data within an Arc. This means that the shard
+/// can be cloned and passed around tasks and threads cheaply.
+///
 /// # Examples
 ///
 /// Create and start a shard and print new and deleted messages:

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -58,6 +58,11 @@ impl Debug for State {
 /// Almost all of the client methods require authentication, and as such, the client must be
 /// supplied with a Discord Token. Get yours [here].
 ///
+/// # Cloning
+///
+/// The client internally wraps its data within an Arc. This means that the
+/// client can be cloned and passed around tasks and threads cheaply.
+///
 /// # Unauthorized behavior
 ///
 /// When the client encounters an Unauthorized response it will take note that

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -82,6 +82,11 @@ struct LavalinkRef {
 /// information about the active playing information of a guild and allows you to send events to the
 /// connected node, such as [`Play`] events.
 ///
+/// # Cloning
+///
+/// The client internally wraps its data within an Arc. This means that the
+/// client can be cloned and passed around tasks and threads cheaply.
+///
 /// [`Play`]: ../model/outgoing/struct.Play.html
 /// [`player`]: #method.player
 /// [`process`]: #method.process

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -196,6 +196,11 @@ struct StandbyRef {
 /// tasks to wait for an event.
 ///
 /// Refer to the crate-level documentation for more information.
+///
+/// # Cloning
+///
+/// Standby internally wraps its data within an Arc. This means that standby can
+/// be cloned and passed around tasks and threads cheaply.
 #[derive(Clone, Debug, Default)]
 pub struct Standby(Arc<StandbyRef>);
 


### PR DESCRIPTION
Clarify the cloning behavior of the cache, gateway's cluster and shard, HTTP client, Lavalink client, and Standby. Specifically, clarify that they internally wrap their data in an Arc, and so can be cheaply cloned.

Closes #562.