### PR TITLE
gateway: add method to send arbitary close codes to a shard.

### DIFF
--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -368,7 +368,11 @@ impl Cluster {
     ///
     /// # Errors
     ///
-    /// Returns a [`SessionInactiveError`] if the shard's session is inactive.
+    /// Returns [`ClusterCommandError::Sending`] if the shard exists, but
+    /// sending the close code failed.
+    ///
+    /// Returns a [`ClusterCommandError::ShardNonexistent`] if the provided shard
+    /// ID does not exist in the cluster.
     ///
     /// [`SessionInactiveError`]: struct.SessionInactiveError.html
     pub fn send_close_code(&self, id: u64, code: u16) -> Result<(), ClusterCommandError> {

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -376,10 +376,11 @@ impl Cluster {
             .shard(id)
             .ok_or(ClusterCommandError::ShardNonexistent { id })?;
 
-        shard.
-            send_close_code(code).map_err(|source| ClusterCommandError::Sending { source })
+        shard
+            .send_close_code(code)
+            .map_err(|source| ClusterCommandError::Sending { source })
     }
-    
+
     /// Return a stream of events from all shards managed by this Cluster.
     ///
     /// Each item in the stream contains both the shard's ID and the event

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -358,6 +358,28 @@ impl Cluster {
             .map_err(|source| ClusterCommandError::Sending { source })
     }
 
+    /// Send a close code to Discord causing a resume or a reconnect.
+    ///
+    /// # Recommended clothes codes
+    ///
+    /// | Re-identify | Resume |
+    /// | ----------- | ------ |
+    /// |        1000 |   1012 |
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SessionInactiveError`] if the shard's session is inactive.
+    ///
+    /// [`SessionInactiveError`]: struct.SessionInactiveError.html
+    pub fn send_close_code(&self, id: u64, code: u16) -> Result<(), ClusterCommandError> {
+        let shard = self
+            .shard(id)
+            .ok_or(ClusterCommandError::ShardNonexistent { id })?;
+
+        shard.
+            send_close_code(code).map_err(|source| ClusterCommandError::Sending { source })
+    }
+    
     /// Return a stream of events from all shards managed by this Cluster.
     ///
     /// Each item in the stream contains both the shard's ID and the event

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -360,7 +360,7 @@ impl Cluster {
 
     /// Send a close code to Discord causing a resume or a reconnect.
     ///
-    /// # Recommended clothes codes
+    /// # Recommended close codes
     ///
     /// | Re-identify | Resume |
     /// | ----------- | ------ |

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -402,7 +402,9 @@ impl Shard {
 
             Ok(())
         } else {
-            Err(CommandError::SessionInactive { source: SessionInactiveError })
+            Err(CommandError::SessionInactive {
+                source: SessionInactiveError,
+            })
         }
     }
 

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -399,7 +399,6 @@ impl Shard {
                 code: code.into(),
                 reason: "".into(),
             }));
-            session.stop_heartbeater();
 
             Ok(())
         } else {

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -380,6 +380,32 @@ impl Shard {
         Ok(())
     }
 
+    /// Send a close code to Discord causing a resume or a reconnect.
+    ///
+    /// # Recommended clothes codes
+    ///
+    /// | Re-identify | Resume |
+    /// | ----------- | ------ |
+    /// |        1000 |   1012 |
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SessionInactiveError`] if the shard's session is inactive.
+    ///
+    /// [`SessionInactiveError`]: struct.SessionInactiveError.html
+    pub fn send_close_code(&self, code: u16) -> Result<(), CommandError> {
+        if let Ok(session) = self.session() {
+            let _ = session.close(Some(CloseFrame {
+                code: code.into(),
+                reason: "".into(),
+            }));
+
+            Ok(())
+        } else {
+            Err(CommandError::SessionInactive { source: SessionInactiveError })
+        }
+    }
+
     /// Create a new stream of events from the shard.
     ///
     /// There can be multiple streams of events. All events will be broadcast to

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -382,7 +382,7 @@ impl Shard {
 
     /// Send a close code to Discord causing a resume or a reconnect.
     ///
-    /// # Recommended clothes codes
+    /// # Recommended close codes
     ///
     /// | Re-identify | Resume |
     /// | ----------- | ------ |

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -390,7 +390,8 @@ impl Shard {
     ///
     /// # Errors
     ///
-    /// Returns a [`SessionInactiveError`] if the shard's session is inactive.
+    /// Returns a [`CommandError::SessionInactive`] if the shard's
+    /// session is inactive.
     ///
     /// [`SessionInactiveError`]: struct.SessionInactiveError.html
     pub fn send_close_code(&self, code: u16) -> Result<(), CommandError> {

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -399,6 +399,7 @@ impl Shard {
                 code: code.into(),
                 reason: "".into(),
             }));
+            session.stop_heartbeater();
 
             Ok(())
         } else {


### PR DESCRIPTION
This is useful if you for whatever reason want to
force a re-identify or a resume if there is issues
with the session.