### PR TITLE
fix(http/update_channel_permission): use type ints

### DIFF
--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -1,6 +1,7 @@
 use super::UpdateChannelPermissionConfigured;
 use crate::request::prelude::*;
 use twilight_model::{
+    channel::permission_overwrite::PermissionOverwriteType,
     guild::Permissions,
     id::{ChannelId, RoleId, UserId},
 };
@@ -54,26 +55,21 @@ impl<'a> UpdateChannelPermission<'a> {
 
     /// Specify this override to be for a member.
     pub fn member(self, user_id: impl Into<UserId>) -> UpdateChannelPermissionConfigured<'a> {
-        self.configure("member", user_id.into().0)
+        self.configure(PermissionOverwriteType::Member(user_id.into()))
     }
 
     /// Specify this override to be for a role.
     pub fn role(self, role_id: impl Into<RoleId>) -> UpdateChannelPermissionConfigured<'a> {
-        self.configure("role", role_id.into().0)
+        self.configure(PermissionOverwriteType::Role(role_id.into()))
     }
 
-    fn configure(
-        self,
-        kind: impl Into<String>,
-        target_id: u64,
-    ) -> UpdateChannelPermissionConfigured<'a> {
+    fn configure(self, target: PermissionOverwriteType) -> UpdateChannelPermissionConfigured<'a> {
         UpdateChannelPermissionConfigured::new(
             self.http,
             self.channel_id,
             self.allow,
             self.deny,
-            kind,
-            target_id,
+            target,
         )
     }
 }

--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -55,15 +55,15 @@ impl<'a> UpdateChannelPermission<'a> {
 
     /// Specify this override to be for a member.
     pub fn member(self, user_id: impl Into<UserId>) -> UpdateChannelPermissionConfigured<'a> {
-        self.configure(PermissionOverwriteType::Member(user_id.into()))
+        self.configure(&PermissionOverwriteType::Member(user_id.into()))
     }
 
     /// Specify this override to be for a role.
     pub fn role(self, role_id: impl Into<RoleId>) -> UpdateChannelPermissionConfigured<'a> {
-        self.configure(PermissionOverwriteType::Role(role_id.into()))
+        self.configure(&PermissionOverwriteType::Role(role_id.into()))
     }
 
