### PR TITLE
feat(cache): add member deserialized from voice state event to cache

### DIFF
--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -665,6 +665,10 @@ impl UpdateCache for VoiceStateUpdate {
         }
 
         cache.cache_voice_state(self.0.clone());
+
+        if let (Some(guild_id), Some(member)) = (self.0.guild_id, &self.0.member) {
+            cache.cache_member(guild_id, member.clone());
+        }
     }
 }
 

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -867,6 +867,64 @@ mod tests {
     }
 
     #[test]
+    fn test_voice_states_members() {
+        use twilight_model::{guild::member::Member, user::User};
+
+        let cache = InMemoryCache::new();
+
+        let mutation = VoiceStateUpdate(VoiceState {
+            channel_id: Some(ChannelId(4)),
+            deaf: false,
+            guild_id: Some(GuildId(2)),
+            member: Some(Member {
+                deaf: false,
+                guild_id: GuildId(2),
+                hoisted_role: None,
+                joined_at: None,
+                mute: false,
+                nick: None,
+                premium_since: None,
+                roles: Vec::new(),
+                user: User {
+                    avatar: Some("".to_owned()),
+                    bot: false,
+                    discriminator: "0001".to_owned(),
+                    email: None,
+                    flags: None,
+                    id: UserId(3),
+                    locale: None,
+                    mfa_enabled: None,
+                    name: "test".to_owned(),
+                    premium_type: None,
+                    public_flags: None,
+                    system: None,
+                    verified: None,
+                },
+            }),
+            mute: false,
+            self_deaf: false,
+            self_mute: false,
+            self_stream: false,
+            session_id: "".to_owned(),
+            suppress: false,
+            token: None,
+            user_id: UserId(3),
+        });
+
+        cache.update(&mutation);
+
+        assert_eq!(cache.0.members.len(), 1);
+        {
+            let entry = cache.0.users.get(&UserId(3)).unwrap();
+            assert_eq!(entry.value().1.len(), 1);
+        }
+        assert_eq!(
+            cache.member(GuildId(2), UserId(3)).unwrap().user.name,
+            "test"
+        );
+    }
+
+    #[test]
     fn test_message_create() {
         use twilight_model::{
             channel::{


### PR DESCRIPTION
The voice state update event contains a partial member object from which a full member object can be constructed using other fields on the event.

This deserialisation is already done, so the member object may as well be added to the cache.

This is useful for bots that do not have the members intent but want to know about members when they are connected to voice.