### PR TITLE
Re-enable hyper's `http1` feature

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -19,7 +19,7 @@ bytes = { default-features = false, version = "1.0" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 futures-channel = { default-features = false, version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
-hyper = { default-features = false, features = ["client", "http2", "runtime"], version = "0.14" }
+hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
 hyper-rustls = { default-features = false, features = ["native-tokio"], optional = true, version = "0.22" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
 percent-encoding = { default-features = false, version = "2" }

--- a/lavalink/examples/basic-lavalink-bot/Cargo.toml
+++ b/lavalink/examples/basic-lavalink-bot/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3"
-hyper = { features = ["client", "http2", "runtime"], version = "0.14" }
+hyper = { features = ["client", "http1", "http2", "runtime"], version = "0.14" }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 serde_json = { version = "1" }


### PR DESCRIPTION
Re-enable `hyper`'s `http1` feature, effectively reverting PR #670 and commit [343ecac].

The motivation behind the original change is that this isn't needed, but it actually is needed. Running any of the HTTP examples with the "native" feature returns with:

```
RequestError { source: hyper::Error(Http2, Error { kind: Proto(FRAME_SIZE_ERROR) }) }
```

Enabling `http1` fixes this.

Reverts #670.

[343ecac]: https://github.com/twilight-rs/twilight/commit/343ecac22ab354740e7af99788695838ad23e25e