### PR TITLE
Upgrade to Tokio 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ crates through the gateway.
 
 ```rust,no_run
 use std::{env, error::Error};
-use tokio::stream::StreamExt;
+use futures::stream::StreamExt;
 use twilight_cache_inmemory::{EventType, InMemoryCache};
 use twilight_gateway::{cluster::{Cluster, ShardScheme}, Event};
 use twilight_http::Client as HttpClient;

--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -22,6 +22,7 @@ twilight-model = { default-features = false, path = "../../model" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 
 [dev-dependencies]
+futures = { default-features = false, version = "0.3" }
 static_assertions = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }
+tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
 twilight-gateway = { path = "../../gateway" }

--- a/cache/in-memory/README.md
+++ b/cache/in-memory/README.md
@@ -14,7 +14,7 @@ Update a cache with events that come in through the gateway:
 
 ```rust,no_run
 use std::env;
-use tokio::stream::StreamExt;
+use futures::stream::StreamExt;
 use twilight_cache_inmemory::InMemoryCache;
 use twilight_gateway::{Intents, Shard};
 

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```rust,no_run
 //! use std::env;
-//! use tokio::stream::StreamExt;
+//! use futures::stream::StreamExt;
 //! use twilight_cache_inmemory::InMemoryCache;
 //! use twilight_gateway::{Intents, Shard};
 //!

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -15,18 +15,19 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.2.6"
 
 [dependencies]
-async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.9.3" }
+async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.11" }
 bitflags = { default-features = false, version = "1" }
 twilight-gateway-queue = { default-features = false, path = "./queue" }
 twilight-http = { default-features = false, path = "../http" }
 twilight-model = { default-features = false, path = "../model" }
 futures-channel = { default-features = false, features = ["sink"], version = "0.3" }
-futures-util = { default-features = false, features = ["std"], version = "0.3" }
+futures-timer = { default-features = false, version = "3.0" }
+futures-util = { default-features = false, features = ["async-await-macro", "std"], version = "0.3" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 once_cell = { default-features = false, features = ["std"], version = "1" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["net", "rt-core", "sync"], version = "0.2" }
+tokio = { default-features = false, features = ["net", "rt", "sync"], version = "1.0" }
 url = { default-features = false, version = "2" }
 # The default backend for flate2; miniz-oxide, works differently
 # from the C-backed backend zlib, When you give it the sync argument
@@ -42,7 +43,7 @@ simd-json = { default-features = false, features = ["serde_impl", "swar-number-p
 [dev-dependencies]
 futures = { default-features = false, version = "0.3" }
 static_assertions = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["rt-core", "macros"], version = "0.2" }
+tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
 
 [features]
 default = ["rustls", "stock-zlib"]

--- a/gateway/examples/cluster/Cargo.toml
+++ b/gateway/examples/cluster/Cargo.toml
@@ -8,4 +8,4 @@ version = "0.1.0"
 twilight-gateway = { path = "../.." }
 futures = "0.3"
 tracing-subscriber = "0.2"
-tokio = { version = "0.2", features = ["macros", "rt-core"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/gateway/examples/intents/Cargo.toml
+++ b/gateway/examples/intents/Cargo.toml
@@ -8,4 +8,4 @@ version = "0.1.0"
 twilight-gateway = { path = "../.." }
 futures = "0.3"
 tracing-subscriber = "0.2"
-tokio = "0.2"
+tokio = "1.0"

--- a/gateway/examples/metrics/Cargo.toml
+++ b/gateway/examples/metrics/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 futures = "0.3"
 log = { default-features = false, version = "0.4" }
 metrics-runtime = { default-features = false, features = ["metrics-exporter-log", "metrics-observer-json"], version = "0.13" }
-tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }
+tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
 tracing-log = { default-features = false, features = ["log-tracer", "std"], version = "0.1" }
 tracing-subscriber = { default-features = false, features = ["fmt"], version = "0.2" }
 twilight-gateway = { path = "../..", features = ["metrics"] }

--- a/gateway/examples/request-members/Cargo.toml
+++ b/gateway/examples/request-members/Cargo.toml
@@ -10,4 +10,4 @@ twilight-gateway = { path = "../.." }
 twilight-model = { path = "../../../model"}
 futures = "0.3"
 tracing-subscriber = "0.2"
-tokio = { version = "0.2", features = ["macros", "rt-core"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/gateway/examples/shard/Cargo.toml
+++ b/gateway/examples/shard/Cargo.toml
@@ -8,4 +8,4 @@ version = "0.1.0"
 twilight-gateway = { path = "../.." }
 futures = "0.3"
 tracing-subscriber = "0.2"
-tokio = { version = "0.2", features = ["macros", "rt-core"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/gateway/queue/Cargo.toml
+++ b/gateway/queue/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.2.1"
 [dependencies]
 futures-channel = { default-features = false, features = ["sink"], version = "0.3" }
 futures-util = { default-features = false, features = ["std", "sink"], version = "0.3" }
-tokio = { default-features = false, features = ["net", "rt-core", "sync"], version = "0.2" }
+tokio = { default-features = false, features = ["net", "rt-multi-thread", "sync"], version = "1.0" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-http = { path = "../../http", default-features = false }
 

--- a/gateway/queue/src/day_limiter.rs
+++ b/gateway/queue/src/day_limiter.rs
@@ -80,7 +80,7 @@ impl DayLimiter {
             lock.current += 1;
         } else {
             let wait = lock.last_check + lock.next_reset;
-            time::delay_until(wait).await;
+            time::sleep_until(wait).await;
             if let Ok(info) = lock.http.gateway().authed().await {
                 let last_check = Instant::now();
                 let next_reset = Duration::from_millis(info.session_start_limit.remaining);

--- a/gateway/queue/src/large_bot_queue.rs
+++ b/gateway/queue/src/large_bot_queue.rs
@@ -5,7 +5,7 @@ use futures_channel::{
 };
 use futures_util::{sink::SinkExt, stream::StreamExt};
 use std::{fmt::Debug, future::Future, pin::Pin, time::Duration};
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 /// Queue built for single-process clusters that require identifying via
 /// [Sharding for Very Large Bots].
@@ -69,7 +69,7 @@ async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
         if let Err(err) = req.send(()) {
             tracing::warn!("skipping, send failed with: {:?}", err);
         }
-        delay_for(DUR).await;
+        sleep(DUR).await;
     }
 }
 

--- a/gateway/queue/src/lib.rs
+++ b/gateway/queue/src/lib.rs
@@ -44,7 +44,7 @@ use futures_channel::{
 };
 use futures_util::{sink::SinkExt, stream::StreamExt};
 use std::{fmt::Debug, future::Future, pin::Pin, time::Duration};
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 /// Queue for shards to request the ability to initialize new sessions with the
 /// gateway.
@@ -114,7 +114,7 @@ async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
         if let Err(err) = req.send(()) {
             tracing::warn!("skipping, send failed: {:?}", err);
         }
-        delay_for(DUR).await;
+        sleep(DUR).await;
     }
 }
 

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -285,7 +285,7 @@ impl Cluster {
     /// let cluster = Cluster::new(env::var("DISCORD_TOKEN")?, Intents::empty()).await?;
     /// cluster.up().await;
     ///
-    /// tokio::time::delay_for(Duration::from_secs(60)).await;
+    /// tokio::time::sleep(Duration::from_secs(60)).await;
     ///
     /// for (shard_id, info) in cluster.info() {
     ///     println!(

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -117,6 +117,10 @@
     warnings
 )]
 #![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
+// Required due to `futures_util::select!`.
+//
+// <https://github.com/rust-lang/futures-rs/issues/1917>
+#![recursion_limit = "256"]
 
 pub mod cluster;
 pub mod shard;

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -294,7 +294,7 @@ impl Shard {
     /// let mut shard = Shard::new(token, intents);
     /// shard.start().await?;
     ///
-    /// tokio_time::delay_for(Duration::from_secs(1)).await;
+    /// tokio_time::sleep(Duration::from_secs(1)).await;
     ///
     /// let info = shard.info()?;
     /// println!("Shard stage: {}", info.stage());

--- a/gateway/src/shard/processor/heartbeat.rs
+++ b/gateway/src/shard/processor/heartbeat.rs
@@ -209,7 +209,7 @@ impl Heartbeater {
         let mut last = true;
 
         loop {
-            tokio::time::delay_for(duration).await;
+            tokio::time::sleep(duration).await;
 
             // Check if a heartbeat acknowledgement was received.
             //

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -770,7 +770,7 @@ impl ShardProcessor {
                 wait_in_seconds = wait.as_secs(),
                 "waiting before attempting a reconnect",
             );
-            tokio::time::delay_for(wait).await;
+            tokio::time::sleep(wait).await;
 
             // Await allowance when doing a full reconnect.
             self.config.queue.request(self.config.shard()).await;
@@ -861,7 +861,7 @@ impl ShardProcessor {
         self.rx = rx;
         self.session = Arc::new(Session::new(tx));
 
-        if let Err(why) = self.wtx.broadcast(Arc::clone(&self.session)) {
+        if let Err(why) = self.wtx.send(Arc::clone(&self.session)) {
             tracing::error!("failed to broadcast new session: {:?}", why);
         }
 

--- a/gateway/src/shard/processor/mod.rs
+++ b/gateway/src/shard/processor/mod.rs
@@ -5,6 +5,7 @@ mod r#impl;
 mod inflater;
 mod session;
 mod socket_forwarder;
+mod throttle;
 
 pub use self::{
     heartbeat::Latency,

--- a/gateway/src/shard/processor/throttle.rs
+++ b/gateway/src/shard/processor/throttle.rs
@@ -1,0 +1,33 @@
+use futures_timer::Delay;
+use futures_util::{future::FutureExt, ready, stream::Stream};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+pub struct Throttle {
+    delay: Delay,
+    duration: Duration,
+}
+
+impl Throttle {
+    pub fn new(duration: Duration) -> Self {
+        Self {
+            delay: Delay::new(duration),
+            duration,
+        }
+    }
+}
+
+impl Stream for Throttle {
+    type Item = ();
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        ready!(self.delay.poll_unpin(cx));
+        let duration = self.duration;
+        self.delay.reset(duration);
+
+        Poll::Ready(Some(()))
+    }
+}

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -19,7 +19,7 @@ bytes = { default-features = false, version = "1.0" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 futures-channel = { default-features = false, version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
-hyper = { default-features = false, features = ["full"], version = "0.14" }
+hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
 hyper-rustls = { default-features = false, features = ["native-tokio"], optional = true, version = "0.22" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
 percent-encoding = { default-features = false, version = "2" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -15,15 +15,15 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.2.7"
 
 [dependencies]
-bytes = { default-features = false, version = "0.5" }
+bytes = { default-features = false, version = "1.0" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 futures-channel = { default-features = false, version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
-hyper = { default-features = false, features = ["runtime"], version = "0.13" }
-hyper-rustls = { default-features = false, features = ["native-tokio"], optional = true, version = "0.21" }
-hyper-tls = { default-features = false, optional = true, version = "0.4" }
+hyper = { default-features = false, features = ["full"], version = "0.14" }
+hyper-rustls = { default-features = false, features = ["native-tokio"], optional = true, version = "0.22" }
+hyper-tls = { default-features = false, optional = true, version = "0.5" }
 percent-encoding = { default-features = false, version = "2" }
-tokio = { default-features = false, features = ["time"], version = "0.2" }
+tokio = { default-features = false, features = ["time"], version = "1.0" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-model = { default-features = false, path = "../model" }
 serde = { default-features = false, features = ["derive"], version = "1" }
@@ -41,5 +41,5 @@ rustls = ["hyper-rustls"]
 [dev-dependencies]
 serde_test = { default-features = false, version = "1" }
 static_assertions = { default-features = false, version = "1.1.0" }
-tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }
 twilight-embed-builder = { default-features = false, path = "../embed-builder" }
+tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }

--- a/http/examples/allowed-mentions/Cargo.toml
+++ b/http/examples/allowed-mentions/Cargo.toml
@@ -9,4 +9,4 @@ version = "0.0.1"
 twilight-http = { path = "../.." }
 twilight-model = { path = "../../../model" }
 tracing-subscriber = "0.2"
-tokio = { version = "0.2", features = ["macros", "rt-core"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/http/examples/get-message/Cargo.toml
+++ b/http/examples/get-message/Cargo.toml
@@ -10,4 +10,4 @@ twilight-http = { path = "../.." }
 twilight-model = { path = "../../../model" }
 futures = "0.3"
 tracing-subscriber = "0.2"
-tokio = { version = "0.2", features = ["macros", "rt-core"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/http/examples/get-message/src/main.rs
+++ b/http/examples/get-message/src/main.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt::init();
 
     let client = Client::new(env::var("DISCORD_TOKEN")?);
-    let channel_id = ChannelId(716280314422624266);
+    let channel_id = ChannelId(381_926_291_785_383_946);
 
     future::join_all((1u8..=10).map(|x| {
         client

--- a/http/examples/get-message/src/main.rs
+++ b/http/examples/get-message/src/main.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt::init();
 
     let client = Client::new(env::var("DISCORD_TOKEN")?);
-    let channel_id = ChannelId(381_926_291_785_383_946);
+    let channel_id = ChannelId(716280314422624266);
 
     future::join_all((1u8..=10).map(|x| {
         client

--- a/http/examples/proxy/Cargo.toml
+++ b/http/examples/proxy/Cargo.toml
@@ -10,4 +10,4 @@ twilight-http = { path = "../.." }
 twilight-model = { path = "../../../model" }
 futures = "0.3"
 tracing-subscriber = "0.2"
-tokio = { version = "0.2", features = ["macros", "rt-core"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -30,7 +30,7 @@ impl ClientBuilder {
     pub fn build(self) -> Client {
         let http = self.hyper_client.unwrap_or_else(|| {
             #[cfg(feature = "hyper-rustls")]
-            let connector = hyper_rustls::HttpsConnector::new();
+            let connector = hyper_rustls::HttpsConnector::with_native_roots();
             #[cfg(all(feature = "hyper-tls", not(feature = "hyper-rustls")))]
             let connector = hyper_tls::HttpsConnector::new();
 

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -10,7 +10,7 @@ use std::{
     num::ParseIntError,
     result::Result as StdResult,
 };
-use tokio::time::Elapsed;
+use tokio::time::error::Elapsed;
 
 #[cfg(not(feature = "simd-json"))]
 use serde_json::Error as JsonError;

--- a/http/src/ratelimiting/bucket.rs
+++ b/http/src/ratelimiting/bucket.rs
@@ -13,7 +13,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use tokio::time::{delay_for, timeout};
+use tokio::time::{sleep, timeout};
 
 #[derive(Clone, Debug)]
 pub enum TimeRemaining {
@@ -234,7 +234,7 @@ impl BucketQueueTask {
         tracing::debug!(path=?self.path, "request got global ratelimited");
         self.global.lock();
         let lock = self.global.0.lock().await;
-        delay_for(Duration::from_millis(wait)).await;
+        sleep(Duration::from_millis(wait)).await;
         self.global.unlock();
 
         drop(lock);
@@ -275,7 +275,7 @@ impl BucketQueueTask {
             "waiting for ratelimit to pass",
         );
 
-        delay_for(wait).await;
+        sleep(wait).await;
 
         tracing::debug!(parent: &span, "done waiting for ratelimit to pass");
 

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.2.1"
 
 [dependencies]
-async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.9.3" }
+async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.11" }
 dashmap = { default-features = false, version = "3" }
 futures-channel = { default-features = false, features = ["std"], version = "0.3" }
 futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }
@@ -24,13 +24,13 @@ tracing = { default-features = false, features = ["std", "attributes"], version 
 percent-encoding = { default-features = false, optional = true, version = "2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }
 serde_json = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["net", "rt-core", "time"], version = "0.2" }
+tokio = { default-features = false, features = ["net", "rt", "time"], version = "1.0" }
 twilight-model = { default-features = false, path = "../model" }
 
 [dev-dependencies]
 serde_test = { default-features = false, version = "1" }
 static_assertions = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }
+tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
 twilight-gateway = { path = "../gateway" }
 twilight-http = { path = "../http" }
 

--- a/lavalink/examples/basic-lavalink-bot/Cargo.toml
+++ b/lavalink/examples/basic-lavalink-bot/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-hyper = { features = ["runtime"], version = "0.14" }
+hyper = { features = ["client", "http1", "http2", "runtime"], version = "0.14" }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 serde_json = { version = "1" }

--- a/lavalink/examples/basic-lavalink-bot/Cargo.toml
+++ b/lavalink/examples/basic-lavalink-bot/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-hyper = { features = ["runtime"], version = "0.13" }
+hyper = { features = ["runtime"], version = "0.14" }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 serde_json = { version = "1" }
-tokio = { features = ["macros", "rt-threaded"], version = "0.2" }
+tokio = { features = ["macros", "rt-multi-thread"], version = "1.0" }
 twilight-gateway = { path = "../../../gateway" }
 twilight-http = { path = "../../../http" }
 twilight-lavalink = { path = "../.." }

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -551,7 +551,7 @@ async fn backoff(
                     seconds,
                     config.address,
                 );
-                tokio_time::delay_for(Duration::from_secs(seconds)).await;
+                tokio_time::sleep(Duration::from_secs(seconds)).await;
 
                 seconds *= 2;
 

--- a/standby/Cargo.toml
+++ b/standby/Cargo.toml
@@ -24,4 +24,4 @@ twilight-model = { default-features = false, path = "../model" }
 [dev-dependencies]
 static_assertions = { default-features = false, version = "1" }
 twilight-gateway = { path = "../gateway" }
-tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }
+tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }

--- a/twilight/Cargo.toml
+++ b/twilight/Cargo.toml
@@ -15,7 +15,8 @@ readme = "../README.md"
 version = "0.2.2"
 
 [dev-dependencies]
-tokio = { default-features = false, features = ["macros", "rt-core"], version = "0.2" }
+futures = { default-features = false, version = "0.3" }
+tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
 tracing-log = { default-features = false, features = ["log-tracer", "std"], version = "0.1" }
 twilight-cache-inmemory = { default-features = false, path = "../cache/in-memory" }
 twilight-command-parser = { path = "../command-parser" }

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -121,7 +121,7 @@
 //!
 //! ```rust,no_run
 //! use std::{env, error::Error};
-//! use tokio::stream::StreamExt;
+//! use futures::stream::StreamExt;
 //! use twilight_cache_inmemory::{EventType, InMemoryCache};
 //! use twilight_gateway::{cluster::{Cluster, ShardScheme}, Event};
 //! use twilight_http::Client as HttpClient;


### PR DESCRIPTION
Upgrade Tokio to 1.0 as well as all related dependencies. In total, this results in upgrading:

- async-tungstenite: 0.11
- hyper: 0.14
- hyper-rustls: 0.22
- hyper-tls: 0.5
- tokio: 1.0

The migration is not very interesting; changing `tokio::time::delay_for`s to `tokio::time:sleep`s and such. Tokio has changed the `rt-core` feature to `rt` and `rt-threaded` to `rt-multi-thread`, so the examples have been updated for this.

Notably, due to `tokio::time::throttle` being moved to a separate crate - `tokio-stream` - and working oddly, a thin throttle stream has been manually implemented.

Blocks on #657.

Closes #649.