### PR TITLE
Move webhook URL methods to util

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -4,7 +4,7 @@ pub use self::builder::ClientBuilder;
 
 use crate::{
     api_error::{ApiError, ErrorCode},
-    error::{Error, Result, UrlError},
+    error::{Error, Result},
     ratelimiting::{RatelimitHeaders, Ratelimiter},
     request::{
         channel::message::allowed_mentions::AllowedMentions,
@@ -1306,29 +1306,9 @@ impl Client {
         DeleteWebhook::new(self, id)
     }
 
-    /// Delete a webhook by its URL.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`UrlError::SegmentMissing`] if the URL can not be parsed.
-    pub fn delete_webhook_from_url(&self, url: impl AsRef<str>) -> Result<DeleteWebhook<'_>> {
-        let (id, _) = parse_webhook_url(url)?;
-        Ok(self.delete_webhook(id))
-    }
-
     /// Update a webhook by ID.
     pub fn update_webhook(&self, webhook_id: WebhookId) -> UpdateWebhook<'_> {
         UpdateWebhook::new(self, webhook_id)
-    }
-
-    /// Update a webhook by its URL.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`UrlError::SegmentMissing`] if the URL can not be parsed.
-    pub fn update_webhook_from_url(&self, url: impl AsRef<str>) -> Result<UpdateWebhook<'_>> {
-        let (id, _) = parse_webhook_url(url)?;
-        Ok(self.update_webhook(id))
     }
 
     /// Update a webhook, with a token, by ID.
@@ -1338,19 +1318,6 @@ impl Client {
         token: impl Into<String>,
     ) -> UpdateWebhookWithToken<'_> {
         UpdateWebhookWithToken::new(self, webhook_id, token)
-    }
-
-    /// Update a webhook, with a token, by its URL.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`UrlError::SegmentMissing`] if the URL can not be parsed.
-    pub fn update_webhook_with_token_from_url(
-        &self,
-        url: impl AsRef<str>,
-    ) -> Result<UpdateWebhookWithToken<'_>> {
-        let (id, token) = parse_webhook_url(url)?;
-        Ok(self.update_webhook_with_token(id, token.ok_or(UrlError::SegmentMissing)?))
     }
 
     /// Executes a webhook, sending a message to its channel.
@@ -1384,16 +1351,6 @@ impl Client {
         token: impl Into<String>,
     ) -> ExecuteWebhook<'_> {
         ExecuteWebhook::new(self, webhook_id, token)
-    }
-
-    /// Execute a webhook by its URL.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`UrlError::SegmentMissing`] if the URL can not be parsed.
-    pub fn execute_webhook_from_url(&self, url: impl AsRef<str>) -> Result<ExecuteWebhook<'_>> {
-        let (id, token) = parse_webhook_url(url)?;
-        Ok(self.execute_webhook(id, token.ok_or(UrlError::SegmentMissing)?))
     }
 
     /// Update a message executed by a webhook.
@@ -1682,65 +1639,5 @@ impl From<HyperClient<HttpsConnector<HttpConnector>>> for Client {
                 default_allowed_mentions: None,
             }),
         }
-    }
-}
-
-/// Parse the webhook ID and token, if it exists in the string.
-fn parse_webhook_url(
-    url: impl AsRef<str>,
-) -> std::result::Result<(WebhookId, Option<String>), UrlError> {
-    let url = url.as_ref();
-
-    let mut segments = {
-        let mut iter = url.split(".com/");
-        iter.next().ok_or(UrlError::SegmentMissing)?;
-
-        iter.next().ok_or(UrlError::SegmentMissing)?.split('/')
-    };
-
-    segments
-        .next()
-        .filter(|s| s == &"api")
-        .ok_or(UrlError::SegmentMissing)?;
-    segments
-        .next()
-        .filter(|s| s == &"webhooks")
-        .ok_or(UrlError::SegmentMissing)?;
-    let id = segments.next().ok_or(UrlError::SegmentMissing)?;
-    let token = segments.next();
-
-    Ok((WebhookId(id.parse()?), token.map(String::from)))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{parse_webhook_url, WebhookId};
-    use std::error::Error;
-
-    #[test]
-    fn parse_webhook_id() -> Result<(), Box<dyn Error>> {
-        assert_eq!(
-            parse_webhook_url("https://discord.com/api/webhooks/123")?,
-            (WebhookId(123), None)
-        );
-        assert!(parse_webhook_url("https://discord.com/foo/bar/456").is_err());
-        assert!(parse_webhook_url("https://discord.com/api/webhooks/").is_err());
-
-        Ok(())
-    }
-
-    #[test]
-    fn parse_webhook_token() -> Result<(), Box<dyn Error>> {
-        assert_eq!(
-            parse_webhook_url("https://discord.com/api/webhooks/456/token")?,
-            (WebhookId(456), Some("token".into()))
-        );
-
-        assert_eq!(
-            parse_webhook_url("https://discord.com/api/webhooks/456/token/slack")?,
-            (WebhookId(456), Some("token".into()))
-        );
-
-        Ok(())
     }
 }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -16,8 +16,9 @@ version = "0.2.0"
 
 [features]
 default = []
