### PR TITLE
model: move CurrentUserGuild from http to model

### DIFF
--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -1,10 +1,10 @@
 use crate::request::prelude::*;
-use serde::{Deserialize, Serialize};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
-use twilight_model::{guild::Permissions, id::GuildId};
+use twilight_model::id::GuildId;
+pub use twilight_model::user::CurrentUserGuild;
 
 /// The error created when the current guilds can not be retrieved as configured.
 #[derive(Clone, Debug)]
@@ -31,31 +31,6 @@ struct GetCurrentUserGuildsFields {
     after: Option<GuildId>,
     before: Option<GuildId>,
     limit: Option<u64>,
-}
-
-/// Information about a guild the current user is in.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct CurrentUserGuild {
-    /// Unique ID.
-    pub id: GuildId,
-    /// Name of the guild.
-    ///
-    /// The name must be at least 2 characters long and at most 100 characters
-    /// long.
-    pub name: String,
-    /// Hash of the icon.
-    ///
-    /// Refer to the [Discord documentation] for more information.
-    ///
-    /// [Discord documentation]: https://discord.com/developers/docs/reference#image-formatting
-    pub icon: Option<String>,
-    /// Whether the current user is the owner.
-    pub owner: bool,
-    /// Permissions of the current user in the guild. This excludes channels'
-    /// permission overwrites.
-    pub permissions: Permissions,
-    /// List of enabled guild features.
-    pub features: Vec<String>,
 }
 
 /// Returns a list of guilds for the current user.
@@ -150,50 +125,3 @@ impl<'a> GetCurrentUserGuilds<'a> {
 }
 
 poll_req!(GetCurrentUserGuilds<'_>, Vec<CurrentUserGuild>);
-
-#[cfg(test)]
-mod tests {
-    use super::{CurrentUserGuild, GuildId};
-    use serde_test::Token;
-    use twilight_model::guild::Permissions;
-
-    #[test]
-    fn test_current_user_guild() {
-        // The example partial guild from the discord docs
-        let value = CurrentUserGuild {
-            id: GuildId(80_351_110_224_678_912),
-            name: "abcd".to_owned(),
-            icon: Some("8342729096ea3675442027381ff50dfe".to_owned()),
-            owner: true,
-            permissions: Permissions::from_bits_truncate(36_953_089),
-            features: vec!["a feature".to_owned()],
-        };
-
-        serde_test::assert_tokens(
-            &value,
-            &[
-                Token::Struct {
-                    name: "CurrentUserGuild",
-                    len: 6,
-                },
-                Token::Str("id"),
-                Token::NewtypeStruct { name: "GuildId" },
-                Token::Str("80351110224678912"),
-                Token::Str("name"),
-                Token::Str("abcd"),
-                Token::Str("icon"),
-                Token::Some,
-                Token::Str("8342729096ea3675442027381ff50dfe"),
-                Token::Str("owner"),
-                Token::Bool(true),
-                Token::Str("permissions"),
-                Token::Str("36953089"),
-                Token::Str("features"),
-                Token::Seq { len: Some(1) },
-                Token::Str("a feature"),
-                Token::SeqEnd,
-                Token::StructEnd,
-            ],
-        );
-    }
-}

--- a/model/src/user/current_user_guild.rs
+++ b/model/src/user/current_user_guild.rs
@@ -1,0 +1,74 @@
+use crate::guild::Permissions;
+use crate::id::GuildId;
+use serde::{Deserialize, Serialize};
+
+/// Information about a guild the current user is in.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CurrentUserGuild {
+    /// Unique ID.
+    pub id: GuildId,
+    /// Name of the guild.
+    ///
+    /// The name must be at least 2 characters long and at most 100 characters
+    /// long.
+    pub name: String,
+    /// Hash of the icon.
+    ///
+    /// Refer to the [Discord documentation] for more information.
+    ///
+    /// [Discord documentation]: https://discord.com/developers/docs/reference#image-formatting
+    pub icon: Option<String>,
+    /// Whether the current user is the owner.
+    pub owner: bool,
+    /// Permissions of the current user in the guild. This excludes channels'
+    /// permission overwrites.
+    pub permissions: Permissions,
+    /// List of enabled guild features.
+    pub features: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CurrentUserGuild, GuildId, Permissions};
+    use serde_test::Token;
+
+    #[test]
+    fn test_current_user_guild() {
+        // The example partial guild from the discord docs
+        let value = CurrentUserGuild {
+            id: GuildId(80_351_110_224_678_912),
+            name: "abcd".to_owned(),
+            icon: Some("8342729096ea3675442027381ff50dfe".to_owned()),
+            owner: true,
+            permissions: Permissions::from_bits_truncate(36_953_089),
+            features: vec!["a feature".to_owned()],
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "CurrentUserGuild",
+                    len: 6,
+                },
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "GuildId" },
+                Token::Str("80351110224678912"),
+                Token::Str("name"),
+                Token::Str("abcd"),
+                Token::Str("icon"),
+                Token::Some,
+                Token::Str("8342729096ea3675442027381ff50dfe"),
+                Token::Str("owner"),
+                Token::Bool(true),
+                Token::Str("permissions"),
+                Token::Str("36953089"),
+                Token::Str("features"),
+                Token::Seq { len: Some(1) },
+                Token::Str("a feature"),
+                Token::SeqEnd,
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/user/current_user_guild.rs
+++ b/model/src/user/current_user_guild.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 
 /// Information about a guild the current user is in.
 ///
-/// This is a partial guild used for the `Get Current User Guilds` endpoint. Refer to the [Discord documentation] for more information.
+/// This is a partial guild used for the `Get Current User Guilds` endpoint.
+/// Refer to the [Discord documentation] for more information.
 ///
 /// [Discord documentation]: https://discord.com/developers/docs/resources/user#get-current-user-guilds-example-partial-guild
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/model/src/user/current_user_guild.rs
+++ b/model/src/user/current_user_guild.rs
@@ -3,6 +3,10 @@ use crate::id::GuildId;
 use serde::{Deserialize, Serialize};
 
 /// Information about a guild the current user is in.
+///
+/// This is a partial guild used for the `Get Current User Guilds` endpoint. Refer to the [Discord documentation] for more information.
+///
+/// [Discord documentation]: https://discord.com/developers/docs/resources/user#get-current-user-guilds-example-partial-guild
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CurrentUserGuild {
     /// Unique ID.

--- a/model/src/user/mod.rs
+++ b/model/src/user/mod.rs
@@ -1,13 +1,15 @@
 mod connection;
 mod connection_visibility;
 mod current_user;
+mod current_user_guild;
 mod flags;
 mod premium_type;
 mod profile;
 
 pub use self::{
     connection::Connection, connection_visibility::ConnectionVisibility, current_user::CurrentUser,
-    flags::UserFlags, premium_type::PremiumType, profile::UserProfile,
+    current_user_guild::CurrentUserGuild, flags::UserFlags, premium_type::PremiumType,
+    profile::UserProfile,
 };
 
 use crate::id::UserId;


### PR DESCRIPTION
This PR moves the CurrentUserGuild struct from http to model. This allows developers to prevent pulling in the http crate for cases where the http client is not needed. (e.g. oauth-related workflows)