### PR TITLE
docs: note msrv of 1.48+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ functionality. Please use the individual crates listed below instead!
 
 ## Installation
 
-Twilight requires the latest stable Rust version.
+Twilight supports a MSRV of Rust 1.48+.
 
 We recommend that most users start out with these crates added to your
 `Cargo.toml`'s `[dependencies]` section:
@@ -223,7 +223,7 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
 [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png
-[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
 [`twilight-cache-inmemory`]: https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html
 [`twilight-command-parser`]: https://twilight.rs/chapter_1_crates/section_5_command_parser.html

--- a/cache/in-memory/README.md
+++ b/cache/in-memory/README.md
@@ -45,6 +45,6 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -45,7 +45,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(rust_2018_idioms, broken_intra_doc_links, unused, warnings)]
 

--- a/command-parser/README.md
+++ b/command-parser/README.md
@@ -52,7 +52,7 @@ match parser.parse("!echo a message") {
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 [`twilight-rs`]: https://github.com/twilight-rs/twilight
 
 <!-- cargo-sync-readme end -->

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -50,7 +50,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 //! [`twilight-rs`]: https://github.com/twilight-rs/twilight
 
 #![deny(

--- a/embed-builder/README.md
+++ b/embed-builder/README.md
@@ -41,7 +41,7 @@ let embed = EmbedBuilder::new()
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 [the discord docs]: https://discord.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
 
 <!-- cargo-sync-readme end -->

--- a/embed-builder/src/lib.rs
+++ b/embed-builder/src/lib.rs
@@ -43,7 +43,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 //! [the discord docs]: https://discord.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
 
 #![deny(

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -96,6 +96,6 @@ fork of zlib that is faster and more effective, but it needs `cmake` to compile.
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -94,7 +94,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/http/README.md
+++ b/http/README.md
@@ -73,6 +73,6 @@ This is enabled by default.
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -71,7 +71,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -110,6 +110,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
 [node]: Node
 [process]: Lavalink::process
-[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -108,7 +108,7 @@
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
 //! [node]: Node
 //! [process]: Lavalink::process
-//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/mention/README.md
+++ b/mention/README.md
@@ -29,6 +29,6 @@ let message = format!("Hey there, {}!", user_id.mention());
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/mention/src/lib.rs
+++ b/mention/src/lib.rs
@@ -27,7 +27,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/model/README.md
+++ b/model/README.md
@@ -35,6 +35,6 @@ or extended by other crates.
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -33,7 +33,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/standby/README.md
+++ b/standby/README.md
@@ -118,6 +118,6 @@ For more examples, check out each of the methods on [`Standby`].
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -118,7 +118,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(rust_2018_idioms, broken_intra_doc_links, unused, warnings)]
 

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Installation
 //!
-//! Twilight requires the latest stable Rust version.
+//! Twilight supports a MSRV of Rust 1.48+.
 //!
 //! We recommend that most users start out with these crates added to your
 //! `Cargo.toml`'s `[dependencies]` section:
@@ -223,7 +223,7 @@
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
 //! [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png
-//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 //! [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
 //! [`twilight-cache-inmemory`]: https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html
 //! [`twilight-command-parser`]: https://twilight.rs/chapter_1_crates/section_5_command_parser.html

--- a/util/README.md
+++ b/util/README.md
@@ -21,7 +21,7 @@ structured information from [Discord snowflakes].
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 [Discord snowflakes]: https://discord.com/developers/docs/reference#snowflakes
 
 <!-- cargo-sync-readme end -->

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -19,7 +19,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-stable-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.48+-93450a.svg?style=for-the-badge&logo=rust
 //! [Discord snowflakes]: https://discord.com/developers/docs/reference#snowflakes
 
 #![deny(


### PR DESCRIPTION
In the badges and root installation instructions, note the MSRV required via #636 of Rust 1.48+.

Closes #635.