### PR TITLE
feat(model): support message mention members

### DIFF
--- a/cache/in-memory/src/model/member.rs
+++ b/cache/in-memory/src/model/member.rs
@@ -45,12 +45,14 @@ impl PartialEq<&PartialMember> for CachedMember {
             self.joined_at.as_ref(),
             self.mute,
             &self.nick,
+            &self.premium_since,
             &self.roles,
         ) == (
             other.deaf,
             other.joined_at.as_ref(),
             other.mute,
             &other.nick,
+            &other.premium_since,
             &other.roles,
         )
     }
@@ -121,6 +123,7 @@ mod tests {
             joined_at: None,
             mute: true,
             nick: Some("member nick".to_owned()),
+            premium_since: None,
             roles: Vec::new(),
         };
 

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -910,6 +910,7 @@ mod tests {
                 joined_at: None,
                 mute: false,
                 nick: Some("member nick".to_owned()),
+                premium_since: None,
                 roles: Vec::new(),
             }),
             mention_channels: Vec::new(),

--- a/model/src/channel/message/mention.rs
+++ b/model/src/channel/message/mention.rs
@@ -1,0 +1,151 @@
+use crate::{
+    guild::PartialMember,
+    id::UserId,
+    user::{self, UserFlags},
+};
+use serde::{Deserialize, Serialize};
+use serde_mappable_seq::Key;
+
+/// Mention of a user in a message.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct Mention {
+    /// Hash of the user's avatar, if any.
+    pub avatar: Option<String>,
+    /// Whether the user is a bot.
+    #[serde(default)]
+    pub bot: bool,
+    /// Discriminator used to differentiate people with the same username.
+    ///
+    /// # serde
+    ///
+    /// The discriminator field can be deserialized from either a string or an
+    /// integer. The field will always serialize into a string due to that being
+    /// the type Discord's API uses.
+    #[serde(with = "user::discriminator")]
+    pub discriminator: String,
+    /// Unique ID of the user.
+    pub id: UserId,
+    /// Member object for the user in the guild, if available.
+    pub member: Option<PartialMember>,
+    #[serde(rename = "username")]
+    /// Username of the user.
+    pub name: String,
+    /// Public flags on the user's account.
+    pub public_flags: UserFlags,
+}
+
+impl Key<'_, UserId> for Mention {
+    fn key(&self) -> UserId {
+        self.id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Mention, PartialMember, UserFlags, UserId};
+    use serde_test::Token;
+
+    #[test]
+    fn test_mention_without_member() {
+        let value = Mention {
+            avatar: None,
+            bot: false,
+            discriminator: "0001".to_owned(),
+            id: UserId(1),
+            member: None,
+            name: "foo".to_owned(),
+            public_flags: UserFlags::empty(),
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "Mention",
+                    len: 7,
+                },
+                Token::Str("avatar"),
+                Token::None,
+                Token::Str("bot"),
+                Token::Bool(false),
+                Token::Str("discriminator"),
+                Token::Str("0001"),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "UserId" },
+                Token::Str("1"),
+                Token::Str("member"),
+                Token::None,
+                Token::Str("username"),
+                Token::Str("foo"),
+                Token::Str("public_flags"),
+                Token::U64(0),
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn test_mention_with_member() {
+        let value = Mention {
+            avatar: None,
+            bot: false,
+            discriminator: "0001".to_owned(),
+            id: UserId(1),
+            member: Some(PartialMember {
+                deaf: false,
+                joined_at: None,
+                mute: true,
+                nick: Some("bar".to_owned()),
+                premium_since: None,
+                roles: Vec::new(),
+            }),
+            name: "foo".to_owned(),
+            public_flags: UserFlags::empty(),
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "Mention",
+                    len: 7,
+                },
+                Token::Str("avatar"),
+                Token::None,
+                Token::Str("bot"),
+                Token::Bool(false),
+                Token::Str("discriminator"),
+                Token::Str("0001"),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "UserId" },
+                Token::Str("1"),
+                Token::Str("member"),
+                Token::Some,
+                Token::Struct {
+                    name: "PartialMember",
+                    len: 6,
+                },
+                Token::Str("deaf"),
+                Token::Bool(false),
+                Token::Str("joined_at"),
+                Token::None,
+                Token::Str("mute"),
+                Token::Bool(true),
+                Token::Str("nick"),
+                Token::Some,
+                Token::Str("bar"),
+                Token::Str("premium_since"),
+                Token::None,
+                Token::Str("roles"),
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
+                Token::StructEnd,
+                Token::Str("username"),
+                Token::Str("foo"),
+                Token::Str("public_flags"),
+                Token::U64(0),
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -3,12 +3,14 @@ mod activity_type;
 mod application;
 mod flags;
 mod kind;
