### PR TITLE
http, lavalink: Remove http1 feature flag from hyper

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -19,7 +19,7 @@ bytes = { default-features = false, version = "1.0" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 futures-channel = { default-features = false, version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
-hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
+hyper = { default-features = false, features = ["client", "http2", "runtime"], version = "0.14" }
 hyper-rustls = { default-features = false, features = ["native-tokio"], optional = true, version = "0.22" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
 percent-encoding = { default-features = false, version = "2" }

--- a/lavalink/examples/basic-lavalink-bot/Cargo.toml
+++ b/lavalink/examples/basic-lavalink-bot/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-hyper = { features = ["client", "http1", "http2", "runtime"], version = "0.14" }
+hyper = { features = ["client", "http2", "runtime"], version = "0.14" }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 serde_json = { version = "1" }


### PR DESCRIPTION
This removes the http1 feature flag from hyper. It means that all connections made will use http2, which is supported by Cloudflare and Discord and has [several advantages](https://blog.restcase.com/http2-benefits-for-rest-apis/) over http1, especially when the same server is requested over and over again, which is the case here.

http1 pulls in quite a bit of conditionally compiled code that won't be used and might make the connections use http1, which isn't desired. Both Discord/Cloudflare and Lavalink support http2 and would benefit from it, so forcing the use of it would only make sense. If a user would like to keep using http1, they can add a `hyper = { version = 0.14, features = ["http1"] }` to their Cargo.toml to force enabling the feature.

Not adding lavalink tag because it only effects the examples.

Tested with the current http-proxy version and works fine with it. When that is rewritten to 0.3, http1 server should be enabled.