### PR TITLE
feat!(http): use hyper instead of reqwest

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -16,25 +16,27 @@ version = "0.2.7"
 
 [dependencies]
 bytes = { default-features = false, version = "0.5" }
+rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 futures-channel = { default-features = false, version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
-twilight-model = { default-features = false, path = "../model" }
-tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
-reqwest = { default-features = false, version = "0.10" }
-serde = { default-features = false, features = ["derive"], version = "1" }
-serde_json = { default-features = false, version = "1" }
-serde_repr = { default-features = false, version = "0.1" }
-tokio = { default-features = false, version = "0.2" }
+hyper = { default-features = false, features = ["runtime"], version = "0.13" }
+hyper-rustls = { default-features = false, features = ["native-tokio"], optional = true, version = "0.21" }
+hyper-tls = { default-features = false, optional = true, version = "0.4" }
 percent-encoding = { default-features = false, version = "2" }
-url = { default-features = false, version = "2" }
+tokio = { default-features = false, features = ["time"], version = "0.2" }
+tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
+twilight-model = { default-features = false, path = "../model" }
+serde = { default-features = false, features = ["derive"], version = "1" }
+serde_json = { default-features = false, features = ["alloc"], version = "1" }
+serde_repr = { default-features = false, version = "0.1" }
 
 # optional
 simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.3" }
 
 [features]
 default = ["rustls"]
-native = ["reqwest/default-tls"]
-rustls = ["reqwest/rustls-tls"]
+native = ["hyper-tls"]
+rustls = ["hyper-rustls"]
 
 [dev-dependencies]
 serde_test = { default-features = false, version = "1" }

--- a/http/README.md
+++ b/http/README.md
@@ -40,12 +40,12 @@ twilight-http = { default-features = false, features = ["rustls", "simd-json"], 
 
 ### TLS
 
-`twilight-http` has features to enable [`reqwest`]'s TLS features. These
+`twilight-http` has features to enable [`hyper`]'s TLS features. These
 features are mutually exclusive. `rustls` is enabled by default.
 
 #### `native`
 
-The `native` feature enables [`reqwest`]'s `default-tls`
+The `native` feature enables [`hyper`]'s `default-tls`
 feature, which is mostly equivalent to using [`native-tls`].
 
 To enable `native`, do something like this in your `Cargo.toml`:
@@ -57,13 +57,13 @@ twilight-http = { default-features = false, features = ["native"], version = "0.
 
 #### `rustls`
 
-The `rustls` feature enables [`reqwest`]'s `rustls` feature, which uses
+The `rustls` feature enables [`hyper`]'s `rustls` feature, which uses
 [`rustls`] as the TLS backend.
 
 This is enabled by default.
 
 [`native-tls`]: https://crates.io/crates/native-tls
-[`reqwest`]: https://crates.io/crates/reqwest
+[`hyper`]: https://crates.io/crates/hyper
 [`rustls`]: https://crates.io/crates/rustls
 [`serde_json`]: https://crates.io/crates/serde_json
 [`simd-json`]: https://crates.io/crates/simd-json

--- a/http/examples/allowed-mentions/src/main.rs
+++ b/http/examples/allowed-mentions/src/main.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .token(env::var("DISCORD_TOKEN")?)
         //add an empty allowed mentions, this will prevent any and all pings
         .default_allowed_mentions(AllowedMentionsBuilder::new().build_solo())
-        .build()?;
+        .build();
     let channel_id = ChannelId(381_926_291_785_383_946);
     let user_id = UserId(77_469_400_222_932_992);
 

--- a/http/examples/proxy/src/main.rs
+++ b/http/examples/proxy/src/main.rs
@@ -1,6 +1,6 @@
 use futures::future;
 use std::error::Error;
-use twilight_http::client::{Client, Proxy};
+use twilight_http::Client;
 use twilight_model::id::ChannelId;
 
 #[tokio::main]
@@ -9,10 +9,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt::init();
 
     let client = Client::builder()
-        .proxy(Proxy::all("http://localhost:3000")?)
-        .proxy_http(true)
+        .proxy("localhost:3000", true)
         .ratelimiter(None)
-        .build()?;
+        .build();
     let channel_id = ChannelId(620_980_184_606_048_278);
 
     future::join_all((1u8..=10).map(|x| {

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -1,10 +1,8 @@
-use super::{Client, State};
+use super::{Client, HttpsConnector, State};
 use crate::{
-    error::{Error, Result},
-    ratelimiting::Ratelimiter,
-    request::channel::message::allowed_mentions::AllowedMentions,
+    ratelimiting::Ratelimiter, request::channel::message::allowed_mentions::AllowedMentions,
 };
-use reqwest::{ClientBuilder as ReqwestClientBuilder, Proxy};
+use hyper::client::{Client as HyperClient, HttpConnector};
 use std::{
     sync::{atomic::AtomicBool, Arc},
     time::Duration,
@@ -14,12 +12,12 @@ use std::{
 /// A builder for [`Client`].
 pub struct ClientBuilder {
     pub(crate) default_allowed_mentions: Option<AllowedMentions>,
-    pub(crate) proxy: Option<Proxy>,
-    pub(crate) proxy_http: bool,
+    pub(crate) proxy: Option<Box<str>>,
     pub(crate) ratelimiter: Option<Ratelimiter>,
-    pub(crate) reqwest_client: Option<ReqwestClientBuilder>,
+    pub(crate) hyper_client: Option<HyperClient<HttpsConnector<HttpConnector>>>,
     pub(crate) timeout: Duration,
     pub(crate) token: Option<Box<str>>,
+    pub(crate) use_http: bool,
 }
 
 impl ClientBuilder {
@@ -29,32 +27,28 @@ impl ClientBuilder {
     }
 
     /// Build the [`Client`].
-    ///
-    /// # Errors
-    ///
-    /// Errors if `reqwest` fails to build the client.
-    pub fn build(self) -> Result<Client> {
-        let mut builder = self
-            .reqwest_client
-            .unwrap_or_else(ReqwestClientBuilder::new)
-            .timeout(self.timeout);
+    pub fn build(self) -> Client {
+        let http = self.hyper_client.unwrap_or_else(|| {
+            #[cfg(feature = "hyper-rustls")]
+            let connector = hyper_rustls::HttpsConnector::new();
+            #[cfg(feature = "hyper-tls")]
+            let connector = hyper_tls::HttpsConnector::new();
 
-        if let Some(proxy) = self.proxy {
-            builder = builder.proxy(proxy)
-        }
+            hyper::client::Builder::default().build(connector)
+        });
 
-        Ok(Client {
+        Client {
             state: Arc::new(State {
-                http: builder
-                    .build()
-                    .map_err(|source| Error::BuildingClient { source })?,
+                http,
+                proxy: self.proxy,
                 ratelimiter: self.ratelimiter,
+                timeout: self.timeout,
                 token_invalid: AtomicBool::new(false),
                 token: self.token,
-                use_http: self.proxy_http,
                 default_allowed_mentions: self.default_allowed_mentions,
+                use_http: self.use_http,
             }),
-        })
+        }
     }
 
     /// Set the default allowed mentions setting to use on all messages sent through the HTTP
@@ -65,32 +59,41 @@ impl ClientBuilder {
         self
     }
 
-    /// Sets the proxy to use for all HTTP requests.
+    /// Set a pre-configured Hyper client builder to build off of.
     ///
-    /// This accepts a `reqwest::Proxy`.
-    pub fn proxy(mut self, proxy: Proxy) -> Self {
-        self.proxy.replace(proxy);
-
-        self
-    }
-
-    /// Set whether to proxy over HTTP.
-    ///
-    /// The default is `false`.
-    pub fn proxy_http(mut self, proxy_http: bool) -> Self {
-        self.proxy_http = proxy_http;
-
-        self
-    }
-
-    /// Set a pre-configured reqwest client builder to build off of.
-    ///
-    /// The proxy and timeout settings in the reqwest client will be overridden by
+    /// The proxy and timeout settings in the Hyper client will be overridden by
     /// those in this builder.
     ///
     /// The default client uses Rustls as its TLS backend.
-    pub fn reqwest_client(mut self, client: ReqwestClientBuilder) -> Self {
-        self.reqwest_client.replace(client);
+    pub fn hyper_client(mut self, client: HyperClient<HttpsConnector<HttpConnector>>) -> Self {
+        self.hyper_client.replace(client);
+
+        self
+    }
+
+    /// Set the proxy to use for all HTTP(S) requests.
+    ///
+    /// **Note** that this isn't currently a traditional proxy, but is for
+    /// working with something like [twilight's HTTP proxy server].
+    ///
+    /// # Examples
+    ///
+    /// Set the proxy to `twilight_http_proxy.internal`:
+    ///
+    /// ```rust
+    /// use twilight_http::Client;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::builder()
+    ///     .proxy("twilight_http_proxy.internal", true)
+    ///     .build();
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [twilight's HTTP proxy server]: https://github.com/twilight-rs/http-proxy
+    pub fn proxy(mut self, proxy_url: impl Into<Box<str>>, use_http: bool) -> Self {
+        self.proxy.replace(proxy_url.into());
+        self.use_http = use_http;
 
         self
     }
@@ -140,12 +143,12 @@ impl Default for ClientBuilder {
     fn default() -> Self {
         Self {
             default_allowed_mentions: None,
+            hyper_client: None,
             proxy: None,
-            proxy_http: false,
-            reqwest_client: None,
             ratelimiter: Some(Ratelimiter::new()),
             timeout: Duration::from_secs(10),
             token: None,
+            use_http: false,
         }
     }
 }

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -31,7 +31,7 @@ impl ClientBuilder {
         let http = self.hyper_client.unwrap_or_else(|| {
             #[cfg(feature = "hyper-rustls")]
             let connector = hyper_rustls::HttpsConnector::new();
-            #[cfg(feature = "hyper-tls")]
+            #[cfg(all(feature = "hyper-tls", not(feature = "hyper-rustls")))]
             let connector = hyper_tls::HttpsConnector::new();
 
             hyper::client::Builder::default().build(connector)

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -91,8 +91,8 @@ impl ClientBuilder {
     /// ```
     ///
     /// [twilight's HTTP proxy server]: https://github.com/twilight-rs/http-proxy
-    pub fn proxy(mut self, proxy_url: impl Into<Box<str>>, use_http: bool) -> Self {
-        self.proxy.replace(proxy_url.into());
+    pub fn proxy(mut self, proxy_url: impl Into<String>, use_http: bool) -> Self {
+        self.proxy.replace(proxy_url.into().into_boxed_str());
         self.use_http = use_http;
 
         self

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1,7 +1,6 @@
 mod builder;
 
 pub use self::builder::ClientBuilder;
-pub use reqwest::Proxy;
 
 use crate::{
     api_error::{ApiError, ErrorCode},
@@ -16,9 +15,11 @@ use crate::{
     API_VERSION,
 };
 use bytes::Bytes;
-use reqwest::{
+use hyper::{
+    body::{self, Buf},
+    client::{Client as HyperClient, HttpConnector},
     header::{HeaderValue, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
-    Body, Client as ReqwestClient, Method, Response, StatusCode,
+    Body, Method, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 use std::{
@@ -29,16 +30,24 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
+    time::Duration,
 };
+use tokio::time;
 use twilight_model::{
     guild::Permissions,
     id::{ChannelId, EmojiId, GuildId, IntegrationId, MessageId, RoleId, UserId, WebhookId},
 };
-use url::Url;
+
+#[cfg(feature = "hyper-rustls")]
+type HttpsConnector<T> = hyper_rustls::HttpsConnector<T>;
+#[cfg(feature = "hyper-tls")]
+type HttpsConnector<T> = hyper_tls::HttpsConnector<T>;
 
 struct State {
-    http: ReqwestClient,
+    http: HyperClient<HttpsConnector<HttpConnector>, Body>,
+    proxy: Option<Box<str>>,
     ratelimiter: Option<Ratelimiter>,
+    timeout: Duration,
     token_invalid: AtomicBool,
     token: Option<Box<str>>,
     use_http: bool,
@@ -48,7 +57,8 @@ struct State {
 impl Debug for State {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.debug_struct("State")
-            .field("http", &"Reqwest HTTP client")
+            .field("http", &self.http)
+            .field("proxy", &self.proxy)
             .field("ratelimiter", &self.ratelimiter)
             .field("token", &self.token)
             .field("use_http", &self.use_http)
@@ -96,7 +106,7 @@ impl Debug for State {
 /// let client = Client::builder()
 ///     .token("my token")
 ///     .timeout(Duration::from_secs(5))
-///     .build()?;
+///     .build();
 /// # Ok(()) }
 /// ```
 ///
@@ -110,12 +120,23 @@ pub struct Client {
 }
 
 impl Client {
-    /// Create a new client with a token.
-    ///
-    /// If you want to customize the client, use [`builder`].
-    ///
-    /// [`builder`]: Self::builder
+    /// Create a new `hyper-rustls` or `hyper-tls` backed client with a token.
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))))]
+    #[cfg(feature = "hyper-rustls")]
     pub fn new(token: impl Into<String>) -> Self {
+        let connector = hyper_rustls::HttpsConnector::new();
+
+        Self::with_connector(token, connector)
+    }
+
+    /// Create a new `hyper-rustls` or `hyper-tls` backed client with a token.
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))))]
+    #[cfg(feature = "hyper-tls")]
+    pub fn new(token: impl Into<String>) -> Self {
+        Self::with_connector(token, hyper_tls::HttpsConnector::new())
+    }
+
+    fn with_connector(token: impl Into<String>, connector: HttpsConnector<HttpConnector>) -> Self {
         let mut token = token.into();
 
         let is_bot = token.starts_with("Bot ");
@@ -129,8 +150,10 @@ impl Client {
 
         Self {
             state: Arc::new(State {
-                http: ReqwestClient::new(),
+                http: HyperClient::builder().build(connector),
+                proxy: None,
                 ratelimiter: Some(Ratelimiter::new()),
+                timeout: Duration::from_secs(10),
                 token_invalid: AtomicBool::new(false),
                 token: Some(token.into_boxed_str()),
                 use_http: false,
@@ -1447,7 +1470,7 @@ impl Client {
     ///
     /// Returns [`Error::Unauthorized`] if the configured token has become
     /// invalid due to expiration, revokation, etc.
-    pub async fn raw(&self, request: Request) -> Result<Response> {
+    pub async fn raw(&self, request: Request) -> Result<Response<Body>> {
         if self.state.token_invalid.load(Ordering::Relaxed) {
             return Err(Error::Unauthorized);
         }
@@ -1462,10 +1485,12 @@ impl Client {
         } = request;
 
         let protocol = if self.state.use_http { "http" } else { "https" };
-        let url = format!("{}://discord.com/api/v{}/{}", protocol, API_VERSION, path);
+        let host = self.state.proxy.as_deref().unwrap_or("discord.com");
+
+        let url = format!("{}://{}/api/v{}/{}", protocol, host, API_VERSION, path);
         tracing::debug!("URL: {:?}", url);
 
-        let mut builder = self.state.http.request(method.clone(), &url);
+        let mut builder = hyper::Request::builder().method(method.clone()).uri(&url);
 
         if let Some(ref token) = self.state.token {
             let value = HeaderValue::from_str(&token).map_err(|source| {
@@ -1478,18 +1503,6 @@ impl Client {
             builder = builder.header(AUTHORIZATION, value);
         }
 
-        if let Some(form) = form {
-            builder = builder.multipart(form);
-        } else if let Some(bytes) = body {
-            let len = bytes.len();
-            builder = builder.body(Body::from(bytes));
-            builder = builder.header(CONTENT_LENGTH, len);
-            let content_type = HeaderValue::from_static("application/json");
-            builder = builder.header(CONTENT_TYPE, content_type);
-        } else if method == Method::PUT || method == Method::POST || method == Method::PATCH {
-            builder = builder.header(CONTENT_LENGTH, 0);
-        }
-
         let user_agent = HeaderValue::from_static(concat!(
             "DiscordBot (",
             env!("CARGO_PKG_HOMEPAGE"),
@@ -1500,15 +1513,51 @@ impl Client {
         builder = builder.header(USER_AGENT, user_agent);
 
         if let Some(req_headers) = req_headers {
-            builder = builder.headers(req_headers);
+            for (maybe_name, value) in req_headers {
+                if let Some(name) = maybe_name {
+                    builder = builder.header(name, value);
+                }
+            }
         }
+
+        let req = if let Some(form) = form {
+            builder = builder.header(CONTENT_TYPE, form.content_type());
+            let form_bytes = form.build();
+            builder = builder.header(CONTENT_LENGTH, form_bytes.len());
+
+            builder
+                .body(Body::from(form_bytes))
+                .map_err(|source| Error::BuildingRequest { source })?
+        } else if let Some(bytes) = body {
+            let len = bytes.len();
+            builder = builder.header(CONTENT_LENGTH, len);
+            let content_type = HeaderValue::from_static("application/json");
+            builder = builder.header(CONTENT_TYPE, content_type);
+
+            builder
+                .body(Body::from(bytes))
+                .map_err(|source| Error::BuildingRequest { source })?
+        } else if method == Method::PUT || method == Method::POST || method == Method::PATCH {
+            builder = builder.header(CONTENT_LENGTH, 0);
+
+            builder
+                .body(Body::empty())
+                .map_err(|source| Error::BuildingRequest { source })?
+        } else {
+            builder
+                .body(Body::empty())
+                .map_err(|source| Error::BuildingRequest { source })?
+        };
+
+        let inner = self.state.http.request(req);
+        let fut = time::timeout(self.state.timeout, inner);
 
         let ratelimiter = match self.state.ratelimiter.as_ref() {
             Some(ratelimiter) => ratelimiter,
             None => {
-                return builder
-                    .send()
+                return fut
                     .await
+                    .map_err(|source| Error::RequestTimedOut { source })?
                     .map_err(|source| Error::RequestError { source })
             }
         };
@@ -1518,9 +1567,9 @@ impl Client {
             .await
             .map_err(|source| Error::RequestCanceled { source })?;
 
-        let resp = builder
-            .send()
+        let resp = fut
             .await
+            .map_err(|source| Error::RequestTimedOut { source })?
             .map_err(|source| Error::RequestError { source })?;
 
         // If the API sent back an Unauthorized response, then the client's
@@ -1553,17 +1602,16 @@ impl Client {
     pub async fn request<T: DeserializeOwned>(&self, request: Request) -> Result<T> {
         let resp = self.make_request(request).await?;
 
-        let bytes = resp
-            .bytes()
+        let mut buf = body::aggregate(resp.into_body())
             .await
             .map_err(|source| Error::ChunkingResponse { source })?;
 
-        let mut bytes_b = bytes.as_ref().to_vec();
+        let mut bytes = buf.to_bytes().to_vec();
 
-        let result = crate::json_from_slice(&mut bytes_b);
+        let result = crate::json_from_slice(&mut bytes);
 
         result.map_err(|source| Error::Parsing {
-            body: (*bytes).to_vec(),
+            body: bytes.to_vec(),
             source,
         })
     }
@@ -1571,9 +1619,11 @@ impl Client {
     pub(crate) async fn request_bytes(&self, request: Request) -> Result<Bytes> {
         let resp = self.make_request(request).await?;
 
-        resp.bytes()
+        let mut buf = hyper::body::aggregate(resp.into_body())
             .await
-            .map_err(|source| Error::ChunkingResponse { source })
+            .map_err(|source| Error::ChunkingResponse { source })?;
+
+        Ok(buf.to_bytes())
     }
 
     /// Execute a request, checking only that the response was a success.
@@ -1590,7 +1640,7 @@ impl Client {
         Ok(())
     }
 
-    async fn make_request(&self, request: Request) -> Result<Response> {
+    async fn make_request(&self, request: Request) -> Result<Response<Body>> {
         let resp = self.raw(request).await?;
         let status = resp.status();
 
@@ -1610,16 +1660,15 @@ impl Client {
             _ => {}
         }
 
-        let bytes = resp
-            .bytes()
+        let mut buf = hyper::body::aggregate(resp.into_body())
             .await
             .map_err(|source| Error::ChunkingResponse { source })?;
 
-        let mut bytes_b = bytes.as_ref().to_vec();
+        let mut bytes = buf.to_bytes().as_ref().to_vec();
 
         let error =
-            crate::json_from_slice::<ApiError>(&mut bytes_b).map_err(|source| Error::Parsing {
-                body: bytes.to_vec(),
+            crate::json_from_slice::<ApiError>(&mut bytes).map_err(|source| Error::Parsing {
+                body: bytes.clone(),
                 source,
             })?;
 
@@ -1630,19 +1679,21 @@ impl Client {
         }
 
         Err(Error::Response {
-            body: bytes.as_ref().to_vec(),
+            body: bytes,
             error,
             status,
         })
     }
 }
 
-impl From<ReqwestClient> for Client {
-    fn from(reqwest_client: ReqwestClient) -> Self {
+impl From<HyperClient<HttpsConnector<HttpConnector>>> for Client {
+    fn from(hyper_client: HyperClient<HttpsConnector<HttpConnector>>) -> Self {
         Self {
             state: Arc::new(State {
-                http: reqwest_client,
+                http: hyper_client,
+                proxy: None,
                 ratelimiter: Some(Ratelimiter::new()),
+                timeout: Duration::from_secs(10),
                 token_invalid: AtomicBool::new(false),
                 token: None,
                 use_http: false,
@@ -1656,8 +1707,14 @@ impl From<ReqwestClient> for Client {
 fn parse_webhook_url(
     url: impl AsRef<str>,
 ) -> std::result::Result<(WebhookId, Option<String>), UrlError> {
-    let url = Url::parse(url.as_ref())?;
-    let mut segments = url.path_segments().ok_or(UrlError::SegmentMissing)?;
+    let url = url.as_ref();
+
+    let mut segments = {
+        let mut iter = url.split(".com/");
+        iter.next().ok_or(UrlError::SegmentMissing)?;
+
+        iter.next().ok_or(UrlError::SegmentMissing)?.split('/')
+    };
 
     segments
         .next()

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -40,7 +40,7 @@ use twilight_model::{
 
 #[cfg(feature = "hyper-rustls")]
 type HttpsConnector<T> = hyper_rustls::HttpsConnector<T>;
-#[cfg(feature = "hyper-tls")]
+#[cfg(all(feature = "hyper-tls", not(feature = "hyper-rustls")))]
 type HttpsConnector<T> = hyper_tls::HttpsConnector<T>;
 
 struct State {
@@ -131,7 +131,7 @@ impl Client {
 
     /// Create a new `hyper-rustls` or `hyper-tls` backed client with a token.
     #[cfg_attr(docsrs, doc(cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))))]
-    #[cfg(feature = "hyper-tls")]
+    #[cfg(all(feature = "hyper-tls", not(feature = "hyper-rustls")))]
     pub fn new(token: impl Into<String>) -> Self {
         Self::with_connector(token, hyper_tls::HttpsConnector::new())
     }

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -122,21 +122,12 @@ pub struct Client {
 impl Client {
     /// Create a new `hyper-rustls` or `hyper-tls` backed client with a token.
     #[cfg_attr(docsrs, doc(cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))))]
-    #[cfg(feature = "hyper-rustls")]
     pub fn new(token: impl Into<String>) -> Self {
+        #[cfg(feature = "hyper-rustls")]
         let connector = hyper_rustls::HttpsConnector::new();
+        #[cfg(all(feature = "hyper-tls", not(feature = "hyper-rustls")))]
+        let connector = hyper_tls::HttpsConnector::new();
 
-        Self::with_connector(token, connector)
-    }
-
-    /// Create a new `hyper-rustls` or `hyper-tls` backed client with a token.
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))))]
-    #[cfg(all(feature = "hyper-tls", not(feature = "hyper-rustls")))]
-    pub fn new(token: impl Into<String>) -> Self {
-        Self::with_connector(token, hyper_tls::HttpsConnector::new())
-    }
-
-    fn with_connector(token: impl Into<String>, connector: HttpsConnector<HttpConnector>) -> Self {
         let mut token = token.into();
 
         let is_bot = token.starts_with("Bot ");

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -1,13 +1,16 @@
 use crate::{api_error::ApiError, ratelimiting::RatelimitError};
 use futures_channel::oneshot::Canceled;
-use reqwest::{header::InvalidHeaderValue, Error as ReqwestError, Response, StatusCode};
+use hyper::{
+    header::InvalidHeaderValue, http::Error as HttpError, Body, Error as HyperError, Response,
+    StatusCode,
+};
 use std::{
     error::Error as StdError,
     fmt::{Display, Error as FmtError, Formatter, Result as FmtResult},
     num::ParseIntError,
     result::Result as StdResult,
 };
-use url::ParseError as UrlParseError;
+use tokio::time::Elapsed;
 
 #[cfg(not(feature = "simd-json"))]
 use serde_json::Error as JsonError;
@@ -19,7 +22,6 @@ pub type Result<T, E = Error> = StdResult<T, E>;
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum UrlError {
-    UrlParsing { source: UrlParseError },
     IdParsing { source: ParseIntError },
     SegmentMissing,
 }
@@ -27,7 +29,6 @@ pub enum UrlError {
 impl Display for UrlError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::UrlParsing { source, .. } => write!(f, "Url path couldn't be parsed: {}", source),
             Self::IdParsing { source, .. } => {
                 write!(f, "Url path segment wasn't a valid ID: {}", source)
             }
@@ -39,16 +40,9 @@ impl Display for UrlError {
 impl StdError for UrlError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Self::UrlParsing { source, .. } => Some(source),
             Self::IdParsing { source, .. } => Some(source),
             Self::SegmentMissing => None,
         }
-    }
-}
-
-impl From<UrlParseError> for UrlError {
-    fn from(source: UrlParseError) -> Self {
-        Self::UrlParsing { source }
     }
 }
 
@@ -61,11 +55,11 @@ impl From<ParseIntError> for UrlError {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
-    BuildingClient {
-        source: ReqwestError,
+    BuildingRequest {
+        source: HttpError,
     },
     ChunkingResponse {
-        source: ReqwestError,
+        source: HyperError,
     },
     CreatingHeader {
         name: String,
@@ -91,7 +85,11 @@ pub enum Error {
         source: Canceled,
     },
     RequestError {
-        source: ReqwestError,
+        source: HyperError,
+    },
+    RequestTimedOut {
+        /// Source of the error when the request timed out.
+        source: Elapsed,
     },
     Response {
         body: Vec<u8>,
@@ -103,7 +101,7 @@ pub enum Error {
     ///
     /// This may occur during Discord API stability incidents.
     ServiceUnavailable {
-        response: Response,
+        response: Response<Body>,
     },
     /// Token in use has become revoked or is otherwise invalid.
     ///
@@ -133,9 +131,7 @@ impl From<UrlError> for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::BuildingClient { .. } => {
-                f.write_str("HTTP client couldn't be built due to a reqwest client error")
-            }
+            Self::BuildingRequest { .. } => f.write_str("failed to build the request"),
             Self::ChunkingResponse { .. } => f.write_str("Chunking the response failed"),
             Self::CreatingHeader { name, .. } => {
                 write!(f, "Parsing the value for header {} failed", name)
@@ -151,6 +147,7 @@ impl Display for Error {
                 f.write_str("Request was canceled either before or while being sent")
             }
             Self::RequestError { .. } => f.write_str("Parsing or sending the response failed"),
+            Self::RequestTimedOut { .. } => f.write_str("request timed out"),
             Self::Response { error, status, .. } => write!(
                 f,
                 "Response error: status code {}, error: {}",
@@ -167,15 +164,16 @@ impl Display for Error {
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
+            Self::BuildingRequest { source } => Some(source),
             Self::CreatingHeader { source, .. } => Some(source),
             Self::Formatting { source } => Some(source),
             Self::Json { source } | Self::Parsing { source, .. } => Some(source),
             Self::Url { source } => Some(source),
             Self::Ratelimiting { source } => Some(source),
             Self::RequestCanceled { source } => Some(source),
-            Self::BuildingClient { source }
-            | Self::ChunkingResponse { source }
+            Self::ChunkingResponse { source }
             | Self::RequestError { source } => Some(source),
+            Self::RequestTimedOut { source } => Some(source),
             Self::Response { .. } | Self::ServiceUnavailable { .. } | Self::Unauthorized => None,
         }
     }

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -171,8 +171,7 @@ impl StdError for Error {
             Self::Url { source } => Some(source),
             Self::Ratelimiting { source } => Some(source),
             Self::RequestCanceled { source } => Some(source),
-            Self::ChunkingResponse { source }
-            | Self::RequestError { source } => Some(source),
+            Self::ChunkingResponse { source } | Self::RequestError { source } => Some(source),
             Self::RequestTimedOut { source } => Some(source),
             Self::Response { .. } | Self::ServiceUnavailable { .. } | Self::Unauthorized => None,
         }

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -38,12 +38,12 @@
 //!
 //! ### TLS
 //!
-//! `twilight-http` has features to enable [`reqwest`]'s TLS features. These
+//! `twilight-http` has features to enable [`hyper`]'s TLS features. These
 //! features are mutually exclusive. `rustls` is enabled by default.
 //!
 //! #### `native`
 //!
-//! The `native` feature enables [`reqwest`]'s `default-tls`
+//! The `native` feature enables [`hyper`]'s `default-tls`
 //! feature, which is mostly equivalent to using [`native-tls`].
 //!
 //! To enable `native`, do something like this in your `Cargo.toml`:
@@ -55,13 +55,13 @@
 //!
 //! #### `rustls`
 //!
-//! The `rustls` feature enables [`reqwest`]'s `rustls` feature, which uses
+//! The `rustls` feature enables [`hyper`]'s `rustls` feature, which uses
 //! [`rustls`] as the TLS backend.
 //!
 //! This is enabled by default.
 //!
 //! [`native-tls`]: https://crates.io/crates/native-tls
-//! [`reqwest`]: https://crates.io/crates/reqwest
+//! [`hyper`]: https://crates.io/crates/hyper
 //! [`rustls`]: https://crates.io/crates/rustls
 //! [`serde_json`]: https://crates.io/crates/serde_json
 //! [`simd-json`]: https://crates.io/crates/simd-json
@@ -89,6 +89,7 @@
     clippy::must_use_candidate,
     clippy::missing_errors_doc
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod api_error;
 pub mod client;

--- a/http/src/ratelimiting/error.rs
+++ b/http/src/ratelimiting/error.rs
@@ -1,4 +1,4 @@
-use reqwest::header::ToStrError;
+use hyper::header::ToStrError;
 use std::{
     error::Error as StdError,
     fmt::{Display, Formatter, Result as FmtResult},

--- a/http/src/ratelimiting/headers.rs
+++ b/http/src/ratelimiting/headers.rs
@@ -1,5 +1,5 @@
 use super::error::{RatelimitError, RatelimitResult};
-use reqwest::header::{HeaderMap, HeaderValue};
+use hyper::header::{HeaderMap, HeaderValue};
 use std::convert::TryFrom;
 
 #[derive(Clone, Debug)]

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -1,9 +1,5 @@
 use super::allowed_mentions::{AllowedMentions, AllowedMentionsBuilder, Unspecified};
-use crate::request::prelude::*;
-use reqwest::{
-    multipart::{Form, Part},
-    Body,
-};
+use crate::request::{multipart::Form, prelude::*};
 use std::{
     collections::HashMap,
     error::Error,
@@ -89,7 +85,7 @@ pub(crate) struct CreateMessageFields {
 /// # Ok(()) }
 /// ```
 pub struct CreateMessage<'a> {
-    attachments: HashMap<String, Body>,
+    attachments: HashMap<String, Vec<u8>>,
     channel_id: ChannelId,
     pub(crate) fields: CreateMessageFields,
     fut: Option<Pending<'a, Message>>,
@@ -120,14 +116,14 @@ impl<'a> CreateMessage<'a> {
     /// Attach a new file to the message.
     ///
     /// The file is raw binary data. It can be an image, or any other kind of file.
-    pub fn attachment(mut self, name: impl Into<String>, file: impl Into<Body>) -> Self {
+    pub fn attachment(mut self, name: impl Into<String>, file: impl Into<Vec<u8>>) -> Self {
         self.attachments.insert(name.into(), file.into());
 
         self
     }
 
     /// Insert multiple attachments into the message.
-    pub fn attachments<N: Into<String>, F: Into<Body>>(
+    pub fn attachments<N: Into<String>, F: Into<Vec<u8>>>(
         mut self,
         attachments: impl IntoIterator<Item = (N, F)>,
     ) -> Self {
@@ -235,17 +231,17 @@ impl<'a> CreateMessage<'a> {
                     },
                 ))
             } else {
-                let mut form = Form::new();
+                let mut multipart = Form::new();
 
                 for (index, (name, file)) in self.attachments.drain().enumerate() {
-                    form = form.part(format!("{}", index), Part::stream(file).file_name(name));
+                    multipart.file(format!("{}", index).as_bytes(), name.as_bytes(), &file);
                 }
 
                 let body = crate::json_to_vec(&self.fields)?;
-                form = form.part("payload_json", Part::bytes(body));
+                multipart.part(b"payload_json", &body);
 
                 Request::from((
-                    form,
+                    multipart,
                     Route::CreateMessage {
                         channel_id: self.channel_id.0,
                     },

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -1,4 +1,5 @@
 use crate::{request::prelude::*, Error};
+use hyper::StatusCode;
 use serde::Deserialize;
 use std::{
     future::Future,
@@ -49,7 +50,7 @@ impl Future for GetGuildVanityUrl<'_> {
                 let bytes = match fut.as_mut().poll(cx) {
                     Poll::Ready(Ok(bytes)) => bytes,
                     Poll::Ready(Err(crate::Error::Response { status, .. }))
-                        if status == reqwest::StatusCode::NOT_FOUND =>
+                        if status == StatusCode::NOT_FOUND =>
                     {
                         return Poll::Ready(Ok(None));
                     }

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -1,4 +1,5 @@
 use crate::request::prelude::*;
+use hyper::StatusCode;
 use serde::de::DeserializeSeed;
 use std::{
     future::Future,
@@ -55,7 +56,7 @@ impl Future for GetMember<'_> {
                 let bytes = match fut.as_mut().poll(cx) {
                     Poll::Ready(Ok(bytes)) => bytes,
                     Poll::Ready(Err(crate::Error::Response { status, .. }))
-                        if status == reqwest::StatusCode::NOT_FOUND =>
+                        if status == StatusCode::NOT_FOUND =>
                     {
                         return Poll::Ready(Ok(None));
                     }

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -36,7 +36,7 @@ macro_rules! poll_req {
                         let bytes = match fut.as_mut().poll(cx) {
                             Poll::Ready(Ok(bytes)) => bytes,
                             Poll::Ready(Err(crate::Error::Response { status, .. }))
-                                if status == reqwest::StatusCode::NOT_FOUND =>
+                                if status == hyper::StatusCode::NOT_FOUND =>
                             {
                                 return Poll::Ready(Ok(None));
                             }
@@ -72,6 +72,7 @@ mod get_gateway;
 mod get_gateway_authed;
 mod get_user_application;
 mod get_voice_regions;
+mod multipart;
 mod validate;
 
 pub use self::{
@@ -82,17 +83,17 @@ pub use self::{
     get_voice_regions::GetVoiceRegions,
 };
 
+use self::multipart::Form;
 use crate::{
     error::{Error, Result},
     routing::{Path, Route},
 };
 use bytes::Bytes;
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
-use reqwest::{
+use hyper::{
     header::{HeaderMap, HeaderName, HeaderValue},
-    multipart::Form,
     Method,
 };
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
 use std::{borrow::Cow, future::Future, pin::Pin};
 

--- a/http/src/request/multipart.rs
+++ b/http/src/request/multipart.rs
@@ -1,0 +1,92 @@
+use rand::{distributions::Alphanumeric, Rng};
+
+#[derive(Debug)]
+pub struct Form {
+    boundary: [u8; 15],
+    buffer: Vec<u8>,
+}
+
+impl Form {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn build(mut self) -> Vec<u8> {
+        self.buffer.extend(b"\r\n");
+        self.boundary();
+        self.buffer.extend(b"--");
+
+        self.buffer
+    }
+
+    pub fn content_type(&self) -> Vec<u8> {
+        const NAME: &str = "multipart/form-data; boundary=";
+
+        let mut content_type = Vec::with_capacity(NAME.len() + 15);
+        content_type.extend(NAME.as_bytes());
+        content_type.extend(&self.boundary);
+
+        content_type
+    }
+
+    pub fn file(&mut self, name: &[u8], filename: &[u8], data: &[u8]) -> &mut Self {
+        self.start();
+        self.name(name);
+        self.filename(filename);
+        self.data(data);
+
+        self
+    }
+
+    pub fn part(&mut self, name: &[u8], data: &[u8]) -> &mut Self {
+        self.start();
+        self.name(name);
+        self.data(data);
+
+        self
+    }
+
+    fn start(&mut self) {
+        self.buffer.extend(b"\r\n");
+        self.boundary();
+        self.buffer.extend(b"\r\nContent-Disposition: form-data");
+    }
+
+    fn boundary(&mut self) {
+        self.buffer.extend(b"--");
+        self.buffer.extend(&self.boundary);
+    }
+
+    fn filename(&mut self, filename: &[u8]) {
+        self.buffer.extend(br#"; filename=""#);
+        self.buffer.extend(filename);
+        self.buffer.push(b'"');
+    }
+
+    fn name(&mut self, name: &[u8]) {
+        self.buffer.extend(br#"; name=""#);
+        self.buffer.extend(name);
+        self.buffer.push(b'"');
+    }
+
+    fn data(&mut self, data: &[u8]) {
+        self.buffer.extend(b"\r\n\r\n");
+        self.buffer.extend(data);
+    }
+}
+
+impl Default for Form {
+    fn default() -> Self {
+        let mut boundary = [0; 15];
+        let mut rng = rand::thread_rng();
+
+        for value in &mut boundary {
+            *value = rng.sample(Alphanumeric);
+        }
+
+        Self {
+            boundary,
+            buffer: Vec::new(),
+        }
+    }
+}

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -1,4 +1,4 @@
-use reqwest::Method;
+use hyper::Method;
 use std::{
     borrow::Cow,
     convert::TryFrom,
@@ -1522,7 +1522,7 @@ impl Route {
 #[cfg(test)]
 mod tests {
     use super::{Path, PathParseError};
-    use reqwest::Method;
+    use hyper::Method;
     use std::{convert::TryFrom, error::Error, str::FromStr};
 
     #[test]

--- a/lavalink/examples/basic-lavalink-bot/Cargo.toml
+++ b/lavalink/examples/basic-lavalink-bot/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
+hyper = { features = ["runtime"], version = "0.13" }
 tracing = "0.1"
 tracing-subscriber = "0.2"
-reqwest = { features = ["json"], version = "0.10" }
 serde_json = { version = "1" }
 tokio = { features = ["macros", "rt-threaded"], version = "0.2" }
 twilight-gateway = { path = "../../../gateway" }


### PR DESCRIPTION
Use `hyper` as the backing HTTP client instead of `reqwest`.

This reduces the depth of the dependency tree and allows us to update faster when downstream crates have breaking changes that break our API and reduces the dependency count. The dependency count has been reduced from 126 to 111.

This comes with mostly minimal API changes:

- `ClientBuilder::build` no longer returns a `Result`
- `ClientBuilder::reqwest_client` is now `hyper_client`
- `ClientBuilder::{proxy_http, proxy}` are combined into `ClientBuilder::proxy` and take an `impl Into<Box<str>>`
- `Client::raw` now returns a Hyper `Response<Body>` instead of a Reqwest one
- `error::UrlError::UrlParsing` has been removed
- `error::Error::BuildingClient` has been removed
- `error::Error::{ChunkingResponse, RequestError}` are now Hyper errors instead of Reqwest errors.
- `CreateMessage::attachment{,s}` now takes a `impl Into<Vec<u8>>` file instead of a reqwest `impl Into<Body>`.

Closes #656.