### PR TITLE
chore: update dashmap, patricia_tree

### DIFF
--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.2.5"
 
 [dependencies]
 bitflags = { default-features = false, version = "1" }
-dashmap = { default-features = false, version = "3" }
+dashmap = { default-features = false, version = "4.0" }
 serde = { default-features = false, features = ["derive", "rc"], version = "1" }
 twilight-model = { default-features = false, path = "../../model" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }

--- a/command-parser/Cargo.toml
+++ b/command-parser/Cargo.toml
@@ -19,7 +19,7 @@ unicase = { default-features = false, version = "2" }
 
 [dev-dependencies]
 criterion = "0.3"
-patricia_tree = "0.2"
+patricia_tree = "0.3"
 static_assertions = { default-features = false, version = "1" }
 
 [[bench]]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -33,7 +33,7 @@ url = { default-features = false, version = "2" }
 # it does not seem to update the total_in of the function to have an offset
 # https://github.com/alexcrichton/flate2-rs/issues/217
 flate2 = { default-features = false, version = "1.0" }
-dashmap = { default-features = false, version = "3" }
+dashmap = { default-features = false, version = "4.0" }
 
 # optional
 metrics = { default-features = false, optional = true, version = "0.12.1" }

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.2.1"
 
 [dependencies]
 async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.9.3" }
-dashmap = { default-features = false, version = "3" }
+dashmap = { default-features = false, version = "4.0" }
 futures-channel = { default-features = false, features = ["std"], version = "0.3" }
 futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }
 http = { default-features = false, optional = true, version = "0.2" }

--- a/standby/Cargo.toml
+++ b/standby/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.2.1"
 
 [dependencies]
-dashmap = { default-features = false, version = "3" }
+dashmap = { default-features = false, version = "4.0" }
 futures-channel = { default-features = false, features = ["std"], version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }


### PR DESCRIPTION
Update `dashmap` from `3` to `4.0` which is used in the `cache-inmemory`, `gateway`, `lavalink`, and `standby` crates. 

Additionally, update `patricia_tree` which is a benchmark development dependency of `command-parser`.

Since these aren't exposed via public API these aren't breaking changes.

PR note: I typo'd dashmap as hyper in the branch name. Hyper is unrelated.