### PR TITLE
feat(model/guild): support role tags 

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -973,6 +973,7 @@ mod tests {
             name: "test".to_owned(),
             permissions: Permissions::empty(),
             position: 0,
+            tags: None,
         }
     }
 

--- a/model/src/gateway/payload/role_update.rs
+++ b/model/src/gateway/payload/role_update.rs
@@ -26,6 +26,7 @@ mod tests {
                 name: "a role".to_owned(),
                 permissions: Permissions::SEND_MESSAGES,
                 position: 12,
+                tags: None,
             },
         };
 

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -17,6 +17,7 @@ mod permissions;
 mod premium_tier;
 mod preview;
 mod prune;
+mod role_tags;
 mod role;
 mod status;
 mod system_channel_flags;
@@ -30,7 +31,7 @@ pub use self::{
     integration_account::IntegrationAccount, integration_application::IntegrationApplication,
     integration_expire_behavior::IntegrationExpireBehavior, member::Member, mfa_level::MfaLevel,
     partial_guild::PartialGuild, partial_member::PartialMember, permissions::Permissions,
-    premium_tier::PremiumTier, preview::GuildPreview, prune::GuildPrune, role::Role,
+    premium_tier::PremiumTier, preview::GuildPreview, prune::GuildPrune, role_tags::RoleTags, role::Role,
     status::GuildStatus, system_channel_flags::SystemChannelFlags,
     unavailable_guild::UnavailableGuild, verification_level::VerificationLevel,
     widget::GuildWidget,

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -17,8 +17,8 @@ mod permissions;
 mod premium_tier;
 mod preview;
 mod prune;
-mod role_tags;
 mod role;
+mod role_tags;
 mod status;
 mod system_channel_flags;
 mod unavailable_guild;
@@ -31,8 +31,8 @@ pub use self::{
     integration_account::IntegrationAccount, integration_application::IntegrationApplication,
     integration_expire_behavior::IntegrationExpireBehavior, member::Member, mfa_level::MfaLevel,
     partial_guild::PartialGuild, partial_member::PartialMember, permissions::Permissions,
-    premium_tier::PremiumTier, preview::GuildPreview, prune::GuildPrune, role_tags::RoleTags, role::Role,
-    status::GuildStatus, system_channel_flags::SystemChannelFlags,
+    premium_tier::PremiumTier, preview::GuildPreview, prune::GuildPrune, role::Role,
+    role_tags::RoleTags, status::GuildStatus, system_channel_flags::SystemChannelFlags,
     unavailable_guild::UnavailableGuild, verification_level::VerificationLevel,
     widget::GuildWidget,
 };

--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -1,3 +1,4 @@
+use super::RoleTags;
 use crate::{guild::Permissions, id::RoleId};
 use serde::{
     de::{DeserializeSeed, Deserializer, SeqAccess, Visitor},
@@ -19,6 +20,9 @@ pub struct Role {
     pub name: String,
     pub permissions: Permissions,
     pub position: i64,
+    /// Tags about the role.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<RoleTags>,
 }
 
 impl Key<'_, RoleId> for Role {
@@ -81,6 +85,7 @@ mod tests {
             name: "test".to_owned(),
             permissions: Permissions::ADMINISTRATOR,
             position: 12,
+            tags: None,
         };
 
         serde_test::assert_tokens(

--- a/model/src/guild/role_tags.rs
+++ b/model/src/guild/role_tags.rs
@@ -1,0 +1,120 @@
+use crate::id::{IntegrationId, UserId};
+use serde::{Deserialize, Serialize};
+
+/// The RoleTags' `premium_subscriber` field is tricky. It's an optional null.
+///
+/// If the field is present, then the value is null, meaning that the role is a
+/// premium subscriber. If the field is not present, it means that the role is
+/// *not* a premium subscriber.
+mod premium_subscriber {
+    use serde::{
+        de::{Deserializer, Error as DeError, Visitor},
+        ser::Serializer,
+    };
+    use std::fmt::{Formatter, Result as FmtResult};
+
+    struct PremiumSubscriberVisitor;
+
+    impl<'de> Visitor<'de> for PremiumSubscriberVisitor {
+        type Value = bool;
+
+        fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+            f.write_str("null")
+        }
+
+        fn visit_none<E: DeError>(self) -> Result<Self::Value, E> {
+            Ok(true)
+        }
+    }
+
+    pub fn serialize<S: Serializer>(
+        _: &bool,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.serialize_none()
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<bool, D::Error> {
+        deserializer.deserialize_option(PremiumSubscriberVisitor)
+    }
+}
+
+fn is_false(value: &bool) -> bool {
+    !value
+}
+
+/// Tags that a [`Role`] has.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct RoleTags {
+    /// ID of the bot the role belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bot_id: Option<UserId>,
+    /// ID of the integration the role belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub integration_id: Option<IntegrationId>,
+    /// Whether this is the guild's premium subscriber role.
+    #[serde(default, skip_serializing_if = "is_false", with = "premium_subscriber")]
+    pub premium_subscriber: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RoleTags;
+    use crate::id::{IntegrationId, UserId};
+    use serde_test::Token;
+
+    #[test]
+    fn test_role_tags_all() {
+        let tags = RoleTags {
+            bot_id: Some(UserId(1)),
+            integration_id: Some(IntegrationId(2)),
+            premium_subscriber: true,
+        };
+
+        serde_test::assert_tokens(
+            &tags,
+            &[
+                Token::Struct {
+                    name: "RoleTags",
+                    len: 3,
+                },
+                Token::Str("bot_id"),
+                Token::Some,
+                Token::NewtypeStruct { name: "UserId" },
+                Token::Str("1"),
+                Token::Str("integration_id"),
+                Token::Some,
+                Token::NewtypeStruct { name: "IntegrationId" },
+                Token::Str("2"),
+                Token::Str("premium_subscriber"),
+                Token::None,
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    /// Test that if all fields are None and premium_subscriber is false, then
+    /// serialize back into the source payload (where all fields are not
+    /// present).
+    #[test]
+    fn test_role_tags_none() {
+        let tags = RoleTags {
+            bot_id: None,
+            integration_id: None,
+            premium_subscriber: false,
+        };
+
+        serde_test::assert_tokens(
+            &tags,
+            &[
+                Token::Struct {
+                    name: "RoleTags",
+                    len: 0,
+                },
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/guild/role_tags.rs
+++ b/model/src/guild/role_tags.rs
@@ -46,6 +46,8 @@ fn is_false(value: &bool) -> bool {
 }
 
 /// Tags that a [`Role`] has.
+///
+/// [`Role`]: super::Role
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct RoleTags {
     /// ID of the bot the role belongs to.

--- a/model/src/guild/role_tags.rs
+++ b/model/src/guild/role_tags.rs
@@ -1,7 +1,7 @@
 use crate::id::{IntegrationId, UserId};
 use serde::{Deserialize, Serialize};
 
-/// The RoleTags' `premium_subscriber` field is tricky. It's an optional null.
+/// The role tags' `premium_subscriber` field is tricky. It's an optional null.
 ///
 /// If the field is present, then the value is null, meaning that the role is a
 /// premium subscriber. If the field is not present, it means that the role is
@@ -27,20 +27,20 @@ mod premium_subscriber {
         }
     }
 
-    pub fn serialize<S: Serializer>(
-        _: &bool,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error> {
+    // Clippy will say this bool can be taken by value, but we need it to be
+    // passed by reference because that's what serde does.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn serialize<S: Serializer>(_: &bool, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_none()
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<bool, D::Error> {
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<bool, D::Error> {
         deserializer.deserialize_option(PremiumSubscriberVisitor)
     }
 }
 
+// Clippy situation is the same as above.
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn is_false(value: &bool) -> bool {
     !value
 }
@@ -86,7 +86,9 @@ mod tests {
                 Token::Str("1"),
                 Token::Str("integration_id"),
                 Token::Some,
-                Token::NewtypeStruct { name: "IntegrationId" },
+                Token::NewtypeStruct {
+                    name: "IntegrationId",
+                },
                 Token::Str("2"),
                 Token::Str("premium_subscriber"),
                 Token::None,
@@ -95,7 +97,7 @@ mod tests {
         );
     }
 
-    /// Test that if all fields are None and premium_subscriber is false, then
+    /// Test that if all fields are None and `premium_subscriber` is false, then
     /// serialize back into the source payload (where all fields are not
     /// present).
     #[test]


### PR DESCRIPTION
Support Role Tags as part of Roles. The Role Tags type has 2 "normal" fields: `bot_id` and `integration_id`. These fields are either not present (meaning null) or present with a value.

There is also a third field called `premium_subscriber`. When not present, the field's real meaning is false. When present, the value is null, with a real meaning of true.

When serializing the Role Tags, we can use this information to conditionally serialize back into the source payload by serializing fields back into the way they started.

Closes #631.