+mod mention;
 mod reaction;
 mod reference;
 
 pub use self::{
     activity::MessageActivity, activity_type::MessageActivityType, application::MessageApplication,
-    flags::MessageFlags, kind::MessageType, reaction::MessageReaction, reference::MessageReference,
+    flags::MessageFlags, kind::MessageType, mention::Mention, reaction::MessageReaction,
+    reference::MessageReference,
 };
 
 use crate::{
@@ -41,7 +43,7 @@ pub struct Message {
     pub mention_everyone: bool,
     pub mention_roles: Vec<RoleId>,
     #[serde(with = "serde_mappable_seq")]
-    pub mentions: HashMap<UserId, User>,
+    pub mentions: HashMap<UserId, Mention>,
     pub pinned: bool,
     #[serde(default)]
     pub reactions: Vec<MessageReaction>,
@@ -98,6 +100,7 @@ mod tests {
                 joined_at: Some("2020-01-01T00:00:00.000000+00:00".to_owned()),
                 mute: false,
                 nick: Some("member nick".to_owned()),
+                premium_since: None,
                 roles: Vec::new(),
             }),
             mention_channels: Vec::new(),
@@ -186,7 +189,7 @@ mod tests {
                 Token::Some,
                 Token::Struct {
                     name: "PartialMember",
-                    len: 5,
+                    len: 6,
                 },
                 Token::Str("deaf"),
                 Token::Bool(false),
@@ -198,6 +201,8 @@ mod tests {
                 Token::Str("nick"),
                 Token::Some,
                 Token::Str("member nick"),
+                Token::Str("premium_since"),
+                Token::None,
                 Token::Str("roles"),
                 Token::Seq { len: Some(0) },
                 Token::SeqEnd,

--- a/model/src/guild/partial_member.rs
+++ b/model/src/guild/partial_member.rs
@@ -7,6 +7,7 @@ pub struct PartialMember {
     pub joined_at: Option<String>,
     pub mute: bool,
     pub nick: Option<String>,
+    pub premium_since: Option<String>,
     pub roles: Vec<RoleId>,
 }
 
@@ -22,6 +23,7 @@ mod tests {
             joined_at: Some("timestamp".to_owned()),
             mute: true,
             nick: Some("a nickname".to_owned()),
+            premium_since: None,
             roles: vec![RoleId(1)],
         };
 
@@ -30,7 +32,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "PartialMember",
-                    len: 5,
+                    len: 6,
                 },
                 Token::Str("deaf"),
                 Token::Bool(false),
@@ -42,6 +44,8 @@ mod tests {
                 Token::Str("nick"),
                 Token::Some,
                 Token::Str("a nickname"),
+                Token::Str("premium_since"),
+                Token::None,
                 Token::Str("roles"),
                 Token::Seq { len: Some(1) },
                 Token::NewtypeStruct { name: "RoleId" },

--- a/model/src/user/mod.rs
+++ b/model/src/user/mod.rs
@@ -14,7 +14,7 @@ use crate::id::UserId;
 use serde::{Deserialize, Serialize};
 use serde_mappable_seq::Key;
 
-mod discriminator {
+pub(crate) mod discriminator {
     use serde::{
         de::{Deserializer, Error as DeError, Visitor},
         ser::Serializer,


### PR DESCRIPTION
Support partial members included in mentions within messages by creating a new `Mention` type.

Closes #566.