### PR TITLE
http: Work around http2 hyper-tls bug

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -184,8 +184,8 @@ impl ReceivingEventError {
         matches!(
             self,
             ReceivingEventError::AuthorizationInvalid { .. }
-            | ReceivingEventError::IntentsDisallowed { .. }
-            | ReceivingEventError::IntentsInvalid { .. }
+                | ReceivingEventError::IntentsDisallowed { .. }
+                | ReceivingEventError::IntentsInvalid { .. }
         )
     }
 

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -22,6 +22,7 @@ futures-util = { default-features = false, features = ["std"], version = "0.3" }
 hyper = { default-features = false, features = ["client", "http2", "runtime"], version = "0.14" }
 hyper-rustls = { default-features = false, features = ["native-tokio"], optional = true, version = "0.22" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
+native-tls = { default-features = false, features = ["alpn"], optional = true, version = "0.2.7" }
 percent-encoding = { default-features = false, version = "2" }
 tokio = { default-features = false, features = ["time"], version = "1.0" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
@@ -35,7 +36,7 @@ simd-json = { default-features = false, features = ["serde_impl", "swar-number-p
 
 [features]
 default = ["rustls"]
-native = ["hyper-tls"]
+native = ["hyper-tls", "native-tls"]
 rustls = ["hyper-rustls"]
 
 [dev-dependencies]


### PR DESCRIPTION
Alternative to #678 

hyper-tls currently is broken when only http2 is enabled because it does not send ALPN protocols unlike rustls (https://github.com/hyperium/hyper-tls/pull/85 is pending for a while now, hyper-rustls pulls in http1 always (see https://github.com/ctz/hyper-rustls/pull/139)).

As we know that http2 is enabled, we can safely send the ALPN ourselves until the hyper-tls PR gets merged, which will require hyper to expose which http versions are enabled and therefore will take longer.