### PR TITLE
Simplify license.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ISC License (ISC)
 
-Copyright (c) 2019, 2020 (c) The Twilight Contributors
+Copyright (c) 2019 (c) The Twilight Contributors
 
 Permission to use, copy, modify, and/or distribute this software for any purpose
 with or without fee is hereby granted, provided that the above copyright notice


### PR DESCRIPTION
Only the year the copyright was introduced by a new party is needed in
the MIT license, so this patch makes the license file more simple so
it does not need to be updated in the future.