### PR TITLE
chore(http): remove re-exports

### DIFF
--- a/http/examples/allowed-mentions/src/main.rs
+++ b/http/examples/allowed-mentions/src/main.rs
@@ -1,5 +1,5 @@
 use std::{env, error::Error};
-use twilight_http::{request::channel::message::allowed_mentions::AllowedMentionsBuilder, Client};
+use twilight_http::{request::channel::allowed_mentions::AllowedMentionsBuilder, Client};
 use twilight_model::id::{ChannelId, UserId};
 
 #[tokio::main]

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -1,7 +1,5 @@
 use super::{Client, HttpsConnector, State};
-use crate::{
-    ratelimiting::Ratelimiter, request::channel::message::allowed_mentions::AllowedMentions,
-};
+use crate::{ratelimiting::Ratelimiter, request::channel::allowed_mentions::AllowedMentions};
 use hyper::client::{Client as HyperClient, HttpConnector};
 use std::{
     sync::{atomic::AtomicBool, Arc},

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{Error, Result},
     ratelimiting::{RatelimitHeaders, Ratelimiter},
     request::{
-        channel::message::allowed_mentions::AllowedMentions,
+        channel::allowed_mentions::AllowedMentions,
         guild::{create_guild::CreateGuildError, create_guild_channel::CreateGuildChannelError},
         prelude::*,
         GetUserApplicationInfo, Request,

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -172,7 +172,7 @@ impl Client {
     ///
     /// Refer to [`allowed_mentions`] for more information.
     ///
-    /// [`allowed_mentions`]: crate::request::channel::message::allowed_mentions
+    /// [`allowed_mentions`]: crate::request::channel::allowed_mentions
     pub fn default_allowed_mentions(&self) -> Option<AllowedMentions> {
         self.state.default_allowed_mentions.clone()
     }

--- a/http/src/request/channel/allowed_mentions.rs
+++ b/http/src/request/channel/allowed_mentions.rs
@@ -88,7 +88,7 @@ impl VisitAllowedMentionsRoles for ExplicitRole {
 /// # Example
 ///
 /// ```rust,no_run
-/// use twilight_http::request::channel::message::allowed_mentions::AllowedMentionsBuilder;
+/// use twilight_http::request::channel::allowed_mentions::AllowedMentionsBuilder;
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 /// let mut allowed_mentions = AllowedMentionsBuilder::new()

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -1,4 +1,4 @@
-use super::allowed_mentions::{AllowedMentions, AllowedMentionsBuilder, Unspecified};
+use super::super::allowed_mentions::{AllowedMentions, AllowedMentionsBuilder, Unspecified};
 use crate::request::{multipart::Form, prelude::*};
 use std::{
     collections::HashMap,

--- a/http/src/request/channel/message/mod.rs
+++ b/http/src/request/channel/message/mod.rs
@@ -16,9 +16,3 @@ pub use self::{
     update_message::UpdateMessage,
 };
 pub use super::super::validate::EmbedValidationError;
-
-// 0.3+: Remove this re-export.
-//
-// This re-export is here because `allowed_mentions` was moved up a module to
-// `request::channel`: <https://github.com/twilight-rs/twilight/pull/643>
-pub use super::allowed_mentions;

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -1,4 +1,4 @@
-use crate::request::{channel::message::allowed_mentions::AllowedMentions, prelude::*};
+use crate::request::{channel::allowed_mentions::AllowedMentions, prelude::*};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -197,7 +197,7 @@ impl<'a> UpdateMessage<'a> {
     ///
     /// Use the [`build_solo`] method to get a [`AllowedMentions`] structure.
     ///
-    /// [`build_solo`]: super::allowed_mentions::AllowedMentionsBuilder::build_solo
+    /// [`build_solo`]: super::super::allowed_mentions::AllowedMentionsBuilder::build_solo
     pub fn allowed_mentions(mut self, allowed: AllowedMentions) -> Self {
         self.fields.allowed_mentions.replace(allowed);
 

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -5,7 +5,7 @@ use crate::{
     error::Result,
     request::{
         self,
-        channel::message::allowed_mentions::AllowedMentions,
+        channel::allowed_mentions::AllowedMentions,
         validate::{self, EmbedValidationError},
         AuditLogReason, AuditLogReasonError, Pending, Request,
     },
@@ -100,7 +100,7 @@ struct UpdateWebhookMessageFields {
 ///
 /// ```no_run
 /// # use twilight_http::Client;
-/// use twilight_http::request::channel::message::allowed_mentions::AllowedMentions;
+/// use twilight_http::request::channel::allowed_mentions::AllowedMentions;
 /// use twilight_model::id::{MessageId, WebhookId};
 ///
 /// # #[tokio::main]

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -3,8 +3,7 @@ use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
-use twilight_model::id::GuildId;
-pub use twilight_model::user::CurrentUserGuild;
+use twilight_model::{id::GuildId, user::CurrentUserGuild};
 
 /// The error created when the current guilds can not be retrieved as configured.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Remove the following re-exports:

- `request::user::get_current_user_guilds::CurrentUserGuild`: instead use `twilight_model::user::CurrentUserGuild`
- `request::channel::message::allowed_mentions`: instead use `request::channel::allowed_mentions`