### PR TITLE
Simplify Embed Builder error handling

### DIFF
--- a/embed-builder/README.md
+++ b/embed-builder/README.md
@@ -16,10 +16,10 @@ Build a simple embed:
 use twilight_embed_builder::{EmbedBuilder, EmbedFieldBuilder};
 
 let embed = EmbedBuilder::new()
-    .description("Here's a list of reasons why Twilight is the best pony:")?
-    .field(EmbedFieldBuilder::new("Wings", "She has wings.")?.inline())
-    .field(EmbedFieldBuilder::new("Horn", "She can do magic, and she's really good at it.")?.inline())
-    .build();
+    .description("Here's a list of reasons why Twilight is the best pony:")
+    .field(EmbedFieldBuilder::new("Wings", "She has wings.").inline())
+    .field(EmbedFieldBuilder::new("Horn", "She can do magic, and she's really good at it.").inline())
+    .build()?;
 ```
 
 Build an embed with an image:
@@ -28,9 +28,9 @@ Build an embed with an image:
 use twilight_embed_builder::{EmbedBuilder, ImageSource};
 
 let embed = EmbedBuilder::new()
-    .description("Here's a cool image of Twilight Sparkle")?
+    .description("Here's a cool image of Twilight Sparkle")
     .image(ImageSource::attachment("bestpony.png")?)
-    .build();
+    .build()?;
 
 ```
 

--- a/embed-builder/src/author.rs
+++ b/embed-builder/src/author.rs
@@ -1,41 +1,7 @@
 //! Create embed authors.
 
 use super::image_source::ImageSource;
-use std::{
-    error::Error,
-    fmt::{Display, Formatter, Result as FmtResult},
-};
 use twilight_model::channel::embed::EmbedAuthor;
-
-/// Error setting an embed author's name.
-///
-/// This is returned from [`EmbedAuthorBuilder::name`].
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum EmbedAuthorNameError {
-    /// Name is empty.
-    Empty {
-        /// Provided name. Although empty, the same owned allocation is
-        /// included.
-        name: String,
-    },
-    /// Name is longer than 256 UTF-16 code points.
-    TooLong {
-        /// Provided name.
-        name: String,
-    },
-}
-
-impl Display for EmbedAuthorNameError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Empty { .. } => f.write_str("the author name is empty"),
-            Self::TooLong { .. } => f.write_str("the author name is too long"),
-        }
-    }
-}
-
-impl Error for EmbedAuthorNameError {}
 
 /// Create an embed author with a builder.
 ///
