### PR TITLE
Expose gateway cluster's send error type

### DIFF
--- a/gateway/src/cluster/mod.rs
+++ b/gateway/src/cluster/mod.rs
@@ -62,5 +62,5 @@ mod r#impl;
 pub use self::{
     builder::{ClusterBuilder, ShardScheme, ShardSchemeRangeError},
     config::Config,
-    r#impl::{Cluster, ClusterCommandError, ClusterStartError},
+    r#impl::{Cluster, ClusterCommandError, ClusterSendError, ClusterStartError},
 };


### PR DESCRIPTION
Expose the `cluster::r#impl::ClusterSendError` type from `cluster`. `ClusterSendError` is returned by `Cluster::send`, however was not exposed from the module and thus can not be named.

Related to #679.