### PR TITLE
gateway: add new shard scheme to start a large bot bucket.

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -56,9 +56,16 @@ pub enum ShardScheme {
     /// For example, if Discord recommends 10 shards, then all 10 shards will be
     /// started.
     Auto,
-    /// Star a single bucket for very large bot sharding
+    /// Manage a single bucket's worth of shards within the cluster.
+    ///
+    /// This is primarily useful for bots in the [Sharding for Very Large Bots]
+    /// program.
+    ///
+    /// [Sharding for Very Large Bots]: https://discord.com/developers/docs/topics/gateway#sharding-for-very-large-bots
     Bucket {
-        /// The shard id of the first shard to start, this should be less than the concurrency.
+        /// The ID of the first shard to start.
+        ///
+        /// This should be less than the concurrency.
         /// If you for example have a concurrency of 16 and the bucket id is 0, it will start:
         /// shard 0, 16, 32, 48 and so on.
         bucket_id: u64,
@@ -68,7 +75,7 @@ pub enum ShardScheme {
         /// [`max_concurrency`]: ::twilight_model::gateway::SessionStartLimit.max_concurrency
         /// [`SessionStartLimit`]: ::twilight_model::gateway::SessionStartLimit
         concurrency: u64,
-        /// The total amount of shards to start, not only in this bucket but the complete total.
+        /// The total number of shards used across all clusters.
         total: u64,
     },
     /// Specifies to start a range of shards.

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -56,6 +56,21 @@ pub enum ShardScheme {
     /// For example, if Discord recommends 10 shards, then all 10 shards will be
     /// started.
     Auto,
+    /// Star a single bucket for very large bot sharding
+    Bucket {
+        /// The shard id of the first shard to start, this should be less than the concurrency.
+        /// If you for example have a concurrency of 16 and the bucket id is 0, it will start:
+        /// shard 0, 16, 32, 48 and so on.
+        bucket_id: u64,
+        /// The amount of concurrency allowed by discord, this is given by the [`max_concurrency`]
+        /// field on [`SessionStartLimit`].
+        ///
+        /// [`max_concurrency`]: ::twilight_model::gateway::SessionStartLimit.max_concurrency
+        /// [`SessionStartLimit`]: ::twilight_model::gateway::SessionStartLimit
+        concurrency: u64,
+        /// The total amount of shards to start, not only in this bucket but the complete total.
+        total: u64,
+    },
     /// Specifies to start a range of shards.
     ///
     /// # Examples

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -147,9 +147,11 @@ impl Cluster {
 
                 [0, gateway.shards - 1, 1, gateway.shards]
             }
-            ShardScheme::Bucket { bucket_id, concurrency, total } => {
-                [*bucket_id, *total, *concurrency, *total]
-            }
+            ShardScheme::Bucket {
+                bucket_id,
+                concurrency,
+                total,
+            } => [*bucket_id, *total, *concurrency, *total],
             ShardScheme::Range { from, to, total } => [*from, *to, 1, *total],
         };
 
@@ -160,7 +162,8 @@ impl Cluster {
             metrics::gauge!("Cluster-Shard-Count", total.try_into().unwrap_or(-1));
         }
 
-        let shards = (from..=to).step_by(step as usize)
+        let shards = (from..=to)
+            .step_by(step as usize)
             .map(|idx| {
                 let mut shard_config = config.shard_config().clone();
                 shard_config.shard = [idx, total];


### PR DESCRIPTION
This is only usefull for users who have a non-1 value of
max_concurrency.