### PR TITLE
Change name of Client#add_role

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -192,7 +192,7 @@ impl Client {
     /// client.add_role(guild_id, user_id, role_id).reason("test")?.await?;
     /// # Ok(()) }
     /// ```
-    pub fn add_role(
+    pub fn add_guild_member_role(
         &self,
         guild_id: GuildId,
         user_id: UserId,


### PR DESCRIPTION
Change the name of Client#add_role to Client#add_guild_member_role to comply with the name on the Discord API documentation.

https://discord.com/developers/docs/resources/guild#add-guild-member-role