### PR TITLE
http: Use HeaderMap.insert instead of appending

### DIFF
--- a/command-parser/src/arguments.rs
+++ b/command-parser/src/arguments.rs
@@ -109,12 +109,11 @@ impl<'a> Iterator for Arguments<'a> {
                     self.idx = i + 1;
 
                     return v.map(str::trim);
-                } else {
-                    self.idx = i;
-                    start_idx = i;
-                    started = true;
-                    continue;
                 }
+                self.idx = i;
+                start_idx = i;
+                started = true;
+                continue;
             } else if ch == '"' {
                 start_idx = i + 1;
                 quoted = true;

--- a/command-parser/src/arguments.rs
+++ b/command-parser/src/arguments.rs
@@ -109,11 +109,12 @@ impl<'a> Iterator for Arguments<'a> {
                     self.idx = i + 1;
 
                     return v.map(str::trim);
+                } else {
+                    self.idx = i;
+                    start_idx = i;
+                    started = true;
+                    continue;
                 }
-                self.idx = i;
-                start_idx = i;
-                started = true;
-                continue;
             } else if ch == '"' {
                 start_idx = i + 1;
                 quoted = true;

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1432,6 +1432,7 @@ impl Client {
     ///
     /// Returns [`Error::Unauthorized`] if the configured token has become
     /// invalid due to expiration, revokation, etc.
+    #[allow(clippy::too_many_lines)]
     pub async fn raw(&self, request: Request) -> Result<Response<Body>> {
         if self.state.token_invalid.load(Ordering::Relaxed) {
             return Err(Error::Unauthorized);


### PR DESCRIPTION
hyper's `RequestBuilder.header` method internally calls `.append` on the HeaderMap (see [here](https://docs.rs/http/0.2.3/http/request/struct.Builder.html#method.header)), which allows for duplicate headers. This won't happen unless a custom `TwilightRequest` is used to make a raw request and happens in the proxy when using the request headers and trying to merge them with the ones twilight adds, as it will just append them, causing 400 errors from Cloudflare.

This makes use of `HeaderMap.insert` to overwrite earlier headers with the same name and prevent this issue. Since hyper's `headers_mut` returns an Option created via `.ok()`, I cannot propagate this into a http::Error and need to do a lot of Option handling for safety.

Tested working with a 0.3 version of the proxy which I will submit after this is merged.