### PR TITLE
feat(gateway): add session id to shard info

### DIFF
--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -151,6 +151,7 @@ impl From<ConnectingError> for ShardStartError {
 pub struct Information {
     id: u64,
     latency: Latency,
+    session_id: Option<String>,
     seq: u64,
     stage: Stage,
 }
@@ -167,6 +168,11 @@ impl Information {
     /// information for the 5 most recent heartbeats.
     pub fn latency(&self) -> &Latency {
         &self.latency
+    }
+
+    /// Return the session ID of the connection.
+    pub fn session_id(&self) -> Option<String> {
+        self.session_id.clone()
     }
 
     /// Current sequence of the connection.
@@ -455,6 +461,7 @@ impl Shard {
         Ok(Information {
             id: self.config().shard()[0],
             latency: session.heartbeats.latency(),
+            session_id: session.id(),
             seq: session.seq(),
             stage: session.stage(),
         })

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -170,9 +170,9 @@ impl Information {
         &self.latency
     }
 
-    /// Return the session ID of the connection.
-    pub fn session_id(&self) -> Option<String> {
-        self.session_id.clone()
+    /// Return an immutable reference to the session ID of the shard.
+    pub fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
     }
 
     /// Current sequence of the connection.


### PR DESCRIPTION
This provides a way of retrieving the session ID for a shard connection without having to call shutdown_resumable, and can be very useful in my case of validating that a certain state cache is valid.