-    fn configure(self, target: PermissionOverwriteType) -> UpdateChannelPermissionConfigured<'a> {
+    fn configure(self, target: &PermissionOverwriteType) -> UpdateChannelPermissionConfigured<'a> {
         UpdateChannelPermissionConfigured::new(
             self.http,
             self.channel_id,

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -101,7 +101,7 @@ mod tests {
     use super::{UpdateChannelPermissionConfigured, UpdateChannelPermissionConfiguredFields};
     use crate::{request::Request, routing::Route, Client};
     use twilight_model::{
-        channel::permission_overwrite::{PermissionOverwriteType, PermissionOverwriteTargetType},
+        channel::permission_overwrite::{PermissionOverwriteTargetType, PermissionOverwriteType},
         guild::Permissions,
         id::{ChannelId, UserId},
     };

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -1,6 +1,6 @@
 use crate::request::prelude::*;
 use twilight_model::{
-    channel::permission_overwrite::{PermissionOverwriteType, PermissionOverwriteTypeName},
+    channel::permission_overwrite::{PermissionOverwriteTargetType, PermissionOverwriteType},
     guild::Permissions,
     id::ChannelId,
 };
@@ -10,7 +10,7 @@ struct UpdateChannelPermissionConfiguredFields {
     allow: Permissions,
     deny: Permissions,
     #[serde(rename = "type")]
-    kind: PermissionOverwriteTypeName,
+    kind: PermissionOverwriteTargetType,
 }
 
 /// Created when either `member` or `role` is called on a `DeleteChannelPermission` struct.
@@ -33,10 +33,10 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
     ) -> Self {
         let (name, target_id) = match target {
             PermissionOverwriteType::Member(user_id) => {
-                (PermissionOverwriteTypeName::Member, user_id.0)
+                (PermissionOverwriteTargetType::Member, user_id.0)
             }
             PermissionOverwriteType::Role(role_id) => {
-                (PermissionOverwriteTypeName::Role, role_id.0)
+                (PermissionOverwriteTargetType::Role, role_id.0)
             }
         };
 
@@ -101,7 +101,7 @@ mod tests {
     use super::{UpdateChannelPermissionConfigured, UpdateChannelPermissionConfiguredFields};
     use crate::{request::Request, routing::Route, Client};
     use twilight_model::{
-        channel::permission_overwrite::{PermissionOverwriteType, PermissionOverwriteTypeName},
+        channel::permission_overwrite::{PermissionOverwriteType, PermissionOverwriteTargetType},
         guild::Permissions,
         id::{ChannelId, UserId},
     };
@@ -121,7 +121,7 @@ mod tests {
         let body = crate::json_to_vec(&UpdateChannelPermissionConfiguredFields {
             allow: Permissions::empty(),
             deny: Permissions::SEND_MESSAGES,
-            kind: PermissionOverwriteTypeName::Member,
+            kind: PermissionOverwriteTargetType::Member,
         })
         .expect("failed to serialize payload");
         let route = Route::UpdatePermissionOverwrite {

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -24,13 +24,12 @@ pub struct UpdateChannelPermissionConfigured<'a> {
 }
 
 impl<'a> UpdateChannelPermissionConfigured<'a> {
-    #[allow(unreachable_code, unused)]
     pub(crate) fn new(
         http: &'a Client,
         channel_id: ChannelId,
         allow: Permissions,
         deny: Permissions,
-        target: PermissionOverwriteType,
+        target: &PermissionOverwriteType,
     ) -> Self {
         let (name, target_id) = match target {
             PermissionOverwriteType::Member(user_id) => {
@@ -115,7 +114,7 @@ mod tests {
             ChannelId(1),
             Permissions::empty(),
             Permissions::SEND_MESSAGES,
-            PermissionOverwriteType::Member(UserId(2)),
+            &PermissionOverwriteType::Member(UserId(2)),
         );
         let actual = builder.request().expect("failed to create request");
 

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -31,11 +31,14 @@ struct PermissionOverwriteData {
     kind: PermissionOverwriteTypeName,
 }
 
+/// Type of a permission overwrite target.
 #[derive(Clone, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionOverwriteTypeName {
+    /// Permission overwrite targets an individual member.
     Member = 1,
+    /// Permission overwrite targets an individual role.
     Role = 0,
 }
 

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -28,14 +28,14 @@ struct PermissionOverwriteData {
     deny: Permissions,
     id: String,
     #[serde(rename = "type")]
-    kind: PermissionOverwriteTypeName,
+    kind: PermissionOverwriteTargetType,
 }
 
 /// Type of a permission overwrite target.
 #[derive(Clone, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 #[serde(rename_all = "snake_case")]
-pub enum PermissionOverwriteTypeName {
+pub enum PermissionOverwriteTargetType {
     /// Permission overwrite targets an individual member.
     Member = 1,
     /// Permission overwrite targets an individual role.
@@ -50,13 +50,13 @@ impl<'de> Deserialize<'de> for PermissionOverwrite {
         let _span_enter = span.enter();
 
         let kind = match data.kind {
-            PermissionOverwriteTypeName::Member => {
+            PermissionOverwriteTargetType::Member => {
                 let id = UserId(data.id.parse().map_err(DeError::custom)?);
                 tracing::trace!(id = %id.0, kind = ?data.kind);
 
                 PermissionOverwriteType::Member(id)
             }
-            PermissionOverwriteTypeName::Role => {
+            PermissionOverwriteTargetType::Role => {
                 let id = RoleId(data.id.parse().map_err(DeError::custom)?);
                 tracing::trace!(id = %id.0, kind = ?data.kind);
 
@@ -82,11 +82,11 @@ impl Serialize for PermissionOverwrite {
         match &self.kind {
             PermissionOverwriteType::Member(id) => {
                 state.serialize_field("id", &id)?;
-                state.serialize_field("type", &(PermissionOverwriteTypeName::Member as u8))?;
+                state.serialize_field("type", &(PermissionOverwriteTargetType::Member as u8))?;
             }
             PermissionOverwriteType::Role(id) => {
                 state.serialize_field("id", &id)?;
-                state.serialize_field("type", &(PermissionOverwriteTypeName::Role as u8))?;
+                state.serialize_field("type", &(PermissionOverwriteTargetType::Role as u8))?;
             }
         }
 
@@ -97,7 +97,7 @@ impl Serialize for PermissionOverwrite {
 #[cfg(test)]
 mod tests {
     use super::{
-        PermissionOverwrite, PermissionOverwriteType, PermissionOverwriteTypeName, Permissions,
+        PermissionOverwrite, PermissionOverwriteType, PermissionOverwriteTargetType, Permissions,
     };
     use crate::id::UserId;
     use serde_test::Token;
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     fn test_overwrite_type_name() {
-        serde_test::assert_tokens(&PermissionOverwriteTypeName::Member, &[Token::U8(1)]);
-        serde_test::assert_tokens(&PermissionOverwriteTypeName::Role, &[Token::U8(0)]);
+        serde_test::assert_tokens(&PermissionOverwriteTargetType::Member, &[Token::U8(1)]);
+        serde_test::assert_tokens(&PermissionOverwriteTargetType::Role, &[Token::U8(0)]);
     }
 }

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -31,10 +31,10 @@ struct PermissionOverwriteData {
     kind: PermissionOverwriteTypeName,
 }
 
-#[derive(Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Clone, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 #[serde(rename_all = "snake_case")]
-enum PermissionOverwriteTypeName {
+pub enum PermissionOverwriteTypeName {
     Member = 1,
     Role = 0,
 }
@@ -93,8 +93,11 @@ impl Serialize for PermissionOverwrite {
 
 #[cfg(test)]
 mod tests {
-    use super::{PermissionOverwrite, PermissionOverwriteType, Permissions};
+    use super::{
+        PermissionOverwrite, PermissionOverwriteType, PermissionOverwriteTypeName, Permissions,
+    };
     use crate::id::UserId;
+    use serde_test::Token;
 
     #[test]
     fn test_overwrite() {
@@ -119,5 +122,11 @@ mod tests {
             overwrite
         );
         assert_eq!(serde_json::to_string_pretty(&overwrite).unwrap(), input);
+    }
+
+    #[test]
+    fn test_overwrite_type_name() {
+        serde_test::assert_tokens(&PermissionOverwriteTypeName::Member, &[Token::U8(1)]);
+        serde_test::assert_tokens(&PermissionOverwriteTypeName::Role, &[Token::U8(0)]);
     }
 }

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -97,7 +97,7 @@ impl Serialize for PermissionOverwrite {
 #[cfg(test)]
 mod tests {
     use super::{
-        PermissionOverwrite, PermissionOverwriteType, PermissionOverwriteTargetType, Permissions,
+        PermissionOverwrite, PermissionOverwriteTargetType, PermissionOverwriteType, Permissions,
     };
     use crate::id::UserId;
     use serde_test::Token;


### PR DESCRIPTION
In the `UpdateChannelPermission` request builder, use the integer values of permission types (0 for role, 1 for member) instead of string values ("role" and "member", respectively). This required v8 change wasn't picked up in the initial implementation. To do this, the internal `PermissionOverwriteTypeName` repr enum has been exposed.

Tests have been added for the permission overwrite type name and the request body itself.

Closes #613.