### PR TITLE
fix(model): fix deserialization for message without stickers

### DIFF
--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -51,6 +51,7 @@ pub struct Message {
     #[serde(rename = "message_reference")]
     pub reference: Option<MessageReference>,
     /// Stickers within the message.
+    #[serde(default)]
     pub stickers: Vec<Sticker>,
     pub timestamp: String,
     pub tts: bool,


### PR DESCRIPTION
Messages may not contain a `stickers` field, this fixes deserialization when the field is absent.