### PR TITLE
fix(gateway): fix unused gateway_url config

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -179,7 +179,7 @@ impl ClusterBuilder {
     ///
     /// [`ClusterStartError::RetrievingGatewayInfo`]: enum.ClusterStartError.html#variant.RetrievingGatewayInfo
     pub async fn build(mut self) -> Result<Cluster, ClusterStartError> {
-        if self.0.shard_config.gateway_url.is_none() {
+        if (self.1).0.gateway_url.is_none() {
             let gateway_url = (self.1)
                 .0
                 .http_client


### PR DESCRIPTION
The current `gateway_url` config on cluster builder is no-op, and is always fetched from the rest api.