### PR TITLE
feat(http,model): support message stickers

### DIFF
--- a/cache/in-memory/src/model/message.rs
+++ b/cache/in-memory/src/model/message.rs
@@ -3,8 +3,8 @@ use twilight_model::{
     channel::{
         embed::Embed,
         message::{
-            Message, MessageActivity, MessageApplication, MessageFlags, MessageReaction,
-            MessageReference, MessageType,
+            sticker::Sticker, Message, MessageActivity, MessageApplication, MessageFlags,
+            MessageReaction, MessageReference, MessageType,
         },
         Attachment, ChannelMention,
     },
@@ -34,6 +34,7 @@ pub struct CachedMessage {
     pub pinned: bool,
     pub reactions: Vec<MessageReaction>,
     pub reference: Option<MessageReference>,
+    pub stickers: Vec<Sticker>,
     pub timestamp: String,
     pub tts: bool,
     pub webhook_id: Option<WebhookId>,
@@ -62,6 +63,7 @@ impl From<Message> for CachedMessage {
             pinned: msg.pinned,
             reactions: msg.reactions,
             reference: msg.reference,
+            stickers: msg.stickers,
             timestamp: msg.timestamp,
             tts: msg.tts,
             webhook_id: msg.webhook_id,

--- a/cache/in-memory/src/model/message.rs
+++ b/cache/in-memory/src/model/message.rs
@@ -3,8 +3,8 @@ use twilight_model::{
     channel::{
         embed::Embed,
         message::{
-            sticker::Sticker, Message, MessageActivity, MessageApplication, MessageFlags,
-            MessageReaction, MessageReference, MessageType,
+            Message, MessageActivity, MessageApplication, MessageFlags, MessageReaction,
+            MessageReference, MessageType, Sticker,
         },
         Attachment, ChannelMention,
     },

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -919,6 +919,7 @@ mod tests {
             pinned: false,
             reactions: Vec::new(),
             reference: None,
+            stickers: Vec::new(),
             timestamp: String::new(),
             tts: false,
             webhook_id: None,

--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -143,6 +143,8 @@ pub enum ErrorCode {
     InviteAcceptedToGuildBotNotIn,
     /// Invalid API version provided
     InvalidApiVersion,
+    /// Invalid sticker sent
+    InvalidStickerSent,
     /// Reaction was blocked
     ReactionBlocked,
     /// API resource is currently overloaded. Try again a little later
@@ -224,6 +226,7 @@ impl ErrorCode {
             Self::InvalidFormBodyOrContentType => 50035,
             Self::InviteAcceptedToGuildBotNotIn => 50036,
             Self::InvalidApiVersion => 50041,
+            Self::InvalidStickerSent => 50081,
             Self::ReactionBlocked => 90001,
             Self::ApiResourceOverloaded => 130_000,
             Self::Other(other) => *other,
@@ -302,6 +305,7 @@ impl From<u64> for ErrorCode {
             50035 => Self::InvalidFormBodyOrContentType,
             50036 => Self::InviteAcceptedToGuildBotNotIn,
             50041 => Self::InvalidApiVersion,
+            50081 => Self::InvalidStickerSent,
             90001 => Self::ReactionBlocked,
             130_000 => Self::ApiResourceOverloaded,
             other => Self::Other(other),
@@ -380,6 +384,7 @@ impl Display for ErrorCode {
             Self::InvalidFormBodyOrContentType => f.write_str("Invalid form body (returned for both application/json and multipart/form-data bodies), or invalid Content-Type provided"),
             Self::InviteAcceptedToGuildBotNotIn => f.write_str("An invite was accepted to a guild the application's bot is not in"),
             Self::InvalidApiVersion => f.write_str("Invalid API version provided"),
+            Self::InvalidStickerSent => f.write_str("Invalid sticker sent"),
             Self::ReactionBlocked => f.write_str("Reaction was blocked"),
             Self::ApiResourceOverloaded => f.write_str("API resource is currently overloaded. Try again a little later"),
             Self::Other(number) => write!(f, "An error code Twilight doesn't have registered: {}", number),

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -13,13 +13,13 @@ pub use self::{
     flags::MessageFlags, kind::MessageType, reaction::MessageReaction, reference::MessageReference,
 };
 
+use self::sticker::Sticker;
 use crate::{
     channel::{embed::Embed, Attachment, ChannelMention},
     guild::PartialMember,
     id::{ChannelId, GuildId, MessageId, RoleId, UserId, WebhookId},
     user::User,
 };
-use self::sticker::Sticker;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -59,7 +59,10 @@ pub struct Message {
 
 #[cfg(test)]
 mod tests {
-    use super::{sticker::{StickerFormatType, StickerId, StickerPackId, Sticker}, Message, MessageFlags, MessageType};
+    use super::{
+        sticker::{Sticker, StickerFormatType, StickerId, StickerPackId},
+        Message, MessageFlags, MessageType,
+    };
     use crate::{
         guild::PartialMember,
         id::{ChannelId, GuildId, MessageId, UserId},
@@ -237,7 +240,6 @@ mod tests {
                 Token::None,
                 Token::Str("stickers"),
                 Token::Seq { len: Some(1) },
-
                 Token::Struct {
                     name: "Sticker",
                     len: 8,
@@ -254,7 +256,9 @@ mod tests {
                 Token::Str("name"),
                 Token::Str("sticker name"),
                 Token::Str("pack_id"),
-                Token::NewtypeStruct { name: "StickerPackId" },
+                Token::NewtypeStruct {
+                    name: "StickerPackId",
+                },
                 Token::Str("2"),
                 Token::Str("preview_asset"),
                 Token::None,

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -11,9 +11,9 @@ mod reference;
 pub use self::{
     activity::MessageActivity, activity_type::MessageActivityType, application::MessageApplication,
     flags::MessageFlags, kind::MessageType, reaction::MessageReaction, reference::MessageReference,
+    sticker::Sticker,
 };
 
-use self::sticker::Sticker;
 use crate::{
     channel::{embed::Embed, Attachment, ChannelMention},
     guild::PartialMember,

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -1,3 +1,5 @@
+pub mod sticker;
+
 mod activity;
 mod activity_type;
 mod application;
@@ -17,6 +19,7 @@ use crate::{
     id::{ChannelId, GuildId, MessageId, RoleId, UserId, WebhookId},
     user::User,
 };
+use self::sticker::Sticker;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -47,6 +50,8 @@ pub struct Message {
     pub reactions: Vec<MessageReaction>,
     #[serde(rename = "message_reference")]
     pub reference: Option<MessageReference>,
+    /// Stickers within the message.
+    pub stickers: Vec<Sticker>,
     pub timestamp: String,
     pub tts: bool,
     pub webhook_id: Option<WebhookId>,
@@ -54,7 +59,7 @@ pub struct Message {
 
 #[cfg(test)]
 mod tests {
-    use super::{Message, MessageFlags, MessageType};
+    use super::{sticker::{StickerFormatType, StickerId, StickerPackId, Sticker}, Message, MessageFlags, MessageType};
     use crate::{
         guild::PartialMember,
         id::{ChannelId, GuildId, MessageId, UserId},
@@ -107,6 +112,16 @@ mod tests {
             pinned: false,
             reactions: Vec::new(),
             reference: None,
+            stickers: vec![Sticker {
+                asset: "foo1".to_owned(),
+                description: "foo2".to_owned(),
+                format_type: StickerFormatType::Png,
+                id: StickerId(1),
+                name: "sticker name".to_owned(),
+                pack_id: StickerPackId(2),
+                preview_asset: None,
+                tags: Some("foo,bar,baz".to_owned()),
+            }],
             timestamp: "2020-02-02T02:02:02.020000+00:00".to_owned(),
             tts: false,
             webhook_id: None,
@@ -117,7 +132,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Message",
-                    len: 23,
+                    len: 24,
                 },
                 Token::Str("activity"),
                 Token::None,
@@ -220,6 +235,34 @@ mod tests {
                 Token::SeqEnd,
                 Token::Str("message_reference"),
                 Token::None,
+                Token::Str("stickers"),
+                Token::Seq { len: Some(1) },
+
+                Token::Struct {
+                    name: "Sticker",
+                    len: 8,
+                },
+                Token::Str("asset"),
+                Token::Str("foo1"),
+                Token::Str("description"),
+                Token::Str("foo2"),
+                Token::Str("format_type"),
+                Token::U8(1),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "StickerId" },
+                Token::Str("1"),
+                Token::Str("name"),
+                Token::Str("sticker name"),
+                Token::Str("pack_id"),
+                Token::NewtypeStruct { name: "StickerPackId" },
+                Token::Str("2"),
+                Token::Str("preview_asset"),
+                Token::None,
+                Token::Str("tags"),
+                Token::Some,
+                Token::Str("foo,bar,baz"),
+                Token::StructEnd,
+                Token::SeqEnd,
                 Token::Str("timestamp"),
                 Token::Str("2020-02-02T02:02:02.020000+00:00"),
                 Token::Str("tts"),

--- a/model/src/channel/message/sticker/id.rs
+++ b/model/src/channel/message/sticker/id.rs
@@ -57,14 +57,18 @@ mod tests {
         serde_test::assert_tokens(
             &StickerPackId(114_941_315_417_899_012),
             &[
-                Token::NewtypeStruct { name: "StickerPackId" },
+                Token::NewtypeStruct {
+                    name: "StickerPackId",
+                },
                 Token::Str("114941315417899012"),
             ],
         );
         serde_test::assert_de_tokens(
             &StickerPackId(114_941_315_417_899_012),
             &[
-                Token::NewtypeStruct { name: "StickerPackId" },
+                Token::NewtypeStruct {
+                    name: "StickerPackId",
+                },
                 Token::U64(114_941_315_417_899_012),
             ],
         );

--- a/model/src/channel/message/sticker/id.rs
+++ b/model/src/channel/message/sticker/id.rs
@@ -1,0 +1,72 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+/// Unique ID denoting a sticker.
+///
+/// # serde
+///
+/// Like all of the IDs in the primary [`crate::id`] crate, these
+/// IDs support deserializing from both integers and strings and serialize into
+/// strings.
+#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct StickerId(#[serde(with = "crate::id::string")] pub u64);
+
+impl Display for StickerId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+/// Unique ID denoting a sticker pack.
+///
+/// # serde
+///
+/// Like all of the IDs in the primary [`crate::id`] crate, these
+/// IDs support deserializing from both integers and strings and serialize into
+/// strings.
+#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct StickerPackId(#[serde(with = "crate::id::string")] pub u64);
+
+impl Display for StickerPackId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StickerId, StickerPackId};
+    use serde_test::Token;
+
+    #[test]
+    fn test_id_deser() {
+        serde_test::assert_tokens(
+            &StickerId(114_941_315_417_899_012),
+            &[
+                Token::NewtypeStruct { name: "StickerId" },
+                Token::Str("114941315417899012"),
+            ],
+        );
+        serde_test::assert_de_tokens(
+            &StickerId(114_941_315_417_899_012),
+            &[
+                Token::NewtypeStruct { name: "StickerId" },
+                Token::U64(114_941_315_417_899_012),
+            ],
+        );
+        serde_test::assert_tokens(
+            &StickerPackId(114_941_315_417_899_012),
+            &[
+                Token::NewtypeStruct { name: "StickerPackId" },
+                Token::Str("114941315417899012"),
+            ],
+        );
+        serde_test::assert_de_tokens(
+            &StickerPackId(114_941_315_417_899_012),
+            &[
+                Token::NewtypeStruct { name: "StickerPackId" },
+                Token::U64(114_941_315_417_899_012),
+            ],
+        );
+    }
+}

--- a/model/src/channel/message/sticker/kind.rs
+++ b/model/src/channel/message/sticker/kind.rs
@@ -1,5 +1,9 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use std::{convert::TryFrom, error::Error, fmt::{Display, Formatter, Result as FmtResult}};
+use std::{
+    convert::TryFrom,
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
 
 /// Format type of a [Sticker][`super::Sticker`].
 #[derive(
@@ -69,8 +73,14 @@ mod tests {
 
     #[test]
     fn test_conversions() {
-        assert_eq!(StickerFormatType::try_from(1).unwrap(), StickerFormatType::Png);
-        assert_eq!(StickerFormatType::try_from(2).unwrap(), StickerFormatType::Apng);
+        assert_eq!(
+            StickerFormatType::try_from(1).unwrap(),
+            StickerFormatType::Png
+        );
+        assert_eq!(
+            StickerFormatType::try_from(2).unwrap(),
+            StickerFormatType::Apng
+        );
         assert_eq!(
             StickerFormatType::try_from(3).unwrap(),
             StickerFormatType::Lottie

--- a/model/src/channel/message/sticker/kind.rs
+++ b/model/src/channel/message/sticker/kind.rs
@@ -1,0 +1,79 @@
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use std::{convert::TryFrom, error::Error, fmt::{Display, Formatter, Result as FmtResult}};
+
+/// Format type of a [Sticker][`super::Sticker`].
+#[derive(
+    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
+)]
+#[repr(u8)]
+pub enum StickerFormatType {
+    /// Sticker format is a PNG.
+    Png = 1,
+    /// Sticker format is an APNG.
+    Apng = 2,
+    /// Sticker format is a LOTTIE.
+    Lottie = 3,
+}
+
+impl TryFrom<u8> for StickerFormatType {
+    type Error = StickerFormatTypeConversionError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Ok(match value {
+            1 => StickerFormatType::Png,
+            2 => StickerFormatType::Apng,
+            3 => StickerFormatType::Lottie,
+            _ => return Err(StickerFormatTypeConversionError { value }),
+        })
+    }
+}
+
+/// Converting into a [`StickerFormatType`] failed.
+///
+/// This occurs only when the input value doesn't map to a sticker type variant.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StickerFormatTypeConversionError {
+    value: u8,
+}
+
+impl<'a> StickerFormatTypeConversionError {
+    /// Retrieve a copy of the input value that couldn't be parsed.
+    pub fn value(&self) -> u8 {
+        self.value
+    }
+}
+
+impl Display for StickerFormatTypeConversionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_fmt(format_args!(
+            "Value ({}) doesn't match a sticker type",
+            self.value,
+        ))
+    }
+}
+
+impl Error for StickerFormatTypeConversionError {}
+
+#[cfg(test)]
+mod tests {
+    use super::StickerFormatType;
+    use serde_test::Token;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn test_variants() {
+        serde_test::assert_tokens(&StickerFormatType::Png, &[Token::U8(1)]);
+        serde_test::assert_tokens(&StickerFormatType::Apng, &[Token::U8(2)]);
+        serde_test::assert_tokens(&StickerFormatType::Lottie, &[Token::U8(3)]);
+    }
+
+    #[test]
+    fn test_conversions() {
+        assert_eq!(StickerFormatType::try_from(1).unwrap(), StickerFormatType::Png);
+        assert_eq!(StickerFormatType::try_from(2).unwrap(), StickerFormatType::Apng);
+        assert_eq!(
+            StickerFormatType::try_from(3).unwrap(),
+            StickerFormatType::Lottie
+        );
+    }
+}

--- a/model/src/channel/message/sticker/mod.rs
+++ b/model/src/channel/message/sticker/mod.rs
@@ -7,7 +7,10 @@
 mod id;
 mod kind;
 
-pub use self::{id::{StickerId, StickerPackId}, kind::{StickerFormatTypeConversionError, StickerFormatType}};
+pub use self::{
+    id::{StickerId, StickerPackId},
+    kind::{StickerFormatType, StickerFormatTypeConversionError},
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -34,7 +37,7 @@ pub struct Sticker {
 
 #[cfg(test)]
 mod tests {
-    use super::{StickerFormatType, StickerId, StickerPackId, Sticker};
+    use super::{Sticker, StickerFormatType, StickerId, StickerPackId};
     use serde_test::Token;
 
     #[test]
@@ -69,7 +72,9 @@ mod tests {
                 Token::Str("name"),
                 Token::Str("sticker name"),
                 Token::Str("pack_id"),
-                Token::NewtypeStruct { name: "StickerPackId" },
+                Token::NewtypeStruct {
+                    name: "StickerPackId",
+                },
                 Token::Str("2"),
                 Token::Str("preview_asset"),
                 Token::None,

--- a/model/src/channel/message/sticker/mod.rs
+++ b/model/src/channel/message/sticker/mod.rs
@@ -32,6 +32,7 @@ pub struct Sticker {
     /// Hash of the preview asset, if it has one.
     pub preview_asset: Option<String>,
     /// CSV list of tags the sticker is assigned to, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<String>,
 }
 

--- a/model/src/channel/message/sticker/mod.rs
+++ b/model/src/channel/message/sticker/mod.rs
@@ -1,0 +1,83 @@
+//! Message stickers.
+//!
+//! See the [Discord documentation] for more information.
+//!
+//! [Discord documentation]: https://discord.com/developers/docs/resources/channel#message-object-message-sticker-structure
+
+mod id;
+mod kind;
+
+pub use self::{id::{StickerId, StickerPackId}, kind::{StickerFormatTypeConversionError, StickerFormatType}};
+
+use serde::{Deserialize, Serialize};
+
+/// Message sticker.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct Sticker {
+    /// Hash of the asset.
+    pub asset: String,
+    /// Description of the sticker.
+    pub description: String,
+    /// Format type.
+    pub format_type: StickerFormatType,
+    /// Unique ID of the sticker.
+    pub id: StickerId,
+    /// Name of the sticker.
+    pub name: String,
+    /// Unique ID of the pack the sticker is in.
+    pub pack_id: StickerPackId,
+    /// Hash of the preview asset, if it has one.
+    pub preview_asset: Option<String>,
+    /// CSV list of tags the sticker is assigned to, if any.
+    pub tags: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StickerFormatType, StickerId, StickerPackId, Sticker};
+    use serde_test::Token;
+
+    #[test]
+    fn test_minimal() {
+        let value = Sticker {
+            asset: "foo1".to_owned(),
+            description: "foo2".to_owned(),
+            format_type: StickerFormatType::Png,
+            id: StickerId(1),
+            name: "sticker name".to_owned(),
+            pack_id: StickerPackId(2),
+            preview_asset: None,
+            tags: Some("foo,bar,baz".to_owned()),
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "Sticker",
+                    len: 8,
+                },
+                Token::Str("asset"),
+                Token::Str("foo1"),
+                Token::Str("description"),
+                Token::Str("foo2"),
+                Token::Str("format_type"),
+                Token::U8(1),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "StickerId" },
+                Token::Str("1"),
+                Token::Str("name"),
+                Token::Str("sticker name"),
+                Token::Str("pack_id"),
+                Token::NewtypeStruct { name: "StickerPackId" },
+                Token::Str("2"),
+                Token::Str("preview_asset"),
+                Token::None,
+                Token::Str("tags"),
+                Token::Some,
+                Token::Str("foo,bar,baz"),
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -918,6 +918,7 @@ mod tests {
             pinned: false,
             reactions: Vec::new(),
             reference: None,
+            stickers: Vec::new(),
             timestamp: String::new(),
             tts: false,
             webhook_id: None,


### PR DESCRIPTION
Support Message Stickers, including the Sticker itself as well Sticker and Sticker Pack IDs and Sticker Format Types.

Discord API documentation: discord/discord-api-docs@b9ffd52

Closes #589.