### PR TITLE
Remove the re-export of allowed_mentions in channel/message/mod.rs

### DIFF
--- a/http/src/request/channel/message/mod.rs
+++ b/http/src/request/channel/message/mod.rs
@@ -16,9 +16,3 @@ pub use self::{
     update_message::UpdateMessage,
 };
 pub use super::super::validate::EmbedValidationError;
-
-// 0.3+: Remove this re-export.
-//
-// This re-export is here because `allowed_mentions` was moved up a module to
-// `request::channel`: <https://github.com/twilight-rs/twilight/pull/643>
-pub use super::allowed_mentions;


### PR DESCRIPTION
As per comment:
```rust
// 0.3+: Remove this re-export.
//
// This re-export is here because `allowed_mentions` was moved up a module to
// `request::channel`: <#643>
```