@@ -47,13 +13,6 @@ impl Error for EmbedAuthorNameError {}
 pub struct EmbedAuthorBuilder(EmbedAuthor);
 
 impl EmbedAuthorBuilder {
-    /// The maximum number of UTF-16 code points that can be in an author name.
-    ///
-    /// This is used by [`name`].
-    ///
-    /// [`name`]: Self::name
-    pub const NAME_LENGTH_LIMIT: usize = 256;
-
     /// Create a new default embed author builder.
     pub fn new() -> Self {
         Self::default()
@@ -74,33 +33,18 @@ impl EmbedAuthorBuilder {
 
     /// The author's name.
     ///
-    /// Refer to [`NAME_LENGTH_LIMIT`] for the maximum number of UTF-16
-    /// code points that can be in a description.
+    /// Refer to [`EmbedBuilder::AUTHOR_NAME_LENGTH_LIMIT`] for the maximum
+    /// number of UTF-16 code points that can be in an author name.
     ///
-    /// # Errors
-    ///
-    /// Returns [`EmbedAuthorNameError::Empty`] if the provided name is empty.
-    ///
-    /// Returns [`EmbedAuthorNameError::TooLong`] if the provided name is longer
-    /// than the maximum number of code points.
-    ///
-    /// [`NAME_LENGTH_LIMIT`]: Self::NAME_LENGTH_LIMIT
-    pub fn name(self, name: impl Into<String>) -> Result<Self, EmbedAuthorNameError> {
+    /// [`EmbedBuilder::AUTHOR_NAME_LENGTH_LIMIT`]: struct.EmbedBuilder.html#associatedconstant.AUTHOR_NAME_LENGTH_LIMIT
+    pub fn name(self, name: impl Into<String>) -> Self {
         self._name(name.into())
     }
 
-    fn _name(mut self, name: String) -> Result<Self, EmbedAuthorNameError> {
-        if name.is_empty() {
-            return Err(EmbedAuthorNameError::Empty { name });
-        }
-
-        if name.chars().count() > Self::NAME_LENGTH_LIMIT {
-            return Err(EmbedAuthorNameError::TooLong { name });
-        }
-
+    fn _name(mut self, name: String) -> Self {
         self.0.name.replace(name);
 
-        Ok(self)
+        self
     }
 
     /// The author's url.
@@ -137,23 +81,12 @@ impl From<EmbedAuthorBuilder> for EmbedAuthor {
 
 #[cfg(test)]
 mod tests {
-    use super::{EmbedAuthorBuilder, EmbedAuthorNameError};
-    use crate::ImageSource;
-    use static_assertions::{assert_fields, assert_impl_all, const_assert};
-    use std::{error::Error, fmt::Debug};
+    use super::EmbedAuthorBuilder;
+    use crate::{EmbedBuilder, EmbedError, ImageSource};
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
     use twilight_model::channel::embed::EmbedAuthor;
 
-    assert_impl_all!(
-        EmbedAuthorNameError: Clone,
-        Debug,
-        Error,
-        Eq,
-        PartialEq,
-        Send,
-        Sync
-    );
-    assert_fields!(EmbedAuthorNameError::Empty: name);
-    assert_fields!(EmbedAuthorNameError::TooLong: name);
     assert_impl_all!(
         EmbedAuthorBuilder: Clone,
         Debug,
@@ -163,7 +96,6 @@ mod tests {
         Send,
         Sync
     );
-    const_assert!(EmbedAuthorBuilder::NAME_LENGTH_LIMIT == 256);
     assert_impl_all!(EmbedAuthor: From<EmbedAuthorBuilder>);
 
     #[test]
@@ -181,23 +113,27 @@ mod tests {
 
     #[test]
     fn test_name_empty() {
-        assert!(matches!(
-            EmbedAuthorBuilder::new().name(""),
-            Err(EmbedAuthorNameError::Empty { .. })
+        let builder = EmbedBuilder::new().author(EmbedAuthorBuilder::new().name(""));
+
+        assert!(matches!(builder.build().unwrap_err(),
+            EmbedError::AuthorNameEmpty { .. }
         ));
     }
 
     #[test]
     fn test_name_too_long() {
-        assert!(EmbedAuthorBuilder::new().name("a".repeat(256)).is_ok());
+        let builder = EmbedBuilder::new().author(EmbedAuthorBuilder::new().name("a".repeat(256)));
+        assert!(builder.build().is_ok());
+
+        let builder = EmbedBuilder::new().author(EmbedAuthorBuilder::new().name("a".repeat(257)));
         assert!(matches!(
-            EmbedAuthorBuilder::new().name("a".repeat(257)),
-            Err(EmbedAuthorNameError::TooLong { .. })
+            builder.build().unwrap_err(),
+            EmbedError::AuthorNameTooLong { .. }
         ));
     }
 
     #[test]
-    fn test_builder() -> Result<(), Box<dyn Error>> {
+    fn test_builder() {
         let expected = EmbedAuthor {
             icon_url: Some("https://example.com/1.png".to_owned()),
             name: Some("an author".to_owned()),
@@ -205,15 +141,13 @@ mod tests {
             url: Some("https://example.com".to_owned()),
         };
 
-        let source = ImageSource::url("https://example.com/1.png")?;
+        let source = ImageSource::url("https://example.com/1.png").unwrap();
         let actual = EmbedAuthorBuilder::new()
             .icon_url(source)
-            .name("an author")?
+            .name("an author")
             .url("https://example.com")
             .build();
 
         assert_eq!(actual, expected);
-
-        Ok(())
     }
 }

--- a/embed-builder/src/author.rs
+++ b/embed-builder/src/author.rs
@@ -36,7 +36,7 @@ impl EmbedAuthorBuilder {
     /// Refer to [`EmbedBuilder::AUTHOR_NAME_LENGTH_LIMIT`] for the maximum
     /// number of UTF-16 code points that can be in an author name.
     ///
-    /// [`EmbedBuilder::AUTHOR_NAME_LENGTH_LIMIT`]: struct.EmbedBuilder.html#associatedconstant.AUTHOR_NAME_LENGTH_LIMIT
+    /// [`EmbedBuilder::AUTHOR_NAME_LENGTH_LIMIT`]: crate::EmbedBuilder::AUTHOR_NAME_LENGTH_LIMIT
     pub fn name(self, name: impl Into<String>) -> Self {
         self._name(name.into())
     }

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -103,8 +103,6 @@ pub enum EmbedError {
     ///
     /// Refer to [`EmbedBuilder::EMBED_LENGTH_LIMIT`] for more information about
     /// what goes into this limit.
-    ///
-    /// [`EmbedBuilder::EMBED_LENGTH_LIMIT`]: struct.EmbedBuilder.html#associatedconstant.EMBED_LENGTH_LIMIT
     TotalContentTooLarge {
         /// The total length of the embed.
         length: usize,
@@ -113,8 +111,6 @@ pub enum EmbedError {
     ///
     /// Refer to [`EmbedBuilder::EMBED_FIELD_LIMIT`] for more information about
     /// what the limit is.
-    ///
-    /// [`EmbedBuilder::EMBED_FIELD_LIMIT`]: struct.EmbedBuilder.html#associatedconstant.EMBED_FIELD_LIMIT
     TooManyFields {
         /// The provided fields.
         fields: Vec<EmbedField>,
@@ -257,31 +253,15 @@ impl EmbedBuilder {
     /// the embed is too large. Refer to [`EMBED_LENGTH_LIMIT`] for the limit
     /// value and what counts towards it.
     ///
-    /// [`AUTHOR_NAME_LENGTH_LIMIT`]: #associatedconstant.AUTHOR_NAME_LENGTH_LIMIT
-    /// [`COLOR_MAXIMUM`]: #associatedconstant.COLOR_MAXIMUM
-    /// [`DESCRIPTION_LENGTH_LIMIT`]: #associatedconstant.DESCRIPTION_LENGTH_LIMIT
-    /// [`EMBED_FIELD_LIMIT`]: #associatedconstant.EMBED_FIELD_LIMIT
-    /// [`EMBED_LENGTH_LIMIT`]: #associatedconstant.EMBED_LENGTH_LIMIT
-    /// [`FIELD_NAME_LENGTH_LIMIT`]: #associatedconstant.FIELD_NAME_LENGTH_LIMIT
-    /// [`FIELD_VALUE_LENGTH_LIMIT`]: #associatedconstant.FIELD_VALUE_LENGTH_LIMIT
-    /// [`FOOTER_TEXT_LENGTH_LIMIT`]: #associatedconstant.FOOTER_TEXT_LENGTH_LIMIT
-    /// [`TITLE_LENGTH_LIMIT`]: #associatedconstant.TITLE_LENGTH_LIMIT
-    /// [`EmbedError::AuthorNameEmpty`]: enum.EmbedError.html#variant.AuthorNameEmpty
-    /// [`EmbedError::AuthorNameTooLong`]: enum.EmbedError.html#variant.AuthorNameTooLong
-    /// [`EmbedError::ColorNotRgb`]: enum.EmbedError.html#variant.ColorNotRgb
-    /// [`EmbedError::ColorZero`]: enum.EmbedError.html#variant.ColorZero
-    /// [`EmbedError::DescriptionEmpty`]: enum.EmbedError.html#variant.DescriptionEmpty
-    /// [`EmbedError::DescriptionTooLong`]: enum.EmbedError.html#variant.DescriptionTooLong
-    /// [`EmbedError::FieldNameEmpty`]: enum.EmbedError.html#variant.FieldNameEmpty
-    /// [`EmbedError::FieldNameTooLong`]: enum.EmbedError.html#variant.FieldNameTooLong
-    /// [`EmbedError::FieldValueEmpty`]: enum.EmbedError.html#variant.FieldValueEmpty
-    /// [`EmbedError::FieldValueTooLong`]: enum.EmbedError.html#variant.FieldValueTooLong
-    /// [`EmbedError::FooterTextEmpty`]: enum.EmbedError.html#variant.FooterTextEmpty
-    /// [`EmbedError::FooterTextTooLong`]: enum.EmbedError.html#variant.FooterTextTooLong
-    /// [`EmbedError::TitleEmpty`]: enum.EmbedError.html#variant.TitleEmpty
-    /// [`EmbedError::TitleTooLong`]: enum.EmbedError.html#variant.TitleTooLong
-    /// [`EmbedError::TooManyFields`]: enum.EmbedError.html#variant.TooManyFields
-    /// [`EmbedError::TotalContentTooLarge`]: enum.EmbedError.html#variant.TotalContentTooLarge
+    /// [`AUTHOR_NAME_LENGTH_LIMIT`]: Self::AUTHOR_NAME_LENGTH_LIMIT
+    /// [`COLOR_MAXIMUM`]: Self::COLOR_MAXIMUM
+    /// [`DESCRIPTION_LENGTH_LIMIT`]: Self::DESCRIPTION_LENGTH_LIMIT
+    /// [`EMBED_FIELD_LIMIT`]: Self::EMBED_FIELD_LIMIT
+    /// [`EMBED_LENGTH_LIMIT`]: Self::EMBED_LENGTH_LIMIT
+    /// [`FIELD_NAME_LENGTH_LIMIT`]: Self::FIELD_NAME_LENGTH_LIMIT
+    /// [`FIELD_VALUE_LENGTH_LIMIT`]: Self::FIELD_VALUE_LENGTH_LIMIT
+    /// [`FOOTER_TEXT_LENGTH_LIMIT`]: Self::FOOTER_TEXT_LENGTH_LIMIT
+    /// [`TITLE_LENGTH_LIMIT`]: Self::TITLE_LENGTH_LIMIT
     #[must_use = "should be used as part of something like a message"]
     pub fn build(mut self) -> Result<Embed, EmbedError> {
         if self.0.fields.len() > Self::EMBED_FIELD_LIMIT {
@@ -452,9 +432,7 @@ impl EmbedBuilder {
     /// # Ok(()) }
     /// ```
     ///
-    /// # Errors
-    ///
-    /// [`COLOR_MAXIMUM`]: #associatedconstant.COLOR_MAXIMUM
+    /// [`COLOR_MAXIMUM`]: Self::COLOR_MAXIMUM
     pub fn color(mut self, color: u32) -> Self {
         self.0.color.replace(color);
 
@@ -476,7 +454,7 @@ impl EmbedBuilder {
     /// # Ok(()) }
     /// ```
     ///
-    /// [`DESCRIPTION_LENGTH_LIMIT`]: #associatedconstant.DESCRIPTION_LENGTH_LIMIT
+    /// [`DESCRIPTION_LENGTH_LIMIT`]: Self::DESCRIPTION_LENGTH_LIMIT
     pub fn description(self, description: impl Into<String>) -> Self {
         self._description(description.into())
     }
@@ -622,7 +600,7 @@ impl EmbedBuilder {
     /// # Ok(()) }
     /// ```
     ///
-    /// [`TITLE_LENGTH_LIMIT`]: #associatedconstant.TITLE_LENGTH_LIMIT
+    /// [`TITLE_LENGTH_LIMIT`]: Self::TITLE_LENGTH_LIMIT
     pub fn title(self, title: impl Into<String>) -> Self {
         self._title(title.into())
     }

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -5,6 +5,7 @@ use std::{
     convert::TryFrom,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
+    mem,
 };
 use twilight_model::channel::embed::{
     Embed, EmbedAuthor, EmbedField, EmbedFooter, EmbedImage, EmbedThumbnail,
@@ -15,12 +16,96 @@ use twilight_model::channel::embed::{
 /// This is returned from [`EmbedBuilder::build`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
-pub enum EmbedBuildError {
+pub enum EmbedError {
+    /// Name is empty.
+    AuthorNameEmpty {
+        /// Provided name. Although empty, the same owned allocation is
+        /// included.
+        name: String,
+    },
+    /// Name is longer than 256 UTF-16 code points.
+    AuthorNameTooLong {
+        /// Provided name.
+        name: String,
+    },
+    /// Color was larger than a valid RGB hexadecimal value.
+    ColorNotRgb {
+        /// Provided color hex value.
+        color: u32,
+    },
+    /// Color was 0. The value would be thrown out by Discord and is equivalent
+    /// to null.
+    ColorZero,
+    /// Description is empty.
+    DescriptionEmpty {
+        /// Provided description. Although empty, the same owned allocation is
+        /// included.
+        description: String,
+    },
+    /// Description is longer than 2048 UTF-16 code points.
+    DescriptionTooLong {
+        /// Provided description.
+        description: String,
+    },
+    /// Name is empty.
+    FieldNameEmpty {
+        /// Provided name. Although empty, the same owned allocation is
+        /// included.
+        name: String,
+        /// Provided value.
+        value: String,
+    },
+    /// Name is longer than 256 UTF-16 code points.
+    FieldNameTooLong {
+        /// Provided name.
+        name: String,
+        /// Provided value.
+        value: String,
+    },
+    /// Value is empty.
+    FieldValueEmpty {
+        /// Provided name.
+        name: String,
+        /// Provided value. Although empty, the same owned allocation is
+        /// included.
+        value: String,
+    },
+    /// Value is longer than 1024 UTF-16 code points.
+    FieldValueTooLong {
+        /// Provided name.
+        name: String,
+        /// Provided value.
+        value: String,
+    },
+    /// Footer text is empty.
+    FooterTextEmpty {
+        /// Provided text. Although empty, the same owned allocation is
+        /// included.
+        text: String,
+    },
+    /// Footer text is longer than 2048 UTF-16 code points.
+    FooterTextTooLong {
+        /// Provided text.
+        text: String,
+    },
+    /// Title is empty.
+    TitleEmpty {
+        /// Provided title. Although empty, the same owned allocation is
+        /// included.
+        title: String,
+    },
+    /// Title is longer than 256 UTF-16 code points.
+    TitleTooLong {
+        /// Provided title.
+        title: String,
+    },
     /// The total content of the embed is too large.
     ///
     /// Refer to [`EmbedBuilder::EMBED_LENGTH_LIMIT`] for more information about
     /// what goes into this limit.
-    ContentTooLarge {
+    ///
+    /// [`EmbedBuilder::EMBED_LENGTH_LIMIT`]: struct.EmbedBuilder.html#associatedconstant.EMBED_LENGTH_LIMIT
+    TotalContentTooLarge {
         /// The total length of the embed.
         length: usize,
     },
@@ -28,108 +113,42 @@ pub enum EmbedBuildError {
     ///
     /// Refer to [`EmbedBuilder::EMBED_FIELD_LIMIT`] for more information about
     /// what the limit is.
+    ///
+    /// [`EmbedBuilder::EMBED_FIELD_LIMIT`]: struct.EmbedBuilder.html#associatedconstant.EMBED_FIELD_LIMIT
     TooManyFields {
         /// The provided fields.
         fields: Vec<EmbedField>,
     },
 }
 
-impl Display for EmbedBuildError {
+impl Display for EmbedError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::ContentTooLarge { .. } => f.write_str("the content of the embed is too large"),
+            Self::AuthorNameEmpty { .. } => f.write_str("the author name is empty"),
+            Self::AuthorNameTooLong { .. } => f.write_str("the author name is too long"),
+            Self::ColorNotRgb { color } => {
+                f.write_fmt(format_args!("the color {} is invalid", color))
+            }
+            Self::ColorZero => f.write_str("the given color value is 0, which is not acceptable"),
+            Self::DescriptionEmpty { .. } => f.write_str("the description is empty"),
+            Self::DescriptionTooLong { .. } => f.write_str("the description is too long"),
+            Self::FieldNameEmpty { .. } => f.write_str("the field name is empty"),
+            Self::FieldNameTooLong { .. } => f.write_str("the field name is too long"),
+            Self::FieldValueEmpty { .. } => f.write_str("the field value is empty"),
+            Self::FieldValueTooLong { .. } => f.write_str("the field value is too long"),
+            Self::FooterTextEmpty { .. } => f.write_str("the footer text is empty"),
+            Self::FooterTextTooLong { .. } => f.write_str("the footer text is too long"),
+            Self::TitleEmpty { .. } => f.write_str("the title is empty"),
+            Self::TitleTooLong { .. } => f.write_str("the title is too long"),
+            Self::TotalContentTooLarge { .. } => {
+                f.write_str("the total content of the embed is too large")
+            }
             Self::TooManyFields { .. } => f.write_str("more than 25 fields were provided"),
         }
     }
 }
 
-impl Error for EmbedBuildError {}
-
-/// Error working with an embed builder.
-///
-/// This is returned from [`EmbedBuilder::color`].
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum EmbedColorError {
-    /// Color was larger than a valid RGB hexadecimal value.
-    NotRgb {
-        /// Provided color hex value.
-        color: u32,
-    },
-    /// Color was 0. The value would be thrown out by Discord and is equivalent
-    /// to null.
-    Zero,
-}
-
-impl Display for EmbedColorError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NotRgb { color } => f.write_fmt(format_args!("the color {} is invalid", color)),
-            Self::Zero => f.write_str("the given color value is 0, which is not acceptable"),
-        }
-    }
-}
-
-impl Error for EmbedColorError {}
-
-/// Error adding a description to an embed builder.
-///
-/// This is returned from [`EmbedBuilder::description`].
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum EmbedDescriptionError {
-    /// Description is empty.
-    Empty {
-        /// Provided description. Although empty, the same owned allocation is
-        /// included.
-        description: String,
-    },
-    /// Description is longer than 2048 UTF-16 code points.
-    TooLong {
-        /// Provided description.
-        description: String,
-    },
-}
-
-impl Display for EmbedDescriptionError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Empty { .. } => f.write_str("the description is empty"),
-            Self::TooLong { .. } => f.write_str("the description is too long"),
-        }
-    }
-}
-
-impl Error for EmbedDescriptionError {}
-
-/// Error adding a title to an embed builder.
-///
-/// This is returned from [`EmbedBuilder::title`].
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum EmbedTitleError {
-    /// Title is empty.
-    Empty {
-        /// Provided title. Although empty, the same owned allocation is
-        /// included.
-        title: String,
-    },
-    /// Title is longer than 256 UTF-16 code points.
-    TooLong {
-        /// Provided title.
-        title: String,
-    },
-}
-
-impl Display for EmbedTitleError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Empty { .. } => f.write_str("the title is empty"),
-            Self::TooLong { .. } => f.write_str("the title is too long"),
-        }
-    }
-}
-
-impl Error for EmbedTitleError {}
+impl Error for EmbedError {}
 
 /// Create an embed with a builder.
 ///
@@ -144,42 +163,34 @@ impl Error for EmbedTitleError {}
 pub struct EmbedBuilder(Embed);
 
 impl EmbedBuilder {
+    /// The maximum number of UTF-16 code points that can be in an author name.
+    pub const AUTHOR_NAME_LENGTH_LIMIT: usize = 256;
+
     /// The maximum accepted color value.
-    ///
-    /// This is used by [`color`].
-    ///
-    /// [`color`]: Self::color
     pub const COLOR_MAXIMUM: u32 = 0xff_ff_ff;
 
     /// The maximum number of UTF-16 code points that can be in a description.
-    ///
-    /// This is used by [`description`].
-    ///
-    /// [`description`]: Self::description
     pub const DESCRIPTION_LENGTH_LIMIT: usize = 2048;
 
     /// The maximum number of fields that can be in an embed.
-    ///
-    /// This is used by [`build`].
-    ///
-    /// [`build`]: Self::build
     pub const EMBED_FIELD_LIMIT: usize = 25;
 
     /// The maximum total textual length of the embed in UTF-16 code points.
     ///
     /// This combines the text of the author name, description, footer text,
     /// field names and values, and title.
-    ///
-    /// This is used by [`build`].
-    ///
-    /// [`build`]: Self::build
     pub const EMBED_LENGTH_LIMIT: usize = 6000;
 
+    /// The maximum number of UTF-16 code points that can be in a field name.
+    pub const FIELD_NAME_LENGTH_LIMIT: usize = 256;
+
+    /// The maximum number of UTF-16 code points that can be in a field value.
+    pub const FIELD_VALUE_LENGTH_LIMIT: usize = 1024;
+
+    /// The maximum number of UTF-16 code points that can be in a footer's text.
+    pub const FOOTER_TEXT_LENGTH_LIMIT: usize = 2048;
+
     /// The maximum number of UTF-16 code points that can be in a title.
-    ///
-    /// This is used by [`title`].
-    ///
-    /// [`title`]: Self::title
     pub const TITLE_LENGTH_LIMIT: usize = 256;
 
     /// Create a new default embed builder.
@@ -199,52 +210,194 @@ impl EmbedBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`EmbedBuildError::ContentTooLarge`] if the textual content of
+    /// Returns [`EmbedError::AuthorNameEmpty`] if the provided name is empty.
+    ///
+    /// Returns [`EmbedError::AuthorNameTooLong`] if the provided name is longer
+    /// than [`AUTHOR_NAME_LENGTH_LIMIT`].
+    ///
+    /// Returns [`EmbedError::ColorNotRgb`] if the provided color is not a valid
+    /// RGB integer. Refer to [`COLOR_MAXIMUM`] to know what the maximum
+    /// accepted value is.
+    ///
+    /// Returns [`EmbedError::ColorZero`] if the provided color is 0, which is
+    /// not an acceptable value.
+    ///
+    /// Returns [`EmbedError::DescriptionEmpty`] if a provided description is
+    /// empty.
+    ///
+    /// Returns [`EmbedError::DescriptionTooLong`] if a provided description is
+    /// longer than [`DESCRIPTION_LENGTH_LIMIT`].
+    ///
+    /// Returns [`EmbedError::FieldNameEmpty`] if a provided field name is
+    /// empty.
+    ///
+    /// Returns [`EmbedError::FieldNameTooLong`] if a provided field name is
+    /// longer than [`FIELD_NAME_LENGTH_LIMIT`].
+    ///
+    /// Returns [`EmbedError::FieldValueEmpty`] if a provided field value is
+    /// empty.
+    ///
+    /// Returns [`EmbedError::FieldValueTooLong`] if a provided field value is
+    /// longer than [`FIELD_VALUE_LENGTH_LIMIT`].
+    ///
+    /// Returns [`EmbedError::FooterTextEmpty`] if the provided text is empty.
+    ///
+    /// Returns [`EmbedError::FooterTextTooLong`] if the provided text is longer
+    /// than the limit defined at [`FOOTER_TEXT_LENGTH_LIMIT`].
+    ///
+    /// Returns [`EmbedError::TitleEmpty`] if the provided title is empty.
+    ///
+    /// Returns [`EmbedError::TitleTooLong`] if the provided text is longer
+    /// than the limit defined at [`TITLE_LENGTH_LIMIT`].
+    ///
+    /// Returns [`EmbedError::TooManyFields`] if there are too many fields
+    /// in the embed. Refer to [`EMBED_FIELD_LIMIT`] for the limit value.
+    ///
+    /// Returns [`EmbedError::TotalContentTooLarge`] if the textual content of
     /// the embed is too large. Refer to [`EMBED_LENGTH_LIMIT`] for the limit
     /// value and what counts towards it.
     ///
-    /// Returns [`EmbedBuildError::TooManyFields`] if there are too many fields
-    /// in the embed. Refer to [`EMBED_FIELD_LIMIT`] for the limit value.
-    ///
-    /// [`EMBED_FIELD_LIMIT`]: Self::EMBED_FIELD_LIMIT
-    /// [`EMBED_LENGTH_LIMIT`]: Self::EMBED_LENGTH_LIMIT
+    /// [`AUTHOR_NAME_LENGTH_LIMIT`]: #associatedconstant.AUTHOR_NAME_LENGTH_LIMIT
+    /// [`COLOR_MAXIMUM`]: #associatedconstant.COLOR_MAXIMUM
+    /// [`DESCRIPTION_LENGTH_LIMIT`]: #associatedconstant.DESCRIPTION_LENGTH_LIMIT
+    /// [`EMBED_FIELD_LIMIT`]: #associatedconstant.EMBED_FIELD_LIMIT
+    /// [`EMBED_LENGTH_LIMIT`]: #associatedconstant.EMBED_LENGTH_LIMIT
+    /// [`FIELD_NAME_LENGTH_LIMIT`]: #associatedconstant.FIELD_NAME_LENGTH_LIMIT
+    /// [`FIELD_VALUE_LENGTH_LIMIT`]: #associatedconstant.FIELD_VALUE_LENGTH_LIMIT
+    /// [`FOOTER_TEXT_LENGTH_LIMIT`]: #associatedconstant.FOOTER_TEXT_LENGTH_LIMIT
+    /// [`TITLE_LENGTH_LIMIT`]: #associatedconstant.TITLE_LENGTH_LIMIT
+    /// [`EmbedError::AuthorNameEmpty`]: enum.EmbedError.html#variant.AuthorNameEmpty
+    /// [`EmbedError::AuthorNameTooLong`]: enum.EmbedError.html#variant.AuthorNameTooLong
+    /// [`EmbedError::ColorNotRgb`]: enum.EmbedError.html#variant.ColorNotRgb
+    /// [`EmbedError::ColorZero`]: enum.EmbedError.html#variant.ColorZero
+    /// [`EmbedError::DescriptionEmpty`]: enum.EmbedError.html#variant.DescriptionEmpty
+    /// [`EmbedError::DescriptionTooLong`]: enum.EmbedError.html#variant.DescriptionTooLong
+    /// [`EmbedError::FieldNameEmpty`]: enum.EmbedError.html#variant.FieldNameEmpty
+    /// [`EmbedError::FieldNameTooLong`]: enum.EmbedError.html#variant.FieldNameTooLong
+    /// [`EmbedError::FieldValueEmpty`]: enum.EmbedError.html#variant.FieldValueEmpty
+    /// [`EmbedError::FieldValueTooLong`]: enum.EmbedError.html#variant.FieldValueTooLong
+    /// [`EmbedError::FooterTextEmpty`]: enum.EmbedError.html#variant.FooterTextEmpty
+    /// [`EmbedError::FooterTextTooLong`]: enum.EmbedError.html#variant.FooterTextTooLong
+    /// [`EmbedError::TitleEmpty`]: enum.EmbedError.html#variant.TitleEmpty
+    /// [`EmbedError::TitleTooLong`]: enum.EmbedError.html#variant.TitleTooLong
+    /// [`EmbedError::TooManyFields`]: enum.EmbedError.html#variant.TooManyFields
+    /// [`EmbedError::TotalContentTooLarge`]: enum.EmbedError.html#variant.TotalContentTooLarge
     #[must_use = "should be used as part of something like a message"]
-    pub fn build(self) -> Result<Embed, EmbedBuildError> {
+    pub fn build(mut self) -> Result<Embed, EmbedError> {
         if self.0.fields.len() > Self::EMBED_FIELD_LIMIT {
-            return Err(EmbedBuildError::TooManyFields {
+            return Err(EmbedError::TooManyFields {
                 fields: self.0.fields,
             });
         }
 
+        if let Some(color) = self.0.color {
+            if color == 0 {
+                return Err(EmbedError::ColorZero);
+            }
+
+            if color > Self::COLOR_MAXIMUM {
+                return Err(EmbedError::ColorNotRgb { color });
+            }
+        }
+
         let mut total = 0;
 
-        if let Some(name) = self
-            .0
-            .author
-            .as_ref()
-            .and_then(|author| author.name.as_ref())
-        {
-            total += name.chars().count();
+        if let Some(mut author) = self.0.author.take() {
+            if let Some(name) = author.name.take() {
+                if name.is_empty() {
+                    return Err(EmbedError::AuthorNameEmpty { name });
+                }
+
+                if name.chars().count() > Self::AUTHOR_NAME_LENGTH_LIMIT {
+                    return Err(EmbedError::AuthorNameTooLong { name });
+                }
+
+                total += name.chars().count();
+                author.name.replace(name);
+            }
+
+            self.0.author.replace(author);
         }
 
-        if let Some(description) = self.0.description.as_ref() {
+        if let Some(description) = self.0.description.take() {
+            if description.is_empty() {
+                return Err(EmbedError::DescriptionEmpty { description });
+            }
+
+            if description.chars().count() > Self::DESCRIPTION_LENGTH_LIMIT {
+                return Err(EmbedError::DescriptionTooLong { description });
+            }
+
             total += description.chars().count();
+            self.0.description.replace(description);
         }
 
-        if let Some(footer) = self.0.footer.as_ref() {
+        if let Some(footer) = self.0.footer.take() {
+            if footer.text.is_empty() {
+                return Err(EmbedError::FooterTextEmpty { text: footer.text });
+            }
+
+            if footer.text.chars().count() > Self::FOOTER_TEXT_LENGTH_LIMIT {
+                return Err(EmbedError::FooterTextTooLong { text: footer.text });
+            }
+
             total += footer.text.chars().count();
+            self.0.footer.replace(footer);
         }
 
-        for field in &self.0.fields {
-            total += field.name.chars().count() + field.value.chars().count();
+        {
+            let field_count = self.0.fields.len();
+            let fields = mem::replace(&mut self.0.fields, Vec::with_capacity(field_count));
+
+            for field in fields {
+                if field.name.is_empty() {
+                    return Err(EmbedError::FieldNameEmpty {
+                        name: field.name,
+                        value: field.value,
+                    });
+                }
+
+                if field.name.chars().count() > Self::FIELD_NAME_LENGTH_LIMIT {
+                    return Err(EmbedError::FieldNameTooLong {
+                        name: field.name,
+                        value: field.value,
+                    });
+                }
+
+                if field.value.is_empty() {
+                    return Err(EmbedError::FieldValueEmpty {
+                        name: field.name,
+                        value: field.value,
+                    });
+                }
+
+                if field.value.chars().count() > Self::FIELD_VALUE_LENGTH_LIMIT {
+                    return Err(EmbedError::FieldValueTooLong {
+                        name: field.name,
+                        value: field.value,
+                    });
+                }
+
+                total += field.name.chars().count() + field.value.chars().count();
+                self.0.fields.push(field);
+            }
         }
 
-        if let Some(title) = self.0.title.as_ref() {
+        if let Some(title) = self.0.title.take() {
+            if title.is_empty() {
+                return Err(EmbedError::TitleEmpty { title });
+            }
+
+            if title.chars().count() > Self::TITLE_LENGTH_LIMIT {
+                return Err(EmbedError::TitleTooLong { title });
+            }
+
             total += title.chars().count();
+            self.0.title.replace(title);
         }
 
         if total > Self::EMBED_LENGTH_LIMIT {
-            return Err(EmbedBuildError::ContentTooLarge { length: total });
+            return Err(EmbedError::TotalContentTooLarge { length: total });
         }
 
         Ok(self.0)
@@ -261,11 +414,11 @@ impl EmbedBuilder {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let author = EmbedAuthorBuilder::new()
-    ///     .name("Twilight")?
+    ///     .name("Twilight")
     ///     .url("https://github.com/twilight-rs/twilight")
     ///     .build();
     ///
-    /// let embed = EmbedBuilder::new().author(author).build();
+    /// let embed = EmbedBuilder::new().author(author).build()?;
     /// # Ok(()) }
     /// ```
     pub fn author(self, author: impl Into<EmbedAuthor>) -> Self {
@@ -281,7 +434,8 @@ impl EmbedBuilder {
     /// Set the color.
     ///
     /// This must be a valid hexadecimal RGB value. `0x000000` is not an
-    /// acceptable value as it would be thrown out by Discord.
+    /// acceptable value as it would be thrown out by Discord. Refer to
+    /// [`COLOR_MAXIMUM`] for the maximum acceptable value.
     ///
     /// # Examples
     ///
@@ -292,34 +446,19 @@ impl EmbedBuilder {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let embed = EmbedBuilder::new()
-    ///     .color(0xfd_69_b3)?
-    ///     .description("a description")?
-    ///     .build();
+    ///     .color(0xfd_69_b3)
+    ///     .description("a description")
+    ///     .build()?;
     /// # Ok(()) }
     /// ```
     ///
     /// # Errors
     ///
-    /// Returns [`EmbedColorError::NotRgb`] if the provided color is not a valid
-    /// RGB integer. Refer to [`COLOR_MAXIMUM`] to know what the maximum
-    /// accepted value is.
-    ///
-    /// Returns [`EmbedColorError::Zero`] if the provided color is 0, which is not
-    /// an acceptable value.
-    ///
-    /// [`COLOR_MAXIMUM`]: Self::COLOR_MAXIMUM
-    pub fn color(mut self, color: u32) -> Result<Self, EmbedColorError> {
-        if color == 0 {
-            return Err(EmbedColorError::Zero);
-        }
-
-        if color > Self::COLOR_MAXIMUM {
-            return Err(EmbedColorError::NotRgb { color });
-        }
-
+    /// [`COLOR_MAXIMUM`]: #associatedconstant.COLOR_MAXIMUM
+    pub fn color(mut self, color: u32) -> Self {
         self.0.color.replace(color);
 
-        Ok(self)
+        self
     }
 
     /// Set the description.
@@ -333,35 +472,19 @@ impl EmbedBuilder {
     /// use twilight_embed_builder::EmbedBuilder;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let embed = EmbedBuilder::new().description("this is an embed")?.build();
+    /// let embed = EmbedBuilder::new().description("this is an embed").build()?;
     /// # Ok(()) }
     /// ```
     ///
-    /// # Errors
-    ///
-    /// Returns [`EmbedDescriptionError::TooLong`] if the provided
-    /// description is longer than the maximum number of code points.
-    ///
-    /// [`DESCRIPTION_LENGTH_LIMIT`]: Self::DESCRIPTION_LENGTH_LIMIT
-    pub fn description(
-        self,
-        description: impl Into<String>,
-    ) -> Result<Self, EmbedDescriptionError> {
+    /// [`DESCRIPTION_LENGTH_LIMIT`]: #associatedconstant.DESCRIPTION_LENGTH_LIMIT
+    pub fn description(self, description: impl Into<String>) -> Self {
         self._description(description.into())
     }
 
-    fn _description(mut self, description: String) -> Result<Self, EmbedDescriptionError> {
-        if description.is_empty() {
-            return Err(EmbedDescriptionError::Empty { description });
-        }
-
-        if description.chars().count() > Self::DESCRIPTION_LENGTH_LIMIT {
-            return Err(EmbedDescriptionError::TooLong { description });
-        }
-
+    fn _description(mut self, description: String) -> Self {
         self.0.description.replace(description);
 
-        Ok(self)
+        self
     }
 
     /// Add a field to the embed.
@@ -373,8 +496,8 @@ impl EmbedBuilder {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let embed = EmbedBuilder::new()
-    ///     .description("this is an embed")?
-    ///     .field(EmbedFieldBuilder::new("a field", "and its value")?)
+    ///     .description("this is an embed")
+    ///     .field(EmbedFieldBuilder::new("a field", "and its value"))
     ///     .build()?;
     /// # Ok(()) }
     /// ```
@@ -397,8 +520,8 @@ impl EmbedBuilder {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let embed = EmbedBuilder::new()
-    ///     .description("this is an embed")?
-    ///     .footer(EmbedFooterBuilder::new("a footer")?)
+    ///     .description("this is an embed")
+    ///     .footer(EmbedFooterBuilder::new("a footer"))
     ///     .build()?;
     /// # Ok(()) }
     /// ```
@@ -424,7 +547,7 @@ impl EmbedBuilder {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let source = ImageSource::url("https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png")?;
     /// let embed = EmbedBuilder::new()
-    ///     .footer(EmbedFooterBuilder::new("twilight")?)
+    ///     .footer(EmbedFooterBuilder::new("twilight"))
     ///     .image(source)
     ///     .build()?;
     /// # Ok(()) }
@@ -452,7 +575,7 @@ impl EmbedBuilder {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let embed = EmbedBuilder::new()
-    ///     .description("a picture of twilight")?
+    ///     .description("a picture of twilight")
     ///     .thumbnail(ImageSource::attachment("twilight.png")?)
     ///     .build()?;
     /// # Ok(()) }
@@ -493,36 +616,21 @@ impl EmbedBuilder {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let embed = EmbedBuilder::new()
-    ///     .title("twilight")?
+    ///     .title("twilight")
     ///     .url("https://github.com/twilight-rs/twilight")
     ///     .build()?;
     /// # Ok(()) }
     /// ```
     ///
-    /// # Errors
-    ///
-    /// Returns [`EmbedTitleError::Empty`] if the provided title is empty.
-    ///
-    /// Returns [`EmbedTitleError::TooLong`] if the provided title is longer
-    /// than the limit defined at [`TITLE_LENGTH_LIMIT`].
-    ///
-    /// [`TITLE_LENGTH_LIMIT`]: Self::TITLE_LENGTH_LIMIT
-    pub fn title(self, title: impl Into<String>) -> Result<Self, EmbedTitleError> {
+    /// [`TITLE_LENGTH_LIMIT`]: #associatedconstant.TITLE_LENGTH_LIMIT
+    pub fn title(self, title: impl Into<String>) -> Self {
         self._title(title.into())
     }
 
-    fn _title(mut self, title: String) -> Result<Self, EmbedTitleError> {
-        if title.is_empty() {
-            return Err(EmbedTitleError::Empty { title });
-        }
-
-        if title.chars().count() > Self::TITLE_LENGTH_LIMIT {
-            return Err(EmbedTitleError::TooLong { title });
-        }
-
+    fn _title(mut self, title: String) -> Self {
         self.0.title.replace(title);
 
-        Ok(self)
+        self
     }
 
     /// Set the URL.
@@ -536,7 +644,7 @@ impl EmbedBuilder {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let embed = EmbedBuilder::new()
-    ///     .description("twilight's repository")?
+    ///     .description("twilight's repository")
     ///     .url("https://github.com/twilight-rs/twilight")
     ///     .build()?;
     /// # Ok(()) }
@@ -578,7 +686,7 @@ impl Default for EmbedBuilder {
 }
 
 impl TryFrom<EmbedBuilder> for Embed {
-    type Error = EmbedBuildError;
+    type Error = EmbedError;
 
     /// Convert an embed builder into an embed.
     ///
@@ -590,82 +698,48 @@ impl TryFrom<EmbedBuilder> for Embed {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        EmbedBuildError, EmbedBuilder, EmbedColorError, EmbedDescriptionError, EmbedTitleError,
-    };
+    use super::{EmbedBuilder, EmbedError};
     use crate::{field::EmbedFieldBuilder, footer::EmbedFooterBuilder, image_source::ImageSource};
     use static_assertions::{assert_fields, assert_impl_all, const_assert};
     use std::{convert::TryFrom, error::Error, fmt::Debug};
     use twilight_model::channel::embed::{Embed, EmbedField, EmbedFooter};
 
-    assert_impl_all!(
-        EmbedBuildError: Clone,
-        Debug,
-        Error,
-        Eq,
-        PartialEq,
-        Send,
-        Sync
-    );
-    assert_fields!(EmbedBuildError::ContentTooLarge: length);
-    assert_fields!(EmbedBuildError::TooManyFields: fields);
-    assert_impl_all!(
-        EmbedColorError: Clone,
-        Debug,
-        Error,
-        Eq,
-        PartialEq,
-        Send,
-        Sync
-    );
-    assert_fields!(EmbedColorError::NotRgb: color);
-    assert_impl_all!(
-        EmbedDescriptionError: Clone,
-        Debug,
-        Error,
-        Eq,
-        PartialEq,
-        Send,
-        Sync
-    );
-    assert_fields!(EmbedDescriptionError::Empty: description);
-    assert_fields!(EmbedDescriptionError::TooLong: description);
-    assert_impl_all!(
-        EmbedTitleError: Clone,
-        Debug,
-        Error,
-        Eq,
-        PartialEq,
-        Send,
-        Sync
-    );
-    assert_fields!(EmbedTitleError::Empty: title);
-    assert_fields!(EmbedTitleError::TooLong: title);
-    assert_impl_all!(
-        EmbedBuilder: Clone,
-        Debug,
-        Default,
-        Eq,
-        PartialEq,
-        Send,
-        Sync
-    );
+    assert_impl_all!(EmbedError: Clone, Debug, Error, Eq, PartialEq, Send, Sync);
+    assert_fields!(EmbedError::AuthorNameEmpty: name);
+    assert_fields!(EmbedError::AuthorNameTooLong: name);
+    assert_fields!(EmbedError::TooManyFields: fields);
+    assert_fields!(EmbedError::ColorNotRgb: color);
+    assert_fields!(EmbedError::DescriptionEmpty: description);
+    assert_fields!(EmbedError::DescriptionTooLong: description);
+    assert_fields!(EmbedError::FooterTextEmpty: text);
+    assert_fields!(EmbedError::FooterTextTooLong: text);
+    assert_fields!(EmbedError::TitleEmpty: title);
+    assert_fields!(EmbedError::TitleTooLong: title);
+    assert_fields!(EmbedError::TotalContentTooLarge: length);
+    assert_fields!(EmbedError::FieldNameEmpty: name, value);
+    assert_fields!(EmbedError::FieldNameTooLong: name, value);
+    assert_fields!(EmbedError::FieldValueEmpty: name, value);
+    assert_fields!(EmbedError::FieldValueTooLong: name, value);
+    const_assert!(EmbedBuilder::AUTHOR_NAME_LENGTH_LIMIT == 256);
     const_assert!(EmbedBuilder::COLOR_MAXIMUM == 0xff_ff_ff);
     const_assert!(EmbedBuilder::DESCRIPTION_LENGTH_LIMIT == 2048);
     const_assert!(EmbedBuilder::EMBED_FIELD_LIMIT == 25);
     const_assert!(EmbedBuilder::EMBED_LENGTH_LIMIT == 6000);
+    const_assert!(EmbedBuilder::FIELD_NAME_LENGTH_LIMIT == 256);
+    const_assert!(EmbedBuilder::FIELD_VALUE_LENGTH_LIMIT == 1024);
+    const_assert!(EmbedBuilder::FOOTER_TEXT_LENGTH_LIMIT == 2048);
     const_assert!(EmbedBuilder::TITLE_LENGTH_LIMIT == 256);
     assert_impl_all!(Embed: TryFrom<EmbedBuilder>);
 
     #[test]
     fn test_color_error() -> Result<(), Box<dyn Error>> {
         assert!(matches!(
-            EmbedBuilder::new().color(0).unwrap_err(),
-            EmbedColorError::Zero
+            EmbedBuilder::new().color(0).build().unwrap_err(),
+            EmbedError::ColorZero
         ));
         assert!(matches!(
-            EmbedBuilder::new().color(u32::MAX).unwrap_err(),
-            EmbedColorError::NotRgb { color }
+            EmbedBuilder::new().color(u32::MAX).build().unwrap_err(),
+            EmbedError::ColorNotRgb { color }
             if color == u32::MAX
         ));
 
@@ -675,14 +749,14 @@ mod tests {
     #[test]
     fn test_description_error() {
         assert!(matches!(
-            EmbedBuilder::new().description("").unwrap_err(),
-            EmbedDescriptionError::Empty { description }
+            EmbedBuilder::new().description("").build().unwrap_err(),
+            EmbedError::DescriptionEmpty { description }
             if description.is_empty()
         ));
         let description_too_long = EmbedBuilder::DESCRIPTION_LENGTH_LIMIT + 1;
         assert!(matches!(
-            EmbedBuilder::new().description("a".repeat(description_too_long)).unwrap_err(),
-            EmbedDescriptionError::TooLong { description }
+            EmbedBuilder::new().description("a".repeat(description_too_long)).build().unwrap_err(),
+            EmbedError::DescriptionTooLong { description }
             if description.len() == description_too_long
         ));
     }
@@ -690,30 +764,32 @@ mod tests {
     #[test]
     fn test_title_error() {
         assert!(matches!(
-            EmbedBuilder::new().title("").unwrap_err(),
-            EmbedTitleError::Empty { title }
+            EmbedBuilder::new().title("").build().unwrap_err(),
+            EmbedError::TitleEmpty { title }
             if title.is_empty()
         ));
         let title_too_long = EmbedBuilder::TITLE_LENGTH_LIMIT + 1;
         assert!(matches!(
-            EmbedBuilder::new().title("a".repeat(title_too_long)).unwrap_err(),
-            EmbedTitleError::TooLong { title }
+            EmbedBuilder::new().title("a".repeat(title_too_long)).build().unwrap_err(),
+            EmbedError::TitleTooLong { title }
             if title.len() == title_too_long
         ));
     }
 
     #[test]
-    fn test_builder() -> Result<(), Box<dyn Error>> {
+    fn test_builder() {
         let footer_image = ImageSource::url(
             "https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png",
-        )?;
+        )
+        .unwrap();
         let embed = EmbedBuilder::new()
-            .color(0x00_43_ff)?
-            .description("Description")?
+            .color(0x00_43_ff)
+            .description("Description")
             .timestamp("123")
-            .footer(EmbedFooterBuilder::new("Warn")?.icon_url(footer_image))
-            .field(EmbedFieldBuilder::new("name", "title")?.inline())
-            .build()?;
+            .footer(EmbedFooterBuilder::new("Warn").icon_url(footer_image))
+            .field(EmbedFieldBuilder::new("name", "title").inline())
+            .build()
+            .unwrap();
 
         let expected = Embed {
             author: None,
@@ -744,7 +820,5 @@ mod tests {
         };
 
         assert_eq!(embed, expected);
-
-        Ok(())
     }
 }

--- a/embed-builder/src/field.rs
+++ b/embed-builder/src/field.rs
@@ -23,8 +23,8 @@ impl EmbedFieldBuilder {
     /// Refer to [`EmbedBuilder::FIELD_VALUE_LENGTH_LIMIT`] for the maximum
     /// number of UTF-16 code poitns that can be in a field value.
     ///
-    /// [`EmbedBuilder::FIELD_NAME_LENGTH_LIMIT`]: struct.EmbedBuilder.html#associatedconstant.FIELD_NAME_LENGTH_LIMIT
-    /// [`EmbedBuilder::FIELD_VALUE_LENGTH_LIMIT`]: struct.EmbedBuilder.html#associatedconstant.FIELD_VALUE_LENGTH_LIMIT
+    /// [`EmbedBuilder::FIELD_NAME_LENGTH_LIMIT`]: crate::EmbedBuilder::FIELD_NAME_LENGTH_LIMIT
+    /// [`EmbedBuilder::FIELD_VALUE_LENGTH_LIMIT`]: crate::EmbedBuilder::FIELD_VALUE_LENGTH_LIMIT
     pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
         Self::_new(name.into(), value.into())
     }

--- a/embed-builder/src/field.rs
+++ b/embed-builder/src/field.rs
@@ -1,61 +1,6 @@
 //! Create embed fields.
 
-use std::{
-    error::Error,
-    fmt::{Display, Formatter, Result as FmtResult},
-};
 use twilight_model::channel::embed::EmbedField;
-
-/// Error creating an embed field.
-///
-/// This is returned from [`EmbedFieldBuilder::new`].
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum EmbedFieldError {
-    /// Name is empty.
-    NameEmpty {
-        /// Provided name. Although empty, the same owned allocation is
-        /// included.
-        name: String,
-        /// Provided value.
-        value: String,
-    },
-    /// Name is longer than 256 UTF-16 code points.
-    NameTooLong {
-        /// Provided name.
-        name: String,
-        /// Provided value.
-        value: String,
-    },
-    /// Value is empty.
-    ValueEmpty {
-        /// Provided name.
-        name: String,
-        /// Provided value. Although empty, the same owned allocation is
-        /// included.
-        value: String,
-    },
-    /// Value is longer than 1024 UTF-16 code points.
-    ValueTooLong {
-        /// Provided name.
-        name: String,
-        /// Provided value.
-        value: String,
-    },
-}
-
-impl Display for EmbedFieldError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NameEmpty { .. } => f.write_str("the field name is empty"),
-            Self::NameTooLong { .. } => f.write_str("the field name is too long"),
-            Self::ValueEmpty { .. } => f.write_str("the field value is empty"),
-            Self::ValueTooLong { .. } => f.write_str("the field value is too long"),
-        }
-    }
-}
-
-impl Error for EmbedFieldError {}
 
 /// Create an embed field with a builder.
 ///
@@ -70,64 +15,26 @@ impl Error for EmbedFieldError {}
 pub struct EmbedFieldBuilder(EmbedField);
 
 impl EmbedFieldBuilder {
-    /// The maximum number of UTF-16 code points that can be in a field name.
-    ///
-    /// This is used by [`new`].
-    ///
-    /// [`new`]: Self::new
-    pub const NAME_LENGTH_LIMIT: usize = 256;
-
-    /// The maximum number of UTF-16 code points that can be in a field value.
-    ///
-    /// This is used by [`new`].
-    ///
-    /// [`new`]: Self::new
-    pub const VALUE_LENGTH_LIMIT: usize = 1024;
-
     /// Create a new default embed field builder.
     ///
-    /// The name is limited to 256 UTF-16 code points, and the value is limited
-    /// to 1024.
+    /// Refer to [`EmbedBuilder::FIELD_NAME_LENGTH_LIMIT`] for the maximum
+    /// number of UTF-16 code poitns that can be in a field name.
     ///
-    /// # Errors
+    /// Refer to [`EmbedBuilder::FIELD_VALUE_LENGTH_LIMIT`] for the maximum
+    /// number of UTF-16 code poitns that can be in a field value.
     ///
-    /// Returns [`EmbedFieldError::NameEmpty`] if the provided name is
-    /// empty.
-    ///
-    /// Returns [`EmbedFieldError::NameTooLong`] if the provided name is
-    /// longer than 256 UTF-16 code points.
-    ///
-    /// Returns [`EmbedFieldError::ValueEmpty`] if the provided value is
-    /// empty.
-    ///
-    /// Returns [`EmbedFieldError::ValueTooLong`] if the provided value
-    /// is longer than 1024 UTF-16 code points.
-    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Result<Self, EmbedFieldError> {
+    /// [`EmbedBuilder::FIELD_NAME_LENGTH_LIMIT`]: struct.EmbedBuilder.html#associatedconstant.FIELD_NAME_LENGTH_LIMIT
+    /// [`EmbedBuilder::FIELD_VALUE_LENGTH_LIMIT`]: struct.EmbedBuilder.html#associatedconstant.FIELD_VALUE_LENGTH_LIMIT
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
         Self::_new(name.into(), value.into())
     }
 
-    fn _new(name: String, value: String) -> Result<Self, EmbedFieldError> {
-        if name.is_empty() {
-            return Err(EmbedFieldError::NameEmpty { name, value });
-        }
-
-        if name.chars().count() > Self::NAME_LENGTH_LIMIT {
-            return Err(EmbedFieldError::NameTooLong { name, value });
-        }
-
-        if value.is_empty() {
-            return Err(EmbedFieldError::ValueEmpty { name, value });
-        }
-
-        if value.chars().count() > Self::VALUE_LENGTH_LIMIT {
-            return Err(EmbedFieldError::ValueTooLong { name, value });
-        }
-
-        Ok(Self(EmbedField {
+    fn _new(name: String, value: String) -> Self {
+        Self(EmbedField {
             inline: false,
             name,
             value,
-        }))
+        })
     }
 
     /// Build into an embed field.
@@ -145,11 +52,9 @@ impl EmbedFieldBuilder {
     /// ```rust
     /// use twilight_embed_builder::EmbedFieldBuilder;
     ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let field = EmbedFieldBuilder::new("twilight", "is cool")?
+    /// let field = EmbedFieldBuilder::new("twilight", "is cool")
     ///     .inline()
     ///     .build();
-    /// # Ok(()) }
     /// ```
     pub fn inline(mut self) -> Self {
         self.0.inline = true;
@@ -169,78 +74,60 @@ impl From<EmbedFieldBuilder> for EmbedField {
 
 #[cfg(test)]
 mod tests {
-    use super::{EmbedFieldBuilder, EmbedFieldError};
-    use static_assertions::{assert_fields, assert_impl_all, const_assert};
-    use std::{error::Error, fmt::Debug};
+    use super::EmbedFieldBuilder;
+    use crate::{EmbedBuilder, EmbedError};
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
     use twilight_model::channel::embed::EmbedField;
 
-    assert_impl_all!(
-        EmbedFieldError: Clone,
-        Debug,
-        Error,
-        Eq,
-        PartialEq,
-        Send,
-        Sync
-    );
-    assert_fields!(EmbedFieldError::NameEmpty: name, value);
-    assert_fields!(EmbedFieldError::NameTooLong: name, value);
-    assert_fields!(EmbedFieldError::ValueEmpty: name, value);
-    assert_fields!(EmbedFieldError::ValueTooLong: name, value);
     assert_impl_all!(EmbedFieldBuilder: Clone, Debug, Eq, PartialEq, Send, Sync);
-    const_assert!(EmbedFieldBuilder::NAME_LENGTH_LIMIT == 256);
-    const_assert!(EmbedFieldBuilder::VALUE_LENGTH_LIMIT == 1024);
     assert_impl_all!(EmbedField: From<EmbedFieldBuilder>);
 
     #[test]
     fn test_new_errors() {
         assert!(matches!(
-            EmbedFieldBuilder::new("", "a"),
-            Err(EmbedFieldError::NameEmpty { name, value })
+            EmbedBuilder::new().field(EmbedFieldBuilder::new("", "a")).build().unwrap_err(),
+            EmbedError::FieldNameEmpty { name, value }
             if name.is_empty() && value.len() == 1
         ));
         assert!(matches!(
-            EmbedFieldBuilder::new("a".repeat(257), "a"),
-            Err(EmbedFieldError::NameTooLong { name, value })
+            EmbedBuilder::new().field(EmbedFieldBuilder::new("a".repeat(257), "a")).build().unwrap_err(),
+            EmbedError::FieldNameTooLong { name, value }
             if name.len() == 257 && value.len() == 1
         ));
         assert!(matches!(
-            EmbedFieldBuilder::new("a", ""),
-            Err(EmbedFieldError::ValueEmpty { name, value })
+            EmbedBuilder::new().field(EmbedFieldBuilder::new("a", "")).build().unwrap_err(),
+            EmbedError::FieldValueEmpty { name, value }
             if name.len() == 1 && value.is_empty()
         ));
         assert!(matches!(
-            EmbedFieldBuilder::new("a", "a".repeat(1025)),
-            Err(EmbedFieldError::ValueTooLong { name, value })
+            EmbedBuilder::new().field(EmbedFieldBuilder::new("a", "a".repeat(1025))).build().unwrap_err(),
+            EmbedError::FieldValueTooLong { name, value }
             if name.len() == 1 && value.len() == 1025
         ));
     }
 
     #[test]
-    fn test_builder_inline() -> Result<(), Box<dyn Error>> {
+    fn test_builder_inline() {
         let expected = EmbedField {
             inline: true,
             name: "name".to_owned(),
             value: "value".to_owned(),
         };
-        let actual = EmbedFieldBuilder::new("name", "value")?.inline().build();
+        let actual = EmbedFieldBuilder::new("name", "value").inline().build();
 
         assert_eq!(actual, expected);
-
-        Ok(())
     }
 
     #[test]
-    fn test_builder_no_inline() -> Result<(), Box<dyn Error>> {
+    fn test_builder_no_inline() {
         let expected = EmbedField {
             inline: false,
             name: "name".to_owned(),
             value: "value".to_owned(),
         };
-        let actual = EmbedFieldBuilder::new("name", "value")?.build();
+        let actual = EmbedFieldBuilder::new("name", "value").build();
 
         assert_eq!(actual, expected);
-
-        Ok(())
     }
 }

--- a/embed-builder/src/footer.rs
+++ b/embed-builder/src/footer.rs
@@ -1,41 +1,7 @@
 //! Create embed footers.
 
 use super::image_source::ImageSource;
-use std::{
-    error::Error,
-    fmt::{Display, Formatter, Result as FmtResult},
-};
 use twilight_model::channel::embed::EmbedFooter;
-
-/// Error creating an embed footer.
-///
-/// This is returned from [`EmbedFooterBuilder::new`].
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum EmbedFooterTextError {
-    /// Text is empty.
-    Empty {
-        /// Provided text. Although empty, the same owned allocation is
-        /// included.
-        text: String,
-    },
-    /// Text is longer than 2048 UTF-16 code points.
-    TooLong {
-        /// Provided text.
-        text: String,
-    },
-}
-
-impl Display for EmbedFooterTextError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Empty { .. } => f.write_str("the footer text is empty"),
-            Self::TooLong { .. } => f.write_str("the footer text is too long"),
-        }
-    }
-}
-
-impl Error for EmbedFooterTextError {}
 
 /// Create an embed footer with a builder.
 ///
@@ -47,41 +13,24 @@ impl Error for EmbedFooterTextError {}
 pub struct EmbedFooterBuilder(EmbedFooter);
 
 impl EmbedFooterBuilder {
-    /// The maximum number of UTF-16 code points that can be in a footer's text.
-    pub const TEXT_LENGTH_LIMIT: usize = 2048;
-
     /// Create a new default embed footer builder.
     ///
-    /// Refer to [`TEXT_LENGTH_LIMIT`] for the maximum number of UTF-16 code
-    /// points that can be in a footer's text.
+    /// Refer to [`EmbedBuilder::FOOTER_TEXT_LENGTH_LIMIT`] for the maximum
+    /// number of UTF-16 code points that can be in a footer's text.
     ///
     /// # Errors
     ///
-    /// Returns [`EmbedFooterTextError::Empty`] if the provided text is
-    /// empty.
-    ///
-    /// Returns [`EmbedFooterTextError::TooLong`] if the provided text is
-    /// longer than the limit defined at [`TEXT_LENGTH_LIMIT`].
-    ///
-    /// [`TEXT_LENGTH_LIMIT`]: Self::TEXT_LENGTH_LIMIT
-    pub fn new(text: impl Into<String>) -> Result<Self, EmbedFooterTextError> {
+    /// [`EmbedBuilder::FOOTER_TEXT_LENGTH_LIMIT`]: struct.EmbedBuilder.html#associatedconstant.FOOTER_TEXT_LENGTH_LIMIT
+    pub fn new(text: impl Into<String>) -> Self {
         Self::_new(text.into())
     }
 
-    fn _new(text: String) -> Result<Self, EmbedFooterTextError> {
-        if text.is_empty() {
-            return Err(EmbedFooterTextError::Empty { text });
-        }
-
-        if text.chars().count() > Self::TEXT_LENGTH_LIMIT {
-            return Err(EmbedFooterTextError::TooLong { text });
-        }
-
-        Ok(Self(EmbedFooter {
+    fn _new(text: String) -> Self {
+        Self(EmbedFooter {
             icon_url: None,
             proxy_icon_url: None,
             text,
-        }))
+        })
     }
 
     /// Build into an embed footer.
@@ -101,7 +50,7 @@ impl EmbedFooterBuilder {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let icon_url = ImageSource::url("https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png")?;
-    /// let footer = EmbedFooterBuilder::new("Twilight")?
+    /// let footer = EmbedFooterBuilder::new("Twilight")
     ///     .icon_url(icon_url)
     ///     .build();
     /// # Ok(()) }
@@ -124,38 +73,26 @@ impl From<EmbedFooterBuilder> for EmbedFooter {
 
 #[cfg(test)]
 mod tests {
-    use super::{EmbedFooterBuilder, EmbedFooterTextError};
-    use crate::ImageSource;
-    use static_assertions::{assert_fields, assert_impl_all, const_assert};
-    use std::{error::Error, fmt::Debug};
+    use super::EmbedFooterBuilder;
+    use crate::{EmbedBuilder, EmbedError, ImageSource};
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
     use twilight_model::channel::embed::EmbedFooter;
 
-    assert_impl_all!(
-        EmbedFooterTextError: Clone,
-        Debug,
-        Error,
-        Eq,
-        PartialEq,
-        Send,
-        Sync
-    );
-    assert_fields!(EmbedFooterTextError::Empty: text);
-    assert_fields!(EmbedFooterTextError::TooLong: text);
     assert_impl_all!(EmbedFooterBuilder: Clone, Debug, Eq, PartialEq, Send, Sync);
-    const_assert!(EmbedFooterBuilder::TEXT_LENGTH_LIMIT == 2048);
     assert_impl_all!(EmbedFooter: From<EmbedFooterBuilder>);
 
     #[test]
-    fn test_text() -> Result<(), Box<dyn Error>> {
+    fn test_text() {
         assert!(matches!(
-            EmbedFooterBuilder::new("").unwrap_err(),
-            EmbedFooterTextError::Empty { text }
+            EmbedBuilder::new().footer(EmbedFooterBuilder::new("")).build().unwrap_err(),
+            EmbedError::FooterTextEmpty { text }
             if text.is_empty()
         ));
-        let too_long_len = EmbedFooterBuilder::TEXT_LENGTH_LIMIT + 1;
+        let too_long_len = EmbedBuilder::FOOTER_TEXT_LENGTH_LIMIT + 1;
         assert!(matches!(
-            EmbedFooterBuilder::new("a".repeat(too_long_len)).unwrap_err(),
-            EmbedFooterTextError::TooLong { text }
+            EmbedBuilder::new().footer(EmbedFooterBuilder::new("a".repeat(too_long_len))).build().unwrap_err(),
+            EmbedError::FooterTextTooLong { text }
             if text.len() == too_long_len
         ));
 
@@ -164,23 +101,19 @@ mod tests {
             proxy_icon_url: None,
             text: "a footer".to_owned(),
         };
-        let actual = EmbedFooterBuilder::new("a footer")?.build();
+        let actual = EmbedFooterBuilder::new("a footer").build();
         assert_eq!(actual, expected);
-
-        Ok(())
     }
 
     #[test]
-    fn test_builder() -> Result<(), Box<dyn Error>> {
+    fn test_builder() {
         let expected = EmbedFooter {
             icon_url: Some("https://example.com/1.png".to_owned()),
             proxy_icon_url: None,
             text: "a footer".to_owned(),
         };
-        let image = ImageSource::url("https://example.com/1.png")?;
-        let actual = EmbedFooterBuilder::new("a footer")?.icon_url(image).build();
+        let image = ImageSource::url("https://example.com/1.png").unwrap();
+        let actual = EmbedFooterBuilder::new("a footer").icon_url(image).build();
         assert_eq!(actual, expected);
-
-        Ok(())
     }
 }

--- a/embed-builder/src/footer.rs
+++ b/embed-builder/src/footer.rs
@@ -18,9 +18,7 @@ impl EmbedFooterBuilder {
     /// Refer to [`EmbedBuilder::FOOTER_TEXT_LENGTH_LIMIT`] for the maximum
     /// number of UTF-16 code points that can be in a footer's text.
     ///
-    /// # Errors
-    ///
-    /// [`EmbedBuilder::FOOTER_TEXT_LENGTH_LIMIT`]: struct.EmbedBuilder.html#associatedconstant.FOOTER_TEXT_LENGTH_LIMIT
+    /// [`EmbedBuilder::FOOTER_TEXT_LENGTH_LIMIT`]: crate::EmbedBuilder::FOOTER_TEXT_LENGTH_LIMIT
     pub fn new(text: impl Into<String>) -> Self {
         Self::_new(text.into())
     }

--- a/embed-builder/src/lib.rs
+++ b/embed-builder/src/lib.rs
@@ -15,10 +15,10 @@
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let embed = EmbedBuilder::new()
-//!     .description("Here's a list of reasons why Twilight is the best pony:")?
-//!     .field(EmbedFieldBuilder::new("Wings", "She has wings.")?.inline())
-//!     .field(EmbedFieldBuilder::new("Horn", "She can do magic, and she's really good at it.")?.inline())
-//!     .build();
+//!     .description("Here's a list of reasons why Twilight is the best pony:")
+//!     .field(EmbedFieldBuilder::new("Wings", "She has wings.").inline())
+//!     .field(EmbedFieldBuilder::new("Horn", "She can do magic, and she's really good at it.").inline())
+//!     .build()?;
 //! # Ok(()) }
 //! ```
 //!
@@ -29,9 +29,9 @@
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let embed = EmbedBuilder::new()
-//!     .description("Here's a cool image of Twilight Sparkle")?
+//!     .description("Here's a cool image of Twilight Sparkle")
 //!     .image(ImageSource::attachment("bestpony.png")?)
-//!     .build();
+//!     .build()?;
 //!
 //! # Ok(()) }
 //! ```
@@ -59,18 +59,16 @@
     warnings
 )]
 
-pub mod author;
-pub mod builder;
-pub mod field;
-pub mod footer;
-pub mod image_source;
+mod author;
+mod builder;
+mod field;
+mod footer;
+mod image_source;
 
 pub use self::{
-    author::{EmbedAuthorBuilder, EmbedAuthorNameError},
-    builder::{
-        EmbedBuildError, EmbedBuilder, EmbedColorError, EmbedDescriptionError, EmbedTitleError,
-    },
-    field::{EmbedFieldBuilder, EmbedFieldError},
-    footer::{EmbedFooterBuilder, EmbedFooterTextError},
+    author::EmbedAuthorBuilder,
+    builder::{EmbedBuilder, EmbedError},
+    field::EmbedFieldBuilder,
+    footer::EmbedFooterBuilder,
     image_source::{ImageSource, ImageSourceAttachmentError, ImageSourceUrlError},
 };

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -209,8 +209,8 @@ impl<'a> UpdateWebhookMessage<'a> {
     /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("token");
     /// let embed = EmbedBuilder::new()
-    ///     .description("Powerful, flexible, and scalable ecosystem of Rust libraries for the Discord API.")?
-    ///     .title("Twilight")?
+    ///     .description("Powerful, flexible, and scalable ecosystem of Rust libraries for the Discord API.")
+    ///     .title("Twilight")
     ///     .url("https://twilight.rs")
     ///     .build()?;
     ///


### PR DESCRIPTION
Simplify the error handling of the Embed Builder and all of its sub-builders. Instead of returning a unique error for any method that can error, use the pattern of delayed error handling: accept potentially invalid input and then, when building the final embed, check all of the input and error if necessary.

Over time we've acquired feedback that the embed builder is difficult to use. There are too many reasons for erroring, and many of the methods can return one. By lazily returning errors when finishing the builder, we can also perform the step of checking the total length of the content of the embed. This removes the duplication of work.