### PR TITLE
fix(model/role_tags): add visit_unit visitor

### DIFF
--- a/model/src/guild/role_tags.rs
+++ b/model/src/guild/role_tags.rs
@@ -25,6 +25,13 @@ mod premium_subscriber {
         fn visit_none<E: DeError>(self) -> Result<Self::Value, E> {
             Ok(true)
         }
+
+        // `visit_none` is used by `serde_json` when a present `null` value is
+        // encountered, but other implementations - such as `simd_json` - may
+        // use `visit_unit` instead.
+        fn visit_unit<E: DeError>(self) -> Result<Self::Value, E> {
+            Ok(true)
+        }
     }
 
     // Clippy will say this bool can be taken by value, but we need it to be


### PR DESCRIPTION
Add a `Visitor::visit_unit` implementation to the `PremiumSubscriberVisitor` in the `RoleTags` deserializer.

`serde_json` uses `Visitor::visit_none` to handle present `null` values, but other implementations such as `simd-json` can/do use `Visitor::visit_unit` instead. `serde_json` does not use `visit_unit`, so we need to support both. In order to handle `simd-json` and any other implementations, handle both.

Refer to https://github.com/simd-lite/simd-json/issues/160 for bug details.