### PR TITLE
fix(model): fix identify compress field

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -741,7 +741,7 @@ impl ShardProcessor {
         self.session.set_stage(Stage::Identifying);
 
         let identify = Identify::new(IdentifyInfo {
-            compression: false,
+            compress: false,
             large_threshold: self.config.large_threshold(),
             intents: self.config.intents(),
             properties: self.properties.clone(),

--- a/model/src/gateway/payload/identify.rs
+++ b/model/src/gateway/payload/identify.rs
@@ -19,7 +19,7 @@ impl Identify {
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct IdentifyInfo {
-    pub compression: bool,
+    pub compress: bool,
     pub intents: Intents,
     pub large_threshold: u64,
     pub presence: Option<UpdateStatusInfo>,


### PR DESCRIPTION
The field is named `compress` and not `compression`.

See https://discord.com/developers/docs/topics/gateway#identify-identify-structure.