### PR TITLE
fix(http): percent encode emoji in URIs

### DIFF
--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -49,17 +49,53 @@ impl<'a> CreateReaction<'a> {
         }
     }
 
+    fn request(&self) -> Request {
+        Request::from(Route::CreateReaction {
+            channel_id: self.channel_id.0,
+            emoji: self.emoji.clone(),
+            message_id: self.message_id.0,
+        })
+    }
+
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::CreateReaction {
-                channel_id: self.channel_id.0,
-                emoji: self.emoji.clone(),
-                message_id: self.message_id.0,
-            },
-        ))));
+        let request = self.request();
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }
 }
 
 poll_req!(CreateReaction<'_>, ());
+
+#[cfg(test)]
+mod tests {
+    use super::CreateReaction;
+    use crate::{
+        request::{channel::reaction::RequestReactionType, Request},
+        routing::Route,
+        Client,
+    };
+    use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+    use twilight_model::id::{ChannelId, MessageId};
+
+    #[test]
+    fn test_request() {
+        let client = Client::new("foo");
+
+        let emoji = RequestReactionType::Unicode {
+            name: String::from("🌃"),
+        };
+
+        let builder = CreateReaction::new(&client, ChannelId(123), MessageId(456), emoji);
+        let actual = builder.request();
+
+        let request = Request::from(Route::CreateReaction {
+            channel_id: 123,
+            emoji: utf8_percent_encode("🌃", NON_ALPHANUMERIC).to_string(),
+            message_id: 456,
+        });
+
+        assert_eq!(actual.path_str, request.path_str);
+    }
+}

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -90,12 +90,12 @@ mod tests {
         let builder = CreateReaction::new(&client, ChannelId(123), MessageId(456), emoji);
         let actual = builder.request();
 
-        let request = Request::from(Route::CreateReaction {
+        let expected = Request::from(Route::CreateReaction {
             channel_id: 123,
             emoji: utf8_percent_encode("\u{1f303}", NON_ALPHANUMERIC).to_string(),
             message_id: 456,
         });
 
-        assert_eq!(actual.path_str, request.path_str);
+        assert_eq!(actual.path_str, expected.path_str);
     }
 }

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -80,6 +80,7 @@ mod tests {
     use twilight_model::id::{ChannelId, MessageId};
 
     #[test]
+    #[allow(clippy::non_ascii_literal)]
     fn test_request() {
         let client = Client::new("foo");
 

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -80,12 +80,11 @@ mod tests {
     use twilight_model::id::{ChannelId, MessageId};
 
     #[test]
-    #[allow(clippy::non_ascii_literal)]
     fn test_request() {
         let client = Client::new("foo");
 
         let emoji = RequestReactionType::Unicode {
-            name: String::from("🌃"),
+            name: String::from("\u{1f303}"),
         };
 
         let builder = CreateReaction::new(&client, ChannelId(123), MessageId(456), emoji);
@@ -93,7 +92,7 @@ mod tests {
 
         let request = Request::from(Route::CreateReaction {
             channel_id: 123,
-            emoji: utf8_percent_encode("🌃", NON_ALPHANUMERIC).to_string(),
+            emoji: utf8_percent_encode("\u{1f303}", NON_ALPHANUMERIC).to_string(),
             message_id: 456,
         });
 

--- a/http/src/request/channel/reaction/mod.rs
+++ b/http/src/request/channel/reaction/mod.rs
@@ -10,6 +10,7 @@ pub use self::{
     delete_all_reactions::DeleteAllReactions, delete_reaction::DeleteReaction,
     get_reactions::GetReactions,
 };
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use std::fmt::Write;
 use twilight_model::{channel::ReactionType, id::EmojiId};
 
@@ -39,6 +40,8 @@ fn format_emoji(emoji: RequestReactionType) -> String {
             let _ = write!(emoji, ":{}", id);
             emoji
         }
-        RequestReactionType::Unicode { name } => name,
+        RequestReactionType::Unicode { name } => {
+            utf8_percent_encode(&name, NON_ALPHANUMERIC).to_string()
+        }
     }
 }


### PR DESCRIPTION
Going from 0.2 to 0.3 breaks create_emoji, and possibly other endpoints involving emojis.

It seems they are no longer getting percent encoded. This results in `Error: BuildingRequest { source: http::Error(InvalidUri(InvalidUriChar)) }` when running the code from the method's documentation.

I can't find any sign of a change that would have lead to this unless it was done automatically under reqwest, but not when using hyper directly.

Making the following modification to the example code works:

```rust
    let emoji = RequestReactionType::Unicode {
        name: utf8_percent_encode("🌃", NON_ALPHANUMERIC).to_string(),
    };
```

I think it would be better if Twilight did this though; perhaps through a change to format_emoji as found in this PR.