### PR TITLE
Gateway, HTTP: Use Box<str> over String

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -152,6 +152,8 @@ impl ClusterBuilder {
             token.insert_str(0, "Bot ");
         }
 
+        let token = token.into_boxed_str();
+
         let http_client = Client::new(token.clone());
 
         let shard_config =

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -162,7 +162,7 @@ impl Cluster {
                 shard_config.shard = [idx, total];
 
                 if let Some(data) = config.resume_sessions.remove(&idx) {
-                    shard_config.session_id = Some(data.session_id);
+                    shard_config.session_id = Some(data.session_id.into_boxed_str());
                     shard_config.sequence = Some(data.sequence);
                 }
 

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -113,7 +113,7 @@ impl ShardBuilder {
             presence: None,
             queue: Arc::new(Box::new(LocalQueue::new())),
             shard: [0, 1],
-            token,
+            token: token.into_boxed_str(),
             session_id: None,
             sequence: None,
         })
@@ -126,7 +126,7 @@ impl ShardBuilder {
 
     /// Set the URL used for connecting to Discord's gateway
     pub fn gateway_url(mut self, gateway_url: Option<String>) -> Self {
-        self.0.gateway_url = gateway_url;
+        self.0.gateway_url = gateway_url.map(String::into_boxed_str);
 
         self
     }

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -11,15 +11,15 @@ use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents}
 /// [`Shard::builder`]: super::Shard::builder
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub(crate) gateway_url: Option<String>,
+    pub(crate) gateway_url: Option<Box<str>>,
     pub(crate) http_client: Client,
     pub(super) intents: Intents,
     pub(super) large_threshold: u64,
     pub(super) presence: Option<UpdateStatusInfo>,
     pub(super) queue: Arc<Box<dyn Queue>>,
     pub(crate) shard: [u64; 2],