+link = ["twilight-model"]
 snowflake = ["twilight-model"]
-full = ["snowflake"]
+full = ["link", "snowflake"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -35,6 +35,10 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "link")]
+#[cfg_attr(docsrs, doc(cfg(feature = "link")))]
+pub mod link;
+
 #[cfg(feature = "snowflake")]
 #[cfg_attr(docsrs, doc(cfg(feature = "snowflake")))]
 pub mod snowflake;

--- a/util/src/link/mod.rs
+++ b/util/src/link/mod.rs
@@ -1,0 +1,3 @@
+//! Utilities for parsing and formatting links to various resources.
+
+pub mod webhook;

--- a/util/src/link/webhook.rs
+++ b/util/src/link/webhook.rs
@@ -1,0 +1,201 @@
+//! Utilities for parsing webhook URLs.
+//!
+//! The URL is typically provided by the desktop client GUI when configuring a
+//! webhook integration.
+
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+    num::ParseIntError,
+};
+use twilight_model::id::WebhookId;
+
+/// Error when [parsing] a webhook URL.
+///
+/// [parsing]: parse
+#[allow(clippy::module_name_repetitions)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum WebhookParseError {
+    /// ID segment in the URL path is not an integer.
+    IdInvalid {
+        /// Reason for the error.
+        source: ParseIntError,
+    },
+    /// Required segment of the URL path is missing.
+    SegmentMissing,
+}
+
+impl Display for WebhookParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::IdInvalid { .. } => f.write_str("url path segment isn't a valid ID"),
+            Self::SegmentMissing => f.write_str("url is missing a required path segment"),
+        }
+    }
+}
+
+impl Error for WebhookParseError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::IdInvalid { source } => Some(source),
+            Self::SegmentMissing => None,
+        }
+    }
+}
+
+/// Parse the webhook ID and token from a webhook URL, if it exists in the
+/// string.
+///
+/// # Examples
+///
+/// Parse a webhook URL with a token:
+///
+/// ```
+/// use twilight_model::id::WebhookId;
+/// use twilight_util::link::webhook;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let url = "https://canary.discord.com/api/webhooks/794590023369752587/tjxHaPHLKp9aEdSwJuLeHhHHGEqIxt1aay4I67FOP9uzsYEWmj0eJmDn-2ZvCYLyOb_K";
+///
+/// let (id, token) = webhook::parse(url)?;
+/// assert_eq!(WebhookId(794590023369752587), id);
+/// assert_eq!(
+///     Some("tjxHaPHLKp9aEdSwJuLeHhHHGEqIxt1aay4I67FOP9uzsYEWmj0eJmDn-2ZvCYLyOb_K"),
+///     token,
+/// );
+/// # Ok(()) }
+/// ```
+///
+/// Parse a webhook URL without a token:
+///
+/// ```
+/// use twilight_model::id::WebhookId;
+/// use twilight_util::link::webhook;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let url = "https://canary.discord.com/api/webhooks/794590023369752587";
+///
+/// let (id, token) = webhook::parse(url)?;
+/// assert_eq!(WebhookId(794590023369752587), id);
+/// assert!(token.is_none());
+/// # Ok(()) }
+/// ```
+///
+/// # Errors
+///
+/// Returns [`WebhookParseError::IdInvalid`] if the ID segment of the URL is not
+/// a valid integer.
+///
+/// Returns [`WebhookParseError::SegmentMissing`] if one of the required
+/// segments is missing. This can be the "api" or "webhooks" standard segment
+/// of the URL or the segment containing the webhook ID.
+pub fn parse(url: &str) -> Result<(WebhookId, Option<&str>), WebhookParseError> {
+    let mut segments = {
+        let mut start = url.split("discord.com/api/webhooks/");
+        let path = start.nth(1).ok_or(WebhookParseError::SegmentMissing)?;
+
+        path.split('/')
+    };
+
+    let id_segment = segments.next().ok_or(WebhookParseError::SegmentMissing)?;
+
+    // If we don't have this check it'll return `IdInvalid`, which isn't right.
+    if id_segment.is_empty() {
+        return Err(WebhookParseError::SegmentMissing);
+    }
+
+    let id = id_segment
+        .parse()
+        .map_err(|source| WebhookParseError::IdInvalid { source })?;
+    let mut token = segments.next();
+
+    // Don't return an empty token if the segment is empty.
+    if token.map(str::is_empty).unwrap_or_default() {
+        token = None;
+    }
+
+    Ok((WebhookId(id), token))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WebhookId, WebhookParseError};
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{
+        error::Error,
+        fmt::{Debug, Display},
+    };
+
+    assert_fields!(WebhookParseError::IdInvalid: source);
+    assert_impl_all!(
+        WebhookParseError: Clone,
+        Debug,
+        Display,
+        Eq,
+        Error,
+        PartialEq
+    );
+
+    #[test]
+    fn test_parse_no_token() {
+        assert_eq!(
+            (WebhookId(123), None),
+            super::parse("https://discord.com/api/webhooks/123").unwrap(),
+        );
+        // There's a / after the ID signifying another segment, but the token
+        // ends up being None.
+        assert_eq!(
+            (WebhookId(123), None),
+            super::parse("https://discord.com/api/webhooks/123").unwrap(),
+        );
+        assert!(super::parse("https://discord.com/api/webhooks/123/")
+            .unwrap()
+            .1
+            .is_none());
+    }
+
+    #[test]
+    fn test_parse_with_token() {
+        assert_eq!(
+            super::parse("https://discord.com/api/webhooks/456/token").unwrap(),
+            (WebhookId(456), Some("token")),
+        );
+        // The value of the segment(s) after the token are ignored.
+        assert_eq!(
+            super::parse("https://discord.com/api/webhooks/456/token/github").unwrap(),
+            (WebhookId(456), Some("token")),
+        );
+        assert_eq!(
+            super::parse("https://discord.com/api/webhooks/456/token/slack").unwrap(),
+            (WebhookId(456), Some("token")),
+        );
+        assert_eq!(
+            super::parse("https://discord.com/api/webhooks/456/token/randomsegment").unwrap(),
+            (WebhookId(456), Some("token")),
+        );
+        assert_eq!(
+            super::parse("https://discord.com/api/webhooks/456/token/one/two/three").unwrap(),
+            (WebhookId(456), Some("token")),
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid() {
+        // Base URL is improper.
+        assert_eq!(
+            WebhookParseError::SegmentMissing,
+            super::parse("https://discord.com/foo/bar/456").unwrap_err(),
+        );
+        // No ID is present.
+        assert_eq!(
+            WebhookParseError::SegmentMissing,
+            super::parse("https://discord.com/api/webhooks/").unwrap_err(),
+        );
+        // ID segment isn't an integer.
+        assert!(matches!(
+            super::parse("https://discord.com/api/webhooks/notaninteger").unwrap_err(),
+            WebhookParseError::IdInvalid { .. },
+        ));
+    }
+}


### PR DESCRIPTION
Remove methods in the client to perform webhook actions by webhook URL.

These methods include:

- delete_webhook_from_url
- execute_webhook_from_url
- update_webhook_with_token_from_url
- update_webhook_from_url

There's not really any *programmatic* reason to have these methods. You don't receive URLs from the API. The only place you get them from is the GUI desktop client, which can easily have the token and ID manually taken out from anyway.

This also removes the `error::UrlError` type and `error::Error::Url` variant, as well as the `url` dependency.