### PR TITLE
Use Vecs in models instead of HashMaps

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -599,32 +599,32 @@ impl InMemoryCache {
         // objects always has a place to put them.
         if self.wants(ResourceType::CHANNEL) {
             self.0.guild_channels.insert(guild.id, HashSet::new());
-            self.cache_guild_channels(guild.id, guild.channels.into_iter().map(|(_, v)| v));
+            self.cache_guild_channels(guild.id, guild.channels);
         }
 
         if self.wants(ResourceType::EMOJI) {
             self.0.guild_emojis.insert(guild.id, HashSet::new());
-            self.cache_emojis(guild.id, guild.emojis.into_iter().map(|(_, v)| v));
+            self.cache_emojis(guild.id, guild.emojis);
         }
 
         if self.wants(ResourceType::MEMBER) {
             self.0.guild_members.insert(guild.id, HashSet::new());
-            self.cache_members(guild.id, guild.members.into_iter().map(|(_, v)| v));
+            self.cache_members(guild.id, guild.members);
         }
 
         if self.wants(ResourceType::PRESENCE) {
             self.0.guild_presences.insert(guild.id, HashSet::new());
-            self.cache_presences(guild.id, guild.presences.into_iter().map(|(_, v)| v));
+            self.cache_presences(guild.id, guild.presences);
         }
 
         if self.wants(ResourceType::ROLE) {
             self.0.guild_roles.insert(guild.id, HashSet::new());
-            self.cache_roles(guild.id, guild.roles.into_iter().map(|(_, v)| v));
+            self.cache_roles(guild.id, guild.roles);
         }
 
         if self.wants(ResourceType::VOICE_STATE) {
             self.0.voice_state_guilds.insert(guild.id, HashSet::new());
-            self.cache_voice_states(guild.voice_states.into_iter().map(|(_, v)| v));
+            self.cache_voice_states(guild.voice_states);
         }
 
         let guild = CachedGuild {
@@ -943,7 +943,7 @@ fn presence_user_id(presence: &Presence) -> UserId {
 #[cfg(test)]
 mod tests {
     use crate::InMemoryCache;
-    use std::{borrow::Cow, collections::HashMap};
+    use std::borrow::Cow;
     use twilight_model::{
         channel::{ChannelType, GuildChannel, TextChannel},
         gateway::payload::{MemberRemove, RoleDelete},
@@ -1066,24 +1066,21 @@ mod tests {
 
     #[test]
     fn test_guild_create_channels_have_guild_ids() {
-        let mut channels = HashMap::new();
-        channels.insert(
-            ChannelId(111),
-            GuildChannel::Text(TextChannel {
-                id: ChannelId(111),
-                guild_id: None,
-                kind: ChannelType::GuildText,
-                last_message_id: None,
-                last_pin_timestamp: None,
-                name: "guild channel with no guild id".to_owned(),
-                nsfw: true,
-                permission_overwrites: Vec::new(),
-                parent_id: None,
-                position: 1,
-                rate_limit_per_user: None,
-                topic: None,
-            }),
-        );
+        let mut channels = Vec::new();
+        channels.push(GuildChannel::Text(TextChannel {
+            id: ChannelId(111),
+            guild_id: None,
+            kind: ChannelType::GuildText,
+            last_message_id: None,
+            last_pin_timestamp: None,
+            name: "guild channel with no guild id".to_owned(),
+            nsfw: true,
+            permission_overwrites: Vec::new(),
+            parent_id: None,
+            position: 1,
+            rate_limit_per_user: None,
+            topic: None,
+        }));
 
         let guild = Guild {
             id: GuildId(123),
@@ -1095,7 +1092,7 @@ mod tests {
             default_message_notifications: DefaultMessageNotificationLevel::Mentions,
             description: None,
             discovery_splash: None,
-            emojis: HashMap::new(),
+            emojis: Vec::new(),
             explicit_content_filter: ExplicitContentFilter::AllMembers,
             features: vec![],
             icon: None,
@@ -1105,7 +1102,7 @@ mod tests {
             max_members: Some(50),
             max_presences: Some(100),
             member_count: Some(25),
-            members: HashMap::new(),
+            members: Vec::new(),
             mfa_level: MfaLevel::Elevated,
             name: "this is a guild".to_owned(),
             owner: Some(false),
@@ -1114,16 +1111,16 @@ mod tests {
             preferred_locale: "en-GB".to_owned(),
             premium_subscription_count: Some(0),
             premium_tier: PremiumTier::None,
-            presences: HashMap::new(),
+            presences: Vec::new(),
             region: "us-east".to_owned(),
-            roles: HashMap::new(),
+            roles: Vec::new(),
             splash: None,
             system_channel_id: None,
             system_channel_flags: SystemChannelFlags::SUPPRESS_JOIN_NOTIFICATIONS,
             rules_channel_id: None,
             unavailable: false,
             verification_level: VerificationLevel::VeryHigh,
-            voice_states: HashMap::new(),
+            voice_states: Vec::new(),
             vanity_url_code: None,
             widget_channel_id: None,
             widget_enabled: None,

--- a/cache/in-memory/src/model/message.rs
+++ b/cache/in-memory/src/model/message.rs
@@ -59,7 +59,7 @@ impl From<Message> for CachedMessage {
             mention_channels: msg.mention_channels,
             mention_everyone: msg.mention_everyone,
             mention_roles: msg.mention_roles,
-            mentions: msg.mentions.keys().copied().collect(),
+            mentions: msg.mentions.iter().map(|mention| mention.id).collect(),
             pinned: msg.pinned,
             reactions: msg.reactions,
             reference: msg.reference,

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -244,7 +244,7 @@ impl UpdateCache for GuildEmojisUpdate {
             return;
         }
 
-        cache.cache_emojis(self.guild_id, self.emojis.values().cloned());
+        cache.cache_emojis(self.guild_id, self.emojis.clone());
     }
 }
 
@@ -315,9 +315,9 @@ impl UpdateCache for MemberChunk {
             return;
         }
 
-        cache.cache_members(self.guild_id, self.members.values().cloned());
+        cache.cache_members(self.guild_id, self.members.clone());
         let mut guild = cache.0.guild_members.entry(self.guild_id).or_default();
-        guild.extend(self.members.keys());
+        guild.extend(self.members.iter().map(|member| member.user.id));
     }
 }
 
@@ -617,7 +617,7 @@ impl UpdateCache for Ready {
         }
 
         if cache.wants(ResourceType::GUILD) {
-            for status in self.guilds.values() {
+            for status in &self.guilds {
                 match status {
                     GuildStatus::Offline(u) => {
                         cache.unavailable_guild(u.id);
@@ -713,7 +713,6 @@ impl UpdateCache for WebhooksUpdate {}
 mod tests {
     use super::*;
     use crate::config::ResourceType;
-    use std::collections::HashMap;
     use twilight_model::{
         channel::{
             message::{MessageFlags, MessageType},
@@ -791,7 +790,7 @@ mod tests {
             mention_channels: Vec::new(),
             mention_everyone: false,
             mention_roles: Vec::new(),
-            mentions: HashMap::new(),
+            mentions: Vec::new(),
             pinned: false,
             reactions: Vec::new(),
             reference: None,
@@ -889,11 +888,11 @@ mod tests {
             approximate_member_count: None,
             approximate_presence_count: None,
             banner: None,
-            channels: HashMap::new(),
+            channels: Vec::new(),
             default_message_notifications: DefaultMessageNotificationLevel::Mentions,
             description: None,
             discovery_splash: None,
-            emojis: HashMap::new(),
+            emojis: Vec::new(),
             explicit_content_filter: ExplicitContentFilter::None,
             features: Vec::new(),
             icon: None,
@@ -905,7 +904,7 @@ mod tests {
             max_presences: None,
             max_video_channel_users: None,
             member_count: None,
-            members: HashMap::new(),
+            members: Vec::new(),
             mfa_level: MfaLevel::None,
             name: "test".to_owned(),
             owner_id: UserId(1),
@@ -914,9 +913,9 @@ mod tests {
             preferred_locale: "en_us".to_owned(),
             premium_subscription_count: None,
             premium_tier: PremiumTier::None,
-            presences: HashMap::new(),
+            presences: Vec::new(),
             region: "us".to_owned(),
-            roles: HashMap::new(),
+            roles: Vec::new(),
             rules_channel_id: None,
             splash: None,
             system_channel_flags: SystemChannelFlags::empty(),
@@ -924,7 +923,7 @@ mod tests {
             unavailable: false,
             vanity_url_code: None,
             verification_level: VerificationLevel::VeryHigh,
-            voice_states: HashMap::new(),
+            voice_states: Vec::new(),
             widget_channel_id: None,
             widget_enabled: None,
         };
@@ -1132,7 +1131,7 @@ mod tests {
             mention_channels: Vec::new(),
             mention_everyone: false,
             mention_roles: Vec::new(),
-            mentions: HashMap::new(),
+            mentions: Vec::new(),
             pinned: false,
             reactions: Vec::new(),
             reference: None,

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -17,7 +17,6 @@ version = "0.2.7"
 [dependencies]
 bitflags = { default-features = false, version = "1" }
 serde = { default-features = false, features = ["derive"], version = "1" }
-serde-mappable-seq = { default-features = false, version = "0.1" }
 serde-value = { default-features = false, version = "0.7" }
 serde_repr = { default-features = false, version = "0.1" }
 tracing = { default-features = false, version = "0.1" }

--- a/model/src/channel/message/mention.rs
+++ b/model/src/channel/message/mention.rs
@@ -4,7 +4,6 @@ use crate::{
     user::{self, UserFlags},
 };
 use serde::{Deserialize, Serialize};
-use serde_mappable_seq::Key;
 
 /// Mention of a user in a message.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -32,12 +31,6 @@ pub struct Mention {
     pub name: String,
     /// Public flags on the user's account.
     pub public_flags: UserFlags,
-}
-
-impl Key<'_, UserId> for Mention {
-    fn key(&self) -> UserId {
-        self.id
-    }
 }
 
 #[cfg(test)]

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -18,11 +18,10 @@ pub use self::{
 use crate::{
     channel::{embed::Embed, Attachment, ChannelMention},
     guild::PartialMember,
-    id::{ChannelId, GuildId, MessageId, RoleId, UserId, WebhookId},
+    id::{ChannelId, GuildId, MessageId, RoleId, WebhookId},
     user::User,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Message {
@@ -49,8 +48,7 @@ pub struct Message {
     pub mention_channels: Vec<ChannelMention>,
     pub mention_everyone: bool,
     pub mention_roles: Vec<RoleId>,
-    #[serde(with = "serde_mappable_seq")]
-    pub mentions: HashMap<UserId, Mention>,
+    pub mentions: Vec<Mention>,
     pub pinned: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub reactions: Vec<MessageReaction>,
@@ -85,7 +83,6 @@ mod tests {
         user::User,
     };
     use serde_test::Token;
-    use std::collections::HashMap;
 
     #[allow(clippy::too_many_lines)]
     #[test]
@@ -128,7 +125,7 @@ mod tests {
             mention_channels: Vec::new(),
             mention_everyone: false,
             mention_roles: Vec::new(),
-            mentions: HashMap::new(),
+            mentions: Vec::new(),
             pinned: false,
             reactions: Vec::new(),
             reference: None,
@@ -321,7 +318,7 @@ mod tests {
             }],
             mention_everyone: false,
             mention_roles: Vec::new(),
-            mentions: HashMap::new(),
+            mentions: Vec::new(),
             pinned: false,
             reactions: vec![MessageReaction {
                 count: 7,

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -26,16 +26,10 @@ pub use self::{
 
 use crate::id::{ChannelId, GuildId, MessageId};
 use serde::{
-    de::{
-        DeserializeSeed, Deserializer, Error as DeError, IgnoredAny, MapAccess, SeqAccess, Visitor,
-    },
+    de::{Deserializer, Error as DeError, IgnoredAny, MapAccess, Visitor},
     Deserialize, Serialize,
 };
-use serde_mappable_seq::Key;
-use std::{
-    collections::HashMap,
-    fmt::{self, Formatter, Result as FmtResult},
-};
+use std::fmt::{self, Formatter, Result as FmtResult};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ConversionError {
@@ -117,16 +111,6 @@ impl GuildChannel {
             Self::Category(category) => category.name.as_ref(),
             Self::Text(text) => text.name.as_ref(),
             Self::Voice(voice) => voice.name.as_ref(),
-        }
-    }
-}
-
-impl Key<'_, ChannelId> for GuildChannel {
-    fn key(&self) -> ChannelId {
-        match self {
-            Self::Category(c) => c.id,
-            Self::Text(c) => c.id,
-            Self::Voice(c) => c.id,
         }
     }
 }
@@ -399,45 +383,6 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
 impl<'de> Deserialize<'de> for GuildChannel {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         deserializer.deserialize_map(GuildChannelVisitor)
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct GuildChannelMapDeserializer;
-
-struct GuildChannelMapVisitor;
-
-impl<'de> Visitor<'de> for GuildChannelMapVisitor {
-    type Value = HashMap<ChannelId, GuildChannel>;
-
-    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_str("a sequence of guild channels")
-    }
-
-    fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
-        let mut map = seq
-            .size_hint()
-            .map_or_else(HashMap::new, HashMap::with_capacity);
-
-        let span = tracing::trace_span!("adding elements to guild channel map");
-        let _span_enter = span.enter();
-
-        while let Some(channel) = seq.next_element::<GuildChannel>()? {
-            let id = channel.id();
-            tracing::trace!(%id, ?channel);
-
-            map.insert(channel.id(), channel);
-        }
-
-        Ok(map)
-    }
-}
-
-impl<'de> DeserializeSeed<'de> for GuildChannelMapDeserializer {
-    type Value = HashMap<ChannelId, GuildChannel>;
-
-    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
-        deserializer.deserialize_seq(GuildChannelMapVisitor)
     }
 }
 

--- a/model/src/gateway/payload/guild_emojis_update.rs
+++ b/model/src/gateway/payload/guild_emojis_update.rs
@@ -1,13 +1,8 @@
-use crate::{
-    guild::Emoji,
-    id::{EmojiId, GuildId},
-};
+use crate::{guild::Emoji, id::GuildId};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct GuildEmojisUpdate {
-    #[serde(with = "serde_mappable_seq")]
-    pub emojis: HashMap<EmojiId, Emoji>,
+    pub emojis: Vec<Emoji>,
     pub guild_id: GuildId,
 }

--- a/model/src/gateway/payload/ready.rs
+++ b/model/src/gateway/payload/ready.rs
@@ -1,11 +1,9 @@
-use crate::{guild::GuildStatus, id::GuildId, user::CurrentUser};
+use crate::{guild::GuildStatus, user::CurrentUser};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Ready {
-    #[serde(with = "serde_mappable_seq")]
-    pub guilds: HashMap<GuildId, GuildStatus>,
+    pub guilds: Vec<GuildStatus>,
     pub session_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard: Option<[u64; 2]>,

--- a/model/src/guild/emoji.rs
+++ b/model/src/guild/emoji.rs
@@ -2,15 +2,7 @@ use crate::{
     id::{EmojiId, RoleId},
     user::User,
 };
-use serde::{
-    de::{DeserializeSeed, Deserializer, SeqAccess, Visitor},
-    Deserialize, Serialize,
-};
-use serde_mappable_seq::Key;
-use std::{
-    collections::HashMap,
-    fmt::{Formatter, Result as FmtResult},
-};
+use serde::{Deserialize, Serialize};
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -32,50 +24,6 @@ pub struct Emoji {
     pub roles: Vec<RoleId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
-}
-
-impl Key<'_, EmojiId> for Emoji {
-    fn key(&self) -> EmojiId {
-        self.id
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EmojiMapDeserializer;
-
-struct EmojiMapVisitor;
-
-impl<'de> Visitor<'de> for EmojiMapVisitor {
-    type Value = HashMap<EmojiId, Emoji>;
-
-    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_str("a sequence of emojis")
-    }
-
-    fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
-        let mut map = seq
-            .size_hint()
-            .map_or_else(HashMap::new, HashMap::with_capacity);
-
-        let span = tracing::trace_span!("adding elements to emoji map");
-        let _span_enter = span.enter();
-
-        while let Some(emoji) = seq.next_element::<Emoji>()? {
-            tracing::trace!(%emoji.id, ?emoji);
-
-            map.insert(emoji.id, emoji);
-        }
-
-        Ok(map)
-    }
-}
-
-impl<'de> DeserializeSeed<'de> for EmojiMapDeserializer {
-    type Value = HashMap<EmojiId, Emoji>;
-
-    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
-        deserializer.deserialize_seq(EmojiMapVisitor)
-    }
 }
 
 #[cfg(test)]

--- a/model/src/guild/integration.rs
+++ b/model/src/guild/integration.rs
@@ -4,7 +4,6 @@ use crate::{
     user::User,
 };
 use serde::{Deserialize, Serialize};
-use serde_mappable_seq::Key;
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct GuildIntegration {
@@ -34,12 +33,6 @@ pub struct GuildIntegration {
     pub syncing: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
-}
-
-impl Key<'_, IntegrationId> for GuildIntegration {
-    fn key(&self) -> IntegrationId {
-        self.id
-    }
 }
 
 #[cfg(test)]

--- a/model/src/guild/partial_guild.rs
+++ b/model/src/guild/partial_guild.rs
@@ -3,10 +3,9 @@ use crate::{
         DefaultMessageNotificationLevel, Emoji, ExplicitContentFilter, MfaLevel, Permissions,
         PremiumTier, Role, SystemChannelFlags, VerificationLevel,
     },
-    id::{ApplicationId, ChannelId, EmojiId, GuildId, RoleId, UserId},
+    id::{ApplicationId, ChannelId, GuildId, UserId},
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PartialGuild {
@@ -18,8 +17,7 @@ pub struct PartialGuild {
     pub default_message_notifications: DefaultMessageNotificationLevel,
     pub description: Option<String>,
     pub discovery_splash: Option<String>,
-    #[serde(with = "serde_mappable_seq")]
-    pub emojis: HashMap<EmojiId, Emoji>,
+    pub emojis: Vec<Emoji>,
     pub explicit_content_filter: ExplicitContentFilter,
     pub features: Vec<String>,
     pub icon: Option<String>,
@@ -41,8 +39,7 @@ pub struct PartialGuild {
     pub premium_subscription_count: Option<u64>,
     pub premium_tier: PremiumTier,
     pub region: String,
-    #[serde(with = "serde_mappable_seq")]
-    pub roles: HashMap<RoleId, Role>,
+    pub roles: Vec<Role>,
     pub rules_channel_id: Option<ChannelId>,
     pub splash: Option<String>,
     pub system_channel_flags: SystemChannelFlags,
@@ -63,7 +60,6 @@ mod tests {
         VerificationLevel,
     };
     use serde_test::Token;
-    use std::collections::HashMap;
 
     #[allow(clippy::too_many_lines)]
     #[test]
@@ -77,7 +73,7 @@ mod tests {
             default_message_notifications: DefaultMessageNotificationLevel::Mentions,
             description: Some("a description".to_owned()),
             discovery_splash: Some("discovery splash hash".to_owned()),
-            emojis: HashMap::new(),
+            emojis: Vec::new(),
             explicit_content_filter: ExplicitContentFilter::MembersWithoutRole,
             features: vec!["a feature".to_owned()],
             icon: Some("icon hash".to_owned()),
@@ -93,7 +89,7 @@ mod tests {
             premium_subscription_count: Some(3),
             premium_tier: PremiumTier::Tier1,
             region: "us-west".to_owned(),
-            roles: HashMap::new(),
+            roles: Vec::new(),
             rules_channel_id: Some(ChannelId(6)),
             splash: Some("splash hash".to_owned()),
             system_channel_flags: SystemChannelFlags::SUPPRESS_PREMIUM_SUBSCRIPTIONS,

--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -1,14 +1,6 @@
 use super::RoleTags;
 use crate::{guild::Permissions, id::RoleId};
-use serde::{
-    de::{DeserializeSeed, Deserializer, SeqAccess, Visitor},
-    Deserialize, Serialize,
-};
-use serde_mappable_seq::Key;
-use std::{
-    collections::HashMap,
-    fmt::{Formatter, Result as FmtResult},
-};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Role {
@@ -23,50 +15,6 @@ pub struct Role {
     /// Tags about the role.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<RoleTags>,
-}
-
-impl Key<'_, RoleId> for Role {
-    fn key(&self) -> RoleId {
-        self.id
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RoleMapDeserializer;
-
-struct RoleMapDeserializerVisitor;
-
-impl<'de> Visitor<'de> for RoleMapDeserializerVisitor {
-    type Value = HashMap<RoleId, Role>;
-
-    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_str("a sequence of roles")
-    }
-
-    fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<Self::Value, S::Error> {
-        let mut map = seq
-            .size_hint()
-            .map_or_else(HashMap::new, HashMap::with_capacity);
-
-        let span = tracing::trace_span!("adding elements to role map");
-        let _span_enter = span.enter();
-
-        while let Some(role) = seq.next_element::<Role>()? {
-            tracing::trace!(%role.id, ?role);
-
-            map.insert(role.id, role);
-        }
-
-        Ok(map)
-    }
-}
-
-impl<'de> DeserializeSeed<'de> for RoleMapDeserializer {
-    type Value = HashMap<RoleId, Role>;
-
-    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
-        deserializer.deserialize_seq(RoleMapDeserializerVisitor)
-    }
 }
 
 #[cfg(test)]

--- a/model/src/guild/status.rs
+++ b/model/src/guild/status.rs
@@ -1,9 +1,5 @@
-use crate::{
-    guild::{Guild, UnavailableGuild},
-    id::GuildId,
-};
+use crate::guild::{Guild, UnavailableGuild};
 use serde::{Deserialize, Serialize};
-use serde_mappable_seq::Key;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(untagged)]
@@ -12,18 +8,10 @@ pub enum GuildStatus {
     Offline(UnavailableGuild),
 }
 
-impl Key<'_, GuildId> for GuildStatus {
-    fn key(&self) -> GuildId {
-        match self {
-            Self::Online(g) => g.id,
-            Self::Offline(u) => u.id,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{GuildId, GuildStatus, UnavailableGuild};
+    use super::{GuildStatus, UnavailableGuild};
+    use crate::id::GuildId;
     use serde_test::Token;
 
     // Notably, the important thing to test is that it's untagged.

--- a/model/src/user/connection.rs
+++ b/model/src/user/connection.rs
@@ -1,14 +1,13 @@
-use crate::{guild::GuildIntegration, id::IntegrationId, user::ConnectionVisibility};
+use crate::{guild::GuildIntegration, user::ConnectionVisibility};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Connection {
     pub friend_sync: bool,
     pub id: String,
-    #[serde(with = "serde_mappable_seq", default)]
-    pub integrations: HashMap<IntegrationId, GuildIntegration>,
+    #[serde(default)]
+    pub integrations: Vec<GuildIntegration>,
     #[serde(rename = "type")]
     pub kind: String,
     pub name: String,
@@ -23,14 +22,13 @@ pub struct Connection {
 mod tests {
     use super::{Connection, ConnectionVisibility};
     use serde_test::Token;
-    use std::collections::HashMap;
 
     #[test]
     fn test_connection() {
         let value = Connection {
             friend_sync: true,
             id: "connection id".to_owned(),
-            integrations: HashMap::new(),
+            integrations: Vec::new(),
             kind: "integration type".to_owned(),
             name: "integration name".to_owned(),
             revoked: Some(false),

--- a/model/src/user/mod.rs
+++ b/model/src/user/mod.rs
@@ -14,7 +14,6 @@ pub use self::{
 
 use crate::id::UserId;
 use serde::{Deserialize, Serialize};
-use serde_mappable_seq::Key;
 
 pub(crate) mod discriminator {
     use serde::{
@@ -83,12 +82,6 @@ pub struct User {
     pub system: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verified: Option<bool>,
-}
-
-impl Key<'_, UserId> for User {
-    fn key(&self) -> UserId {
-        self.id
-    }
 }
 
 #[cfg(test)]

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -858,7 +858,7 @@ mod tests {
     use super::Standby;
     use futures_util::StreamExt;
     use static_assertions::assert_impl_all;
-    use std::{collections::HashMap, fmt::Debug};
+    use std::fmt::Debug;
     use twilight_model::{
         channel::{
             message::{Message, MessageType},
@@ -906,7 +906,7 @@ mod tests {
             mention_channels: Vec::new(),
             mention_everyone: false,
             mention_roles: Vec::new(),
-            mentions: HashMap::new(),
+            mentions: Vec::new(),
             pinned: false,
             reactions: Vec::new(),
             reference: None,
@@ -995,7 +995,7 @@ mod tests {
     #[tokio::test]
     async fn test_wait_for_event() {
         let ready = Ready {
-            guilds: HashMap::new(),
+            guilds: Vec::new(),
             session_id: String::new(),
             shard: Some([5, 7]),
             user: CurrentUser {


### PR DESCRIPTION
Use Vecs to store lists of entities instead of HashMaps. HashMaps will take a bit more memory and time to deserialize and a `Vec` is closer to the actual API representation. If users need a HashMap of a list of entities then one can easily be made via `HashMap::from_iter`.

This also removes the `serde-mappable-seq` dependency, which is deprecated.