-    pub(super) token: String,
-    pub(crate) session_id: Option<String>,
+    pub(super) token: Box<str>,
+    pub(crate) session_id: Option<Box<str>>,
     pub(crate) sequence: Option<u64>,
 }
 

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -152,7 +152,7 @@ impl From<ConnectingError> for ShardStartError {
 pub struct Information {
     id: u64,
     latency: Latency,
-    session_id: Option<String>,
+    session_id: Option<Box<str>>,
     seq: u64,
     stage: Stage,
 }
@@ -344,7 +344,7 @@ impl Shard {
     /// couldn't be retrieved from the HTTP API.
     pub async fn start(&mut self) -> Result<(), ShardStartError> {
         let url = if let Some(u) = self.0.config.gateway_url.clone() {
-            u
+            u.into_string()
         } else {
             self.0
                 .config
@@ -580,7 +580,7 @@ impl Shard {
         session.stop_heartbeater();
 
         let data = session_id.map(|id| ResumeSession {
-            session_id: id,
+            session_id: id.into_string(),
             sequence,
         });
 

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -461,7 +461,8 @@ impl ShardProcessor {
         metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "Dispatch");
 
         self.session.set_stage(Stage::Connected);
-        self.session.set_id(ready.session_id.clone().into_boxed_str());
+        self.session
+            .set_id(ready.session_id.clone().into_boxed_str());
 
         self.emitter.event(Event::ShardConnected(Connected {
             heartbeat_interval: self.session.heartbeat_interval(),

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -236,8 +236,8 @@ pub struct ShardProcessor {
     pub rx: UnboundedReceiver<Message>,
     pub session: Arc<Session>,
     inflater: Inflater,
-    url: String,
-    resume: Option<(u64, String)>,
+    url: Box<str>,
+    resume: Option<(u64, Box<str>)>,
     wtx: WatchSender<Arc<Session>>,
 }
 
@@ -292,7 +292,7 @@ impl ShardProcessor {
             rx,
             session,
             inflater: Inflater::new(shard_id),
-            url,
+            url: url.into_boxed_str(),
             resume: None,
             wtx,
         };
@@ -461,7 +461,7 @@ impl ShardProcessor {
         metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "Dispatch");
 
         self.session.set_stage(Stage::Connected);
-        self.session.set_id(ready.session_id.clone());
+        self.session.set_id(ready.session_id.clone().into_boxed_str());
 
         self.emitter.event(Event::ShardConnected(Connected {
             heartbeat_interval: self.session.heartbeat_interval(),
@@ -530,7 +530,7 @@ impl ShardProcessor {
             // it is some.
             let (seq, id) = self.resume.take().unwrap();
             tracing::debug!("resuming with sequence {}, session id {}", seq, id);
-            let payload = Resume::new(seq, &id, self.config.token());
+            let payload = Resume::new(seq, id.clone().into_string(), self.config.token());
 
             // Set id so it is correct for next resume.
             self.session.set_id(id);
@@ -797,7 +797,7 @@ impl ShardProcessor {
         }
 
         self.emitter.event(Event::ShardConnecting(Connecting {
-            gateway: self.url.clone(),
+            gateway: self.url.clone().into_string(),
             shard_id: self.config.shard()[0],
         }));
     }

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -63,7 +63,7 @@ pub struct Session {
     pub heartbeater_handle: Arc<MutexSync<Option<AbortHandle>>>,
     pub heartbeats: Arc<Heartbeats>,
     pub heartbeat_interval: AtomicU64,
-    pub id: MutexSync<Option<String>>,
+    pub id: MutexSync<Option<Box<str>>>,
     pub seq: Arc<AtomicU64>,
     pub stage: AtomicU8,
     pub tx: UnboundedSender<TungsteniteMessage>,
@@ -150,15 +150,11 @@ impl Session {
         self.send(Heartbeat::new(self.seq()))
     }
 
-    pub fn id(&self) -> Option<String> {
+    pub fn id(&self) -> Option<Box<str>> {
         self.id.lock().expect("id poisoned").clone()
     }
 
-    pub fn set_id(&self, new_id: impl Into<String>) {
-        self._set_id(new_id.into())
-    }
-
-    fn _set_id(&self, new_id: String) {
+    pub fn set_id(&self, new_id: Box<str>) {
         self.id.lock().expect("id poisoned").replace(new_id);
     }
 

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -19,7 +19,7 @@ pub struct ClientBuilder {
     pub(crate) ratelimiter: Option<Ratelimiter>,
     pub(crate) reqwest_client: Option<ReqwestClientBuilder>,
     pub(crate) timeout: Duration,
-    pub(crate) token: Option<String>,
+    pub(crate) token: Option<Box<str>>,
 }
 
 impl ClientBuilder {
@@ -130,7 +130,7 @@ impl ClientBuilder {
             token.insert_str(0, "Bot ");
         }
 
-        self.token.replace(token);
+        self.token.replace(token.into_boxed_str());
 
         self
     }

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -40,7 +40,7 @@ struct State {
     http: ReqwestClient,
     ratelimiter: Option<Ratelimiter>,
     token_invalid: AtomicBool,
-    token: Option<String>,
+    token: Option<Box<str>>,
     use_http: bool,
     pub(crate) default_allowed_mentions: Option<AllowedMentions>,
 }
@@ -132,7 +132,7 @@ impl Client {
                 http: ReqwestClient::new(),
                 ratelimiter: Some(Ratelimiter::new()),
                 token_invalid: AtomicBool::new(false),
-                token: Some(token),
+                token: Some(token.into_boxed_str()),
                 use_http: false,
                 default_allowed_mentions: None,
             }),
@@ -151,7 +151,7 @@ impl Client {
     /// If the initial token provided is not prefixed with `Bot `, it will be, and this method
     /// reflects that.
     pub fn token(&self) -> Option<&str> {
-        self.state.token.as_ref().map(AsRef::as_ref)
+        self.state.token.as_deref()
     }
 
     /// Get the default allowed mentions for sent messages.


### PR DESCRIPTION
Where possible, internally use `Box<str>` over Strings. This is particularly useful where we keep strings but won't ever mutate them again. This will reduce the size from 24 bytes to 16 bytes.

This does not change public APIs.