### PR TITLE
Hide inner error sources

### DIFF
--- a/embed-builder/src/author.rs
+++ b/embed-builder/src/author.rs
@@ -82,7 +82,7 @@ impl From<EmbedAuthorBuilder> for EmbedAuthor {
 #[cfg(test)]
 mod tests {
     use super::EmbedAuthorBuilder;
-    use crate::{EmbedBuilder, EmbedError, ImageSource};
+    use crate::{EmbedBuilder, EmbedErrorType, ImageSource};
     use static_assertions::assert_impl_all;
     use std::fmt::Debug;
     use twilight_model::channel::embed::EmbedAuthor;
@@ -115,8 +115,8 @@ mod tests {
     fn test_name_empty() {
         let builder = EmbedBuilder::new().author(EmbedAuthorBuilder::new().name(""));
 
-        assert!(matches!(builder.build().unwrap_err(),
-            EmbedError::AuthorNameEmpty { .. }
+        assert!(matches!(builder.build().unwrap_err().kind(),
+            EmbedErrorType::AuthorNameEmpty { .. }
         ));
     }
 
@@ -127,8 +127,8 @@ mod tests {
 
         let builder = EmbedBuilder::new().author(EmbedAuthorBuilder::new().name("a".repeat(257)));
         assert!(matches!(
-            builder.build().unwrap_err(),
-            EmbedError::AuthorNameTooLong { .. }
+            builder.build().unwrap_err().kind(),
+            EmbedErrorType::AuthorNameTooLong { .. }
         ));
     }
 

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -28,8 +28,8 @@ impl EmbedError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -14,9 +14,69 @@ use twilight_model::channel::embed::{
 /// Error building an embed.
 ///
 /// This is returned from [`EmbedBuilder::build`].
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
+pub struct EmbedError {
+    kind: EmbedErrorType,
+}
+
+impl EmbedError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &EmbedErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (EmbedErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
+}
+
+impl Display for EmbedError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            EmbedErrorType::AuthorNameEmpty { .. } => f.write_str("the author name is empty"),
+            EmbedErrorType::AuthorNameTooLong { .. } => f.write_str("the author name is too long"),
+            EmbedErrorType::ColorNotRgb { color } => {
+                f.write_fmt(format_args!("the color {} is invalid", color))
+            }
+            EmbedErrorType::ColorZero => {
+                f.write_str("the given color value is 0, which is not acceptable")
+            }
+            EmbedErrorType::DescriptionEmpty { .. } => f.write_str("the description is empty"),
+            EmbedErrorType::DescriptionTooLong { .. } => f.write_str("the description is too long"),
+            EmbedErrorType::FieldNameEmpty { .. } => f.write_str("the field name is empty"),
+            EmbedErrorType::FieldNameTooLong { .. } => f.write_str("the field name is too long"),
+            EmbedErrorType::FieldValueEmpty { .. } => f.write_str("the field value is empty"),
+            EmbedErrorType::FieldValueTooLong { .. } => f.write_str("the field value is too long"),
+            EmbedErrorType::FooterTextEmpty { .. } => f.write_str("the footer text is empty"),
+            EmbedErrorType::FooterTextTooLong { .. } => f.write_str("the footer text is too long"),
+            EmbedErrorType::TitleEmpty { .. } => f.write_str("the title is empty"),
+            EmbedErrorType::TitleTooLong { .. } => f.write_str("the title is too long"),
+            EmbedErrorType::TotalContentTooLarge { .. } => {
+                f.write_str("the total content of the embed is too large")
+            }
+            EmbedErrorType::TooManyFields { .. } => {
+                f.write_str("more than 25 fields were provided")
+            }
+        }
+    }
+}
+
+impl Error for EmbedError {}
+
+/// Type of [`EmbedError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum EmbedError {
+pub enum EmbedErrorType {
     /// Name is empty.
     AuthorNameEmpty {
         /// Provided name. Although empty, the same owned allocation is
@@ -117,35 +177,6 @@ pub enum EmbedError {
     },
 }
 
-impl Display for EmbedError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::AuthorNameEmpty { .. } => f.write_str("the author name is empty"),
-            Self::AuthorNameTooLong { .. } => f.write_str("the author name is too long"),
-            Self::ColorNotRgb { color } => {
-                f.write_fmt(format_args!("the color {} is invalid", color))
-            }
-            Self::ColorZero => f.write_str("the given color value is 0, which is not acceptable"),
-            Self::DescriptionEmpty { .. } => f.write_str("the description is empty"),
-            Self::DescriptionTooLong { .. } => f.write_str("the description is too long"),
-            Self::FieldNameEmpty { .. } => f.write_str("the field name is empty"),
-            Self::FieldNameTooLong { .. } => f.write_str("the field name is too long"),
-            Self::FieldValueEmpty { .. } => f.write_str("the field value is empty"),
-            Self::FieldValueTooLong { .. } => f.write_str("the field value is too long"),
-            Self::FooterTextEmpty { .. } => f.write_str("the footer text is empty"),
-            Self::FooterTextTooLong { .. } => f.write_str("the footer text is too long"),
-            Self::TitleEmpty { .. } => f.write_str("the title is empty"),
-            Self::TitleTooLong { .. } => f.write_str("the title is too long"),
-            Self::TotalContentTooLarge { .. } => {
-                f.write_str("the total content of the embed is too large")
-            }
-            Self::TooManyFields { .. } => f.write_str("more than 25 fields were provided"),
-        }
-    }
-}
-
-impl Error for EmbedError {}
-
 /// Create an embed with a builder.
 ///
 /// # Examples
@@ -206,52 +237,56 @@ impl EmbedBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`EmbedError::AuthorNameEmpty`] if the provided name is empty.
+    /// Returns an [`EmbedError::AuthorNameEmpty`] error type if the provided
+    /// name is empty.
     ///
-    /// Returns [`EmbedError::AuthorNameTooLong`] if the provided name is longer
-    /// than [`AUTHOR_NAME_LENGTH_LIMIT`].
+    /// Returns an [`EmbedError::AuthorNameTooLong`] error type if the provided
+    /// name is longer than [`AUTHOR_NAME_LENGTH_LIMIT`].
     ///
-    /// Returns [`EmbedError::ColorNotRgb`] if the provided color is not a valid
-    /// RGB integer. Refer to [`COLOR_MAXIMUM`] to know what the maximum
-    /// accepted value is.
+    /// Returns an [`EmbedError::ColorNotRgb`] error type if the provided color
+    /// is not a valid RGB integer. Refer to [`COLOR_MAXIMUM`] to know what the
+    /// maximum accepted value is.
     ///
-    /// Returns [`EmbedError::ColorZero`] if the provided color is 0, which is
-    /// not an acceptable value.
+    /// Returns an [`EmbedError::ColorZero`] error type if the provided color is
+    /// 0, which is not an acceptable value.
     ///
-    /// Returns [`EmbedError::DescriptionEmpty`] if a provided description is
-    /// empty.
+    /// Returns an [`EmbedError::DescriptionEmpty`] error type if a provided
+    /// description is empty.
     ///
-    /// Returns [`EmbedError::DescriptionTooLong`] if a provided description is
-    /// longer than [`DESCRIPTION_LENGTH_LIMIT`].
+    /// Returns an [`EmbedError::DescriptionTooLong`] error type if a provided
+    /// description is longer than [`DESCRIPTION_LENGTH_LIMIT`].
     ///
-    /// Returns [`EmbedError::FieldNameEmpty`] if a provided field name is
-    /// empty.
+    /// Returns an [`EmbedError::FieldNameEmpty`] error type if a provided field
+    /// name is empty.
     ///
-    /// Returns [`EmbedError::FieldNameTooLong`] if a provided field name is
-    /// longer than [`FIELD_NAME_LENGTH_LIMIT`].
+    /// Returns an [`EmbedError::FieldNameTooLong`] error type if a provided
+    /// field name is longer than [`FIELD_NAME_LENGTH_LIMIT`].
     ///
-    /// Returns [`EmbedError::FieldValueEmpty`] if a provided field value is
-    /// empty.
+    /// Returns an [`EmbedError::FieldValueEmpty`] error type if a provided
+    /// field value is empty.
     ///
-    /// Returns [`EmbedError::FieldValueTooLong`] if a provided field value is
-    /// longer than [`FIELD_VALUE_LENGTH_LIMIT`].
+    /// Returns an [`EmbedError::FieldValueTooLong`] error type if a provided
+    /// field value is longer than [`FIELD_VALUE_LENGTH_LIMIT`].
     ///
-    /// Returns [`EmbedError::FooterTextEmpty`] if the provided text is empty.
+    /// Returns an [`EmbedError::FooterTextEmpty`] error type if the provided
+    /// text is empty.
     ///
-    /// Returns [`EmbedError::FooterTextTooLong`] if the provided text is longer
-    /// than the limit defined at [`FOOTER_TEXT_LENGTH_LIMIT`].
+    /// Returns an [`EmbedError::FooterTextTooLong`] error type if the provided
+    /// text is longer than the limit defined at [`FOOTER_TEXT_LENGTH_LIMIT`].
     ///
-    /// Returns [`EmbedError::TitleEmpty`] if the provided title is empty.
+    /// Returns an [`EmbedError::TitleEmpty`] error type if the provided title
+    /// is empty.
     ///
-    /// Returns [`EmbedError::TitleTooLong`] if the provided text is longer
-    /// than the limit defined at [`TITLE_LENGTH_LIMIT`].
+    /// Returns an [`EmbedError::TitleTooLong`] error type if the provided text
+    /// is longer than the limit defined at [`TITLE_LENGTH_LIMIT`].
     ///
-    /// Returns [`EmbedError::TooManyFields`] if there are too many fields
-    /// in the embed. Refer to [`EMBED_FIELD_LIMIT`] for the limit value.
+    /// Returns an [`EmbedError::TooManyFields`] error type if there are too
+    /// many fields in the embed. Refer to [`EMBED_FIELD_LIMIT`] for the limit
+    /// value.
     ///
-    /// Returns [`EmbedError::TotalContentTooLarge`] if the textual content of
-    /// the embed is too large. Refer to [`EMBED_LENGTH_LIMIT`] for the limit
-    /// value and what counts towards it.
+    /// Returns an [`EmbedError::TotalContentTooLarge`] error type if the
+    /// textual content of the embed is too large. Refer to
+    /// [`EMBED_LENGTH_LIMIT`] for the limit value and what counts towards it.
     ///
     /// [`AUTHOR_NAME_LENGTH_LIMIT`]: Self::AUTHOR_NAME_LENGTH_LIMIT
     /// [`COLOR_MAXIMUM`]: Self::COLOR_MAXIMUM
@@ -262,21 +297,28 @@ impl EmbedBuilder {
     /// [`FIELD_VALUE_LENGTH_LIMIT`]: Self::FIELD_VALUE_LENGTH_LIMIT
     /// [`FOOTER_TEXT_LENGTH_LIMIT`]: Self::FOOTER_TEXT_LENGTH_LIMIT
     /// [`TITLE_LENGTH_LIMIT`]: Self::TITLE_LENGTH_LIMIT
+    #[allow(clippy::clippy::too_many_lines)]
     #[must_use = "should be used as part of something like a message"]
     pub fn build(mut self) -> Result<Embed, EmbedError> {
         if self.0.fields.len() > Self::EMBED_FIELD_LIMIT {
-            return Err(EmbedError::TooManyFields {
-                fields: self.0.fields,
+            return Err(EmbedError {
+                kind: EmbedErrorType::TooManyFields {
+                    fields: self.0.fields,
+                },
             });
         }
 
         if let Some(color) = self.0.color {
             if color == 0 {
-                return Err(EmbedError::ColorZero);
+                return Err(EmbedError {
+                    kind: EmbedErrorType::ColorZero,
+                });
             }
 
             if color > Self::COLOR_MAXIMUM {
-                return Err(EmbedError::ColorNotRgb { color });
+                return Err(EmbedError {
+                    kind: EmbedErrorType::ColorNotRgb { color },
+                });
             }
         }
 
@@ -285,11 +327,15 @@ impl EmbedBuilder {
         if let Some(mut author) = self.0.author.take() {
             if let Some(name) = author.name.take() {
                 if name.is_empty() {
-                    return Err(EmbedError::AuthorNameEmpty { name });
+                    return Err(EmbedError {
+                        kind: EmbedErrorType::AuthorNameEmpty { name },
+                    });
                 }
 
                 if name.chars().count() > Self::AUTHOR_NAME_LENGTH_LIMIT {
-                    return Err(EmbedError::AuthorNameTooLong { name });
+                    return Err(EmbedError {
+                        kind: EmbedErrorType::AuthorNameTooLong { name },
+                    });
                 }
 
                 total += name.chars().count();
@@ -301,11 +347,15 @@ impl EmbedBuilder {
 
         if let Some(description) = self.0.description.take() {
             if description.is_empty() {
-                return Err(EmbedError::DescriptionEmpty { description });
+                return Err(EmbedError {
+                    kind: EmbedErrorType::DescriptionEmpty { description },
+                });
             }
 
             if description.chars().count() > Self::DESCRIPTION_LENGTH_LIMIT {
-                return Err(EmbedError::DescriptionTooLong { description });
+                return Err(EmbedError {
+                    kind: EmbedErrorType::DescriptionTooLong { description },
+                });
             }
 
             total += description.chars().count();
@@ -314,11 +364,15 @@ impl EmbedBuilder {
 
         if let Some(footer) = self.0.footer.take() {
             if footer.text.is_empty() {
-                return Err(EmbedError::FooterTextEmpty { text: footer.text });
+                return Err(EmbedError {
+                    kind: EmbedErrorType::FooterTextEmpty { text: footer.text },
+                });
             }
 
             if footer.text.chars().count() > Self::FOOTER_TEXT_LENGTH_LIMIT {
-                return Err(EmbedError::FooterTextTooLong { text: footer.text });
+                return Err(EmbedError {
+                    kind: EmbedErrorType::FooterTextTooLong { text: footer.text },
+                });
             }
 
             total += footer.text.chars().count();
@@ -331,30 +385,38 @@ impl EmbedBuilder {
 
             for field in fields {
                 if field.name.is_empty() {
-                    return Err(EmbedError::FieldNameEmpty {
-                        name: field.name,
-                        value: field.value,
+                    return Err(EmbedError {
+                        kind: EmbedErrorType::FieldNameEmpty {
+                            name: field.name,
+                            value: field.value,
+                        },
                     });
                 }
 
                 if field.name.chars().count() > Self::FIELD_NAME_LENGTH_LIMIT {
-                    return Err(EmbedError::FieldNameTooLong {
-                        name: field.name,
-                        value: field.value,
+                    return Err(EmbedError {
+                        kind: EmbedErrorType::FieldNameTooLong {
+                            name: field.name,
+                            value: field.value,
+                        },
                     });
                 }
 
                 if field.value.is_empty() {
-                    return Err(EmbedError::FieldValueEmpty {
-                        name: field.name,
-                        value: field.value,
+                    return Err(EmbedError {
+                        kind: EmbedErrorType::FieldValueEmpty {
+                            name: field.name,
+                            value: field.value,
+                        },
                     });
                 }
 
                 if field.value.chars().count() > Self::FIELD_VALUE_LENGTH_LIMIT {
-                    return Err(EmbedError::FieldValueTooLong {
-                        name: field.name,
-                        value: field.value,
+                    return Err(EmbedError {
+                        kind: EmbedErrorType::FieldValueTooLong {
+                            name: field.name,
+                            value: field.value,
+                        },
                     });
                 }
 
@@ -365,11 +427,15 @@ impl EmbedBuilder {
 
         if let Some(title) = self.0.title.take() {
             if title.is_empty() {
-                return Err(EmbedError::TitleEmpty { title });
+                return Err(EmbedError {
+                    kind: EmbedErrorType::TitleEmpty { title },
+                });
             }
 
             if title.chars().count() > Self::TITLE_LENGTH_LIMIT {
-                return Err(EmbedError::TitleTooLong { title });
+                return Err(EmbedError {
+                    kind: EmbedErrorType::TitleTooLong { title },
+                });
             }
 
             total += title.chars().count();
@@ -377,7 +443,9 @@ impl EmbedBuilder {
         }
 
         if total > Self::EMBED_LENGTH_LIMIT {
-            return Err(EmbedError::TotalContentTooLarge { length: total });
+            return Err(EmbedError {
+                kind: EmbedErrorType::TotalContentTooLarge { length: total },
+            });
         }
 
         Ok(self.0)
@@ -676,28 +744,29 @@ impl TryFrom<EmbedBuilder> for Embed {
 
 #[cfg(test)]
 mod tests {
-    use super::{EmbedBuilder, EmbedError};
+    use super::{EmbedBuilder, EmbedError, EmbedErrorType};
     use crate::{field::EmbedFieldBuilder, footer::EmbedFooterBuilder, image_source::ImageSource};
     use static_assertions::{assert_fields, assert_impl_all, const_assert};
     use std::{convert::TryFrom, error::Error, fmt::Debug};
     use twilight_model::channel::embed::{Embed, EmbedField, EmbedFooter};
 
-    assert_impl_all!(EmbedError: Clone, Debug, Error, Eq, PartialEq, Send, Sync);
-    assert_fields!(EmbedError::AuthorNameEmpty: name);
-    assert_fields!(EmbedError::AuthorNameTooLong: name);
-    assert_fields!(EmbedError::TooManyFields: fields);
-    assert_fields!(EmbedError::ColorNotRgb: color);
-    assert_fields!(EmbedError::DescriptionEmpty: description);
-    assert_fields!(EmbedError::DescriptionTooLong: description);
-    assert_fields!(EmbedError::FooterTextEmpty: text);
-    assert_fields!(EmbedError::FooterTextTooLong: text);
-    assert_fields!(EmbedError::TitleEmpty: title);
-    assert_fields!(EmbedError::TitleTooLong: title);
-    assert_fields!(EmbedError::TotalContentTooLarge: length);
-    assert_fields!(EmbedError::FieldNameEmpty: name, value);
-    assert_fields!(EmbedError::FieldNameTooLong: name, value);
-    assert_fields!(EmbedError::FieldValueEmpty: name, value);
-    assert_fields!(EmbedError::FieldValueTooLong: name, value);
+    assert_impl_all!(EmbedErrorType: Debug, Send, Sync);
+    assert_fields!(EmbedErrorType::AuthorNameEmpty: name);
+    assert_fields!(EmbedErrorType::AuthorNameTooLong: name);
+    assert_fields!(EmbedErrorType::TooManyFields: fields);
+    assert_fields!(EmbedErrorType::ColorNotRgb: color);
+    assert_fields!(EmbedErrorType::DescriptionEmpty: description);
+    assert_fields!(EmbedErrorType::DescriptionTooLong: description);
+    assert_fields!(EmbedErrorType::FooterTextEmpty: text);
+    assert_fields!(EmbedErrorType::FooterTextTooLong: text);
+    assert_fields!(EmbedErrorType::TitleEmpty: title);
+    assert_fields!(EmbedErrorType::TitleTooLong: title);
+    assert_fields!(EmbedErrorType::TotalContentTooLarge: length);
+    assert_fields!(EmbedErrorType::FieldNameEmpty: name, value);
+    assert_fields!(EmbedErrorType::FieldNameTooLong: name, value);
+    assert_fields!(EmbedErrorType::FieldValueEmpty: name, value);
+    assert_fields!(EmbedErrorType::FieldValueTooLong: name, value);
+    assert_impl_all!(EmbedError: Debug, Send, Sync);
     const_assert!(EmbedBuilder::AUTHOR_NAME_LENGTH_LIMIT == 256);
     const_assert!(EmbedBuilder::COLOR_MAXIMUM == 0xff_ff_ff);
     const_assert!(EmbedBuilder::DESCRIPTION_LENGTH_LIMIT == 2048);
@@ -712,13 +781,13 @@ mod tests {
     #[test]
     fn test_color_error() -> Result<(), Box<dyn Error>> {
         assert!(matches!(
-            EmbedBuilder::new().color(0).build().unwrap_err(),
-            EmbedError::ColorZero
+            EmbedBuilder::new().color(0).build().unwrap_err().kind(),
+            EmbedErrorType::ColorZero
         ));
         assert!(matches!(
-            EmbedBuilder::new().color(u32::MAX).build().unwrap_err(),
-            EmbedError::ColorNotRgb { color }
-            if color == u32::MAX
+            EmbedBuilder::new().color(u32::MAX).build().unwrap_err().kind(),
+            EmbedErrorType::ColorNotRgb { color }
+            if *color == u32::MAX
         ));
 
         Ok(())
@@ -727,14 +796,14 @@ mod tests {
     #[test]
     fn test_description_error() {
         assert!(matches!(
-            EmbedBuilder::new().description("").build().unwrap_err(),
-            EmbedError::DescriptionEmpty { description }
+            EmbedBuilder::new().description("").build().unwrap_err().kind(),
+            EmbedErrorType::DescriptionEmpty { description }
             if description.is_empty()
         ));
         let description_too_long = EmbedBuilder::DESCRIPTION_LENGTH_LIMIT + 1;
         assert!(matches!(
-            EmbedBuilder::new().description("a".repeat(description_too_long)).build().unwrap_err(),
-            EmbedError::DescriptionTooLong { description }
+            EmbedBuilder::new().description("a".repeat(description_too_long)).build().unwrap_err().kind(),
+            EmbedErrorType::DescriptionTooLong { description }
             if description.len() == description_too_long
         ));
     }
@@ -742,14 +811,14 @@ mod tests {
     #[test]
     fn test_title_error() {
         assert!(matches!(
-            EmbedBuilder::new().title("").build().unwrap_err(),
-            EmbedError::TitleEmpty { title }
+            EmbedBuilder::new().title("").build().unwrap_err().kind(),
+            EmbedErrorType::TitleEmpty { title }
             if title.is_empty()
         ));
         let title_too_long = EmbedBuilder::TITLE_LENGTH_LIMIT + 1;
         assert!(matches!(
-            EmbedBuilder::new().title("a".repeat(title_too_long)).build().unwrap_err(),
-            EmbedError::TitleTooLong { title }
+            EmbedBuilder::new().title("a".repeat(title_too_long)).build().unwrap_err().kind(),
+            EmbedErrorType::TitleTooLong { title }
             if title.len() == title_too_long
         ));
     }

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -237,54 +237,54 @@ impl EmbedBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an [`EmbedError::AuthorNameEmpty`] error type if the provided
-    /// name is empty.
+    /// Returns an [`EmbedErrorType::AuthorNameEmpty`] error type if the
+    /// provided name is empty.
     ///
-    /// Returns an [`EmbedError::AuthorNameTooLong`] error type if the provided
-    /// name is longer than [`AUTHOR_NAME_LENGTH_LIMIT`].
+    /// Returns an [`EmbedErrorType::AuthorNameTooLong`] error type if the
+    /// provided name is longer than [`AUTHOR_NAME_LENGTH_LIMIT`].
     ///
-    /// Returns an [`EmbedError::ColorNotRgb`] error type if the provided color
-    /// is not a valid RGB integer. Refer to [`COLOR_MAXIMUM`] to know what the
-    /// maximum accepted value is.
+    /// Returns an [`EmbedErrorType::ColorNotRgb`] error type if the provided
+    /// color is not a valid RGB integer. Refer to [`COLOR_MAXIMUM`] to know
+    /// what the maximum accepted value is.
     ///
-    /// Returns an [`EmbedError::ColorZero`] error type if the provided color is
-    /// 0, which is not an acceptable value.
+    /// Returns an [`EmbedErrorType::ColorZero`] error type if the provided
+    /// color is 0, which is not an acceptable value.
     ///
-    /// Returns an [`EmbedError::DescriptionEmpty`] error type if a provided
+    /// Returns an [`EmbedErrorType::DescriptionEmpty`] error type if a provided
     /// description is empty.
     ///
-    /// Returns an [`EmbedError::DescriptionTooLong`] error type if a provided
-    /// description is longer than [`DESCRIPTION_LENGTH_LIMIT`].
+    /// Returns an [`EmbedErrorType::DescriptionTooLong`] error type if a
+    /// provided description is longer than [`DESCRIPTION_LENGTH_LIMIT`].
     ///
-    /// Returns an [`EmbedError::FieldNameEmpty`] error type if a provided field
-    /// name is empty.
+    /// Returns an [`EmbedErrorType::FieldNameEmpty`] error type if a provided
+    /// field name is empty.
     ///
-    /// Returns an [`EmbedError::FieldNameTooLong`] error type if a provided
+    /// Returns an [`EmbedErrorType::FieldNameTooLong`] error type if a provided
     /// field name is longer than [`FIELD_NAME_LENGTH_LIMIT`].
     ///
-    /// Returns an [`EmbedError::FieldValueEmpty`] error type if a provided
+    /// Returns an [`EmbedErrorType::FieldValueEmpty`] error type if a provided
     /// field value is empty.
     ///
-    /// Returns an [`EmbedError::FieldValueTooLong`] error type if a provided
-    /// field value is longer than [`FIELD_VALUE_LENGTH_LIMIT`].
+    /// Returns an [`EmbedErrorType::FieldValueTooLong`] error type if a
+    /// provided field value is longer than [`FIELD_VALUE_LENGTH_LIMIT`].
     ///
-    /// Returns an [`EmbedError::FooterTextEmpty`] error type if the provided
-    /// text is empty.
+    /// Returns an [`EmbedErrorType::FooterTextEmpty`] error type if the
+    /// provided text is empty.
     ///
-    /// Returns an [`EmbedError::FooterTextTooLong`] error type if the provided
-    /// text is longer than the limit defined at [`FOOTER_TEXT_LENGTH_LIMIT`].
+    /// Returns an [`EmbedErrorType::FooterTextTooLong`] error type if the
+    /// provided text is longer than the limit defined at [`FOOTER_TEXT_LENGTH_LIMIT`].
     ///
-    /// Returns an [`EmbedError::TitleEmpty`] error type if the provided title
-    /// is empty.
+    /// Returns an [`EmbedErrorType::TitleEmpty`] error type if the provided
+    /// title is empty.
     ///
-    /// Returns an [`EmbedError::TitleTooLong`] error type if the provided text
-    /// is longer than the limit defined at [`TITLE_LENGTH_LIMIT`].
+    /// Returns an [`EmbedErrorType::TitleTooLong`] error type if the provided
+    /// text is longer than the limit defined at [`TITLE_LENGTH_LIMIT`].
     ///
-    /// Returns an [`EmbedError::TooManyFields`] error type if there are too
+    /// Returns an [`EmbedErrorType::TooManyFields`] error type if there are too
     /// many fields in the embed. Refer to [`EMBED_FIELD_LIMIT`] for the limit
     /// value.
     ///
-    /// Returns an [`EmbedError::TotalContentTooLarge`] error type if the
+    /// Returns an [`EmbedErrorType::TotalContentTooLarge`] error type if the
     /// textual content of the embed is too large. Refer to
     /// [`EMBED_LENGTH_LIMIT`] for the limit value and what counts towards it.
     ///

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -21,7 +21,7 @@ pub struct EmbedError {
 
 impl EmbedError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &EmbedErrorType {
         &self.kind
     }

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -766,7 +766,7 @@ mod tests {
     assert_fields!(EmbedErrorType::FieldNameTooLong: name, value);
     assert_fields!(EmbedErrorType::FieldValueEmpty: name, value);
     assert_fields!(EmbedErrorType::FieldValueTooLong: name, value);
-    assert_impl_all!(EmbedError: Debug, Send, Sync);
+    assert_impl_all!(EmbedError: Error, Send, Sync);
     const_assert!(EmbedBuilder::AUTHOR_NAME_LENGTH_LIMIT == 256);
     const_assert!(EmbedBuilder::COLOR_MAXIMUM == 0xff_ff_ff);
     const_assert!(EmbedBuilder::DESCRIPTION_LENGTH_LIMIT == 2048);

--- a/embed-builder/src/field.rs
+++ b/embed-builder/src/field.rs
@@ -75,7 +75,7 @@ impl From<EmbedFieldBuilder> for EmbedField {
 #[cfg(test)]
 mod tests {
     use super::EmbedFieldBuilder;
-    use crate::{EmbedBuilder, EmbedError};
+    use crate::{EmbedBuilder, EmbedErrorType};
     use static_assertions::assert_impl_all;
     use std::fmt::Debug;
     use twilight_model::channel::embed::EmbedField;
@@ -86,23 +86,23 @@ mod tests {
     #[test]
     fn test_new_errors() {
         assert!(matches!(
-            EmbedBuilder::new().field(EmbedFieldBuilder::new("", "a")).build().unwrap_err(),
-            EmbedError::FieldNameEmpty { name, value }
+            EmbedBuilder::new().field(EmbedFieldBuilder::new("", "a")).build().unwrap_err().kind(),
+            EmbedErrorType::FieldNameEmpty { name, value }
             if name.is_empty() && value.len() == 1
         ));
         assert!(matches!(
-            EmbedBuilder::new().field(EmbedFieldBuilder::new("a".repeat(257), "a")).build().unwrap_err(),
-            EmbedError::FieldNameTooLong { name, value }
+            EmbedBuilder::new().field(EmbedFieldBuilder::new("a".repeat(257), "a")).build().unwrap_err().kind(),
+            EmbedErrorType::FieldNameTooLong { name, value }
             if name.len() == 257 && value.len() == 1
         ));
         assert!(matches!(
-            EmbedBuilder::new().field(EmbedFieldBuilder::new("a", "")).build().unwrap_err(),
-            EmbedError::FieldValueEmpty { name, value }
+            EmbedBuilder::new().field(EmbedFieldBuilder::new("a", "")).build().unwrap_err().kind(),
+            EmbedErrorType::FieldValueEmpty { name, value }
             if name.len() == 1 && value.is_empty()
         ));
         assert!(matches!(
-            EmbedBuilder::new().field(EmbedFieldBuilder::new("a", "a".repeat(1025))).build().unwrap_err(),
-            EmbedError::FieldValueTooLong { name, value }
+            EmbedBuilder::new().field(EmbedFieldBuilder::new("a", "a".repeat(1025))).build().unwrap_err().kind(),
+            EmbedErrorType::FieldValueTooLong { name, value }
             if name.len() == 1 && value.len() == 1025
         ));
     }

--- a/embed-builder/src/footer.rs
+++ b/embed-builder/src/footer.rs
@@ -72,7 +72,7 @@ impl From<EmbedFooterBuilder> for EmbedFooter {
 #[cfg(test)]
 mod tests {
     use super::EmbedFooterBuilder;
-    use crate::{EmbedBuilder, EmbedError, ImageSource};
+    use crate::{EmbedBuilder, EmbedErrorType, ImageSource};
     use static_assertions::assert_impl_all;
     use std::fmt::Debug;
     use twilight_model::channel::embed::EmbedFooter;
@@ -83,14 +83,14 @@ mod tests {
     #[test]
     fn test_text() {
         assert!(matches!(
-            EmbedBuilder::new().footer(EmbedFooterBuilder::new("")).build().unwrap_err(),
-            EmbedError::FooterTextEmpty { text }
+            EmbedBuilder::new().footer(EmbedFooterBuilder::new("")).build().unwrap_err().kind(),
+            EmbedErrorType::FooterTextEmpty { text }
             if text.is_empty()
         ));
         let too_long_len = EmbedBuilder::FOOTER_TEXT_LENGTH_LIMIT + 1;
         assert!(matches!(
-            EmbedBuilder::new().footer(EmbedFooterBuilder::new("a".repeat(too_long_len))).build().unwrap_err(),
-            EmbedError::FooterTextTooLong { text }
+            EmbedBuilder::new().footer(EmbedFooterBuilder::new("a".repeat(too_long_len))).build().unwrap_err().kind(),
+            EmbedErrorType::FooterTextTooLong { text }
             if text.len() == too_long_len
         ));
 

--- a/embed-builder/src/image_source.rs
+++ b/embed-builder/src/image_source.rs
@@ -53,6 +53,7 @@ impl Display for ImageSourceAttachmentError {
 
 impl Error for ImageSourceAttachmentError {}
 
+/// Type of [`ImageSourceAttachmentError`] that occurred.
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 #[non_exhaustive]
@@ -108,6 +109,7 @@ impl Display for ImageSourceUrlError {
 
 impl Error for ImageSourceUrlError {}
 
+/// Type of [`ImageSourceUrlError`] that occurred.
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 #[non_exhaustive]

--- a/embed-builder/src/image_source.rs
+++ b/embed-builder/src/image_source.rs
@@ -21,8 +21,8 @@ impl ImageSourceAttachmentError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 
@@ -80,8 +80,8 @@ impl ImageSourceUrlError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/embed-builder/src/image_source.rs
+++ b/embed-builder/src/image_source.rs
@@ -14,7 +14,7 @@ pub struct ImageSourceAttachmentError {
 
 impl ImageSourceAttachmentError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &ImageSourceAttachmentErrorType {
         &self.kind
     }
@@ -73,7 +73,7 @@ pub struct ImageSourceUrlError {
 
 impl ImageSourceUrlError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &ImageSourceUrlErrorType {
         &self.kind
     }

--- a/embed-builder/src/image_source.rs
+++ b/embed-builder/src/image_source.rs
@@ -7,31 +7,111 @@ use std::{
 
 /// Error creating an embed field.
 #[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum ImageSourceAttachmentError {
-    /// An extension is present in the provided filename but it is empty.
-    ExtensionEmpty,
-    /// An extension is missing in the provided filename.
-    ExtensionMissing,
+#[derive(Debug)]
+pub struct ImageSourceAttachmentError {
+    kind: ImageSourceAttachmentErrorType,
+}
+
+impl ImageSourceAttachmentError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &ImageSourceAttachmentErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        ImageSourceAttachmentErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
 }
 
 impl Display for ImageSourceAttachmentError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::ExtensionEmpty { .. } => f.write_str("the extension is empty"),
-            Self::ExtensionMissing { .. } => f.write_str("the extension is missing"),
+        match &self.kind {
+            ImageSourceAttachmentErrorType::ExtensionEmpty { .. } => {
+                f.write_str("the extension is empty")
+            }
+            ImageSourceAttachmentErrorType::ExtensionMissing { .. } => {
+                f.write_str("the extension is missing")
+            }
         }
     }
 }
 
 impl Error for ImageSourceAttachmentError {}
 
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ImageSourceAttachmentErrorType {
+    /// An extension is present in the provided filename but it is empty.
+    ExtensionEmpty,
+    /// An extension is missing in the provided filename.
+    ExtensionMissing,
+}
+
 /// Error creating an embed field.
 #[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
+pub struct ImageSourceUrlError {
+    kind: ImageSourceUrlErrorType,
+}
+
+impl ImageSourceUrlError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &ImageSourceUrlErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        ImageSourceUrlErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for ImageSourceUrlError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            ImageSourceUrlErrorType::ProtocolUnsupported { .. } => {
+                f.write_str("the provided URL's protocol is unsupported by Discord")
+            }
+        }
+    }
+}
+
+impl Error for ImageSourceUrlError {}
+
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum ImageSourceUrlError {
+pub enum ImageSourceUrlErrorType {
     /// The Protocol of the URL is unsupported by the Discord REST API.
     ///
     /// Refer to [`ImageSource::url`] for a list of protocols that are acceptable.
@@ -40,18 +120,6 @@ pub enum ImageSourceUrlError {
         url: String,
     },
 }
-
-impl Display for ImageSourceUrlError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::ProtocolUnsupported { .. } => {
-                f.write_str("the provided URL's protocol is unsupported by Discord")
-            }
-        }
-    }
-}
-
-impl Error for ImageSourceUrlError {}
 
 /// Image sourcing for embed images.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -65,27 +133,30 @@ impl ImageSource {
     ///
     /// # Errors
     ///
-    /// Returns [`ImageSourceAttachmentError::ExtensionEmpty`] if an extension exists
-    /// but is empty.
+    /// Returns an [`ImageSourceAttachmentErrorType::ExtensionEmpty`] if an
+    /// extension exists but is empty.
     ///
-    /// Returns [`ImageSourceAttachmentError::ExtensionMissing`] if an extension is
-    /// missing.
+    /// Returns an [`ImageSourceAttachmentErrorType::ExtensionMissing`] if an
+    /// extension is missing.
     pub fn attachment(filename: impl AsRef<str>) -> Result<Self, ImageSourceAttachmentError> {
         Self::_attachment(filename.as_ref())
     }
 
     fn _attachment(filename: &str) -> Result<Self, ImageSourceAttachmentError> {
-        let dot = filename
-            .rfind('.')
-            .ok_or(ImageSourceAttachmentError::ExtensionMissing)?
-            + 1;
+        let dot = filename.rfind('.').ok_or(ImageSourceAttachmentError {
+            kind: ImageSourceAttachmentErrorType::ExtensionMissing,
+        })? + 1;
 
         if filename
             .get(dot..)
-            .ok_or(ImageSourceAttachmentError::ExtensionMissing)?
+            .ok_or(ImageSourceAttachmentError {
+                kind: ImageSourceAttachmentErrorType::ExtensionMissing,
+            })?
             .is_empty()
         {
-            return Err(ImageSourceAttachmentError::ExtensionEmpty);
+            return Err(ImageSourceAttachmentError {
+                kind: ImageSourceAttachmentErrorType::ExtensionEmpty,
+            });
         }
 
         Ok(Self(format!("attachment://{}", filename)))
@@ -100,14 +171,17 @@ impl ImageSource {
     ///
     /// # Errors
     ///
-    /// Returns [`ImageSourceUrlError::ProtocolUnsupported`] if the URL's protocol is unsupported.
+    /// Returns an [`ImageSourceUrlErrorType::ProtocolUnsupported`] error type
+    /// if the URL's protocol is unsupported.
     pub fn url(url: impl Into<String>) -> Result<Self, ImageSourceUrlError> {
         Self::_url(url.into())
     }
 
     fn _url(url: String) -> Result<Self, ImageSourceUrlError> {
         if !url.starts_with("https:") && !url.starts_with("http:") {
-            return Err(ImageSourceUrlError::ProtocolUnsupported { url });
+            return Err(ImageSourceUrlError {
+                kind: ImageSourceUrlErrorType::ProtocolUnsupported { url },
+            });
         }
 
         Ok(Self(url))
@@ -116,40 +190,29 @@ impl ImageSource {
 
 #[cfg(test)]
 mod tests {
-    use super::{ImageSource, ImageSourceAttachmentError, ImageSourceUrlError};
+    use super::{
+        ImageSource, ImageSourceAttachmentError, ImageSourceAttachmentErrorType,
+        ImageSourceUrlError, ImageSourceUrlErrorType,
+    };
     use static_assertions::{assert_fields, assert_impl_all};
     use std::{error::Error, fmt::Debug};
 
-    assert_impl_all!(
-        ImageSourceAttachmentError: Clone,
-        Debug,
-        Error,
-        Eq,
-        PartialEq,
-        Send,
-        Sync
-    );
-    assert_impl_all!(
-        ImageSourceUrlError: Clone,
-        Debug,
-        Error,
-        Eq,
-        PartialEq,
-        Send,
-        Sync
-    );
-    assert_fields!(ImageSourceUrlError::ProtocolUnsupported: url);
+    assert_impl_all!(ImageSourceAttachmentErrorType: Debug, Send, Sync);
+    assert_impl_all!(ImageSourceAttachmentError: Error, Send, Sync);
+    assert_impl_all!(ImageSourceUrlErrorType: Debug, Send, Sync);
+    assert_impl_all!(ImageSourceUrlError: Error, Send, Sync);
+    assert_fields!(ImageSourceUrlErrorType::ProtocolUnsupported: url);
     assert_impl_all!(ImageSource: Clone, Debug, Eq, PartialEq, Send, Sync);
 
     #[test]
     fn test_attachment() -> Result<(), Box<dyn Error>> {
         assert!(matches!(
-            ImageSource::attachment("abc").unwrap_err(),
-            ImageSourceAttachmentError::ExtensionMissing
+            ImageSource::attachment("abc").unwrap_err().kind(),
+            ImageSourceAttachmentErrorType::ExtensionMissing
         ));
         assert!(matches!(
-            ImageSource::attachment("abc.").unwrap_err(),
-            ImageSourceAttachmentError::ExtensionEmpty
+            ImageSource::attachment("abc.").unwrap_err().kind(),
+            ImageSourceAttachmentErrorType::ExtensionEmpty
         ));
         assert_eq!(
             ImageSource::attachment("abc.png")?,
@@ -162,8 +225,8 @@ mod tests {
     #[test]
     fn test_url() -> Result<(), Box<dyn Error>> {
         assert!(matches!(
-            ImageSource::url("ftp://example.com/foo").unwrap_err(),
-            ImageSourceUrlError::ProtocolUnsupported { url }
+            ImageSource::url("ftp://example.com/foo").unwrap_err().kind(),
+            ImageSourceUrlErrorType::ProtocolUnsupported { url }
             if url == "ftp://example.com/foo"
         ));
         assert_eq!(

--- a/embed-builder/src/lib.rs
+++ b/embed-builder/src/lib.rs
@@ -67,7 +67,7 @@ mod image_source;
 
 pub use self::{
     author::EmbedAuthorBuilder,
-    builder::{EmbedBuilder, EmbedError},
+    builder::{EmbedBuilder, EmbedError, EmbedErrorType},
     field::EmbedFieldBuilder,
     footer::EmbedFooterBuilder,
     image_source::{ImageSource, ImageSourceAttachmentError, ImageSourceUrlError},

--- a/embed-builder/src/lib.rs
+++ b/embed-builder/src/lib.rs
@@ -58,17 +58,17 @@
     unused,
     warnings
 )]
+pub mod image_source;
 
 mod author;
 mod builder;
 mod field;
 mod footer;
-mod image_source;
 
 pub use self::{
     author::EmbedAuthorBuilder,
     builder::{EmbedBuilder, EmbedError, EmbedErrorType},
     field::EmbedFieldBuilder,
     footer::EmbedFooterBuilder,
-    image_source::{ImageSource, ImageSourceAttachmentError, ImageSourceUrlError},
+    image_source::ImageSource,
 };

--- a/gateway/queue/src/day_limiter.rs
+++ b/gateway/queue/src/day_limiter.rs
@@ -11,8 +11,8 @@ use tokio::{
 /// Creating a day limiter queue failed.
 #[derive(Debug)]
 pub struct DayLimiterError {
-    cause: Option<Box<dyn Error + Send + Sync>>,
     kind: DayLimiterErrorType,
+    source: Option<Box<dyn Error + Send + Sync>>,
 }
 
 impl Display for DayLimiterError {
@@ -27,9 +27,9 @@ impl Display for DayLimiterError {
 
 impl Error for DayLimiterError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.cause
+        self.source
             .as_ref()
-            .map(|cause| &**cause as &(dyn Error + 'static))
+            .map(|source| &**source as &(dyn Error + 'static))
     }
 }
 
@@ -61,8 +61,8 @@ impl DayLimiter {
             .authed()
             .await
             .map_err(|source| DayLimiterError {
-                cause: Some(Box::new(source)),
                 kind: DayLimiterErrorType::RetrievingSessionAvailability,
+                source: Some(Box::new(source)),
             })?;
 
         let last_check = Instant::now();

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -214,6 +214,8 @@ impl ClusterBuilder {
     ///
     /// Returns a [`ClusterStartErrorType::RetrievingGatewayInfo`] error type if
     /// there was an HTTP error Retrieving the gateway information.
+    ///
+    /// [`ClusterStartErrorType::RetrievingGatewayInfo`]: super::ClusterStartErrorType::RetrievingGatewayInfo
     pub async fn build(mut self) -> Result<Cluster, ClusterStartError> {
         if (self.1).0.gateway_url.is_none() {
             let gateway_url = (self.1)
@@ -265,6 +267,9 @@ impl ClusterBuilder {
     ///
     /// Returns a [`LargeThresholdErrorType::TooMany`] error type if the
     /// provided value is above 250.
+    ///
+    /// [`LargeThresholdErrorType::TooFew`]: crate::shard::LargeThresholdErrorType::TooFew
+    /// [`LargeThresholdErrorType::TooMany`]: crate::shard::LargeThresholdErrorType::TooMany
     pub fn large_threshold(mut self, large_threshold: u64) -> Result<Self, LargeThresholdError> {
         self.1 = self.1.large_threshold(large_threshold)?;
 

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -23,7 +23,7 @@ pub struct ShardSchemeRangeError {
 
 impl ShardSchemeRangeError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &ShardSchemeRangeErrorType {
         &self.kind
     }

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -30,8 +30,8 @@ impl ShardSchemeRangeError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -17,7 +17,55 @@ use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents}
 
 /// Starting a cluster failed.
 #[derive(Debug)]
-pub enum ShardSchemeRangeError {
+pub struct ShardSchemeRangeError {
+    kind: ShardSchemeRangeErrorType,
+}
+
+impl ShardSchemeRangeError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &ShardSchemeRangeErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        ShardSchemeRangeErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for ShardSchemeRangeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            ShardSchemeRangeErrorType::IdTooLarge { end, start, total } => {
+                f.write_fmt(format_args!(
+                    "The shard ID range {}-{}/{} is larger than the total",
+                    start, end, total
+                ))
+            }
+        }
+    }
+}
+
+impl Error for ShardSchemeRangeError {}
+
+/// Type of [`ShardSchemeRangeError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ShardSchemeRangeErrorType {
     /// Start of the shard range was greater than the end or total.
     IdTooLarge {
         /// Last shard in the range to manage.
@@ -28,19 +76,6 @@ pub enum ShardSchemeRangeError {
         total: u64,
     },
 }
-
-impl Display for ShardSchemeRangeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::IdTooLarge { end, start, total } => f.write_fmt(format_args!(
-                "The shard ID range {}-{}/{} is larger than the total",
-                start, end, total
-            )),
-        }
-    }
-}
-
-impl Error for ShardSchemeRangeError {}
 
 /// The method of sharding to use.
 ///
@@ -105,7 +140,9 @@ impl<T: RangeBounds<u64>> TryFrom<(T, u64)> for ShardScheme {
         };
 
         if start > end {
-            return Err(ShardSchemeRangeError::IdTooLarge { end, start, total });
+            return Err(ShardSchemeRangeError {
+                kind: ShardSchemeRangeErrorType::IdTooLarge { end, start, total },
+            });
         }
 
         Ok(Self::Range {
@@ -175,8 +212,8 @@ impl ClusterBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`ClusterStartError::RetrievingGatewayInfo`] if there was an
-    /// HTTP error Retrieving the gateway information.
+    /// Returns a [`ClusterStartErrorType::RetrievingGatewayInfo`] error type if
+    /// there was an HTTP error Retrieving the gateway information.
     pub async fn build(mut self) -> Result<Cluster, ClusterStartError> {
         if (self.1).0.gateway_url.is_none() {
             let gateway_url = (self.1)
@@ -223,11 +260,11 @@ impl ClusterBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`LargeThresholdError::TooFew`] if the provided value is below
-    /// 50.
+    /// Returns a [`LargeThresholdErrorType::TooFew`] error type if the provided
+    /// value is below 50.
     ///
-    /// Returns [`LargeThresholdError::TooMany`] if the provided value is above
-    /// 250.
+    /// Returns a [`LargeThresholdErrorType::TooMany`] error type if the
+    /// provided value is above 250.
     pub fn large_threshold(mut self, large_threshold: u64) -> Result<Self, LargeThresholdError> {
         self.1 = self.1.large_threshold(large_threshold)?;
 
@@ -317,7 +354,7 @@ impl<T: Into<String>> From<(T, Intents)> for ClusterBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::{ClusterBuilder, ShardScheme, ShardSchemeRangeError};
+    use super::{ClusterBuilder, ShardScheme, ShardSchemeRangeError, ShardSchemeRangeErrorType};
     use crate::Intents;
     use static_assertions::{assert_fields, assert_impl_all};
     use std::{
@@ -327,7 +364,8 @@ mod tests {
         hash::Hash,
     };
 
-    assert_fields!(ShardSchemeRangeError::IdTooLarge: end, start, total);
+    assert_fields!(ShardSchemeRangeErrorType::IdTooLarge: end, start, total);
+    assert_impl_all!(ShardSchemeRangeError: Debug, Send, Sync);
     assert_fields!(ShardScheme::Range: from, to, total);
     assert_impl_all!(ClusterBuilder: Debug, From<(String, Intents)>, Send, Sync);
     assert_impl_all!(ShardSchemeRangeError: Debug, Display, Error, Send, Sync);

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -28,7 +28,7 @@ pub struct ClusterCommandError {
 
 impl ClusterCommandError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &ClusterCommandErrorType {
         &self.kind
     }
@@ -109,7 +109,7 @@ pub struct ClusterSendError {
 
 impl ClusterSendError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &ClusterSendErrorType {
         &self.kind
     }
@@ -169,7 +169,7 @@ pub struct ClusterStartError {
 
 impl ClusterStartError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &ClusterStartErrorType {
         &self.kind
     }

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -3,7 +3,7 @@ use super::{
     config::Config,
 };
 use crate::{
-    shard::{raw_message::Message, CommandError, Information, ResumeSession, SendError, Shard},
+    shard::{raw_message::Message, Information, ResumeSession, Shard},
     EventTypeFlags, Intents,
 };
 use futures_util::{
@@ -17,41 +17,62 @@ use std::{
     iter::FromIterator,
     sync::{Arc, Mutex},
 };
-use twilight_http::Error as HttpError;
 use twilight_model::gateway::event::Event;
 
 /// Sending a command to a shard failed.
 #[derive(Debug)]
-#[non_exhaustive]
-pub enum ClusterCommandError {
-    /// The shard exists, but sending the provided value failed.
-    Sending {
-        /// Reason for the error.
-        source: CommandError,
-    },
-    /// Provided shard ID does not exist.
-    ShardNonexistent {
-        /// Provided shard ID.
-        id: u64,
-    },
+pub struct ClusterCommandError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: ClusterCommandErrorType,
 }
 
 impl ClusterCommandError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &ClusterCommandErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        ClusterCommandErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, self.cause)
+    }
+
     fn from_send(error: ClusterSendError) -> Self {
-        match error {
-            ClusterSendError::Sending { source } => Self::Sending {
-                source: CommandError::from_send(source),
+        let (kind, cause) = error.into_parts();
+
+        match kind {
+            ClusterSendErrorType::Sending => Self {
+                cause,
+                kind: ClusterCommandErrorType::Sending,
             },
-            ClusterSendError::ShardNonexistent { id } => Self::ShardNonexistent { id },
+            ClusterSendErrorType::ShardNonexistent { id } => Self {
+                cause,
+                kind: ClusterCommandErrorType::ShardNonexistent { id },
+            },
         }
     }
 }
 
 impl Display for ClusterCommandError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Sending { source } => Display::fmt(source, f),
-            Self::ShardNonexistent { id } => {
+        match &self.kind {
+            ClusterCommandErrorType::Sending => {
+                f.write_str("sending the message over the websocket failed")
+            }
+            ClusterCommandErrorType::ShardNonexistent { id } => {
                 f.write_fmt(format_args!("shard {} does not exist", id,))
             }
         }
@@ -60,22 +81,18 @@ impl Display for ClusterCommandError {
 
 impl Error for ClusterCommandError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::Sending { source } => Some(source),
-            Self::ShardNonexistent { .. } => None,
-        }
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
     }
 }
 
-/// Sending a raw websocket message via a shard failed.
+/// Type of [`ClusterCommandError`] that occurred.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum ClusterSendError {
+pub enum ClusterCommandErrorType {
     /// The shard exists, but sending the provided value failed.
-    Sending {
-        /// Reason for the error.
-        source: SendError,
-    },
+    Sending,
     /// Provided shard ID does not exist.
     ShardNonexistent {
         /// Provided shard ID.
@@ -83,11 +100,39 @@ pub enum ClusterSendError {
     },
 }
 
+/// Sending a raw websocket message via a shard failed.
+#[derive(Debug)]
+pub struct ClusterSendError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: ClusterSendErrorType,
+}
+
+impl ClusterSendError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &ClusterSendErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (ClusterSendErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, self.cause)
+    }
+}
+
 impl Display for ClusterSendError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Sending { source } => Display::fmt(source, f),
-            Self::ShardNonexistent { id } => {
+        match &self.kind {
+            ClusterSendErrorType::Sending => f.write_str("failed to send message over websocket"),
+            ClusterSendErrorType::ShardNonexistent { id } => {
                 f.write_fmt(format_args!("shard {} does not exist", id))
             }
         }
@@ -96,34 +141,56 @@ impl Display for ClusterSendError {
 
 impl Error for ClusterSendError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::Sending { source } => Some(source),
-            Self::ShardNonexistent { .. } => None,
-        }
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
     }
+}
+
+/// Type of [`ClusterSendError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ClusterSendErrorType {
+    /// The shard exists, but sending the provided value failed.
+    Sending,
+    /// Provided shard ID does not exist.
+    ShardNonexistent {
+        /// Provided shard ID.
+        id: u64,
+    },
 }
 
 /// Starting a cluster failed.
 #[derive(Debug)]
-#[non_exhaustive]
-pub enum ClusterStartError {
-    /// Retrieving the bot's gateway information via the HTTP API failed.
-    ///
-    /// This can occur when using [automatic sharding] and retrieval of the
-    /// number of recommended number of shards to start fails, which can happen
-    /// due to something like a network or response parsing issue.
-    ///
-    /// [automatic sharding]: ShardScheme::Auto
-    RetrievingGatewayInfo {
-        /// Reason for the error.
-        source: HttpError,
-    },
+pub struct ClusterStartError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: ClusterStartErrorType,
+}
+
+impl ClusterStartError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &ClusterStartErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (ClusterStartErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, self.cause)
+    }
 }
 
 impl Display for ClusterStartError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::RetrievingGatewayInfo { .. } => {
+        match &self.kind {
+            ClusterStartErrorType::RetrievingGatewayInfo { .. } => {
                 f.write_str("getting the bot's gateway info failed")
             }
         }
@@ -132,10 +199,24 @@ impl Display for ClusterStartError {
 
 impl Error for ClusterStartError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::RetrievingGatewayInfo { source } => Some(source),
-        }
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
     }
+}
+
+/// Type of [`ClusterStartErrorType`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ClusterStartErrorType {
+    /// Retrieving the bot's gateway information via the HTTP API failed.
+    ///
+    /// This can occur when using [automatic sharding] and retrieval of the
+    /// number of recommended number of shards to start fails, which can happen
+    /// due to something like a network or response parsing issue.
+    ///
+    /// [automatic sharding]: ShardScheme::Auto
+    RetrievingGatewayInfo,
 }
 
 #[derive(Debug)]
@@ -169,8 +250,8 @@ impl Cluster {
     ///
     /// # Errors
     ///
-    /// Returns [`ClusterStartError::RetrievingGatewayInfo`] if there was an
-    /// HTTP error Retrieving the gateway information.
+    /// Returns a [`ClusterStartErrorType::RetrievingGatewayInfo`] error type if
+    /// there was an HTTP error Retrieving the gateway information.
     ///
     /// [`builder`]: Self::builder
     pub async fn new(
@@ -185,11 +266,14 @@ impl Cluster {
             ShardScheme::Auto => {
                 let http = config.http_client();
 
-                let gateway = http
-                    .gateway()
-                    .authed()
-                    .await
-                    .map_err(|source| ClusterStartError::RetrievingGatewayInfo { source })?;
+                let gateway =
+                    http.gateway()
+                        .authed()
+                        .await
+                        .map_err(|source| ClusterStartError {
+                            cause: Some(Box::new(source)),
+                            kind: ClusterStartErrorType::RetrievingGatewayInfo,
+                        })?;
 
                 [0, gateway.shards - 1, gateway.shards]
             }
@@ -358,35 +442,39 @@ impl Cluster {
     ///
     /// # Errors
     ///
-    /// Returns [`ClusterCommandError::Sending`] if the shard exists, but
-    /// sending it failed.
+    /// Returns a [`ClusterCommandErrorType::Sending`] error type if the shard
+    /// exists, but sending it failed.
     ///
-    /// Returns [`ClusterCommandError::ShardNonexistent`] if the provided shard
-    /// ID does not exist in the cluster.
+    /// Returns a [`ClusterCommandErrorType::ShardNonexistent`] error type if
+    /// the provided shard ID does not exist in the cluster.
     pub async fn command(
         &self,
         id: u64,
         value: &impl serde::Serialize,
     ) -> Result<(), ClusterCommandError> {
-        let shard = self
-            .shard(id)
-            .ok_or(ClusterCommandError::ShardNonexistent { id })?;
+        let shard = self.shard(id).ok_or(ClusterCommandError {
+            cause: None,
+            kind: ClusterCommandErrorType::ShardNonexistent { id },
+        })?;
 
         shard
             .command(value)
             .await
-            .map_err(|source| ClusterCommandError::Sending { source })
+            .map_err(|source| ClusterCommandError {
+                cause: Some(Box::new(source)),
+                kind: ClusterCommandErrorType::Sending,
+            })
     }
 
     /// Send a raw command to the specified shard.
     ///
     /// # Errors
     ///
-    /// Returns [`ClusterCommandError::Sending`] if the shard exists, but
-    /// sending it failed.
+    /// Returns a [`ClusterCommandErrorType::Sending`] error type if the shard
+    /// exists, but sending it failed.
     ///
-    /// Returns [`ClusterCommandError::ShardNonexistent`] if the provided shard
-    /// ID does not exist in the cluster.
+    /// Returns a [`ClusterCommandErrorType::ShardNonexistent`] error type if
+    /// the provided shard ID does not exist in the cluster.
     #[deprecated(note = "Use `send` which is more versatile", since = "0.3.0")]
     pub async fn command_raw(&self, id: u64, value: Vec<u8>) -> Result<(), ClusterCommandError> {
         self.send(id, Message::Binary(value))
@@ -422,22 +510,26 @@ impl Cluster {
     ///
     /// # Errors
     ///
-    /// Returns [`ClusterCommandError::Sending`] if the shard exists, but
-    /// sending the close code failed.
+    /// Returns [`ClusterCommandErrorType::Sending`] error type if the shard
+    /// exists, but sending the close code failed.
     ///
-    /// Returns a [`ClusterCommandError::ShardNonexistent`] if the provided shard
-    /// ID does not exist in the cluster.
+    /// Returns a [`ClusterCommandErrorType::ShardNonexistent`] error type if
+    /// the provided shard ID does not exist in the cluster.
     ///
     /// [`SessionInactiveError`]: struct.SessionInactiveError.html
     pub async fn send(&self, id: u64, message: Message) -> Result<(), ClusterSendError> {
-        let shard = self
-            .shard(id)
-            .ok_or(ClusterSendError::ShardNonexistent { id })?;
+        let shard = self.shard(id).ok_or(ClusterSendError {
+            cause: None,
+            kind: ClusterSendErrorType::ShardNonexistent { id },
+        })?;
 
         shard
             .send(message)
             .await
-            .map_err(|source| ClusterSendError::Sending { source })
+            .map_err(|source| ClusterSendError {
+                cause: Some(Box::new(source)),
+                kind: ClusterSendErrorType::Sending,
+            })
     }
 
     /// Return a stream of events from all shards managed by this Cluster.
@@ -526,17 +618,20 @@ impl Cluster {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cluster, ClusterCommandError, ClusterSendError, ClusterStartError};
+    use super::{
+        Cluster, ClusterCommandError, ClusterCommandErrorType, ClusterSendError,
+        ClusterSendErrorType, ClusterStartError, ClusterStartErrorType,
+    };
     use static_assertions::{assert_fields, assert_impl_all};
     use std::{error::Error, fmt::Debug};
 
-    assert_fields!(ClusterCommandError::Sending: source);
-    assert_fields!(ClusterCommandError::ShardNonexistent: id);
-    assert_impl_all!(ClusterCommandError: Debug, Error, Send, Sync);
-    assert_fields!(ClusterSendError::Sending: source);
-    assert_fields!(ClusterSendError::ShardNonexistent: id);
-    assert_impl_all!(ClusterSendError: Debug, Error, Send, Sync);
-    assert_fields!(ClusterStartError::RetrievingGatewayInfo: source);
-    assert_impl_all!(ClusterStartError: Debug, Error, Send, Sync);
+    assert_impl_all!(ClusterCommandErrorType: Debug, Send, Sync);
+    assert_fields!(ClusterCommandErrorType::ShardNonexistent: id);
+    assert_impl_all!(ClusterCommandError: Error, Send, Sync);
+    assert_impl_all!(ClusterSendErrorType: Debug, Send, Sync);
+    assert_fields!(ClusterSendErrorType::ShardNonexistent: id);
+    assert_impl_all!(ClusterSendError: Error, Send, Sync);
+    assert_impl_all!(ClusterStartErrorType: Debug, Send, Sync);
+    assert_impl_all!(ClusterStartError: Error, Send, Sync);
     assert_impl_all!(Cluster: Clone, Debug, Send, Sync);
 }

--- a/gateway/src/cluster/mod.rs
+++ b/gateway/src/cluster/mod.rs
@@ -60,7 +60,10 @@ mod config;
 mod r#impl;
 
 pub use self::{
-    builder::{ClusterBuilder, ShardScheme, ShardSchemeRangeError},
+    builder::{ClusterBuilder, ShardScheme, ShardSchemeRangeError, ShardSchemeRangeErrorType},
     config::Config,
-    r#impl::{Cluster, ClusterCommandError, ClusterSendError, ClusterStartError},
+    r#impl::{
+        Cluster, ClusterCommandError, ClusterCommandErrorType, ClusterStartError,
+        ClusterStartErrorType,
+    },
 };

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -25,8 +25,8 @@ impl LargeThresholdError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 
@@ -90,8 +90,8 @@ impl ShardIdError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -18,7 +18,7 @@ pub struct LargeThresholdError {
 
 impl LargeThresholdError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &LargeThresholdErrorType {
         &self.kind
     }
@@ -83,7 +83,7 @@ pub struct ShardIdError {
 
 impl ShardIdError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &ShardIdErrorType {
         &self.kind
     }

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -115,6 +115,7 @@ impl Display for ShardIdError {
 
 impl Error for ShardIdError {}
 
+/// Type of [`ShardIdError`] that occurred.
 #[derive(Debug)]
 pub enum ShardIdErrorType {
     /// Provided shard ID is higher than provided total shard count.

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -12,7 +12,55 @@ use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents}
 ///
 /// Returned by [`ShardBuilder::large_threshold`].
 #[derive(Debug)]
-pub enum LargeThresholdError {
+pub struct LargeThresholdError {
+    kind: LargeThresholdErrorType,
+}
+
+impl LargeThresholdError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &LargeThresholdErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        LargeThresholdErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for LargeThresholdError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            LargeThresholdErrorType::TooFew { .. } => {
+                f.write_str("provided large threshold value is fewer than 50")
+            }
+            LargeThresholdErrorType::TooMany { .. } => {
+                f.write_str("provided large threshold value is more than 250")
+            }
+        }
+    }
+}
+
+impl Error for LargeThresholdError {}
+
+/// Type of [`LargeThresholdError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum LargeThresholdErrorType {
     /// Provided large threshold value is too few in number.
     TooFew {
         /// Provided value.
@@ -25,35 +73,39 @@ pub enum LargeThresholdError {
     },
 }
 
-impl Display for LargeThresholdError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::TooFew { .. } => f.write_str("provided large threshold value is fewer than 50"),
-            Self::TooMany { .. } => f.write_str("provided large threshold value is more than 250"),
-        }
-    }
-}
-
-impl Error for LargeThresholdError {}
-
 /// Shard ID configuration is invalid.
 ///
 /// Returned by [`ShardBuilder::shard`].
 #[derive(Debug)]
-pub enum ShardIdError {
-    /// Provided shard ID is higher than provided total shard count.
-    IdTooLarge {
-        /// Shard ID.
-        id: u64,
-        /// Total shard count.
-        total: u64,
-    },
+pub struct ShardIdError {
+    kind: ShardIdErrorType,
+}
+
+impl ShardIdError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &ShardIdErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (ShardIdErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
 }
 
 impl Display for ShardIdError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::IdTooLarge { id, total } => f.write_fmt(format_args!(
+        match &self.kind {
+            ShardIdErrorType::IdTooLarge { id, total } => f.write_fmt(format_args!(
                 "provided shard ID {} is larger than the total {}",
                 id, total,
             )),
@@ -62,6 +114,17 @@ impl Display for ShardIdError {
 }
 
 impl Error for ShardIdError {}
+
+#[derive(Debug)]
+pub enum ShardIdErrorType {
+    /// Provided shard ID is higher than provided total shard count.
+    IdTooLarge {
+        /// Shard ID.
+        id: u64,
+        /// Total shard count.
+        total: u64,
+    },
+}
 
 /// Builder to configure and construct a shard.
 ///
@@ -154,22 +217,26 @@ impl ShardBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`LargeThresholdError::TooFew`] if the provided value is below
-    /// 50.
+    /// Returns a [`LargeThresholdErrorType::TooFew`] error type if the provided
+    /// value is below 50.
     ///
-    /// Returns [`LargeThresholdError::TooMany`] if the provided value is above
-    /// 250.
+    /// Returns a [`LargeThresholdErrorType::TooMany`] error type if the
+    /// provided value is above 250.
     pub fn large_threshold(mut self, large_threshold: u64) -> Result<Self, LargeThresholdError> {
         match large_threshold {
             0..=49 => {
-                return Err(LargeThresholdError::TooFew {
-                    value: large_threshold,
+                return Err(LargeThresholdError {
+                    kind: LargeThresholdErrorType::TooFew {
+                        value: large_threshold,
+                    },
                 })
             }
             50..=250 => {}
             251..=u64::MAX => {
-                return Err(LargeThresholdError::TooMany {
-                    value: large_threshold,
+                return Err(LargeThresholdError {
+                    kind: LargeThresholdErrorType::TooMany {
+                        value: large_threshold,
+                    },
                 })
             }
         }
@@ -236,13 +303,15 @@ impl ShardBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`ShardIdError::IdTooLarge`] if the shard ID to connect as is
-    /// larger than the total.
+    /// Returns a [`ShardIdErrorType::IdTooLarge`] error type if the shard ID to
+    /// connect as is larger than the total.
     pub fn shard(mut self, shard_id: u64, shard_total: u64) -> Result<Self, ShardIdError> {
         if shard_id >= shard_total {
-            return Err(ShardIdError::IdTooLarge {
-                id: shard_id,
-                total: shard_total,
+            return Err(ShardIdError {
+                kind: ShardIdErrorType::IdTooLarge {
+                    id: shard_id,
+                    total: shard_total,
+                },
             });
         }
 
@@ -260,14 +329,17 @@ impl<T: Into<String>> From<(T, Intents)> for ShardBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::{LargeThresholdError, ShardBuilder, ShardIdError};
+    use super::{
+        LargeThresholdError, LargeThresholdErrorType, ShardBuilder, ShardIdError, ShardIdErrorType,
+    };
     use crate::Intents;
     use static_assertions::{assert_fields, assert_impl_all};
     use std::{error::Error, fmt::Debug};
 
-    assert_fields!(LargeThresholdError::TooFew: value);
-    assert_fields!(LargeThresholdError::TooMany: value);
-    assert_impl_all!(LargeThresholdError: Debug, Error, Send, Sync);
+    assert_impl_all!(LargeThresholdErrorType: Debug, Send, Sync);
+    assert_fields!(LargeThresholdErrorType::TooFew: value);
+    assert_fields!(LargeThresholdErrorType::TooMany: value);
+    assert_impl_all!(LargeThresholdError: Error, Send, Sync);
     assert_impl_all!(
         ShardBuilder: Clone,
         Debug,
@@ -275,6 +347,7 @@ mod tests {
         Send,
         Sync
     );
-    assert_fields!(ShardIdError::IdTooLarge: id, total);
-    assert_impl_all!(ShardIdError: Debug, Error, Send, Sync);
+    assert_impl_all!(ShardIdErrorType: Debug, Send, Sync);
+    assert_fields!(ShardIdErrorType::IdTooLarge: id, total);
+    assert_impl_all!(ShardIdError: Error, Send, Sync);
 }

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -36,7 +36,7 @@ pub struct CommandError {
 
 impl CommandError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &CommandErrorType {
         &self.kind
     }
@@ -127,7 +127,7 @@ pub struct SendError {
 
 impl SendError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &SendErrorType {
         &self.kind
     }
@@ -184,7 +184,7 @@ pub struct ShardStartError {
 
 impl ShardStartError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &ShardStartErrorType {
         &self.kind
     }

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -3,17 +3,15 @@ use super::{
     config::Config,
     event::Events,
     json,
-    processor::{ConnectingError, Latency, Session, ShardProcessor},
+    processor::{ConnectingErrorType, Latency, Session, ShardProcessor},
     raw_message::Message,
     sink::ShardSink,
     stage::Stage,
 };
 use crate::{listener::Listeners, EventTypeFlags, Intents};
-use async_tungstenite::tungstenite::{
-    protocol::{frame::coding::CloseCode, CloseFrame as TungsteniteCloseFrame},
-    Error as TungsteniteError, Message as TungsteniteMessage,
+use async_tungstenite::tungstenite::protocol::{
+    frame::coding::CloseCode, CloseFrame as TungsteniteCloseFrame,
 };
-use futures_channel::mpsc::TrySendError;
 use futures_util::{
     future::{self, AbortHandle},
     stream::StreamExt,
@@ -27,66 +25,88 @@ use std::{
     sync::{atomic::Ordering, Arc},
 };
 use tokio::sync::watch::Receiver as WatchReceiver;
-use twilight_http::Error as HttpError;
 use twilight_model::gateway::event::Event;
-use url::ParseError as UrlParseError;
-
-#[cfg(not(feature = "simd-json"))]
-use serde_json::Error as JsonError;
-#[cfg(feature = "simd-json")]
-use simd_json::Error as JsonError;
 
 /// Sending a command failed.
 #[derive(Debug)]
-#[non_exhaustive]
-pub enum CommandError {
-    /// Sending the payload over the WebSocket failed. This is indicative of a
-    /// shutdown shard.
-    Sending {
-        /// Reason for the error.
-        source: TrySendError<TungsteniteMessage>,
-    },
-    /// Serializing the payload as JSON failed.
-    Serializing {
-        /// Reason for the error.
-        source: JsonError,
-    },
-    /// Shard's session is inactive because the shard hasn't been started.
-    SessionInactive {
-        /// Reason for the error.
-        source: SessionInactiveError,
-    },
+pub struct CommandError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: CommandErrorType,
+}
+
+impl CommandError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &CommandErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (CommandErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
 }
 
 impl CommandError {
     pub(crate) fn from_send(error: SendError) -> Self {
-        match error {
-            SendError::Sending { source } => Self::Sending { source },
-            SendError::SessionInactive { source } => Self::SessionInactive { source },
+        let (kind, cause) = error.into_parts();
+
+        let new_kind = match kind {
+            SendErrorType::Sending => CommandErrorType::Sending,
+            SendErrorType::SessionInactive => CommandErrorType::SessionInactive,
+        };
+
+        Self {
+            cause,
+            kind: new_kind,
         }
     }
 }
 
 impl Display for CommandError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_str("the shard session is inactive and has not been started")
+        match &self.kind {
+            CommandErrorType::Sending => {
+                f.write_str("sending the message over the websocket failed")
+            }
+            CommandErrorType::Serializing => f.write_str("serializing the value as json failed"),
+            CommandErrorType::SessionInactive => Display::fmt(&SessionInactiveError, f),
+        }
     }
 }
 
 impl Error for CommandError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::Sending { source } => Some(source),
-            Self::Serializing { source } => Some(source),
-            Self::SessionInactive { source } => Some(source),
-        }
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
     }
+}
+
+/// Type of [`CommandError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CommandErrorType {
+    /// Sending the payload over the WebSocket failed. This is indicative of a
+    /// shutdown shard.
+    Sending,
+    /// Serializing the payload as JSON failed.
+    Serializing,
+    /// Shard's session is inactive because the shard hasn't been started.
+    SessionInactive,
 }
 
 /// Shard's session is inactive.
 ///
 /// This means that the shard has not yet been started.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub struct SessionInactiveError;
 
@@ -100,37 +120,96 @@ impl Error for SessionInactiveError {}
 
 /// Starting a shard and connecting to the gateway failed.
 #[derive(Debug)]
+pub struct SendError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: SendErrorType,
+}
+
+impl SendError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &SendErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (SendErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
+}
+
+impl Display for SendError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            SendErrorType::Sending { .. } => {
+                f.write_str("sending the message over the websocket failed")
+            }
+            SendErrorType::SessionInactive { .. } => f.write_str("shard hasn't been started"),
+        }
+    }
+}
+
+impl Error for SendError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
+    }
+}
+
+/// Type of [`SendError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum ShardStartError {
-    /// Establishing a connection to the gateway failed.
-    Establishing {
-        /// Reason for the error.
-        source: TungsteniteError,
-    },
-    /// Parsing the gateway URL provided by Discord to connect to the gateway
-    /// failed due to an invalid URL.
-    ParsingGatewayUrl {
-        /// Reason for the error.
-        source: UrlParseError,
-        /// URL that couldn't be parsed.
-        url: String,
-    },
-    /// Retrieving the gateway URL via the Twilight HTTP client failed.
-    RetrievingGatewayUrl {
-        /// The reason for the error.
-        source: HttpError,
-    },
+pub enum SendErrorType {
+    /// Sending the payload over the WebSocket failed. This is indicative of a
+    /// shard that isn't properly running.
+    Sending,
+    /// Shard's session is inactive because the shard hasn't been started.
+    SessionInactive,
+}
+
+/// Starting a shard and connecting to the gateway failed.
+#[derive(Debug)]
+pub struct ShardStartError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: ShardStartErrorType,
+}
+
+impl ShardStartError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &ShardStartErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (ShardStartErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
 }
 
 impl Display for ShardStartError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Establishing { source } => Display::fmt(source, f),
-            Self::ParsingGatewayUrl { source, url } => f.write_fmt(format_args!(
-                "the gateway url `{}` is invalid: {}",
-                url, source,
-            )),
-            Self::RetrievingGatewayUrl { .. } => {
+        match &self.kind {
+            ShardStartErrorType::Establishing => f.write_str("establishing the connection failed"),
+            ShardStartErrorType::ParsingGatewayUrl { url } => {
+                f.write_fmt(format_args!("the gateway url `{}` is invalid", url,))
+            }
+            ShardStartErrorType::RetrievingGatewayUrl => {
                 f.write_str("retrieving the gateway URL via HTTP failed")
             }
         }
@@ -139,56 +218,26 @@ impl Display for ShardStartError {
 
 impl Error for ShardStartError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::Establishing { source } => Some(source),
-            Self::ParsingGatewayUrl { source, .. } => Some(source),
-            Self::RetrievingGatewayUrl { source } => Some(source),
-        }
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
     }
 }
 
-impl From<ConnectingError> for ShardStartError {
-    fn from(error: ConnectingError) -> Self {
-        match error {
-            ConnectingError::Establishing { source } => Self::Establishing { source },
-            ConnectingError::ParsingUrl { source, url } => Self::ParsingGatewayUrl { source, url },
-        }
-    }
-}
-
-/// Starting a shard and connecting to the gateway failed.
+/// Type of [`ShardStartError`] that occurred.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum SendError {
-    /// Sending the payload over the WebSocket failed. This is indicative of a
-    /// shard that isn't properly running.
-    Sending {
-        /// Reason for the error.
-        source: TrySendError<TungsteniteMessage>,
+pub enum ShardStartErrorType {
+    /// Establishing a connection to the gateway failed.
+    Establishing,
+    /// Parsing the gateway URL provided by Discord to connect to the gateway
+    /// failed due to an invalid URL.
+    ParsingGatewayUrl {
+        /// URL that couldn't be parsed.
+        url: String,
     },
-    /// Shard's session is inactive because the shard hasn't been started.
-    SessionInactive {
-        /// Reason for the error.
-        source: SessionInactiveError,
-    },
-}
-
-impl Display for SendError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Sending { .. } => f.write_str("sending the message over the websocket failed"),
-            Self::SessionInactive { .. } => f.write_str("shard hasn't been started"),
-        }
-    }
-}
-
-impl Error for SendError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::Sending { source } => Some(source),
-            Self::SessionInactive { source } => Some(source),
-        }
-    }
+    /// Retrieving the gateway URL via the Twilight HTTP client failed.
+    RetrievingGatewayUrl,
 }
 
 /// Information about a shard, including its latency, current session sequence,
@@ -241,6 +290,7 @@ impl Information {
         self.stage
     }
 }
+
 /// Details to resume a gateway session.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ResumeSession {
@@ -379,14 +429,14 @@ impl Shard {
     ///
     /// # Errors
     ///
-    /// Returns [`ShardStartError::Establishing`] if establishing a connection
-    /// to the gateway failed.
+    /// Returns a [`ShardStartErrorType::Establishing`] error type if
+    /// establishing a connection to the gateway failed.
     ///
-    /// Returns [`ShardStartError::ParsingGatewayUrl`] if the gateway URL
-    /// couldn't be parsed.
+    /// Returns a [`ShardStartErrorType::ParsingGatewayUrl`] error type if the
+    /// gateway URL couldn't be parsed.
     ///
-    /// Returns [`ShardStartError::RetrievingGatewayUrl`] if the gateway URL
-    /// couldn't be retrieved from the HTTP API.
+    /// Returns a [`ShardStartErrorType::RetrievingGatewayUrl`] error type if
+    /// the gateway URL couldn't be retrieved from the HTTP API.
     pub async fn start(&mut self) -> Result<(), ShardStartError> {
         let url = if let Some(u) = self.0.config.gateway_url.clone() {
             u.into_string()
@@ -397,15 +447,33 @@ impl Shard {
                 .gateway()
                 .authed()
                 .await
-                .map_err(|source| ShardStartError::RetrievingGatewayUrl { source })?
+                .map_err(|source| ShardStartError {
+                    cause: Some(Box::new(source)),
+                    kind: ShardStartErrorType::RetrievingGatewayUrl,
+                })?
                 .url
         };
 
         let config = Arc::clone(&self.0.config);
         let listeners = self.0.listeners.clone();
-        let (processor, wrx) = ShardProcessor::new(config, url, listeners)
-            .await
-            .map_err(ShardStartError::from)?;
+        let (processor, wrx) =
+            ShardProcessor::new(config, url, listeners)
+                .await
+                .map_err(|source| {
+                    let (kind, cause) = source.into_parts();
+
+                    let new_kind = match kind {
+                        ConnectingErrorType::Establishing => ShardStartErrorType::Establishing,
+                        ConnectingErrorType::ParsingUrl { url } => {
+                            ShardStartErrorType::ParsingGatewayUrl { url }
+                        }
+                    };
+
+                    ShardStartError {
+                        cause,
+                        kind: new_kind,
+                    }
+                })?;
         let (fut, handle) = future::abortable(processor.run());
 
         tokio::spawn(async move {
@@ -526,16 +594,20 @@ impl Shard {
     ///
     /// # Errors
     ///
-    /// Returns [`CommandError::Sending`] if the message could not be sent
-    /// over the websocket. This indicates the shard is currently restarting.
+    /// Returns a [`CommandErrorType::Sending`] error type if the message could
+    /// not be sent over the websocket. This indicates the shard is currently
+    /// restarting.
     ///
-    /// Returns [`CommandError::Serializing`] if the provided value failed to
-    /// serialize into JSON.
+    /// Returns a [`CommandErrorType::Serializing`] error type if the provided
+    /// value failed to serialize into JSON.
     ///
-    /// Returns [`CommandError::SessionInactive`] if the shard has not been
-    /// started.
+    /// Returns a [`CommandErrorType::SessionInactive`] error type if the shard
+    /// has not been started.
     pub async fn command(&self, value: &impl serde::Serialize) -> Result<(), CommandError> {
-        let json = json::to_vec(value).map_err(|source| CommandError::Serializing { source })?;
+        let json = json::to_vec(value).map_err(|source| CommandError {
+            cause: Some(Box::new(source)),
+            kind: CommandErrorType::Serializing,
+        })?;
 
         self.send(Message::Binary(json))
             .await
@@ -586,11 +658,12 @@ impl Shard {
     ///
     /// # Errors
     ///
-    /// Returns a [`SendError::Sending`] if there is an issue with sending via
-    /// the shard's session. This may occur when the shard is between sessions.
+    /// Returns a [`SendErrorType::Sending`] error type if there is an issue
+    /// with sending via the shard's session. This may occur when the shard is
+    /// between sessions.
     ///
-    /// Returns [`SendError::SessionInactive`] when the shard has not been
-    /// started.
+    /// Returns [`SendErrorType::SessionInactive`] error type when the shard has
+    /// not been started.
     ///
     /// [`shutdown`]: Self::shutdown
     pub async fn send(&self, message: Message) -> Result<(), SendError> {
@@ -601,28 +674,34 @@ impl Shard {
             session
                 .tx
                 .unbounded_send(message.into_tungstenite())
-                .map_err(|source| SendError::Sending { source })
+                .map_err(|source| SendError {
+                    cause: Some(Box::new(source)),
+                    kind: SendErrorType::Sending,
+                })
         } else {
-            Err(SendError::SessionInactive {
-                source: SessionInactiveError,
+            Err(SendError {
+                cause: Some(Box::new(SessionInactiveError)),
+                kind: SendErrorType::SessionInactive,
             })
         }
     }
 
     /// Send a raw command over the gateway.
     ///
-    /// This method should be used with caution, [`command`] should be preferred.
+    /// This method should be used with caution, [`command`] should be
+    /// preferred.
     ///
     /// # Errors
     ///
-    /// Returns [`CommandError::Sending`] if the message could not be sent
-    /// over the websocket. This indicates the shard is currently restarting.
+    /// Returns a [`CommandErrorType::Sending`] error type if the message could
+    /// not be sent over the websocket. This indicates the shard is currently
+    /// restarting.
     ///
-    /// Returns [`CommandError::Serializing`] if the provided value failed to
-    /// serialize into JSON.
+    /// Returns a [`CommandErrorType::Serializing`] error type if the provided
+    /// value failed to serialize into JSON.
     ///
-    /// Returns [`CommandError::SessionInactive`] if the shard has not been
-    /// started.
+    /// Returns a [`CommandErrorType::SessionInactive`] error type if the shard
+    /// has not been started.
     ///
     /// [`command`]: Self::command
     #[deprecated(note = "Use `send` which is more versatile", since = "0.3.0")]
@@ -709,39 +788,21 @@ impl Shard {
 #[cfg(test)]
 mod tests {
     use super::{
-        CommandError, ConnectingError, Information, ResumeSession, SendError, SessionInactiveError,
-        Shard, ShardStartError,
+        CommandError, CommandErrorType, Information, ResumeSession, SendError, SendErrorType,
+        SessionInactiveError, Shard, ShardStartError, ShardStartErrorType,
     };
     use static_assertions::{assert_fields, assert_impl_all};
     use std::{error::Error, fmt::Debug};
 
-    assert_fields!(CommandError::Sending: source);
-    assert_fields!(CommandError::Serializing: source);
-    assert_fields!(CommandError::SessionInactive: source);
-    assert_impl_all!(CommandError: Debug, Error, Send, Sync);
+    assert_impl_all!(CommandErrorType: Debug, Send, Sync);
+    assert_impl_all!(CommandError: Error, Send, Sync);
     assert_impl_all!(Information: Clone, Debug, Send, Sync);
     assert_impl_all!(ResumeSession: Clone, Debug, Send, Sync);
-    assert_impl_all!(
-        SessionInactiveError: Clone,
-        Debug,
-        Error,
-        Eq,
-        PartialEq,
-        Send,
-        Sync
-    );
-    assert_fields!(SendError::Sending: source);
-    assert_fields!(SendError::SessionInactive: source);
-    assert_impl_all!(SendError: Debug, Error, Send, Sync);
-    assert_fields!(ShardStartError::Establishing: source);
-    assert_fields!(ShardStartError::ParsingGatewayUrl: source, url);
-    assert_fields!(ShardStartError::RetrievingGatewayUrl: source);
-    assert_impl_all!(
-        ShardStartError: Debug,
-        Error,
-        From<ConnectingError>,
-        Send,
-        Sync
-    );
+    assert_impl_all!(SendErrorType: Debug, Send, Sync);
+    assert_impl_all!(SendError: Error, Send, Sync);
+    assert_impl_all!(SessionInactiveError: Error, Send, Sync);
+    assert_fields!(ShardStartErrorType::ParsingGatewayUrl: url);
+    assert_impl_all!(ShardStartErrorType: Debug, Send, Sync);
+    assert_impl_all!(ShardStartError: Error, Send, Sync);
     assert_impl_all!(Shard: Clone, Debug, Send, Sync);
 }

--- a/gateway/src/shard/json.rs
+++ b/gateway/src/shard/json.rs
@@ -10,36 +10,44 @@ use std::{
 use twilight_model::gateway::event::GatewayEvent;
 
 #[derive(Debug)]
-pub enum GatewayEventParsingError {
-    /// Deserializing the GatewayEvent payload from JSON failed.
-    Deserializing {
-        /// Reason for the error.
-        source: JsonError,
-    },
-    /// The payload received from Discord was an unrecognized or invalid
-    /// structure.
-    ///
-    /// The payload was either invalid JSON or did not contain the necessary
-    /// "op" key in the object.
-    PayloadInvalid,
+pub struct GatewayEventParsingError {
+    pub(super) cause: Option<Box<dyn Error + Send + Sync>>,
+    pub(super) kind: GatewayEventParsingErrorType,
 }
 
 impl Display for GatewayEventParsingError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Deserializing { source } => Display::fmt(source, f),
-            Self::PayloadInvalid => f.write_str("payload is an invalid json structure"),
+        match &self.kind {
+            GatewayEventParsingErrorType::Deserializing => {
+                f.write_str("deserializing gateway event as json failed")
+            }
+            GatewayEventParsingErrorType::PayloadInvalid => {
+                f.write_str("payload is an invalid json structure")
+            }
         }
     }
 }
 
 impl Error for GatewayEventParsingError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::Deserializing { source } => Some(source),
-            Self::PayloadInvalid => None,
-        }
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
     }
+}
+
+/// Type of [`GatewayEventParsingError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum GatewayEventParsingErrorType {
+    /// Deserializing the GatewayEvent payload from JSON failed.
+    Deserializing,
+    /// The payload received from Discord was an unrecognized or invalid
+    /// structure.
+    ///
+    /// The payload was either invalid JSON or did not contain the necessary
+    /// "op" key in the object.
+    PayloadInvalid,
 }
 
 /// Parse a gateway event from a string using `serde_json` with headers.
@@ -71,7 +79,10 @@ pub fn parse_gateway_event(
         .map_err(|source| {
             tracing::debug!("invalid JSON: {}", json);
 
-            GatewayEventParsingError::Deserializing { source }
+            GatewayEventParsingError {
+                cause: Some(Box::new(source)),
+                kind: GatewayEventParsingErrorType::Deserializing,
+            }
         })
 }
 
@@ -105,24 +116,30 @@ pub fn parse_gateway_event(
     // UTF-8 valid, but that's fine because it won't be used again.
     let json_bytes = unsafe { json.as_bytes_mut() };
 
-    let mut json_deserializer = Deserializer::from_slice(json_bytes)
-        .map_err(|_| GatewayEventParsingError::PayloadInvalid)?;
+    let mut json_deserializer =
+        Deserializer::from_slice(json_bytes).map_err(|_| GatewayEventParsingError {
+            cause: None,
+            kind: GatewayEventParsingErrorType::PayloadInvalid,
+        })?;
 
     gateway_deserializer
         .deserialize(&mut json_deserializer)
         .map_err(|source| {
             tracing::debug!("invalid JSON: {}", json);
 
-            GatewayEventParsingError::Deserializing { source }
+            GatewayEventParsingError {
+                cause: Some(Box::new(source)),
+                kind: GatewayEventParsingErrorType::Deserializing,
+            }
         })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::GatewayEventParsingError;
-    use static_assertions::{assert_fields, assert_impl_all};
+    use super::{GatewayEventParsingError, GatewayEventParsingErrorType};
+    use static_assertions::assert_impl_all;
     use std::{error::Error, fmt::Debug};
 
-    assert_fields!(GatewayEventParsingError::Deserializing: source);
-    assert_impl_all!(GatewayEventParsingError: Debug, Error, Send, Sync);
+    assert_impl_all!(GatewayEventParsingErrorType: Debug, Send, Sync);
+    assert_impl_all!(GatewayEventParsingError: Error, Send, Sync);
 }

--- a/gateway/src/shard/json.rs
+++ b/gateway/src/shard/json.rs
@@ -11,7 +11,7 @@ use twilight_model::gateway::event::GatewayEvent;
 
 #[derive(Debug)]
 pub struct GatewayEventParsingError {
-    pub(super) cause: Option<Box<dyn Error + Send + Sync>>,
+    pub(super) source: Option<Box<dyn Error + Send + Sync>>,
     pub(super) kind: GatewayEventParsingErrorType,
 }
 
@@ -30,9 +30,9 @@ impl Display for GatewayEventParsingError {
 
 impl Error for GatewayEventParsingError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.cause
+        self.source
             .as_ref()
-            .map(|cause| &**cause as &(dyn Error + 'static))
+            .map(|source| &**source as &(dyn Error + 'static))
     }
 }
 
@@ -80,8 +80,8 @@ pub fn parse_gateway_event(
             tracing::debug!("invalid JSON: {}", json);
 
             GatewayEventParsingError {
-                cause: Some(Box::new(source)),
                 kind: GatewayEventParsingErrorType::Deserializing,
+                source: Some(Box::new(source)),
             }
         })
 }
@@ -118,8 +118,8 @@ pub fn parse_gateway_event(
 
     let mut json_deserializer =
         Deserializer::from_slice(json_bytes).map_err(|_| GatewayEventParsingError {
-            cause: None,
             kind: GatewayEventParsingErrorType::PayloadInvalid,
+            source: None,
         })?;
 
     gateway_deserializer
@@ -128,8 +128,8 @@ pub fn parse_gateway_event(
             tracing::debug!("invalid JSON: {}", json);
 
             GatewayEventParsingError {
-                cause: Some(Box::new(source)),
                 kind: GatewayEventParsingErrorType::Deserializing,
+                source: Some(Box::new(source)),
             }
         })
 }

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -31,13 +31,15 @@ mod processor;
 mod sink;
 
 pub use self::{
-    builder::{LargeThresholdError, ShardBuilder, ShardIdError},
+    builder::{
+        LargeThresholdError, LargeThresholdErrorType, ShardBuilder, ShardIdError, ShardIdErrorType,
+    },
     config::Config,
     event::Events,
     processor::heartbeat::Latency,
     r#impl::{
-        CommandError, Information, ResumeSession, SendError, SessionInactiveError, Shard,
-        ShardStartError,
+        CommandError, CommandErrorType, Information, ResumeSession, SendError, SendErrorType,
+        SessionInactiveError, Shard, ShardStartError, ShardStartErrorType,
     },
     sink::ShardSink,
     stage::Stage,

--- a/gateway/src/shard/processor/emitter.rs
+++ b/gateway/src/shard/processor/emitter.rs
@@ -1,4 +1,4 @@
-use super::super::json::{self, GatewayEventParsingError};
+use super::super::json;
 use crate::{listener::Listeners, EventTypeFlags};
 use std::{
     convert::TryFrom,
@@ -8,7 +8,41 @@ use std::{
 use twilight_model::gateway::event::{shard::Payload, Event};
 
 #[derive(Debug)]
-pub enum EmitJsonError {
+pub struct EmitJsonError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: EmitJsonErrorType,
+}
+
+impl EmitJsonError {
+    pub fn into_parts(self) -> (EmitJsonErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, self.cause)
+    }
+}
+
+impl Display for EmitJsonError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            EmitJsonErrorType::EventTypeUnknown { event_type, op } => f.write_fmt(format_args!(
+                "provided event type ({:?})/op ({}) pair is unknown",
+                event_type, op,
+            )),
+            EmitJsonErrorType::Parsing => f.write_str("parsing a gateway event failed"),
+        }
+    }
+}
+
+impl Error for EmitJsonError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
+    }
+}
+
+/// Type of [`EmitJsonError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum EmitJsonErrorType {
     /// Provided event type and/or opcode combination doesn't match a known
     /// event type flag.
     EventTypeUnknown {
@@ -18,31 +52,7 @@ pub enum EmitJsonError {
         op: u8,
     },
     /// Parsing a a gateway event failed.
-    Parsing {
-        /// Reason for the error.
-        source: GatewayEventParsingError,
-    },
-}
-
-impl Display for EmitJsonError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::EventTypeUnknown { event_type, op } => f.write_fmt(format_args!(
-                "provided event type ({:?})/op ({}) pair is unknown",
-                event_type, op,
-            )),
-            Self::Parsing { source } => Display::fmt(source, f),
-        }
-    }
-}
-
-impl Error for EmitJsonError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::EventTypeUnknown { .. } => None,
-            Self::Parsing { source } => Some(source),
-        }
-    }
+    Parsing,
 }
 
 /// Emitter over a map of listeners with some useful things on top to abstract
@@ -126,9 +136,12 @@ impl Emitter {
         json: &mut str,
     ) -> Result<(), EmitJsonError> {
         let flag = EventTypeFlags::try_from((op, event_type)).map_err(|(op, event_type)| {
-            EmitJsonError::EventTypeUnknown {
-                event_type: event_type.map(ToOwned::to_owned),
-                op,
+            EmitJsonError {
+                cause: None,
+                kind: EmitJsonErrorType::EventTypeUnknown {
+                    event_type: event_type.map(ToOwned::to_owned),
+                    op,
+                },
             }
         })?;
 
@@ -136,8 +149,13 @@ impl Emitter {
             return Ok(());
         }
 
-        let gateway_event = json::parse_gateway_event(op, seq, event_type, json)
-            .map_err(|source| EmitJsonError::Parsing { source })?;
+        let gateway_event =
+            json::parse_gateway_event(op, seq, event_type, json).map_err(|source| {
+                EmitJsonError {
+                    cause: Some(Box::new(source)),
+                    kind: EmitJsonErrorType::Parsing,
+                }
+            })?;
         self.event(Event::from(gateway_event));
 
         Ok(())

--- a/gateway/src/shard/processor/heartbeat.rs
+++ b/gateway/src/shard/processor/heartbeat.rs
@@ -232,16 +232,16 @@ impl Heartbeater {
             let seq = self.seq.load(Ordering::Acquire);
             let heartbeat = Heartbeat::new(seq);
             let bytes = json::to_vec(&heartbeat).map_err(|source| SessionSendError {
-                cause: Some(Box::new(source)),
                 kind: SessionSendErrorType::Serializing,
+                source: Some(Box::new(source)),
             })?;
 
             tracing::debug!(seq, "sending heartbeat");
             self.tx
                 .unbounded_send(TungsteniteMessage::Binary(bytes))
                 .map_err(|source| SessionSendError {
-                    cause: Some(Box::new(source)),
                     kind: SessionSendErrorType::Sending,
+                    source: Some(Box::new(source)),
                 })?;
             tracing::debug!(seq, "sent heartbeat");
             self.heartbeats.send();

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -1,22 +1,21 @@
 use super::{
     super::{
         config::Config,
-        json::{self, GatewayEventParsingError},
+        json::{self, GatewayEventParsingError, GatewayEventParsingErrorType},
         stage::Stage,
         ShardStream,
     },
-    emitter::{EmitJsonError, Emitter},
+    emitter::{EmitJsonErrorType, Emitter},
     inflater::Inflater,
-    session::{Session, SessionSendError},
+    session::{Session, SessionSendError, SessionSendErrorType},
     socket_forwarder::SocketForwarder,
 };
 use crate::{event::EventTypeFlags, listener::Listeners};
 use async_tungstenite::tungstenite::{
     protocol::{frame::coding::CloseCode, CloseFrame},
-    Error as TungsteniteError, Message,
+    Message,
 };
-use flate2::DecompressError;
-use futures_channel::mpsc::{TrySendError, UnboundedReceiver};
+use futures_channel::mpsc::UnboundedReceiver;
 use futures_util::stream::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -24,7 +23,7 @@ use std::{
     env::consts::OS,
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
-    str::{self, Utf8Error},
+    str,
     sync::{atomic::Ordering, Arc},
     time::Duration,
 };
@@ -43,39 +42,91 @@ use twilight_model::gateway::{
     },
     Intents, OpCode,
 };
-use url::{ParseError as UrlParseError, Url};
+use url::Url;
 
 /// Connecting to the gateway failed.
 #[derive(Debug)]
-#[non_exhaustive]
-pub enum ConnectingError {
-    Establishing { source: TungsteniteError },
-    ParsingUrl { source: UrlParseError, url: String },
+pub struct ConnectingError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: ConnectingErrorType,
+}
+
+impl ConnectingError {
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (ConnectingErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, self.cause)
+    }
 }
 
 impl Display for ConnectingError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Establishing { source } => Display::fmt(source, f),
-            Self::ParsingUrl { source, url } => f.write_fmt(format_args!(
-                "the gateway url `{}` is invalid: {}",
-                url, source,
-            )),
+        match &self.kind {
+            ConnectingErrorType::Establishing => f.write_str("failed to establish the connection"),
+            ConnectingErrorType::ParsingUrl { url } => {
+                f.write_fmt(format_args!("the gateway url `{}` is invalid", url,))
+            }
         }
     }
 }
 
 impl Error for ConnectingError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::Establishing { source } => Some(source),
-            Self::ParsingUrl { source, .. } => Some(source),
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
+    }
+}
+
+/// Type of [`ConnectingError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ConnectingErrorType {
+    Establishing,
+    ParsingUrl { url: String },
+}
+
+#[derive(Debug)]
+struct ProcessError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: ProcessErrorType,
+}
+
+impl ProcessError {
+    fn fatal(&self) -> bool {
+        matches!(self.kind, ProcessErrorType::SendingClose { .. } | ProcessErrorType::SessionSend { .. })
+    }
+}
+
+impl Display for ProcessError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            ProcessErrorType::EventTypeUnknown { event_type, op } => f.write_fmt(format_args!(
+                "provided event type ({:?})/op ({}) pair is unknown",
+                event_type, op,
+            )),
+            ProcessErrorType::ParsingPayload => f.write_str("payload could not be parsed as json"),
+            ProcessErrorType::PayloadNotUtf8 { .. } => {
+                f.write_str("the payload from Discord wasn't UTF-8 valid")
+            }
+            ProcessErrorType::SendingClose => f.write_str("couldn't send close message"),
+            ProcessErrorType::SequenceMissing => f.write_str("sequence missing from payload"),
+            ProcessErrorType::SessionSend => f.write_str("shard hasn't been started"),
         }
     }
 }
 
+impl Error for ProcessError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
+    }
+}
+
+/// Type of [`ProcessError`] that occurred.
 #[derive(Debug)]
-enum ProcessError {
+enum ProcessErrorType {
     /// Provided event type and/or opcode combination doesn't match a known
     /// event type flag.
     EventTypeUnknown {
@@ -85,77 +136,87 @@ enum ProcessError {
         op: u8,
     },
     /// There was an error parsing a GatewayEvent payload.
-    ParsingPayload {
-        /// Reason for the error.
-        source: GatewayEventParsingError,
-    },
+    ParsingPayload,
     /// The binary payload received from Discord wasn't validly encoded as
     /// UTF-8.
-    PayloadNotUtf8 {
-        /// Source error when converting to a UTF-8 valid string.
-        source: Utf8Error,
-    },
+    PayloadNotUtf8,
     /// A close message tried to be sent but the receiving half was dropped.
     /// This typically means that the shard is shutdown.
-    SendingClose {
-        /// Reason for the error.
-        source: TrySendError<Message>,
-    },
+    SendingClose,
     /// The sequence was missing from the payload.
     SequenceMissing,
     /// Sending a message over the session was unsuccessful.
-    SessionSend {
-        /// Reason for the error.
-        source: SessionSendError,
-    },
-}
-
-impl ProcessError {
-    fn fatal(&self) -> bool {
-        matches!(self, Self::SendingClose { .. } | Self::SessionSend { .. })
-    }
-}
-
-impl Display for ProcessError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::EventTypeUnknown { event_type, op } => f.write_fmt(format_args!(
-                "provided event type ({:?})/op ({}) pair is unknown",
-                event_type, op,
-            )),
-            Self::ParsingPayload { source } => Display::fmt(source, f),
-            Self::PayloadNotUtf8 { .. } => {
-                f.write_str("the payload from Discord wasn't UTF-8 valid")
-            }
-            Self::SendingClose { source } => Display::fmt(source, f),
-            Self::SequenceMissing => f.write_str("sequence missing from payload"),
-            Self::SessionSend { source } => Display::fmt(source, f),
-        }
-    }
-}
-
-impl Error for ProcessError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::ParsingPayload { source } => Some(source),
-            Self::PayloadNotUtf8 { source } => Some(source),
-            Self::SendingClose { source } => Some(source),
-            Self::SessionSend { source } => Some(source),
-            Self::EventTypeUnknown { .. } | Self::SequenceMissing => None,
-        }
-    }
+    SessionSend,
 }
 
 #[derive(Debug)]
-#[non_exhaustive]
-enum ReceivingEventError {
+struct ReceivingEventError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: ReceivingEventErrorType,
+}
+
+impl ReceivingEventError {
+    fn fatal(&self) -> bool {
+        matches!(
+            self.kind,
+            ReceivingEventErrorType::AuthorizationInvalid { .. }
+            | ReceivingEventErrorType::IntentsDisallowed { .. }
+            | ReceivingEventErrorType::IntentsInvalid { .. }
+        )
+    }
+
+    fn reconnectable(&self) -> bool {
+        matches!(self.kind, ReceivingEventErrorType::Decompressing)
+    }
+
+    fn resumable(&self) -> bool {
+        matches!(self.kind, ReceivingEventErrorType::EventStreamEnded)
+    }
+}
+
+impl Display for ReceivingEventError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            ReceivingEventErrorType::AuthorizationInvalid { shard_id, .. } => f.write_fmt(
+                format_args!("the authorization token for shard {} is invalid", shard_id),
+            ),
+            ReceivingEventErrorType::Decompressing => {
+                f.write_str("a frame could not be decompressed")
+            }
+            ReceivingEventErrorType::IntentsDisallowed { intents, shard_id } => {
+                f.write_fmt(format_args!(
+                    "at least one of the intents ({:?}) for shard {} are disallowed",
+                    intents, shard_id
+                ))
+            }
+            ReceivingEventErrorType::IntentsInvalid { intents, shard_id } => {
+                f.write_fmt(format_args!(
+                    "at least one of the intents ({:?}) for shard {} are invalid",
+                    intents, shard_id
+                ))
+            }
+            ReceivingEventErrorType::EventStreamEnded => {
+                f.write_str("event stream from gateway ended")
+            }
+        }
+    }
+}
+
+impl Error for ReceivingEventError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
+    }
+}
+
+/// Type of [`ReceivingEventError`] that occurred.
+#[derive(Debug)]
+enum ReceivingEventErrorType {
     /// Provided authorization token is invalid.
     AuthorizationInvalid { shard_id: u64, token: String },
     /// Decompressing a frame from Discord failed.
-    Decompressing {
-        /// Reason for the error.
-        source: DecompressError,
-    },
+    Decompressing,
     /// The event stream has ended, this is recoverable by resuming.
     EventStreamEnded,
     /// Current user isn't allowed to use at least one of the configured
@@ -178,48 +239,6 @@ enum ReceivingEventError {
         shard_id: u64,
     },
 }
-
-impl ReceivingEventError {
-    fn fatal(&self) -> bool {
-        matches!(
-            self,
-            ReceivingEventError::AuthorizationInvalid { .. }
-                | ReceivingEventError::IntentsDisallowed { .. }
-                | ReceivingEventError::IntentsInvalid { .. }
-        )
-    }
-
-    fn reconnectable(&self) -> bool {
-        matches!(self, ReceivingEventError::Decompressing { .. })
-    }
-
-    fn resumable(&self) -> bool {
-        matches!(self, ReceivingEventError::EventStreamEnded)
-    }
-}
-
-impl Display for ReceivingEventError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::AuthorizationInvalid { shard_id, .. } => f.write_fmt(format_args!(
-                "the authorization token for shard {} is invalid",
-                shard_id
-            )),
-            Self::Decompressing { .. } => f.write_str("a frame could not be decompressed"),
-            Self::IntentsDisallowed { intents, shard_id } => f.write_fmt(format_args!(
-                "at least one of the intents ({:?}) for shard {} are disallowed",
-                intents, shard_id
-            )),
-            Self::IntentsInvalid { intents, shard_id } => f.write_fmt(format_args!(
-                "at least one of the intents ({:?}) for shard {} are invalid",
-                intents, shard_id
-            )),
-            Self::EventStreamEnded => f.write_str("event stream from gateway ended"),
-        }
-    }
-}
-
-impl Error for ReceivingEventError {}
 
 #[derive(Deserialize)]
 struct ReadyMinimal {
@@ -346,8 +365,11 @@ impl ShardProcessor {
 
     async fn process(&mut self) -> Result<(), ProcessError> {
         let (op, seq, event_type) = {
-            let json = str::from_utf8_mut(self.inflater.buffer_mut())
-                .map_err(|source| ProcessError::PayloadNotUtf8 { source })?;
+            let json =
+                str::from_utf8_mut(self.inflater.buffer_mut()).map_err(|source| ProcessError {
+                    cause: Some(Box::new(source)),
+                    kind: ProcessErrorType::PayloadNotUtf8,
+                })?;
 
             tracing::trace!(%json, "Received JSON");
             let emitter = self.emitter.clone();
@@ -372,8 +394,12 @@ impl ShardProcessor {
                         "received payload without opcode",
                     );
 
-                    return Err(ProcessError::ParsingPayload {
-                        source: GatewayEventParsingError::PayloadInvalid,
+                    return Err(ProcessError {
+                        cause: Some(Box::new(GatewayEventParsingError {
+                            cause: None,
+                            kind: GatewayEventParsingErrorType::PayloadInvalid,
+                        })),
+                        kind: ProcessErrorType::ParsingPayload,
                     });
                 };
 
@@ -395,8 +421,12 @@ impl ShardProcessor {
                 } else if op == OpCode::Reconnect as u8 {
                     GatewayEvent::Reconnect
                 } else {
-                    json::parse_gateway_event(op, seq, event_type.as_deref(), json)
-                        .map_err(|source| ProcessError::ParsingPayload { source })?
+                    json::parse_gateway_event(op, seq, event_type.as_deref(), json).map_err(
+                        |source| ProcessError {
+                            cause: Some(Box::new(source)),
+                            kind: ProcessErrorType::ParsingPayload,
+                        },
+                    )?
                 };
 
                 self.process_gateway_event(&gateway_event).await?;
@@ -409,7 +439,10 @@ impl ShardProcessor {
                 return Ok(());
             }
 
-            let seq = seq.ok_or(ProcessError::SequenceMissing)?;
+            let seq = seq.ok_or(ProcessError {
+                cause: None,
+                kind: ProcessErrorType::SequenceMissing,
+            })?;
 
             if event_type.as_deref() == Some("RESUMED") {
                 self.process_resumed(seq);
@@ -424,8 +457,12 @@ impl ShardProcessor {
                 return Ok(());
             } else if event_type.as_deref() == Some("READY") {
                 let ready = json::from_slice::<ReadyMinimal>(self.inflater.buffer_mut()).map_err(
-                    |source| ProcessError::ParsingPayload {
-                        source: GatewayEventParsingError::Deserializing { source },
+                    |source| ProcessError {
+                        cause: Some(Box::new(GatewayEventParsingError {
+                            cause: Some(Box::new(source)),
+                            kind: GatewayEventParsingErrorType::Deserializing,
+                        })),
+                        kind: ProcessErrorType::ParsingPayload,
                     },
                 )?;
                 self.process_ready(&ready.d);
@@ -445,10 +482,19 @@ impl ShardProcessor {
 
         self.emitter
             .json(op, Some(seq), event_type.as_deref(), json)
-            .map_err(|source| match source {
-                EmitJsonError::Parsing { source } => ProcessError::ParsingPayload { source },
-                EmitJsonError::EventTypeUnknown { event_type, op } => {
-                    ProcessError::EventTypeUnknown { event_type, op }
+            .map_err(|source| {
+                let (kind, cause) = source.into_parts();
+
+                let new_kind = match kind {
+                    EmitJsonErrorType::Parsing => ProcessErrorType::ParsingPayload,
+                    EmitJsonErrorType::EventTypeUnknown { event_type, op } => {
+                        ProcessErrorType::EventTypeUnknown { event_type, op }
+                    }
+                };
+
+                ProcessError {
+                    cause,
+                    kind: new_kind,
                 }
             })
     }
@@ -538,9 +584,10 @@ impl ShardProcessor {
                 self.session.start_heartbeater();
             }
 
-            self.send(payload)
-                .await
-                .map_err(|source| ProcessError::SessionSend { source })?;
+            self.send(payload).await.map_err(|source| ProcessError {
+                cause: Some(Box::new(source)),
+                kind: ProcessErrorType::SessionSend,
+            })?;
         } else {
             self.session.set_stage(Stage::Identifying);
 
@@ -549,9 +596,10 @@ impl ShardProcessor {
                 self.session.start_heartbeater();
             }
 
-            self.identify()
-                .await
-                .map_err(|source| ProcessError::SessionSend { source })?;
+            self.identify().await.map_err(|source| ProcessError {
+                cause: Some(Box::new(source)),
+                kind: ProcessErrorType::SessionSend,
+            })?;
         }
 
         Ok(())
@@ -584,7 +632,10 @@ impl ShardProcessor {
         };
         self.session
             .close(Some(frame))
-            .map_err(|source| ProcessError::SendingClose { source })?;
+            .map_err(|source| ProcessError {
+                cause: Some(Box::new(source)),
+                kind: ProcessErrorType::SendingClose,
+            })?;
         self.resume().await;
 
         Ok(())
@@ -594,7 +645,7 @@ impl ShardProcessor {
         if let Err(source) = self.session.send(payload) {
             tracing::warn!("sending message failed: {:?}", source);
 
-            if matches!(source, SessionSendError::Sending { .. }) {
+            if matches!(source.kind(), SessionSendErrorType::Sending { .. }) {
                 self.reconnect().await;
             }
 
@@ -619,11 +670,10 @@ impl ShardProcessor {
         loop {
             // Returns None when the socket forwarder has ended, meaning the
             // connection was dropped.
-            let mut msg = self
-                .rx
-                .next()
-                .await
-                .ok_or(ReceivingEventError::EventStreamEnded)?;
+            let mut msg = self.rx.next().await.ok_or(ReceivingEventError {
+                cause: None,
+                kind: ReceivingEventErrorType::EventStreamEnded,
+            })?;
 
             if self.handle_message(&mut msg).await? {
                 return Ok(());
@@ -656,7 +706,12 @@ impl ShardProcessor {
                 let bytes = match self.inflater.msg() {
                     Ok(Some(bytes)) => bytes,
                     Ok(None) => return Ok(false),
-                    Err(source) => return Err(ReceivingEventError::Decompressing { source }),
+                    Err(source) => {
+                        return Err(ReceivingEventError {
+                            cause: Some(Box::new(source)),
+                            kind: ReceivingEventErrorType::Decompressing,
+                        })
+                    }
                 };
 
                 self.emitter.bytes(bytes);
@@ -691,21 +746,30 @@ impl ShardProcessor {
         if let Some(close_frame) = close_frame {
             match close_frame.code {
                 CloseCode::Library(4004) => {
-                    return Err(ReceivingEventError::AuthorizationInvalid {
-                        shard_id: self.config.shard()[0],
-                        token: self.config.token().to_owned(),
+                    return Err(ReceivingEventError {
+                        cause: None,
+                        kind: ReceivingEventErrorType::AuthorizationInvalid {
+                            shard_id: self.config.shard()[0],
+                            token: self.config.token().to_owned(),
+                        },
                     });
                 }
                 CloseCode::Library(4013) => {
-                    return Err(ReceivingEventError::IntentsInvalid {
-                        intents: self.config.intents(),
-                        shard_id: self.config.shard()[0],
+                    return Err(ReceivingEventError {
+                        cause: None,
+                        kind: ReceivingEventErrorType::IntentsInvalid {
+                            intents: self.config.intents(),
+                            shard_id: self.config.shard()[0],
+                        },
                     });
                 }
                 CloseCode::Library(4014) => {
-                    return Err(ReceivingEventError::IntentsDisallowed {
-                        intents: self.config.intents(),
-                        shard_id: self.config.shard()[0],
+                    return Err(ReceivingEventError {
+                        cause: None,
+                        kind: ReceivingEventErrorType::IntentsDisallowed {
+                            intents: self.config.intents(),
+                            shard_id: self.config.shard()[0],
+                        },
                     });
                 }
                 _ => {}
@@ -718,14 +782,19 @@ impl ShardProcessor {
     }
 
     async fn connect(url: &str) -> Result<ShardStream, ConnectingError> {
-        let url = Url::parse(url).map_err(|source| ConnectingError::ParsingUrl {
-            source,
-            url: url.to_owned(),
+        let url = Url::parse(url).map_err(|source| ConnectingError {
+            cause: Some(Box::new(source)),
+            kind: ConnectingErrorType::ParsingUrl {
+                url: url.to_owned(),
+            },
         })?;
 
         let (stream, _) = async_tungstenite::tokio::connect_async(url)
             .await
-            .map_err(|source| ConnectingError::Establishing { source })?;
+            .map_err(|source| ConnectingError {
+                cause: Some(Box::new(source)),
+                kind: ConnectingErrorType::Establishing,
+            })?;
 
         tracing::debug!("Shook hands with remote");
 

--- a/gateway/src/shard/processor/mod.rs
+++ b/gateway/src/shard/processor/mod.rs
@@ -9,6 +9,6 @@ mod throttle;
 
 pub use self::{
     heartbeat::Latency,
-    r#impl::{ConnectingError, ShardProcessor},
+    r#impl::{ConnectingError, ConnectingErrorType, ShardProcessor},
     session::Session,
 };

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -22,37 +22,41 @@ use std::{
 };
 use twilight_model::gateway::payload::Heartbeat;
 
-#[cfg(not(feature = "simd-json"))]
-use serde_json::Error as JsonError;
-#[cfg(feature = "simd-json")]
-use simd_json::Error as JsonError;
-
 #[derive(Debug)]
-pub enum SessionSendError {
-    Sending {
-        source: TrySendError<TungsteniteMessage>,
-    },
-    Serializing {
-        source: JsonError,
-    },
+pub struct SessionSendError {
+    pub(super) cause: Option<Box<dyn Error + Send + Sync>>,
+    pub(super) kind: SessionSendErrorType,
+}
+
+impl SessionSendError {
+    /// Immutable reference to the type of error that occurred.
+    pub fn kind(&self) -> &SessionSendErrorType {
+        &self.kind
+    }
 }
 
 impl Display for SessionSendError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Serializing { source } => Display::fmt(source, f),
-            Self::Sending { source } => Display::fmt(source, f),
+        match &self.kind {
+            SessionSendErrorType::Serializing => f.write_str("failed to serialize payload as json"),
+            SessionSendErrorType::Sending => f.write_str("failed to send message over websocket"),
         }
     }
 }
 
 impl Error for SessionSendError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::Sending { source } => Some(source),
-            Self::Serializing { source } => Some(source),
-        }
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
     }
+}
+
+/// Type of [`SessionSendError`] that occurred.
+#[derive(Debug)]
+pub enum SessionSendErrorType {
+    Sending,
+    Serializing,
 }
 
 #[derive(Debug)]
@@ -88,19 +92,24 @@ impl Session {
     ///
     /// # Errors
     ///
-    /// Returns [`SessionSendError::Serializing`] when there is an error
-    /// serializing the payload into an acceptable format.
+    /// Returns a [`SessionSendErrorType::Serializing`] error type when there is
+    /// an error serializing the payload into an acceptable format.
     ///
-    /// Returns [`SessionSendError::Sending`] when the receiving channel has hung
-    /// up. This will only happen when the shard has either not started or has
-    /// already shutdown.
+    /// Returns a [`SessionSendErrorType::Sending`] error type when the
+    /// receiving channel has hung up. This will only happen when the shard has
+    /// either not started or has already shutdown.
     pub fn send(&self, payload: impl Serialize) -> Result<(), SessionSendError> {
-        let bytes =
-            json::to_vec(&payload).map_err(|source| SessionSendError::Serializing { source })?;
+        let bytes = json::to_vec(&payload).map_err(|source| SessionSendError {
+            cause: Some(Box::new(source)),
+            kind: SessionSendErrorType::Serializing,
+        })?;
 
         self.tx
             .unbounded_send(TungsteniteMessage::Binary(bytes))
-            .map_err(|source| SessionSendError::Sending { source })?;
+            .map_err(|source| SessionSendError {
+                cause: Some(Box::new(source)),
+                kind: SessionSendErrorType::Sending,
+            })?;
 
         Ok(())
     }

--- a/gateway/src/shard/stage.rs
+++ b/gateway/src/shard/stage.rs
@@ -24,7 +24,7 @@ pub struct StageConversionError {
 
 impl StageConversionError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &StageConversionErrorType {
         &self.kind
     }

--- a/gateway/src/shard/stage.rs
+++ b/gateway/src/shard/stage.rs
@@ -31,8 +31,8 @@ impl StageConversionError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/gateway/src/shard/stage.rs
+++ b/gateway/src/shard/stage.rs
@@ -17,9 +17,53 @@ use std::{
 };
 
 /// Reason for a failure while parsing a value into a [`Stage`].
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct StageConversionError {
+    kind: StageConversionErrorType,
+}
+
+impl StageConversionError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &StageConversionErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        StageConversionErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for StageConversionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            StageConversionErrorType::InvalidInteger { value } => {
+                write!(f, "The integer {} is invalid", value)
+            }
+        }
+    }
+}
+
+impl Error for StageConversionError {}
+
+/// Type of [`StageConversionError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum StageConversionError {
+pub enum StageConversionErrorType {
     /// The integer isn't one that maps to a stage. For example, 7 might not map
     /// to a Stage variant.
     InvalidInteger {
@@ -27,16 +71,6 @@ pub enum StageConversionError {
         value: u8,
     },
 }
-
-impl Display for StageConversionError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::InvalidInteger { value } => write!(f, "The integer {} is invalid", value),
-        }
-    }
-}
-
-impl Error for StageConversionError {}
 
 /// The current connection stage of a [`Shard`].
 ///
@@ -88,7 +122,11 @@ impl TryFrom<u8> for Stage {
             2 => Self::Handshaking,
             3 => Self::Identifying,
             4 => Self::Resuming,
-            other => return Err(StageConversionError::InvalidInteger { value: other }),
+            other => {
+                return Err(StageConversionError {
+                    kind: StageConversionErrorType::InvalidInteger { value: other },
+                })
+            }
         })
     }
 }

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -101,7 +101,7 @@ impl Debug for State {
 /// the configured token is invalid. This may occur when the token has been
 /// revoked or expired. When this happens, you must create a new client with the
 /// new token. The client will no longer execute requests in order to
-/// prevent API bans and will always return [`Error::Unauthorized`].
+/// prevent API bans and will always return [`ErrorType::Unauthorized`].
 ///
 /// # Examples
 ///
@@ -313,21 +313,6 @@ impl Client {
     ///
     /// All fields are optional. The minimum length of the name is 2 UTF-16 characters and the
     /// maximum is 100 UTF-16 characters.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`UpdateChannelError::NameInvalid`] when the length of the name is either fewer
-    /// than 2 UTF-16 characters or more than 100 UTF-16 characters.
-    ///
-    /// Returns a [`UpdateChannelError::RateLimitPerUserInvalid`] when the seconds of the rate limit
-    /// per user is more than 21600.
-    ///
-    /// Returns a [`UpdateChannelError::TopicInvalid`] when the length of the topic is more than
-    /// 1024 UTF-16 characters.
-    ///
-    /// [`UpdateChannelError::NameInvalid`]: crate::request::channel::update_channel::UpdateChannelError::NameInvalid
-    /// [`UpdateChannelError::RateLimitPerUserInvalid`]: crate::request::channel::update_channel::UpdateChannelError::RateLimitPerUserInvalid
-    /// [`UpdateChannelError::TopicInvalid`]: crate::request::channel::update_channel::UpdateChannelError::TopicInvalid
     pub fn update_channel(&self, channel_id: ChannelId) -> UpdateChannel<'_> {
         UpdateChannel::new(self, channel_id)
     }
@@ -383,14 +368,15 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns [`GetChannelMessagesError::LimitInvalid`] if the amount is less than 1 or greater than 100.
+    /// Returns a [`GetChannelMessagesErrorType::LimitInvalid`] error type if
+    /// the amount is less than 1 or greater than 100.
     ///
     /// [`after`]: GetChannelMessages::after
     /// [`around`]: GetChannelMessages::around
     /// [`before`]: GetChannelMessages::before
     /// [`GetChannelMessagesConfigured`]: crate::request::channel::message::GetChannelMessagesConfigured
     /// [`limit`]: GetChannelMessages::limit
-    /// [`GetChannelMessagesError::LimitInvalid`]: crate::request::channel::message::get_channel_messages::GetChannelMessagesError::LimitInvalid
+    /// [`GetChannelMessagesErrorType::LimitInvalid`]: crate::request::channel::message::get_channel_messages::GetChannelMessagesErrorType::LimitInvalid
     pub fn channel_messages(&self, channel_id: ChannelId) -> GetChannelMessages<'_> {
         GetChannelMessages::new(self, channel_id)
     }
@@ -487,13 +473,6 @@ impl Client {
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns [`GetCurrentUserGuildsError::LimitInvalid`] if the amount is greater
-    /// than 100.
-    ///
-    /// [`GetCurrentUserGuildsError::LimitInvalid`]: crate::request::user::get_current_user_guilds::GetCurrentUserGuildsError::LimitInvalid
     pub fn current_user_guilds(&self) -> GetCurrentUserGuilds<'_> {
         GetCurrentUserGuilds::new(self)
     }
@@ -635,9 +614,10 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateGuildError::NameInvalid`] if the name length is too short or too long.
+    /// Returns a [`CreateGuildErrorType::NameInvalid`] error type if the name
+    /// length is too short or too long.
     ///
-    /// [`CreateGuildError::NameInvalid`]: crate::request::guild::create_guild::CreateGuildError::NameInvalid
+    /// [`CreateGuildErrorType::NameInvalid`]: crate::request::guild::create_guild::CreateGuildErrorType::NameInvalid
     pub fn create_guild(
         &self,
         name: impl Into<String>,
@@ -676,19 +656,18 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns a [`CreateGuildChannelError::NameInvalid`] when the length of the name is either
-    /// fewer than 2 UTF-16 characters or more than 100 UTF-16 characters.
+    /// Returns a [`CreateGuildChannelErrorType::NameInvalid`] error type when
+    /// the length of the name is either fewer than 2 UTF-16 characters or more than 100 UTF-16 characters.
     ///
-    /// Returns a [`CreateGuildChannelError::RateLimitPerUserInvalid`] when the seconds of the rate
-    /// limit per user is more than 21600.
+    /// Returns a [`CreateGuildChannelErrorType::RateLimitPerUserInvalid`] error
+    /// type when the seconds of the rate limit per user is more than 21600.
     ///
-    /// Returns a [`CreateGuildChannelError::TopicInvalid`] when the length of the topic is more
-    /// than
-    /// 1024 UTF-16 characters.
+    /// Returns a [`CreateGuildChannelErrorType::TopicInvalid`] error type when
+    /// the length of the topic is more than 1024 UTF-16 characters.
     ///
-    /// [`CreateGuildChannelError::NameInvalid`]: crate::request::guild::create_guild_channel::CreateGuildChannelError::NameInvalid
-    /// [`CreateGuildChannelError::RateLimitPerUserInvalid`]: crate::request::guild::create_guild_channel::CreateGuildChannelError::RateLimitPerUserInvalid
-    /// [`CreateGuildChannelError::TopicInvalid`]: crate::request::guild::create_guild_channel::CreateGuildChannelError::TopicInvalid
+    /// [`CreateGuildChannelErrorType::NameInvalid`]: crate::request::guild::create_guild_channel::CreateGuildChannelErrorType::NameInvalid
+    /// [`CreateGuildChannelErrorType::RateLimitPerUserInvalid`]: crate::request::guild::create_guild_channel::CreateGuildChannelErrorType::RateLimitPerUserInvalid
+    /// [`CreateGuildChannelErrorType::TopicInvalid`]: crate::request::guild::create_guild_channel::CreateGuildChannelErrorType::TopicInvalid
     pub fn create_guild_channel(
         &self,
         guild_id: GuildId,
@@ -802,9 +781,10 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns [`GetGuildMembersError::LimitInvalid`] if the limit is invalid.
+    /// Returns a [`GetGuildMembersErrorType::LimitInvalid`] error type if the
+    /// limit is invalid.
     ///
-    /// [`GetGuildMembersError::LimitInvalid`]: crate::request::guild::member::get_guild_members::GetGuildMembersError::LimitInvalid
+    /// [`GetGuildMembersErrorType::LimitInvalid`]: crate::request::guild::member::get_guild_members::GetGuildMembersErrorType::LimitInvalid
     pub fn guild_members(&self, guild_id: GuildId) -> GetGuildMembers<'_> {
         GetGuildMembers::new(self, guild_id)
     }
@@ -822,10 +802,10 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns [`AddGuildMemberError::NicknameInvalid`] if the nickname is too
-    /// short or too long.
+    /// Returns [`AddGuildMemberErrorType::NicknameInvalid`] if the nickname is
+    /// too short or too long.
     ///
-    /// [`AddGuildMemberError::NickNameInvalid`]: crate::request::guild::member::add_guild_member::AddGuildMemberError::NicknameInvalid
+    /// [`AddGuildMemberErrorType::NickNameInvalid`]: crate::request::guild::member::add_guild_member::AddGuildMemberErrorType::NicknameInvalid
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#add-guild-member
     pub fn add_guild_member(
@@ -848,10 +828,10 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns [`UpdateGuildMemberError::NicknameInvalid`] if the nickname length is too short or too
+    /// Returns [`UpdateGuildMemberErrorType::NicknameInvalid`] if the nickname length is too short or too
     /// long.
     ///
-    /// [`UpdateGuildMemberError::NicknameInvalid`]: crate::request::guild::member::update_guild_member::UpdateGuildMemberError::NicknameInvalid
+    /// [`UpdateGuildMemberErrorType::NicknameInvalid`]: crate::request::guild::member::update_guild_member::UpdateGuildMemberErrorType::NicknameInvalid
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild-member
     pub fn update_guild_member(&self, guild_id: GuildId, user_id: UserId) -> UpdateGuildMember<'_> {
@@ -1017,18 +997,20 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// The method [`content`] returns [`CreateMessageError::ContentInvalid`] if the content is
-    /// over 2000 UTF-16 characters.
+    /// The method [`content`] returns
+    /// [`CreateMessageErrorType::ContentInvalid`] if the content is over 2000
+    /// UTF-16 characters.
     ///
-    /// The method [`embed`] returns [`CreateMessageError::EmbedTooLarge`] if the length of the
-    /// embed is over 6000 characters.
+    /// The method [`embed`] returns
+    /// [`CreateMessageErrorType::EmbedTooLarge`] if the length of the embed
+    /// is over 6000 characters.
     ///
     /// [`content`]: crate::request::channel::message::create_message::CreateMessage::content
     /// [`embed`]: crate::request::channel::message::create_message::CreateMessage::embed
-    /// [`CreateMessageError::ContentInvalid`]:
-    /// crate::request::channel::message::create_message::CreateMessageError::ContentInvalid
-    /// [`CreateMessageError::EmbedTooLarge`]:
-    /// crate::request::channel::message::create_message::CreateMessageError::EmbedTooLarge
+    /// [`CreateMessageErrorType::ContentInvalid`]:
+    /// crate::request::channel::message::create_message::CreateMessageErrorType::ContentInvalid
+    /// [`CreateMessageErrorType::EmbedTooLarge`]:
+    /// crate::request::channel::message::create_message::CreateMessageErrorType::EmbedTooLarge
     pub fn create_message(&self, channel_id: ChannelId) -> CreateMessage<'_> {
         CreateMessage::new(self, channel_id)
     }

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -15,7 +15,7 @@ pub type Result<T, E = Error> = StdResult<T, E>;
 
 #[derive(Debug)]
 pub struct Error {
-    pub(super) cause: Option<Box<dyn StdError + Send + Sync>>,
+    pub(super) source: Option<Box<dyn StdError + Send + Sync>>,
     pub(super) kind: ErrorType,
 }
 
@@ -27,21 +27,21 @@ impl Error {
     }
 
     /// Consume the error, returning the source error if there is any.
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn StdError + Send + Sync>> {
-        self.cause
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn StdError + Send + Sync>> {
+        self.source
     }
 
     /// Consume the error, returning the owned error type and the source error.
     #[must_use = "consuming the error into its parts has no effect if left unused"]
     pub fn into_parts(self) -> (ErrorType, Option<Box<dyn StdError + Send + Sync>>) {
-        (self.kind, self.cause)
+        (self.kind, self.source)
     }
 
     pub(super) fn json(source: JsonError) -> Self {
         Self {
-            cause: Some(Box::new(source)),
             kind: ErrorType::Json,
+            source: Some(Box::new(source)),
         }
     }
 }
@@ -82,9 +82,9 @@ impl Display for Error {
 
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        self.cause
+        self.source
             .as_ref()
-            .map(|cause| &**cause as &(dyn StdError + 'static))
+            .map(|source| &**source as &(dyn StdError + 'static))
     }
 }
 

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -1,15 +1,10 @@
-use crate::{api_error::ApiError, ratelimiting::RatelimitError};
-use futures_channel::oneshot::Canceled;
-use hyper::{
-    header::InvalidHeaderValue, http::Error as HttpError, Body, Error as HyperError, Response,
-    StatusCode,
-};
+use crate::api_error::ApiError;
+use hyper::{Body, Response, StatusCode};
 use std::{
     error::Error as StdError,
-    fmt::{Display, Error as FmtError, Formatter, Result as FmtResult},
+    fmt::{Display, Formatter, Result as FmtResult},
     result::Result as StdResult,
 };
-use tokio::time::error::Elapsed;
 
 #[cfg(not(feature = "simd-json"))]
 use serde_json::Error as JsonError;
@@ -19,41 +14,98 @@ use simd_json::Error as JsonError;
 pub type Result<T, E = Error> = StdResult<T, E>;
 
 #[derive(Debug)]
+pub struct Error {
+    pub(super) cause: Option<Box<dyn StdError + Send + Sync>>,
+    pub(super) kind: ErrorType,
+}
+
+impl Error {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &ErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn StdError + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (ErrorType, Option<Box<dyn StdError + Send + Sync>>) {
+        (self.kind, self.cause)
+    }
+
+    pub(super) fn json(source: JsonError) -> Self {
+        Self {
+            cause: Some(Box::new(source)),
+            kind: ErrorType::Json,
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            ErrorType::BuildingRequest => f.write_str("failed to build the request"),
+            ErrorType::ChunkingResponse => f.write_str("Chunking the response failed"),
+            ErrorType::CreatingHeader { name, .. } => {
+                write!(f, "Parsing the value for header {} failed", name)
+            }
+            ErrorType::Formatting => f.write_str("Formatting a string failed"),
+            ErrorType::Json => f.write_str("Given value couldn't be serialized"),
+            ErrorType::Parsing { body, .. } => {
+                write!(f, "Response body couldn't be deserialized: {:?}", body)
+            }
+            ErrorType::Ratelimiting => f.write_str("Ratelimiting failure"),
+            ErrorType::RequestCanceled => {
+                f.write_str("Request was canceled either before or while being sent")
+            }
+            ErrorType::RequestError => f.write_str("Parsing or sending the response failed"),
+            ErrorType::RequestTimedOut => f.write_str("request timed out"),
+            ErrorType::Response { error, status, .. } => write!(
+                f,
+                "Response error: status code {}, error: {}",
+                status, error
+            ),
+            ErrorType::ServiceUnavailable { .. } => {
+                f.write_str("api may be temporarily unavailable (received a 503)")
+            }
+            ErrorType::Unauthorized => {
+                f.write_str("token in use is invalid, expired, or is revoked")
+            }
+        }
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn StdError + 'static))
+    }
+}
+
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum Error {
-    BuildingRequest {
-        source: HttpError,
-    },
-    ChunkingResponse {
-        source: HyperError,
-    },
+/// Type of [`Error`] that occurred.
+pub enum ErrorType {
+    BuildingRequest,
+    ChunkingResponse,
     CreatingHeader {
         name: String,
-        source: InvalidHeaderValue,
     },
-    Formatting {
-        source: FmtError,
-    },
-    Json {
-        source: JsonError,
-    },
+    Formatting,
+    Json,
     Parsing {
         body: Vec<u8>,
-        source: JsonError,
     },
-    Ratelimiting {
-        source: RatelimitError,
-    },
-    RequestCanceled {
-        source: Canceled,
-    },
-    RequestError {
-        source: HyperError,
-    },
-    RequestTimedOut {
-        /// Source of the error when the request timed out.
-        source: Elapsed,
-    },
+    Ratelimiting,
+    RequestCanceled,
+    RequestError,
+    RequestTimedOut,
     Response {
         body: Vec<u8>,
         error: ApiError,
@@ -71,64 +123,4 @@ pub enum Error {
     /// This can occur if a bot token is invalidated or an access token expires
     /// or is revoked. Recreate the client to configure a new token.
     Unauthorized,
-}
-
-impl From<FmtError> for Error {
-    fn from(source: FmtError) -> Self {
-        Self::Formatting { source }
-    }
-}
-
-impl From<JsonError> for Error {
-    fn from(source: JsonError) -> Self {
-        Self::Json { source }
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::BuildingRequest { .. } => f.write_str("failed to build the request"),
-            Self::ChunkingResponse { .. } => f.write_str("Chunking the response failed"),
-            Self::CreatingHeader { name, .. } => {
-                write!(f, "Parsing the value for header {} failed", name)
-            }
-            Self::Formatting { .. } => f.write_str("Formatting a string failed"),
-            Self::Json { .. } => f.write_str("Given value couldn't be serialized"),
-            Self::Parsing { body, .. } => {
-                write!(f, "Response body couldn't be deserialized: {:?}", body)
-            }
-            Self::Ratelimiting { .. } => f.write_str("Ratelimiting failure"),
-            Self::RequestCanceled { .. } => {
-                f.write_str("Request was canceled either before or while being sent")
-            }
-            Self::RequestError { .. } => f.write_str("Parsing or sending the response failed"),
-            Self::RequestTimedOut { .. } => f.write_str("request timed out"),
-            Self::Response { error, status, .. } => write!(
-                f,
-                "Response error: status code {}, error: {}",
-                status, error
-            ),
-            Self::ServiceUnavailable { .. } => {
-                f.write_str("api may be temporarily unavailable (received a 503)")
-            }
-            Self::Unauthorized => f.write_str("token in use is invalid, expired, or is revoked"),
-        }
-    }
-}
-
-impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::BuildingRequest { source } => Some(source),
-            Self::CreatingHeader { source, .. } => Some(source),
-            Self::Formatting { source } => Some(source),
-            Self::Json { source } | Self::Parsing { source, .. } => Some(source),
-            Self::Ratelimiting { source } => Some(source),
-            Self::RequestCanceled { source } => Some(source),
-            Self::ChunkingResponse { source } | Self::RequestError { source } => Some(source),
-            Self::RequestTimedOut { source } => Some(source),
-            Self::Response { .. } | Self::ServiceUnavailable { .. } | Self::Unauthorized => None,
-        }
-    }
 }

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -21,7 +21,7 @@ pub struct Error {
 
 impl Error {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &ErrorType {
         &self.kind
     }

--- a/http/src/ratelimiting/error.rs
+++ b/http/src/ratelimiting/error.rs
@@ -15,7 +15,7 @@ pub struct RatelimitError {
 
 impl RatelimitError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &RatelimitErrorType {
         &self.kind
     }

--- a/http/src/ratelimiting/error.rs
+++ b/http/src/ratelimiting/error.rs
@@ -9,7 +9,7 @@ pub type RatelimitResult<T> = StdResult<T, RatelimitError>;
 
 #[derive(Debug)]
 pub struct RatelimitError {
-    pub(super) cause: Option<Box<dyn Error + Send + Sync>>,
+    pub(super) source: Option<Box<dyn Error + Send + Sync>>,
     pub(super) kind: RatelimitErrorType,
 }
 
@@ -21,28 +21,28 @@ impl RatelimitError {
     }
 
     /// Consume the error, returning the source error if there is any.
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
-        self.cause
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.source
     }
 
     /// Consume the error, returning the owned error type and the source error.
     #[must_use = "consuming the error into its parts has no effect if left unused"]
     pub fn into_parts(self) -> (RatelimitErrorType, Option<Box<dyn Error + Send + Sync>>) {
-        (self.kind, self.cause)
+        (self.kind, self.source)
     }
 
     pub(super) fn header_missing(name: &'static str) -> Self {
         Self {
-            cause: None,
             kind: RatelimitErrorType::HeaderMissing { name },
+            source: None,
         }
     }
 
     pub(super) fn header_not_utf8(name: &'static str, value: Vec<u8>, source: ToStrError) -> Self {
         Self {
-            cause: Some(Box::new(source)),
             kind: RatelimitErrorType::HeaderNotUtf8 { name, value },
+            source: Some(Box::new(source)),
         }
     }
 }
@@ -78,9 +78,9 @@ impl Display for RatelimitError {
 
 impl Error for RatelimitError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.cause
+        self.source
             .as_ref()
-            .map(|cause| &**cause as &(dyn Error + 'static))
+            .map(|source| &**source as &(dyn Error + 'static))
     }
 }
 

--- a/http/src/ratelimiting/error.rs
+++ b/http/src/ratelimiting/error.rs
@@ -1,64 +1,73 @@
 use hyper::header::ToStrError;
 use std::{
-    error::Error as StdError,
+    error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
-    num::{ParseFloatError, ParseIntError},
     result::Result as StdResult,
-    str::ParseBoolError,
 };
 
 pub type RatelimitResult<T> = StdResult<T, RatelimitError>;
 
 #[derive(Debug)]
-#[non_exhaustive]
-pub enum RatelimitError {
-    NoHeaders,
-    HeaderMissing {
-        name: &'static str,
-    },
-    HeaderNotUtf8 {
-        name: &'static str,
-        source: ToStrError,
-        value: Vec<u8>,
-    },
-    ParsingBoolText {
-        name: &'static str,
-        source: ParseBoolError,
-        text: String,
-    },
-    ParsingFloatText {
-        name: &'static str,
-        source: ParseFloatError,
-        text: String,
-    },
-    ParsingIntText {
-        name: &'static str,
-        source: ParseIntError,
-        text: String,
-    },
+pub struct RatelimitError {
+    pub(super) cause: Option<Box<dyn Error + Send + Sync>>,
+    pub(super) kind: RatelimitErrorType,
+}
+
+impl RatelimitError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &RatelimitErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (RatelimitErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, self.cause)
+    }
+
+    pub(super) fn header_missing(name: &'static str) -> Self {
+        Self {
+            cause: None,
+            kind: RatelimitErrorType::HeaderMissing { name },
+        }
+    }
+
+    pub(super) fn header_not_utf8(name: &'static str, value: Vec<u8>, source: ToStrError) -> Self {
+        Self {
+            cause: Some(Box::new(source)),
+            kind: RatelimitErrorType::HeaderNotUtf8 { name, value },
+        }
+    }
 }
 
 impl Display for RatelimitError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NoHeaders => f.write_str("No headers are present"),
-            Self::HeaderMissing { name } => {
+        match &self.kind {
+            RatelimitErrorType::NoHeaders => f.write_str("No headers are present"),
+            RatelimitErrorType::HeaderMissing { name } => {
                 write!(f, "At least one header, {:?}, is missing", name)
             }
-            Self::HeaderNotUtf8 { name, value, .. } => {
+            RatelimitErrorType::HeaderNotUtf8 { name, value, .. } => {
                 write!(f, "The header {:?} has invalid UTF-16: {:?}", name, value)
             }
-            Self::ParsingBoolText { name, text, .. } => write!(
+            RatelimitErrorType::ParsingBoolText { name, text, .. } => write!(
                 f,
                 "The header {:?} should be a bool but isn't: {:?}",
                 name, text
             ),
-            Self::ParsingFloatText { name, text, .. } => write!(
+            RatelimitErrorType::ParsingFloatText { name, text, .. } => write!(
                 f,
                 "The header {:?} should be a float but isn't: {:?}",
                 name, text
             ),
-            Self::ParsingIntText { name, text, .. } => write!(
+            RatelimitErrorType::ParsingIntText { name, text, .. } => write!(
                 f,
                 "The header {:?} should be an integer but isn't: {:?}",
                 name, text
@@ -67,14 +76,21 @@ impl Display for RatelimitError {
     }
 }
 
-impl StdError for RatelimitError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::HeaderNotUtf8 { source, .. } => Some(source),
-            Self::ParsingBoolText { source, .. } => Some(source),
-            Self::ParsingFloatText { source, .. } => Some(source),
-            Self::ParsingIntText { source, .. } => Some(source),
-            Self::NoHeaders | Self::HeaderMissing { .. } => None,
-        }
+impl Error for RatelimitError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
     }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum RatelimitErrorType {
+    NoHeaders,
+    HeaderMissing { name: &'static str },
+    HeaderNotUtf8 { name: &'static str, value: Vec<u8> },
+    ParsingBoolText { name: &'static str, text: String },
+    ParsingFloatText { name: &'static str, text: String },
+    ParsingIntText { name: &'static str, text: String },
 }

--- a/http/src/ratelimiting/headers.rs
+++ b/http/src/ratelimiting/headers.rs
@@ -1,4 +1,4 @@
-use super::error::{RatelimitError, RatelimitResult};
+use super::error::{RatelimitError, RatelimitErrorType, RatelimitResult};
 use hyper::header::{HeaderMap, HeaderValue};
 use std::convert::TryFrom;
 
@@ -109,23 +109,19 @@ fn parse_map(map: &HeaderMap<HeaderValue>) -> RatelimitResult<RatelimitHeaders> 
 fn header_bool(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitResult<bool> {
     let value = map
         .get(name)
-        .ok_or(RatelimitError::HeaderMissing { name })?;
+        .ok_or_else(|| RatelimitError::header_missing(name))?;
 
-    let text = value
-        .to_str()
-        .map_err(|source| RatelimitError::HeaderNotUtf8 {
-            name,
-            source,
-            value: value.as_bytes().to_owned(),
-        })?;
+    let text = value.to_str().map_err(|source| {
+        RatelimitError::header_not_utf8(name, value.as_bytes().to_owned(), source)
+    })?;
 
-    let end = text
-        .parse()
-        .map_err(|source| RatelimitError::ParsingBoolText {
+    let end = text.parse().map_err(|source| RatelimitError {
+        cause: Some(Box::new(source)),
+        kind: RatelimitErrorType::ParsingBoolText {
             name,
-            source,
             text: text.to_owned(),
-        })?;
+        },
+    })?;
 
     Ok(end)
 }
@@ -133,23 +129,19 @@ fn header_bool(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitRes
 fn header_float(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitResult<f64> {
     let value = map
         .get(name)
-        .ok_or(RatelimitError::HeaderMissing { name })?;
+        .ok_or_else(|| RatelimitError::header_missing(name))?;
 
-    let text = value
-        .to_str()
-        .map_err(|source| RatelimitError::HeaderNotUtf8 {
-            name,
-            source,
-            value: value.as_bytes().to_owned(),
-        })?;
+    let text = value.to_str().map_err(|source| {
+        RatelimitError::header_not_utf8(name, value.as_bytes().to_owned(), source)
+    })?;
 
-    let end = text
-        .parse()
-        .map_err(|source| RatelimitError::ParsingFloatText {
+    let end = text.parse().map_err(|source| RatelimitError {
+        cause: Some(Box::new(source)),
+        kind: RatelimitErrorType::ParsingFloatText {
             name,
-            source,
             text: text.to_owned(),
-        })?;
+        },
+    })?;
 
     Ok(end)
 }
@@ -157,23 +149,19 @@ fn header_float(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitRe
 fn header_int(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitResult<u64> {
     let value = map
         .get(name)
-        .ok_or(RatelimitError::HeaderMissing { name })?;
+        .ok_or_else(|| RatelimitError::header_missing(name))?;
 
-    let text = value
-        .to_str()
-        .map_err(|source| RatelimitError::HeaderNotUtf8 {
-            name,
-            source,
-            value: value.as_bytes().to_owned(),
-        })?;
+    let text = value.to_str().map_err(|source| {
+        RatelimitError::header_not_utf8(name, value.as_bytes().to_owned(), source)
+    })?;
 
-    let end = text
-        .parse()
-        .map_err(|source| RatelimitError::ParsingIntText {
+    let end = text.parse().map_err(|source| RatelimitError {
+        cause: Some(Box::new(source)),
+        kind: RatelimitErrorType::ParsingIntText {
             name,
-            source,
             text: text.to_owned(),
-        })?;
+        },
+    })?;
 
     Ok(end)
 }
@@ -181,15 +169,11 @@ fn header_int(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitResu
 fn header_str<'a>(map: &'a HeaderMap<HeaderValue>, name: &'static str) -> RatelimitResult<&'a str> {
     let value = map
         .get(name)
-        .ok_or(RatelimitError::HeaderMissing { name })?;
+        .ok_or_else(|| RatelimitError::header_missing(name))?;
 
-    let text = value
-        .to_str()
-        .map_err(|source| RatelimitError::HeaderNotUtf8 {
-            name,
-            source,
-            value: value.as_bytes().to_owned(),
-        })?;
+    let text = value.to_str().map_err(|source| {
+        RatelimitError::header_not_utf8(name, value.as_bytes().to_owned(), source)
+    })?;
 
     Ok(text)
 }

--- a/http/src/ratelimiting/headers.rs
+++ b/http/src/ratelimiting/headers.rs
@@ -116,11 +116,11 @@ fn header_bool(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitRes
     })?;
 
     let end = text.parse().map_err(|source| RatelimitError {
-        cause: Some(Box::new(source)),
         kind: RatelimitErrorType::ParsingBoolText {
             name,
             text: text.to_owned(),
         },
+        source: Some(Box::new(source)),
     })?;
 
     Ok(end)
@@ -136,11 +136,11 @@ fn header_float(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitRe
     })?;
 
     let end = text.parse().map_err(|source| RatelimitError {
-        cause: Some(Box::new(source)),
         kind: RatelimitErrorType::ParsingFloatText {
             name,
             text: text.to_owned(),
         },
+        source: Some(Box::new(source)),
     })?;
 
     Ok(end)
@@ -156,11 +156,11 @@ fn header_int(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitResu
     })?;
 
     let end = text.parse().map_err(|source| RatelimitError {
-        cause: Some(Box::new(source)),
         kind: RatelimitErrorType::ParsingIntText {
             name,
             text: text.to_owned(),
         },
+        source: Some(Box::new(source)),
     })?;
 
     Ok(end)

--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -57,22 +57,49 @@ impl AuditLogReasonError {
         if reason.chars().count() <= Self::AUDIT_REASON_LENGTH {
             Ok(reason)
         } else {
-            Err(AuditLogReasonError::TooLarge { reason })
+            Err(AuditLogReasonError {
+                kind: AuditLogReasonErrorType::TooLarge { reason },
+            })
         }
     }
 }
 
 /// The error created when a reason can not be used as configured.
-#[derive(Clone, Debug)]
-pub enum AuditLogReasonError {
-    /// Returned when the reason is over 512 UTF-16 characters.
-    TooLarge { reason: String },
+#[derive(Debug)]
+pub struct AuditLogReasonError {
+    kind: AuditLogReasonErrorType,
+}
+
+impl AuditLogReasonError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &AuditLogReasonErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        AuditLogReasonErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
 }
 
 impl Display for AuditLogReasonError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::TooLarge { reason } => write!(
+        match &self.kind {
+            AuditLogReasonErrorType::TooLarge { reason } => write!(
                 f,
                 "the audit log reason is {} characters long, but the max is {}",
                 reason.chars().count(),
@@ -83,6 +110,14 @@ impl Display for AuditLogReasonError {
 }
 
 impl Error for AuditLogReasonError {}
+
+/// Type of [`AuditLogReasonError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum AuditLogReasonErrorType {
+    /// Returned when the reason is over 512 UTF-16 characters.
+    TooLarge { reason: String },
+}
 
 #[cfg(test)]
 mod test {

--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -72,7 +72,7 @@ pub struct AuditLogReasonError {
 
 impl AuditLogReasonError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &AuditLogReasonErrorType {
         &self.kind
     }

--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -79,8 +79,8 @@ impl AuditLogReasonError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/channel/follow_news_channel.rs
+++ b/http/src/request/channel/follow_news_channel.rs
@@ -31,7 +31,7 @@ impl<'a> FollowNewsChannel<'a> {
 
     fn start(&mut self) -> Result<()> {
         let request = Request::from((
-            crate::json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
             Route::FollowNewsChannel {
                 channel_id: self.channel_id.0,
             },

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -114,7 +114,7 @@ impl<'a> CreateInvite<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::CreateInvite {
                     channel_id: self.channel_id.0,
@@ -122,7 +122,7 @@ impl<'a> CreateInvite<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::CreateInvite {
                     channel_id: self.channel_id.0,
                 },

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -11,9 +11,57 @@ use twilight_model::{
 };
 
 /// The error created when a messsage can not be created as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct CreateMessageError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: CreateMessageErrorType,
+}
+
+impl CreateMessageError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &CreateMessageErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (CreateMessageErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, self.cause)
+    }
+}
+
+impl Display for CreateMessageError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            CreateMessageErrorType::ContentInvalid { .. } => {
+                f.write_str("the message content is invalid")
+            }
+            CreateMessageErrorType::EmbedTooLarge { .. } => {
+                f.write_str("the embed's contents are too long")
+            }
+        }
+    }
+}
+
+impl Error for CreateMessageError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
+    }
+}
+
+/// Type of [`CreateMessageError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum CreateMessageError {
+pub enum CreateMessageErrorType {
     /// Returned when the content is over 2000 UTF-16 characters.
     ContentInvalid {
         /// Provided content.
@@ -23,27 +71,7 @@ pub enum CreateMessageError {
     EmbedTooLarge {
         /// Provided embed.
         embed: Box<Embed>,
-        /// The source of the error.
-        source: EmbedValidationError,
     },
-}
-
-impl Display for CreateMessageError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::ContentInvalid { .. } => f.write_str("the message content is invalid"),
-            Self::EmbedTooLarge { .. } => f.write_str("the embed's contents are too long"),
-        }
-    }
-}
-
-impl Error for CreateMessageError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::ContentInvalid { .. } => None,
-            Self::EmbedTooLarge { source, .. } => Some(source),
-        }
-    }
 }
 
 #[derive(Default, Serialize)]
@@ -140,15 +168,18 @@ impl<'a> CreateMessage<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateMessageError::ContentInvalid`] if the content length is
-    /// too long.
+    /// Returns a [`CreateMessageErrorType::ContentInvalid`] error type if the
+    /// content length is too long.
     pub fn content(self, content: impl Into<String>) -> Result<Self, CreateMessageError> {
         self._content(content.into())
     }
 
     fn _content(mut self, content: String) -> Result<Self, CreateMessageError> {
         if !validate::content_limit(&content) {
-            return Err(CreateMessageError::ContentInvalid { content });
+            return Err(CreateMessageError {
+                cause: None,
+                kind: CreateMessageErrorType::ContentInvalid { content },
+            });
         }
 
         self.fields.content.replace(content);
@@ -167,15 +198,18 @@ impl<'a> CreateMessage<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateMessageError::EmbedTooLarge`] if the embed is too large.
+    /// Returns a [`CreateMessageErrorType::EmbedTooLarge`] error type if the
+    /// embed is too large.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#embed-limits
     /// [`EmbedBuilder`]: https://docs.rs/twilight-embed-builder/*/twilight_embed_builder
     pub fn embed(mut self, embed: Embed) -> Result<Self, CreateMessageError> {
         if let Err(source) = validate::embed(&embed) {
-            return Err(CreateMessageError::EmbedTooLarge {
-                embed: Box::new(embed),
-                source,
+            return Err(CreateMessageError {
+                cause: Some(Box::new(source)),
+                kind: CreateMessageErrorType::EmbedTooLarge {
+                    embed: Box::new(embed),
+                },
             });
         }
 
@@ -225,7 +259,7 @@ impl<'a> CreateMessage<'a> {
         self.fut.replace(Box::pin(self.http.request(
             if self.attachments.is_empty() {
                 Request::from((
-                    crate::json_to_vec(&self.fields)?,
+                    crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                     Route::CreateMessage {
                         channel_id: self.channel_id.0,
                     },
@@ -237,7 +271,7 @@ impl<'a> CreateMessage<'a> {
                     multipart.file(format!("{}", index).as_bytes(), name.as_bytes(), &file);
                 }
 
-                let body = crate::json_to_vec(&self.fields)?;
+                let body = crate::json_to_vec(&self.fields).map_err(HttpError::json)?;
                 multipart.part(b"payload_json", &body);
 
                 Request::from((

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -19,7 +19,7 @@ pub struct CreateMessageError {
 
 impl CreateMessageError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &CreateMessageErrorType {
         &self.kind
     }

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -42,7 +42,7 @@ impl<'a> DeleteMessages<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::DeleteMessages {
                     channel_id: self.channel_id.0,
@@ -50,7 +50,7 @@ impl<'a> DeleteMessages<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::DeleteMessages {
                     channel_id: self.channel_id.0,
                 },

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -17,7 +17,7 @@ pub struct GetChannelMessagesError {
 
 impl GetChannelMessagesError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &GetChannelMessagesErrorType {
         &self.kind
     }

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -24,8 +24,8 @@ impl GetChannelMessagesError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -10,25 +10,57 @@ use twilight_model::{
 };
 
 /// The error returned if the request can not be created as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct GetChannelMessagesError {
+    kind: GetChannelMessagesErrorType,
+}
+
+impl GetChannelMessagesError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &GetChannelMessagesErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        GetChannelMessagesErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for GetChannelMessagesError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            GetChannelMessagesErrorType::LimitInvalid { .. } => f.write_str("the limit is invalid"),
+        }
+    }
+}
+
+impl Error for GetChannelMessagesError {}
+
+/// Type of [`GetChannelMessagesError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum GetChannelMessagesError {
+pub enum GetChannelMessagesErrorType {
     /// The maximum number of messages to retrieve is either 0 or more than 100.
     LimitInvalid {
         /// Provided maximum number of messages to retrieve.
         limit: u64,
     },
 }
-
-impl Display for GetChannelMessagesError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
-        }
-    }
-}
-
-impl Error for GetChannelMessagesError {}
 
 #[derive(Default)]
 struct GetChannelMessagesFields {
@@ -62,10 +94,6 @@ struct GetChannelMessagesFields {
 ///
 /// # Ok(()) }
 /// ```
-///
-/// # Errors
-///
-/// Returns [`GetChannelMessagesError::LimitInvalid`] if the amount is less than 1 or greater than 100.
 ///
 /// [`after`]: Self::after
 /// [`around`]: Self::around
@@ -128,11 +156,13 @@ impl<'a> GetChannelMessages<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`GetChannelMessagesError::LimitInvalid`] if the amount is less than 1 or greater than
-    /// 100.
+    /// Returns a [`GetChannelMessagesErrorType::LimitInvalid`] error type if
+    /// the amount is less than 1 or greater than 100.
     pub fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesError> {
         if !validate::get_channel_messages_limit(limit) {
-            return Err(GetChannelMessagesError::LimitInvalid { limit });
+            return Err(GetChannelMessagesError {
+                kind: GetChannelMessagesErrorType::LimitInvalid { limit },
+            });
         }
 
         self.fields.limit.replace(limit);

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -16,7 +16,7 @@ pub struct GetChannelMessagesConfiguredError {
 
 impl GetChannelMessagesConfiguredError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &GetChannelMessagesConfiguredErrorType {
         &self.kind
     }

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -9,25 +9,59 @@ use twilight_model::{
 };
 
 /// The error returned if the request can not be created as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct GetChannelMessagesConfiguredError {
+    kind: GetChannelMessagesConfiguredErrorType,
+}
+
+impl GetChannelMessagesConfiguredError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &GetChannelMessagesConfiguredErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        GetChannelMessagesConfiguredErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for GetChannelMessagesConfiguredError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            GetChannelMessagesConfiguredErrorType::LimitInvalid { .. } => {
+                f.write_str("the limit is invalid")
+            }
+        }
+    }
+}
+
+impl Error for GetChannelMessagesConfiguredError {}
+
+/// Type of [`GetChannelMessagesConfiguredError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum GetChannelMessagesConfiguredError {
+pub enum GetChannelMessagesConfiguredErrorType {
     /// The maximum number of messages to retrieve is either 0 or more than 100.
     LimitInvalid {
         /// Provided maximum number of messages to retrieve.
         limit: u64,
     },
 }
-
-impl Display for GetChannelMessagesConfiguredError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
-        }
-    }
-}
-
-impl Error for GetChannelMessagesConfiguredError {}
 
 struct GetChannelMessagesConfiguredFields {
     limit: Option<u64>,
@@ -76,11 +110,13 @@ impl<'a> GetChannelMessagesConfigured<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`GetChannelMessagesConfiguredError::LimitInvalid`] if the
-    /// amount is greater than 21600.
+    /// Returns a [`GetChannelMessagesConfiguredErrorType::LimitInvalid`] error
+    /// type if the amount is greater than 21600.
     pub fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesConfiguredError> {
         if !validate::get_channel_messages_limit(limit) {
-            return Err(GetChannelMessagesConfiguredError::LimitInvalid { limit });
+            return Err(GetChannelMessagesConfiguredError {
+                kind: GetChannelMessagesConfiguredErrorType::LimitInvalid { limit },
+            });
         }
 
         self.fields.limit.replace(limit);

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -23,8 +23,8 @@ impl GetChannelMessagesConfiguredError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -9,9 +9,57 @@ use twilight_model::{
 };
 
 /// The error created when a message can not be updated as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct UpdateMessageError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: UpdateMessageErrorType,
+}
+
+impl UpdateMessageError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &UpdateMessageErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (UpdateMessageErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, self.cause)
+    }
+}
+
+impl Display for UpdateMessageError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            UpdateMessageErrorType::ContentInvalid { .. } => {
+                f.write_str("the message content is invalid")
+            }
+            UpdateMessageErrorType::EmbedTooLarge { .. } => {
+                f.write_str("the embed's contents are too long")
+            }
+        }
+    }
+}
+
+impl Error for UpdateMessageError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
+    }
+}
+
+/// Type of [`UpdateMessageError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum UpdateMessageError {
+pub enum UpdateMessageErrorType {
     /// Returned when the content is over 2000 UTF-16 characters.
     ContentInvalid {
         /// Provided content.
@@ -21,27 +69,7 @@ pub enum UpdateMessageError {
     EmbedTooLarge {
         /// Provided embed.
         embed: Box<Embed>,
-        /// The source of the error.
-        source: EmbedValidationError,
     },
-}
-
-impl Display for UpdateMessageError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::ContentInvalid { .. } => f.write_str("the message content is invalid"),
-            Self::EmbedTooLarge { .. } => f.write_str("the embed's contents are too long"),
-        }
-    }
-}
-
-impl Error for UpdateMessageError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::ContentInvalid { .. } => None,
-            Self::EmbedTooLarge { source, .. } => Some(source),
-        }
-    }
 }
 
 #[derive(Default, Serialize)]
@@ -134,8 +162,8 @@ impl<'a> UpdateMessage<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`UpdateMessageError::ContentInvalid`] if the content length is
-    /// too long.
+    /// Returns an [`UpdateMessageErrorType::ContentInvalid`] error type if the
+    /// content length is too long.
     pub fn content(self, content: impl Into<Option<String>>) -> Result<Self, UpdateMessageError> {
         self._content(content.into())
     }
@@ -143,8 +171,11 @@ impl<'a> UpdateMessage<'a> {
     fn _content(mut self, content: Option<String>) -> Result<Self, UpdateMessageError> {
         if let Some(content_ref) = content.as_ref() {
             if !validate::content_limit(content_ref) {
-                return Err(UpdateMessageError::ContentInvalid {
-                    content: content.expect("content is known to be some"),
+                return Err(UpdateMessageError {
+                    cause: None,
+                    kind: UpdateMessageErrorType::ContentInvalid {
+                        content: content.expect("content is known to be some"),
+                    },
                 });
             }
         }
@@ -167,9 +198,11 @@ impl<'a> UpdateMessage<'a> {
     fn _embed(mut self, embed: Option<Embed>) -> Result<Self, UpdateMessageError> {
         if let Some(embed_ref) = embed.as_ref() {
             if let Err(source) = validate::embed(&embed_ref) {
-                return Err(UpdateMessageError::EmbedTooLarge {
-                    embed: Box::new(embed.expect("embed is known to be some")),
-                    source,
+                return Err(UpdateMessageError {
+                    cause: Some(Box::new(source)),
+                    kind: UpdateMessageErrorType::EmbedTooLarge {
+                        embed: Box::new(embed.expect("embed is known to be some")),
+                    },
                 });
             }
         }
@@ -206,7 +239,7 @@ impl<'a> UpdateMessage<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
             Route::UpdateMessage {
                 channel_id: self.channel_id.0,
                 message_id: self.message_id.0,

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -17,7 +17,7 @@ pub struct UpdateMessageError {
 
 impl UpdateMessageError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &UpdateMessageErrorType {
         &self.kind
     }

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -16,7 +16,7 @@ pub struct GetReactionsError {
 
 impl GetReactionsError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &GetReactionsErrorType {
         &self.kind
     }

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -9,25 +9,52 @@ use twilight_model::{
 };
 
 /// The error created if the reactions can not be retrieved as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct GetReactionsError {
+    kind: GetReactionsErrorType,
+}
+
+impl GetReactionsError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &GetReactionsErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (GetReactionsErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
+}
+
+impl Display for GetReactionsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            GetReactionsErrorType::LimitInvalid { .. } => f.write_str("the limit is invalid"),
+        }
+    }
+}
+
+impl Error for GetReactionsError {}
+
+/// Type of [`GetReactionsError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum GetReactionsError {
+pub enum GetReactionsErrorType {
     /// The number of reactions to retrieve must be between 1 and 100, inclusive.
     LimitInvalid {
         /// The provided maximum number of reactions to get.
         limit: u64,
     },
 }
-
-impl Display for GetReactionsError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
-        }
-    }
-}
-
-impl Error for GetReactionsError {}
 
 #[derive(Default)]
 struct GetReactionsFields {
@@ -87,10 +114,13 @@ impl<'a> GetReactions<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`GetReactionsError::LimitInvalid`] if the amount is greater than 100.
+    /// Returns a [`GetReactionsErrorType::LimitInvalid`] error type if the
+    /// amount is greater than 100.
     pub fn limit(mut self, limit: u64) -> Result<Self, GetReactionsError> {
         if !validate::get_reactions_limit(limit) {
-            return Err(GetReactionsError::LimitInvalid { limit });
+            return Err(GetReactionsError {
+                kind: GetReactionsErrorType::LimitInvalid { limit },
+            });
         }
 
         self.fields.limit.replace(limit);

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -23,8 +23,8 @@ impl GetReactionsError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -16,7 +16,7 @@ pub struct UpdateChannelError {
 
 impl UpdateChannelError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &UpdateChannelErrorType {
         &self.kind
     }

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -9,9 +9,51 @@ use twilight_model::{
 };
 
 /// Returned when the channel can not be updated as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct UpdateChannelError {
+    kind: UpdateChannelErrorType,
+}
+
+impl UpdateChannelError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &UpdateChannelErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (UpdateChannelErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
+}
+
+impl Display for UpdateChannelError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            UpdateChannelErrorType::NameInvalid { .. } => {
+                f.write_str("the length of the name is invalid")
+            }
+            UpdateChannelErrorType::RateLimitPerUserInvalid { .. } => {
+                f.write_str("the rate limit per user is invalid")
+            }
+            UpdateChannelErrorType::TopicInvalid { .. } => f.write_str("the topic is invalid"),
+        }
+    }
+}
+
+impl Error for UpdateChannelError {}
+
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum UpdateChannelError {
+pub enum UpdateChannelErrorType {
     /// The length of the name is either fewer than 2 UTF-16 characters or
     /// more than 100 UTF-16 characters.
     NameInvalid {
@@ -29,20 +71,6 @@ pub enum UpdateChannelError {
         topic: String,
     },
 }
-
-impl Display for UpdateChannelError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NameInvalid { .. } => f.write_str("the length of the name is invalid"),
-            Self::RateLimitPerUserInvalid { .. } => {
-                f.write_str("the rate limit per user is invalid")
-            }
-            Self::TopicInvalid { .. } => f.write_str("the topic is invalid"),
-        }
-    }
-}
-
-impl Error for UpdateChannelError {}
 
 // The Discord API doesn't require the `name` and `kind` fields to be present,
 // but it does require them to be non-null.
@@ -120,15 +148,17 @@ impl<'a> UpdateChannel<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`UpdateChannelError::NameInvalid`] if the name length is
-    /// too short or too long.
+    /// Returns an [`UpdateChannelErrorType::NameInvalid`] error type if the name
+    /// length is too short or too long.
     pub fn name(self, name: impl Into<String>) -> Result<Self, UpdateChannelError> {
         self._name(name.into())
     }
 
     fn _name(mut self, name: String) -> Result<Self, UpdateChannelError> {
         if !validate::channel_name(&name) {
-            return Err(UpdateChannelError::NameInvalid { name });
+            return Err(UpdateChannelError {
+                kind: UpdateChannelErrorType::NameInvalid { name },
+            });
         }
 
         self.fields.name.replace(name);
@@ -182,8 +212,8 @@ impl<'a> UpdateChannel<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`UpdateChannelError::RateLimitPerUserInvalid`] if the amount is greater than
-    /// 21600.
+    /// Returns an [`UpdateChannelErrorType::RateLimitPerUserInvalid`] error
+    /// type if the amount is greater than 21600.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure>
     pub fn rate_limit_per_user(
@@ -191,8 +221,10 @@ impl<'a> UpdateChannel<'a> {
         rate_limit_per_user: u64,
     ) -> Result<Self, UpdateChannelError> {
         if rate_limit_per_user > 21600 {
-            return Err(UpdateChannelError::RateLimitPerUserInvalid {
-                rate_limit_per_user,
+            return Err(UpdateChannelError {
+                kind: UpdateChannelErrorType::RateLimitPerUserInvalid {
+                    rate_limit_per_user,
+                },
             });
         }
 
@@ -207,8 +239,8 @@ impl<'a> UpdateChannel<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`UpdateChannelError::TopicInvalid`] if the topic length is
-    /// too long.
+    /// Returns an [`UpdateChannelErrorType::TopicInvalid`] error type if the topic
+    /// length is too long.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure
     pub fn topic(self, topic: impl Into<String>) -> Result<Self, UpdateChannelError> {
@@ -217,7 +249,9 @@ impl<'a> UpdateChannel<'a> {
 
     fn _topic(mut self, topic: String) -> Result<Self, UpdateChannelError> {
         if topic.chars().count() > 1024 {
-            return Err(UpdateChannelError::TopicInvalid { topic });
+            return Err(UpdateChannelError {
+                kind: UpdateChannelErrorType::TopicInvalid { topic },
+            });
         }
 
         self.fields.topic.replace(topic);
@@ -254,7 +288,7 @@ impl<'a> UpdateChannel<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::UpdateChannel {
                     channel_id: self.channel_id.0,
@@ -262,7 +296,7 @@ impl<'a> UpdateChannel<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::UpdateChannel {
                     channel_id: self.channel_id.0,
                 },

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -23,8 +23,8 @@ impl UpdateChannelError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -104,17 +104,6 @@ struct UpdateChannelFields {
 ///
 /// All fields are optional. The minimum length of the name is 2 UTF-16 characters and the maximum
 /// is 100 UTF-16 characters.
-///
-/// # Errors
-///
-/// Returns a [`UpdateChannelError::NameInvalid`] when the length of the name is either fewer than
-/// 2 UTF-16 characters or more than 100 UTF-16 characters.
-///
-/// Returns a [`UpdateChannelError::RateLimitPerUserInvalid`] when the seconds of the rate limit per
-/// user is more than 21600.
-///
-/// Returns a [`UpdateChannelError::TopicInvalid`] when the length of the topic is more than
-/// 1024 UTF-16 characters.
 pub struct UpdateChannel<'a> {
     channel_id: ChannelId,
     fields: UpdateChannelFields,

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -58,7 +58,7 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
         Ok(if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::UpdatePermissionOverwrite {
                     channel_id: self.channel_id.0,
@@ -67,7 +67,7 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::UpdatePermissionOverwrite {
                     channel_id: self.channel_id.0,
                     target_id: self.target_id,

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -65,7 +65,7 @@ impl<'a> CreateWebhook<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::CreateWebhook {
                     channel_id: self.channel_id.0,
@@ -73,7 +73,7 @@ impl<'a> CreateWebhook<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::CreateWebhook {
                     channel_id: self.channel_id.0,
                 },

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -134,7 +134,7 @@ impl<'a> ExecuteWebhook<'a> {
 
     fn start(&mut self) -> Result<()> {
         let request = Request::from((
-            crate::json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
             Route::ExecuteWebhook {
                 token: self.token.to_owned(),
                 wait: self.fields.wait,

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -69,7 +69,7 @@ impl<'a> UpdateWebhook<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::UpdateWebhook {
                     token: None,
@@ -78,7 +78,7 @@ impl<'a> UpdateWebhook<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::UpdateWebhook {
                     token: None,
                     webhook_id: self.webhook_id.0,

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -28,7 +28,7 @@ pub struct UpdateWebhookMessageError {
 
 impl UpdateWebhookMessageError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &UpdateWebhookMessageErrorType {
         &self.kind
     }

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -2,12 +2,10 @@
 
 use crate::{
     client::Client,
-    error::Result,
+    error::{Error as HttpError, Result},
     request::{
-        self,
-        channel::allowed_mentions::AllowedMentions,
-        validate::{self, EmbedValidationError},
-        AuditLogReason, AuditLogReasonError, Pending, Request,
+        self, channel::allowed_mentions::AllowedMentions, validate, AuditLogReason,
+        AuditLogReasonError, Pending, Request,
     },
     routing::Route,
 };
@@ -22,9 +20,66 @@ use twilight_model::{
 };
 
 /// A webhook's message can not be updated as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct UpdateWebhookMessageError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: UpdateWebhookMessageErrorType,
+}
+
+impl UpdateWebhookMessageError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &UpdateWebhookMessageErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        UpdateWebhookMessageErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, self.cause)
+    }
+}
+
+impl Display for UpdateWebhookMessageError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            UpdateWebhookMessageErrorType::ContentInvalid { .. } => {
+                f.write_str("message content is invalid")
+            }
+            UpdateWebhookMessageErrorType::EmbedTooLarge { .. } => {
+                f.write_str("length of one of the embeds is too large")
+            }
+            UpdateWebhookMessageErrorType::TooManyEmbeds { embeds } => f.write_fmt(format_args!(
+                "{} embeds were provided, but only 10 may be provided",
+                embeds.len()
+            )),
+        }
+    }
+}
+
+impl Error for UpdateWebhookMessageError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
+    }
+}
+
+/// Type of [`UpdateWebhookMessageError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum UpdateWebhookMessageError {
+pub enum UpdateWebhookMessageErrorType {
     /// Content is over 2000 UTF-16 characters.
     ContentInvalid {
         /// Provided content.
@@ -40,8 +95,6 @@ pub enum UpdateWebhookMessageError {
         ///
         /// [`embeds`]: Self::EmbedTooLarge.embeds
         index: usize,
-        /// Source of the error.
-        source: EmbedValidationError,
     },
     /// Too many embeds were provided.
     ///
@@ -50,28 +103,6 @@ pub enum UpdateWebhookMessageError {
         /// Provided embeds.
         embeds: Vec<Embed>,
     },
-}
-
-impl Display for UpdateWebhookMessageError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::ContentInvalid { .. } => f.write_str("message content is invalid"),
-            Self::EmbedTooLarge { .. } => f.write_str("length of one of the embeds is too large"),
-            Self::TooManyEmbeds { embeds } => f.write_fmt(format_args!(
-                "{} embeds were provided, but only 10 may be provided",
-                embeds.len()
-            )),
-        }
-    }
-}
-
-impl Error for UpdateWebhookMessageError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::EmbedTooLarge { source, .. } => Some(source),
-            Self::ContentInvalid { .. } | Self::TooManyEmbeds { .. } => None,
-        }
-    }
 }
 
 #[derive(Default, Serialize)]
@@ -168,13 +199,16 @@ impl<'a> UpdateWebhookMessage<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`UpdateWebhookMessageError::ContentInvalid`] if the content
-    /// length is too long.
+    /// Returns an [`UpdateWebhookMessageErrorType::ContentInvalid`] error type if
+    /// the content length is too long.
     pub fn content(mut self, content: Option<String>) -> Result<Self, UpdateWebhookMessageError> {
         if let Some(content_ref) = content.as_ref() {
             if !validate::content_limit(content_ref) {
-                return Err(UpdateWebhookMessageError::ContentInvalid {
-                    content: content.expect("content is known to be some"),
+                return Err(UpdateWebhookMessageError {
+                    cause: None,
+                    kind: UpdateWebhookMessageErrorType::ContentInvalid {
+                        content: content.expect("content is known to be some"),
+                    },
                 });
             }
         }
@@ -222,28 +256,33 @@ impl<'a> UpdateWebhookMessage<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`UpdateWebhookMessageError::EmbedTooLarge`] if one of the
-    /// embeds are too large.
+    /// Returns an [`UpdateWebhookMessageErrorType::EmbedTooLarge`] error type
+    /// if one of the embeds are too large.
     ///
-    /// Returns [`UpdateWebhookMessageError::TooManyEmbeds`] if more than 10
-    /// embeds are provided.
+    /// Returns an [`UpdateWebhookMessageErrorType::TooManyEmbeds`] error type
+    /// if more than 10 embeds are provided.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#embed-limits
     /// [`EMBED_COUNT_LIMIT`]: Self::EMBED_COUNT_LIMIT
     pub fn embeds(mut self, embeds: Option<Vec<Embed>>) -> Result<Self, UpdateWebhookMessageError> {
         if let Some(embeds_present) = embeds.as_deref() {
             if embeds_present.len() > Self::EMBED_COUNT_LIMIT {
-                return Err(UpdateWebhookMessageError::TooManyEmbeds {
-                    embeds: embeds.expect("embeds are known to be present"),
+                return Err(UpdateWebhookMessageError {
+                    cause: None,
+                    kind: UpdateWebhookMessageErrorType::TooManyEmbeds {
+                        embeds: embeds.expect("embeds are known to be present"),
+                    },
                 });
             }
 
             for (idx, embed) in embeds_present.iter().enumerate() {
                 if let Err(source) = validate::embed(&embed) {
-                    return Err(UpdateWebhookMessageError::EmbedTooLarge {
-                        embeds: embeds.expect("embeds are known to be present"),
-                        index: idx,
-                        source,
+                    return Err(UpdateWebhookMessageError {
+                        cause: Some(Box::new(source)),
+                        kind: UpdateWebhookMessageErrorType::EmbedTooLarge {
+                            embeds: embeds.expect("embeds are known to be present"),
+                            index: idx,
+                        },
                     });
                 }
             }
@@ -255,7 +294,7 @@ impl<'a> UpdateWebhookMessage<'a> {
     }
 
     fn request(&self) -> Result<Request> {
-        let body = crate::json_to_vec(&self.fields)?;
+        let body = crate::json_to_vec(&self.fields).map_err(HttpError::json)?;
         let route = Route::UpdateWebhookMessage {
             message_id: self.message_id.0,
             token: self.token.clone(),

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -53,7 +53,7 @@ impl<'a> UpdateWebhookWithToken<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
             Route::UpdateWebhook {
                 token: Some(self.token.clone()),
                 webhook_id: self.webhook_id.0,

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -6,20 +6,36 @@ use std::{
 use twilight_model::id::{GuildId, UserId};
 
 /// The error created when the ban can not be created as configured.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub enum CreateBanError {
-    /// The number of days' worth of messages to delete is greater than 7.
-    DeleteMessageDaysInvalid {
-        /// Provided number of days' worth of messages to delete.
-        days: u64,
-    },
+#[derive(Debug)]
+pub struct CreateBanError {
+    kind: CreateBanErrorType,
+}
+
+impl CreateBanError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &CreateBanErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (CreateBanErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
 }
 
 impl Display for CreateBanError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::DeleteMessageDaysInvalid { .. } => {
+        match &self.kind {
+            CreateBanErrorType::DeleteMessageDaysInvalid { .. } => {
                 f.write_str("the number of days' worth of messages to delete is invalid")
             }
         }
@@ -27,6 +43,17 @@ impl Display for CreateBanError {
 }
 
 impl Error for CreateBanError {}
+
+/// Type of [`CreateBanError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CreateBanErrorType {
+    /// The number of days' worth of messages to delete is greater than 7.
+    DeleteMessageDaysInvalid {
+        /// Provided number of days' worth of messages to delete.
+        days: u64,
+    },
+}
 
 #[derive(Default)]
 struct CreateBanFields {
@@ -83,11 +110,13 @@ impl<'a> CreateBan<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateBanError::DeleteMessageDaysInvalid`] if the number of days
-    /// is greater than 7.
+    /// Returns a [`CreateBanErrorType::DeleteMessageDaysInvalid`] error type if
+    /// the number of days is greater than 7.
     pub fn delete_message_days(mut self, days: u64) -> Result<Self, CreateBanError> {
         if !validate::ban_delete_message_days(days) {
-            return Err(CreateBanError::DeleteMessageDaysInvalid { days });
+            return Err(CreateBanError {
+                kind: CreateBanErrorType::DeleteMessageDaysInvalid { days },
+            });
         }
 
         self.fields.delete_message_days.replace(days);

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -13,7 +13,7 @@ pub struct CreateBanError {
 
 impl CreateBanError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &CreateBanErrorType {
         &self.kind
     }

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -20,8 +20,8 @@ impl CreateBanError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -24,8 +24,8 @@ impl RoleFieldsError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 
@@ -179,8 +179,8 @@ impl TextFieldsError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 
@@ -385,8 +385,8 @@ impl VoiceFieldsError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 
@@ -527,8 +527,8 @@ impl CategoryFieldsError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -10,9 +10,51 @@ use twilight_model::{
 };
 
 /// Error building role fields.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
+pub struct RoleFieldsError {
+    kind: RoleFieldsErrorType,
+}
+
+impl RoleFieldsError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &RoleFieldsErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (RoleFieldsErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
+}
+
+impl Display for RoleFieldsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            RoleFieldsErrorType::ColorNotRgb { color } => {
+                f.write_fmt(format_args!("the color {} is invalid", color))
+            }
+            RoleFieldsErrorType::IdInvalid => {
+                f.write_str("the given id value is 1, which is not acceptable")
+            }
+        }
+    }
+}
+
+impl Error for RoleFieldsError {}
+
+/// Type of [`RoleFieldsError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum RoleFieldsError {
+pub enum RoleFieldsErrorType {
     /// Color was larger than a valid RGB hexadecimal value.
     ColorNotRgb {
         /// Provided color hex value.
@@ -21,19 +63,6 @@ pub enum RoleFieldsError {
     /// Invalid id for builders.
     IdInvalid,
 }
-
-impl Display for RoleFieldsError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::ColorNotRgb { color } => {
-                f.write_fmt(format_args!("the color {} is invalid", color))
-            }
-            Self::IdInvalid => f.write_str("the given id value is 1, which is not acceptable"),
-        }
-    }
-}
-
-impl Error for RoleFieldsError {}
 
 /// A builder for role fields.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -74,10 +103,13 @@ impl RoleFieldsBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`RoleFieldsError::ColorNotRgb`] if the color is not valid RGB.
+    /// Returns a [`RoleFieldsErrorType::ColorNotRgb`] error type if the color
+    /// is not valid RGB.
     pub fn color(mut self, color: u32) -> Result<Self, RoleFieldsError> {
         if color > Self::COLOR_MAXIMUM {
-            return Err(RoleFieldsError::ColorNotRgb { color });
+            return Err(RoleFieldsError {
+                kind: RoleFieldsErrorType::ColorNotRgb { color },
+            });
         }
 
         self.0.color.replace(color);
@@ -96,10 +128,13 @@ impl RoleFieldsBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`RoleFieldsError::IdInvalid`] if the id is set to 1.
+    /// Returns a [`RoleFieldsErrorType::IdInvalid`] error type if the ID is set
+    /// to 1.
     pub fn id(mut self, id: RoleId) -> Result<Self, RoleFieldsError> {
         if id == Self::ROLE_ID {
-            return Err(RoleFieldsError::IdInvalid);
+            return Err(RoleFieldsError {
+                kind: RoleFieldsErrorType::IdInvalid,
+            });
         }
 
         self.0.id = id;
@@ -130,9 +165,57 @@ impl RoleFieldsBuilder {
 }
 
 /// Error building text fields.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
+pub struct TextFieldsError {
+    kind: TextFieldsErrorType,
+}
+
+impl TextFieldsError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &TextFieldsErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (TextFieldsErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
+}
+
+impl Display for TextFieldsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            TextFieldsErrorType::NameTooShort { name } => {
+                f.write_fmt(format_args!("the name is too short: {}", name.len()))
+            }
+            TextFieldsErrorType::NameTooLong { name } => {
+                f.write_fmt(format_args!("the name is too long: {}", name.len()))
+            }
+            TextFieldsErrorType::RateLimitInvalid { limit } => {
+                f.write_fmt(format_args!("the rate limit {} is invalid", limit))
+            }
+            TextFieldsErrorType::TopicTooLong { topic } => {
+                f.write_fmt(format_args!("the topic is too long: {}", topic.len()))
+            }
+        }
+    }
+}
+
+impl Error for TextFieldsError {}
+
+/// Type of [`TextFieldsError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum TextFieldsError {
+pub enum TextFieldsErrorType {
     /// The name is too short.
     NameTooShort {
         /// The invalid name.
@@ -154,27 +237,6 @@ pub enum TextFieldsError {
         topic: String,
     },
 }
-
-impl Display for TextFieldsError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NameTooShort { name } => {
-                f.write_fmt(format_args!("the name is too short: {}", name.len()))
-            }
-            Self::NameTooLong { name } => {
-                f.write_fmt(format_args!("the name is too long: {}", name.len()))
-            }
-            Self::RateLimitInvalid { limit } => {
-                f.write_fmt(format_args!("the rate limit {} is invalid", limit))
-            }
-            Self::TopicTooLong { topic } => {
-                f.write_fmt(format_args!("the topic is too long: {}", topic.len()))
-            }
-        }
-    }
-}
-
-impl Error for TextFieldsError {}
 
 /// A builder for text fields.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -214,20 +276,26 @@ impl TextFieldsBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`TextFieldsError::NameTooShort`] if the name is too short.
+    /// Returns a [`TextFieldsErrorType::NameTooShort`] error type if the name
+    /// is too short.
     ///
-    /// Returns [`TextFieldsError::NameTooLong`] if the name is too long.
+    /// Returns a [`TextFieldsErrorType::NameTooLong`] error type if the name is
+    /// too long.
     pub fn new(name: impl Into<String>) -> Result<Self, TextFieldsError> {
         Self::_new(name.into())
     }
 
     fn _new(name: String) -> Result<Self, TextFieldsError> {
         if name.len() < Self::MIN_NAME_LENGTH {
-            return Err(TextFieldsError::NameTooShort { name });
+            return Err(TextFieldsError {
+                kind: TextFieldsErrorType::NameTooShort { name },
+            });
         }
 
         if name.len() > Self::MAX_NAME_LENGTH {
-            return Err(TextFieldsError::NameTooLong { name });
+            return Err(TextFieldsError {
+                kind: TextFieldsErrorType::NameTooLong { name },
+            });
         }
 
         Ok(Self(TextFields {
@@ -265,10 +333,13 @@ impl TextFieldsBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`TextFieldsError::RateLimitInvalid`] if the rate limit is invalid.
+    /// Returns a [`TextFieldsErrorType::RateLimitInvalid`] error type if the
+    /// rate limit is invalid.
     pub fn rate_limit_per_user(mut self, limit: u64) -> Result<Self, TextFieldsError> {
         if limit > Self::MAX_RATE_LIMIT {
-            return Err(TextFieldsError::RateLimitInvalid { limit });
+            return Err(TextFieldsError {
+                kind: TextFieldsErrorType::RateLimitInvalid { limit },
+            });
         }
 
         self.0.rate_limit_per_user.replace(limit);
@@ -280,14 +351,17 @@ impl TextFieldsBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`TextFieldsError::TopicTooLong`] if the topic is too long.
+    /// Returns a [`TextFieldsErrorType::TopicTooLong`] error type if the topic
+    /// is too long.
     pub fn topic(self, topic: impl Into<String>) -> Result<Self, TextFieldsError> {
         self._topic(topic.into())
     }
 
     fn _topic(mut self, topic: String) -> Result<Self, TextFieldsError> {
         if topic.len() > Self::MAX_TOPIC_LENGTH {
-            return Err(TextFieldsError::TopicTooLong { topic });
+            return Err(TextFieldsError {
+                kind: TextFieldsErrorType::TopicTooLong { topic },
+            });
         }
 
         self.0.topic.replace(topic);
@@ -297,9 +371,51 @@ impl TextFieldsBuilder {
 }
 
 /// Error building voice fields.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
+pub struct VoiceFieldsError {
+    kind: VoiceFieldsErrorType,
+}
+
+impl VoiceFieldsError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &VoiceFieldsErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (VoiceFieldsErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
+}
+
+impl Display for VoiceFieldsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            VoiceFieldsErrorType::NameTooShort { name } => {
+                f.write_fmt(format_args!("the name is too short: {}", name.len()))
+            }
+            VoiceFieldsErrorType::NameTooLong { name } => {
+                f.write_fmt(format_args!("the name is too long: {}", name.len()))
+            }
+        }
+    }
+}
+
+impl Error for VoiceFieldsError {}
+
+/// Type of [`VoiceFieldsError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum VoiceFieldsError {
+pub enum VoiceFieldsErrorType {
     /// The name is too short.
     NameTooShort {
         /// The invalid name.
@@ -311,21 +427,6 @@ pub enum VoiceFieldsError {
         name: String,
     },
 }
-
-impl Display for VoiceFieldsError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NameTooShort { name } => {
-                f.write_fmt(format_args!("the name is too short: {}", name.len()))
-            }
-            Self::NameTooLong { name } => {
-                f.write_fmt(format_args!("the name is too long: {}", name.len()))
-            }
-        }
-    }
-}
-
-impl Error for VoiceFieldsError {}
 
 /// A builder for voice fields.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -351,20 +452,26 @@ impl VoiceFieldsBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`VoiceFieldsError::NameTooShort`] if the name is too short.
+    /// Returns a [`VoiceFieldsErrorType::NameTooShort`] error type if the name
+    /// is too short.
     ///
-    /// Returns [`VoiceFieldsError::NameTooLong`] if the name is too long.
+    /// Returns a [`VoiceFieldsErrorType::NameTooLong`] error type if the name
+    /// is too long.
     pub fn new(name: impl Into<String>) -> Result<Self, VoiceFieldsError> {
         Self::_new(name.into())
     }
 
     fn _new(name: String) -> Result<Self, VoiceFieldsError> {
         if name.len() < Self::MIN_NAME_LENGTH {
-            return Err(VoiceFieldsError::NameTooShort { name });
+            return Err(VoiceFieldsError {
+                kind: VoiceFieldsErrorType::NameTooShort { name },
+            });
         }
 
         if name.len() > Self::MAX_NAME_LENGTH {
-            return Err(VoiceFieldsError::NameTooLong { name });
+            return Err(VoiceFieldsError {
+                kind: VoiceFieldsErrorType::NameTooLong { name },
+            });
         }
 
         Ok(Self(VoiceFields {
@@ -406,9 +513,56 @@ impl VoiceFieldsBuilder {
 }
 
 /// Error creating category fields.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
+pub struct CategoryFieldsError {
+    kind: CategoryFieldsErrorType,
+}
+
+impl CategoryFieldsError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &CategoryFieldsErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        CategoryFieldsErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for CategoryFieldsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            CategoryFieldsErrorType::NameTooShort { name } => {
+                f.write_fmt(format_args!("the name is too short: {}", name.len()))
+            }
+            CategoryFieldsErrorType::NameTooLong { name } => {
+                f.write_fmt(format_args!("the name is too long: {}", name.len()))
+            }
+        }
+    }
+}
+
+impl Error for CategoryFieldsError {}
+
+/// Type of [`CategoryFieldsError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum CategoryFieldsError {
+pub enum CategoryFieldsErrorType {
     /// The name is too short.
     NameTooShort {
         /// The invalid name.
@@ -420,21 +574,6 @@ pub enum CategoryFieldsError {
         name: String,
     },
 }
-
-impl Display for CategoryFieldsError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NameTooShort { name } => {
-                f.write_fmt(format_args!("the name is too short: {}", name.len()))
-            }
-            Self::NameTooLong { name } => {
-                f.write_fmt(format_args!("the name is too long: {}", name.len()))
-            }
-        }
-    }
-}
-
-impl Error for CategoryFieldsError {}
 
 /// A builder for a category channel, and its children.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -463,20 +602,26 @@ impl CategoryFieldsBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`CategoryFieldsError::NameTooShort`] if the name is too short.
+    /// Returns a [`CategoryFieldsErrorType::NameTooShort`] error type if the
+    /// name is too short.
     ///
-    /// Returns [`CategoryFieldsError::NameTooLong`] if the name is too long.
+    /// Returns a [`CategoryFieldsErrorType::NameTooLong`] error type if the
+    /// name is too long.
     pub fn new(name: impl Into<String>) -> Result<Self, CategoryFieldsError> {
         Self::_new(name.into())
     }
 
     fn _new(name: String) -> Result<Self, CategoryFieldsError> {
         if name.len() < Self::MIN_NAME_LENGTH {
-            return Err(CategoryFieldsError::NameTooShort { name });
+            return Err(CategoryFieldsError {
+                kind: CategoryFieldsErrorType::NameTooShort { name },
+            });
         }
 
         if name.len() > Self::MAX_NAME_LENGTH {
-            return Err(CategoryFieldsError::NameTooLong { name });
+            return Err(CategoryFieldsError {
+                kind: CategoryFieldsErrorType::NameTooLong { name },
+            });
         }
 
         Ok(Self {
@@ -574,8 +719,9 @@ impl GuildChannelFieldsBuilder {
 mod tests {
     use super::{
         super::{CategoryFields, GuildChannelFields, RoleFields, TextFields, VoiceFields},
-        CategoryFieldsBuilder, CategoryFieldsError, GuildChannelFieldsBuilder, RoleFieldsBuilder,
-        RoleFieldsError, TextFieldsBuilder, TextFieldsError, VoiceFieldsBuilder, VoiceFieldsError,
+        CategoryFieldsBuilder, CategoryFieldsErrorType, GuildChannelFieldsBuilder,
+        RoleFieldsBuilder, RoleFieldsErrorType, TextFieldsBuilder, TextFieldsErrorType,
+        VoiceFieldsBuilder, VoiceFieldsErrorType,
     };
     use twilight_model::{
         channel::{
@@ -608,12 +754,13 @@ mod tests {
 
     #[test]
     fn test_role_fields() {
-        assert_eq!(
-            RoleFieldsError::ColorNotRgb { color: 123_123_123 },
+        assert!(matches!(
             RoleFieldsBuilder::new("role")
                 .color(123_123_123)
                 .unwrap_err()
-        );
+                .kind(),
+            RoleFieldsErrorType::ColorNotRgb { color: 123_123_123 },
+        ));
 
         let fields = RoleFieldsBuilder::new("rolename")
             .color(0x12_34_56)
@@ -641,12 +788,11 @@ mod tests {
 
     #[test]
     fn test_voice_fields() {
-        assert_eq!(
-            VoiceFieldsError::NameTooShort {
-                name: String::from("c")
-            },
-            VoiceFieldsBuilder::new("c").unwrap_err()
-        );
+        assert!(matches!(
+            VoiceFieldsBuilder::new("c").unwrap_err().kind(),
+            VoiceFieldsErrorType::NameTooShort { name }
+            if name == "c"
+        ));
 
         let fields = voice();
 
@@ -681,12 +827,11 @@ mod tests {
 
     #[test]
     fn test_text_fields() {
-        assert_eq!(
-            TextFieldsError::NameTooShort {
-                name: String::from("b")
-            },
-            TextFieldsBuilder::new("b").unwrap_err()
-        );
+        assert!(matches!(
+            TextFieldsBuilder::new("b").unwrap_err().kind(),
+            TextFieldsErrorType::NameTooShort { name }
+            if name == "b"
+        ));
 
         let fields = text();
 
@@ -718,12 +863,11 @@ mod tests {
 
     #[test]
     fn test_category_fields() {
-        assert_eq!(
-            CategoryFieldsError::NameTooShort {
-                name: String::from("a")
-            },
-            CategoryFieldsBuilder::new("a").unwrap_err()
-        );
+        assert!(matches!(
+            CategoryFieldsBuilder::new("a").unwrap_err().kind(),
+            CategoryFieldsErrorType::NameTooShort { name }
+            if name == "a"
+        ));
 
         let fields = category();
         let channels = GuildChannelFieldsBuilder::new().add_category_builder(fields);

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -17,7 +17,7 @@ pub struct RoleFieldsError {
 
 impl RoleFieldsError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &RoleFieldsErrorType {
         &self.kind
     }
@@ -172,7 +172,7 @@ pub struct TextFieldsError {
 
 impl TextFieldsError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &TextFieldsErrorType {
         &self.kind
     }
@@ -378,7 +378,7 @@ pub struct VoiceFieldsError {
 
 impl VoiceFieldsError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &VoiceFieldsErrorType {
         &self.kind
     }
@@ -520,7 +520,7 @@ pub struct CategoryFieldsError {
 
 impl CategoryFieldsError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &CategoryFieldsErrorType {
         &self.kind
     }

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -17,9 +17,52 @@ mod builder;
 pub use self::builder::*;
 
 /// The error returned when the guild can not be created as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct CreateGuildError {
+    kind: CreateGuildErrorType,
+}
+
+impl CreateGuildError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &CreateGuildErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (CreateGuildErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
+}
+
+impl Display for CreateGuildError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            CreateGuildErrorType::NameInvalid { .. } => f.write_str("the guild name is invalid"),
+            CreateGuildErrorType::TooManyChannels { .. } => {
+                f.write_str("too many channels were provided")
+            }
+            CreateGuildErrorType::TooManyRoles { .. } => {
+                f.write_str("too many roles were provided")
+            }
+        }
+    }
+}
+
+impl Error for CreateGuildError {}
+
+/// Type of [`CreateGuildError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum CreateGuildError {
+pub enum CreateGuildErrorType {
     /// The name of the guild is either fewer than 2 UTF-16 characters or more than 100 UTF-16
     /// characters.
     NameInvalid {
@@ -41,18 +84,6 @@ pub enum CreateGuildError {
         roles: Vec<RoleFields>,
     },
 }
-
-impl Display for CreateGuildError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NameInvalid { .. } => f.write_str("the guild name is invalid"),
-            Self::TooManyChannels { .. } => f.write_str("too many channels were provided"),
-            Self::TooManyRoles { .. } => f.write_str("too many roles were provided"),
-        }
-    }
-}
-
-impl Error for CreateGuildError {}
 
 #[derive(Serialize)]
 struct CreateGuildFields {
@@ -192,10 +223,6 @@ impl From<VoiceFieldsBuilder> for VoiceFields {
 ///
 /// The minimum length of the name is 2 UTF-16 characters and the maximum is 100 UTF-16 characters.
 /// This endpoint can only be used by bots in less than 10 guilds.
-///
-/// # Errors
-///
-/// Returns [`CreateGuildError::NameInvalid`] if the name length is too short or too long.
 pub struct CreateGuild<'a> {
     fields: CreateGuildFields,
     fut: Option<Pending<'a, PartialGuild>>,
@@ -209,7 +236,9 @@ impl<'a> CreateGuild<'a> {
 
     fn _new(http: &'a Client, name: String) -> Result<Self, CreateGuildError> {
         if !validate::guild_name(&name) {
-            return Err(CreateGuildError::NameInvalid { name });
+            return Err(CreateGuildError {
+                kind: CreateGuildErrorType::NameInvalid { name },
+            });
         }
 
         Ok(Self {
@@ -279,12 +308,15 @@ impl<'a> CreateGuild<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateGuildError::TooManyChannels`] if the number of channels is over 500.
+    /// Returns a [`CreateGuildErrorType::TooManyChannels`] error type if the
+    /// number of channels is over 500.
     pub fn channels(mut self, channels: Vec<GuildChannelFields>) -> Result<Self, CreateGuildError> {
         // Error 30013
         // <https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#json>
         if channels.len() > 500 {
-            return Err(CreateGuildError::TooManyChannels { channels });
+            return Err(CreateGuildError {
+                kind: CreateGuildErrorType::TooManyChannels { channels },
+            });
         }
 
         self.fields.channels.replace(channels);
@@ -378,11 +410,13 @@ impl<'a> CreateGuild<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateGuildError::TooManyRoles`] if the number of roles is
-    /// over 250.
+    /// Returns a [`CreateGuildErrorType::TooManyRoles`] error type if the
+    /// number of roles is over 250.
     pub fn roles(mut self, mut roles: Vec<RoleFields>) -> Result<Self, CreateGuildError> {
         if roles.len() > 250 {
-            return Err(CreateGuildError::TooManyRoles { roles });
+            return Err(CreateGuildError {
+                kind: CreateGuildErrorType::TooManyRoles { roles },
+            });
         }
 
         if let Some(prev_roles) = self.fields.roles.as_mut() {
@@ -399,7 +433,7 @@ impl<'a> CreateGuild<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
             Route::CreateGuild,
         )))));
 

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -31,8 +31,8 @@ impl CreateGuildError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -24,7 +24,7 @@ pub struct CreateGuildError {
 
 impl CreateGuildError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &CreateGuildErrorType {
         &self.kind
     }

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -16,7 +16,7 @@ pub struct CreateGuildChannelError {
 
 impl CreateGuildChannelError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &CreateGuildChannelErrorType {
         &self.kind
     }

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -9,9 +9,41 @@ use twilight_model::{
 };
 
 /// Returned when the channel can not be created as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct CreateGuildChannelError {
+    kind: CreateGuildChannelErrorType,
+}
+
+impl CreateGuildChannelError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &CreateGuildChannelErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        CreateGuildChannelErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+/// Type of [`CreateGuildChannelError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum CreateGuildChannelError {
+pub enum CreateGuildChannelErrorType {
     /// The length of the name is either fewer than 2 UTF-16 characters or
     /// more than 100 UTF-16 characters.
     NameInvalid {
@@ -32,12 +64,14 @@ pub enum CreateGuildChannelError {
 
 impl Display for CreateGuildChannelError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NameInvalid { .. } => f.write_str("the length of the name is invalid"),
-            Self::RateLimitPerUserInvalid { .. } => {
+        match &self.kind {
+            CreateGuildChannelErrorType::NameInvalid { .. } => {
+                f.write_str("the length of the name is invalid")
+            }
+            CreateGuildChannelErrorType::RateLimitPerUserInvalid { .. } => {
                 f.write_str("the rate limit per user is invalid")
             }
-            Self::TopicInvalid { .. } => f.write_str("the topic is invalid"),
+            CreateGuildChannelErrorType::TopicInvalid { .. } => f.write_str("the topic is invalid"),
         }
     }
 }
@@ -71,17 +105,6 @@ struct CreateGuildChannelFields {
 ///
 /// All fields are optional except for name. The minimum length of the name is 2 UTF-16 characters
 /// and the maximum is 100 UTF-16 characters.
-///
-/// # Errors
-///
-/// Returns a [`CreateGuildChannelError::NameInvalid`] when the length of the name is either fewer
-/// than 2 UTF-16 characters or more than 100 UTF-16 characters.
-///
-/// Returns a [`CreateGuildChannelError::RateLimitPerUserInvalid`] when the seconds of the rate
-/// limit per user is more than 21600.
-///
-/// Returns a [`CreateGuildChannelError::TopicInvalid`] when the length of the topic is more than
-/// 1024 UTF-16 characters.
 pub struct CreateGuildChannel<'a> {
     fields: CreateGuildChannelFields,
     fut: Option<Pending<'a, GuildChannel>>,
@@ -105,7 +128,9 @@ impl<'a> CreateGuildChannel<'a> {
         name: String,
     ) -> Result<Self, CreateGuildChannelError> {
         if !validate::channel_name(&name) {
-            return Err(CreateGuildChannelError::NameInvalid { name });
+            return Err(CreateGuildChannelError {
+                kind: CreateGuildChannelErrorType::NameInvalid { name },
+            });
         }
 
         Ok(Self {
@@ -187,8 +212,8 @@ impl<'a> CreateGuildChannel<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateGuildChannelError::RateLimitPerUserInvalid`] if the amount is greater than
-    /// 21600.
+    /// Returns a [`CreateGuildChannelErrorType::RateLimitPerUserInvalid`] error
+    /// type if the amount is greater than 21600.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure
     pub fn rate_limit_per_user(
@@ -196,8 +221,10 @@ impl<'a> CreateGuildChannel<'a> {
         rate_limit_per_user: u64,
     ) -> Result<Self, CreateGuildChannelError> {
         if rate_limit_per_user > 21600 {
-            return Err(CreateGuildChannelError::RateLimitPerUserInvalid {
-                rate_limit_per_user,
+            return Err(CreateGuildChannelError {
+                kind: CreateGuildChannelErrorType::RateLimitPerUserInvalid {
+                    rate_limit_per_user,
+                },
             });
         }
 
@@ -212,8 +239,8 @@ impl<'a> CreateGuildChannel<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateGuildChannelError::TopicInvalid`] if the topic length is
-    /// too long.
+    /// Returns a [`CreateGuildChannelErrorType::TopicInvalid`] error type if
+    /// the topic length is too long.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure
     pub fn topic(self, topic: impl Into<String>) -> Result<Self, CreateGuildChannelError> {
@@ -222,7 +249,9 @@ impl<'a> CreateGuildChannel<'a> {
 
     fn _topic(mut self, topic: String) -> Result<Self, CreateGuildChannelError> {
         if topic.chars().count() > 1024 {
-            return Err(CreateGuildChannelError::TopicInvalid { topic });
+            return Err(CreateGuildChannelError {
+                kind: CreateGuildChannelErrorType::TopicInvalid { topic },
+            });
         }
 
         self.fields.topic.replace(topic);
@@ -246,7 +275,7 @@ impl<'a> CreateGuildChannel<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::CreateChannel {
                     guild_id: self.guild_id.0,
@@ -254,7 +283,7 @@ impl<'a> CreateGuildChannel<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::CreateChannel {
                     guild_id: self.guild_id.0,
                 },

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -23,8 +23,8 @@ impl CreateGuildChannelError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -16,7 +16,7 @@ pub struct CreateGuildPruneError {
 
 impl CreateGuildPruneError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &CreateGuildPruneErrorType {
         &self.kind
     }

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -9,22 +9,56 @@ use twilight_model::{
 };
 
 /// The error created when the guild prune can not be created as configured.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub enum CreateGuildPruneError {
-    /// The number of days is 0.
-    DaysInvalid,
+#[derive(Debug)]
+pub struct CreateGuildPruneError {
+    kind: CreateGuildPruneErrorType,
+}
+
+impl CreateGuildPruneError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &CreateGuildPruneErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        CreateGuildPruneErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
 }
 
 impl Display for CreateGuildPruneError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::DaysInvalid { .. } => f.write_str("the number of days is invalid"),
+        match &self.kind {
+            CreateGuildPruneErrorType::DaysInvalid { .. } => {
+                f.write_str("the number of days is invalid")
+            }
         }
     }
 }
 
 impl Error for CreateGuildPruneError {}
+
+/// Type of [`CreateGuildPruneError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CreateGuildPruneErrorType {
+    /// The number of days is 0.
+    DaysInvalid,
+}
 
 #[derive(Default)]
 struct CreateGuildPruneFields {
@@ -79,10 +113,13 @@ impl<'a> CreateGuildPrune<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateGuildPruneError::DaysInvalid`] if the number of days is 0.
+    /// Returns a [`CreateGuildPruneErrorType::DaysInvalid`] error type if the
+    /// number of days is 0.
     pub fn days(mut self, days: u64) -> Result<Self, CreateGuildPruneError> {
         if !validate::guild_prune_days(days) {
-            return Err(CreateGuildPruneError::DaysInvalid);
+            return Err(CreateGuildPruneError {
+                kind: CreateGuildPruneErrorType::DaysInvalid,
+            });
         }
 
         self.fields.days.replace(days);

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -23,8 +23,8 @@ impl CreateGuildPruneError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -62,7 +62,7 @@ impl<'a> CreateEmoji<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::CreateEmoji {
                     guild_id: self.guild_id.0,
@@ -70,7 +70,7 @@ impl<'a> CreateEmoji<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::CreateEmoji {
                     guild_id: self.guild_id.0,
                 },

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -52,7 +52,7 @@ impl<'a> UpdateEmoji<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::UpdateEmoji {
                     emoji_id: self.emoji_id.0,
@@ -61,7 +61,7 @@ impl<'a> UpdateEmoji<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::UpdateEmoji {
                     emoji_id: self.emoji_id.0,
                     guild_id: self.guild_id.0,

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -9,25 +9,52 @@ use twilight_model::{
 };
 
 /// The error returned when the audit log can not be requested as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct GetAuditLogError {
+    kind: GetAuditLogErrorType,
+}
+
+impl GetAuditLogError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &GetAuditLogErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (GetAuditLogErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
+}
+
+impl Display for GetAuditLogError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            GetAuditLogErrorType::LimitInvalid { .. } => f.write_str("the limit is invalid"),
+        }
+    }
+}
+
+impl Error for GetAuditLogError {}
+
+/// Type of [`GetAuditLogError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum GetAuditLogError {
+pub enum GetAuditLogErrorType {
     /// The limit is either 0 or more than 100.
     LimitInvalid {
         /// Provided maximum number of audit logs to get.
         limit: u64,
     },
 }
-
-impl Display for GetAuditLogError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
-        }
-    }
-}
-
-impl Error for GetAuditLogError {}
 
 #[derive(Default)]
 struct GetAuditLogFields {
@@ -93,11 +120,13 @@ impl<'a> GetAuditLog<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`GetAuditLogError::LimitInvalid`] if the `limit` is 0 or
-    /// greater than 100.
+    /// Returns a [`GetAuditLogErrorType::LimitInvalid`] error type if the
+    /// `limit` is 0 or greater than 100.
     pub fn limit(mut self, limit: u64) -> Result<Self, GetAuditLogError> {
         if !validate::get_audit_log_limit(limit) {
-            return Err(GetAuditLogError::LimitInvalid { limit });
+            return Err(GetAuditLogError {
+                kind: GetAuditLogErrorType::LimitInvalid { limit },
+            });
         }
 
         self.fields.limit.replace(limit);

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -16,7 +16,7 @@ pub struct GetAuditLogError {
 
 impl GetAuditLogError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &GetAuditLogErrorType {
         &self.kind
     }

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -23,8 +23,8 @@ impl GetAuditLogError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -23,8 +23,8 @@ impl GetGuildPruneCountError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -9,22 +9,56 @@ use twilight_model::{
 };
 
 /// The error created when the guild prune count can not be requested as configured.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub enum GetGuildPruneCountError {
-    /// The number of days is 0.
-    DaysInvalid,
+#[derive(Debug)]
+pub struct GetGuildPruneCountError {
+    kind: GetGuildPruneCountErrorType,
+}
+
+impl GetGuildPruneCountError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &GetGuildPruneCountErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        GetGuildPruneCountErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
 }
 
 impl Display for GetGuildPruneCountError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::DaysInvalid => f.write_str("the number of days is invalid"),
+        match &self.kind {
+            GetGuildPruneCountErrorType::DaysInvalid => {
+                f.write_str("the number of days is invalid")
+            }
         }
     }
 }
 
 impl Error for GetGuildPruneCountError {}
+
+/// Type of [`GetGuildPruneCountError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum GetGuildPruneCountErrorType {
+    /// The number of days is 0.
+    DaysInvalid,
+}
 
 #[derive(Default)]
 struct GetGuildPruneCountFields {
@@ -57,11 +91,13 @@ impl<'a> GetGuildPruneCount<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`GetGuildPruneCountError::DaysInvalid`] if the number of days
-    /// is 0.
+    /// Returns a [`GetGuildPruneCountErrorType::DaysInvalid`] error type if the
+    /// number of days is 0.
     pub fn days(mut self, days: u64) -> Result<Self, GetGuildPruneCountError> {
         if !validate::guild_prune_days(days) {
-            return Err(GetGuildPruneCountError::DaysInvalid);
+            return Err(GetGuildPruneCountError {
+                kind: GetGuildPruneCountErrorType::DaysInvalid,
+            });
         }
 
         self.fields.days.replace(days);

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -16,7 +16,7 @@ pub struct GetGuildPruneCountError {
 
 impl GetGuildPruneCountError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &GetGuildPruneCountErrorType {
         &self.kind
     }

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -1,4 +1,7 @@
-use crate::{request::prelude::*, Error};
+use crate::{
+    error::{Error, ErrorType},
+    request::prelude::*,
+};
 use hyper::StatusCode;
 use serde::Deserialize;
 use std::{
@@ -49,9 +52,10 @@ impl Future for GetGuildVanityUrl<'_> {
             if let Some(fut) = self.as_mut().fut.as_mut() {
                 let bytes = match fut.as_mut().poll(cx) {
                     Poll::Ready(Ok(bytes)) => bytes,
-                    Poll::Ready(Err(crate::Error::Response { status, .. }))
-                        if status == StatusCode::NOT_FOUND =>
-                    {
+                    Poll::Ready(Err(Error {
+                        cause: None,
+                        kind: ErrorType::Response { status, .. },
+                    })) if status == StatusCode::NOT_FOUND => {
                         return Poll::Ready(Ok(None));
                     }
                     Poll::Ready(Err(why)) => return Poll::Ready(Err(why)),
@@ -60,11 +64,11 @@ impl Future for GetGuildVanityUrl<'_> {
 
                 let mut bytes = bytes.as_ref().to_vec();
                 let vanity_url =
-                    crate::json_from_slice::<VanityUrl>(&mut bytes).map_err(|source| {
-                        Error::Parsing {
+                    crate::json_from_slice::<VanityUrl>(&mut bytes).map_err(|source| Error {
+                        cause: Some(Box::new(source)),
+                        kind: ErrorType::Parsing {
                             body: bytes.to_vec(),
-                            source,
-                        }
+                        },
                     })?;
 
                 return Poll::Ready(Ok(Some(vanity_url.code)));

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -53,8 +53,8 @@ impl Future for GetGuildVanityUrl<'_> {
                 let bytes = match fut.as_mut().poll(cx) {
                     Poll::Ready(Ok(bytes)) => bytes,
                     Poll::Ready(Err(Error {
-                        cause: None,
                         kind: ErrorType::Response { status, .. },
+                        source: None,
                     })) if status == StatusCode::NOT_FOUND => {
                         return Poll::Ready(Ok(None));
                     }
@@ -65,10 +65,10 @@ impl Future for GetGuildVanityUrl<'_> {
                 let mut bytes = bytes.as_ref().to_vec();
                 let vanity_url =
                     crate::json_from_slice::<VanityUrl>(&mut bytes).map_err(|source| Error {
-                        cause: Some(Box::new(source)),
                         kind: ErrorType::Parsing {
                             body: bytes.to_vec(),
                         },
+                        source: Some(Box::new(source)),
                     })?;
 
                 return Poll::Ready(Ok(Some(vanity_url.code)));

--- a/http/src/request/guild/integration/create_guild_integration.rs
+++ b/http/src/request/guild/integration/create_guild_integration.rs
@@ -44,7 +44,7 @@ impl<'a> CreateGuildIntegration<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::CreateGuildIntegration {
                     guild_id: self.guild_id.0,
@@ -52,7 +52,7 @@ impl<'a> CreateGuildIntegration<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::CreateGuildIntegration {
                     guild_id: self.guild_id.0,
                 },

--- a/http/src/request/guild/integration/update_guild_integration.rs
+++ b/http/src/request/guild/integration/update_guild_integration.rs
@@ -68,7 +68,7 @@ impl<'a> UpdateGuildIntegration<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::UpdateGuildIntegration {
                     guild_id: self.guild_id.0,
@@ -77,7 +77,7 @@ impl<'a> UpdateGuildIntegration<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::UpdateGuildIntegration {
                     guild_id: self.guild_id.0,
                     integration_id: self.integration_id.0,

--- a/http/src/request/guild/member/add_guild_member.rs
+++ b/http/src/request/guild/member/add_guild_member.rs
@@ -1,4 +1,7 @@
-use crate::request::prelude::*;
+use crate::{
+    error::{Error as HttpError, ErrorType},
+    request::prelude::*,
+};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -12,23 +15,56 @@ use twilight_model::{
 };
 
 /// Member cannot be added as configured.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub enum AddGuildMemberError {
-    /// Nickname is either empty or the length is more than 32 UTF-16
-    /// characters.
-    NicknameInvalid { nickname: String },
+#[derive(Debug)]
+pub struct AddGuildMemberError {
+    kind: AddGuildMemberErrorType,
+}
+
+impl AddGuildMemberError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &AddGuildMemberErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        AddGuildMemberErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
 }
 
 impl Display for AddGuildMemberError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NicknameInvalid { .. } => f.write_str("nickname length is invalid"),
+        match &self.kind {
+            AddGuildMemberErrorType::NicknameInvalid { .. } => {
+                f.write_str("nickname length is invalid")
+            }
         }
     }
 }
 
 impl Error for AddGuildMemberError {}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum AddGuildMemberErrorType {
+    /// Nickname is either empty or the length is more than 32 UTF-16
+    /// characters.
+    NicknameInvalid { nickname: String },
+}
 
 #[derive(Serialize)]
 struct AddGuildMemberFields {
@@ -55,11 +91,6 @@ pub struct AddGuildMember<'a> {
 ///
 /// An access token for the user with `guilds.join` scope is required. All other
 /// fields are optional. Refer to [the discord docs] for more information.
-///
-/// # Errors
-///
-/// Returns [`AddGuildMemberError::NicknameInvalid`] if the nickname is too
-/// short or too long.
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#add-guild-member
 impl<'a> AddGuildMember<'a> {
@@ -110,15 +141,17 @@ impl<'a> AddGuildMember<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`AddGuildMemberError::NicknameInvalid`] if the nickname is too
-    /// short or too long.
+    /// Returns an [`AddGuildMemberErrorType::NicknameInvalid`] error type if
+    /// the nickname is too short or too long.
     pub fn nick(self, nick: impl Into<String>) -> Result<Self, AddGuildMemberError> {
         self._nick(nick.into())
     }
 
     fn _nick(mut self, nick: String) -> Result<Self, AddGuildMemberError> {
         if !validate::nickname(&nick) {
-            return Err(AddGuildMemberError::NicknameInvalid { nickname: nick });
+            return Err(AddGuildMemberError {
+                kind: AddGuildMemberErrorType::NicknameInvalid { nickname: nick },
+            });
         }
 
         self.fields.nick.replace(nick);
@@ -135,7 +168,7 @@ impl<'a> AddGuildMember<'a> {
 
     fn start(&mut self) -> Result<()> {
         let request = Request::from((
-            crate::json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
             Route::AddGuildMember {
                 guild_id: self.guild_id.0,
                 user_id: self.user_id.0,
@@ -167,9 +200,9 @@ impl Future for AddGuildMember<'_> {
                 }
 
                 return Poll::Ready(crate::json_from_slice(&mut bytes).map(Some).map_err(
-                    |source| crate::Error::Parsing {
-                        body: bytes,
-                        source,
+                    |source| HttpError {
+                        cause: Some(Box::new(source)),
+                        kind: ErrorType::Parsing { body: bytes },
                     },
                 ));
             }

--- a/http/src/request/guild/member/add_guild_member.rs
+++ b/http/src/request/guild/member/add_guild_member.rs
@@ -29,8 +29,8 @@ impl AddGuildMemberError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 
@@ -201,8 +201,8 @@ impl Future for AddGuildMember<'_> {
 
                 return Poll::Ready(crate::json_from_slice(&mut bytes).map(Some).map_err(
                     |source| HttpError {
-                        cause: Some(Box::new(source)),
                         kind: ErrorType::Parsing { body: bytes },
+                        source: Some(Box::new(source)),
                     },
                 ));
             }

--- a/http/src/request/guild/member/add_guild_member.rs
+++ b/http/src/request/guild/member/add_guild_member.rs
@@ -22,7 +22,7 @@ pub struct AddGuildMemberError {
 
 impl AddGuildMemberError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &AddGuildMemberErrorType {
         &self.kind
     }

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -26,7 +26,7 @@ pub struct GetGuildMembersError {
 
 impl GetGuildMembersError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &GetGuildMembersErrorType {
         &self.kind
     }

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -19,25 +19,57 @@ use serde_json::Value;
 use simd_json::value::OwnedValue as Value;
 
 /// The error created when the members can not be fetched as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct GetGuildMembersError {
+    kind: GetGuildMembersErrorType,
+}
+
+impl GetGuildMembersError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &GetGuildMembersErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        GetGuildMembersErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for GetGuildMembersError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            GetGuildMembersErrorType::LimitInvalid { .. } => f.write_str("the limit is invalid"),
+        }
+    }
+}
+
+impl Error for GetGuildMembersError {}
+
+/// Type of [`GetGuildMembersError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum GetGuildMembersError {
+pub enum GetGuildMembersErrorType {
     /// The limit is either 0 or more than 1000.
     LimitInvalid {
         /// Provided limit.
         limit: u64,
     },
 }
-
-impl Display for GetGuildMembersError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
-        }
-    }
-}
-
-impl Error for GetGuildMembersError {}
 
 #[derive(Default)]
 struct GetGuildMembersFields {
@@ -102,11 +134,13 @@ impl<'a> GetGuildMembers<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`GetGuildMembersError::LimitInvalid`] if the limit is 0 or
-    /// greater than 1000.
+    /// Returns a [`GetGuildMembersErrorType::LimitInvalid`] error type if the
+    /// limit is 0 or greater than 1000.
     pub fn limit(mut self, limit: u64) -> Result<Self, GetGuildMembersError> {
         if !validate::get_guild_members_limit(limit) {
-            return Err(GetGuildMembersError::LimitInvalid { limit });
+            return Err(GetGuildMembersError {
+                kind: GetGuildMembersErrorType::LimitInvalid { limit },
+            });
         }
 
         self.fields.limit.replace(limit);
@@ -152,11 +186,16 @@ impl Future for GetGuildMembers<'_> {
                 let mut members = Vec::new();
 
                 let mut bytes = bytes.as_ref().to_vec();
-                let values = crate::json_from_slice::<Vec<Value>>(&mut bytes)?;
+                let values =
+                    crate::json_from_slice::<Vec<Value>>(&mut bytes).map_err(HttpError::json)?;
 
                 for value in values {
                     let member_deserializer = MemberDeserializer::new(self.guild_id);
-                    members.push(member_deserializer.deserialize(value)?);
+                    members.push(
+                        member_deserializer
+                            .deserialize(value)
+                            .map_err(HttpError::json)?,
+                    );
                 }
 
                 Poll::Ready(Ok(members))

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -33,8 +33,8 @@ impl GetGuildMembersError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -100,10 +100,6 @@ struct GetGuildMembersFields {
 /// let members = client.guild_members(guild_id).after(user_id).await?;
 /// # Ok(()) }
 /// ```
-///
-/// # Errors
-///
-/// Returns [`GetGuildMembersError::LimitInvalid`] if the limit is invalid.
 pub struct GetGuildMembers<'a> {
     fields: GetGuildMembersFields,
     fut: Option<Pending<'a, Bytes>>,

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -59,8 +59,8 @@ impl Future for GetMember<'_> {
                 let bytes = match fut.as_mut().poll(cx) {
                     Poll::Ready(Ok(bytes)) => bytes,
                     Poll::Ready(Err(Error {
-                        cause: None,
                         kind: ErrorType::Response { status, .. },
+                        source: None,
                     })) if status == StatusCode::NOT_FOUND => {
                         return Poll::Ready(Ok(None));
                     }

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -60,7 +60,7 @@ impl Future for GetMember<'_> {
                     Poll::Ready(Ok(bytes)) => bytes,
                     Poll::Ready(Err(Error {
                         kind: ErrorType::Response { status, .. },
-                        source: None,
+                        ..
                     })) if status == StatusCode::NOT_FOUND => {
                         return Poll::Ready(Ok(None));
                     }

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -1,4 +1,7 @@
-use crate::request::prelude::*;
+use crate::{
+    error::{Error, ErrorType},
+    request::prelude::*,
+};
 use hyper::StatusCode;
 use serde::de::DeserializeSeed;
 use std::{
@@ -55,9 +58,10 @@ impl Future for GetMember<'_> {
             if let Some(fut) = self.as_mut().fut.as_mut() {
                 let bytes = match fut.as_mut().poll(cx) {
                     Poll::Ready(Ok(bytes)) => bytes,
-                    Poll::Ready(Err(crate::Error::Response { status, .. }))
-                        if status == StatusCode::NOT_FOUND =>
-                    {
+                    Poll::Ready(Err(Error {
+                        cause: None,
+                        kind: ErrorType::Response { status, .. },
+                    })) if status == StatusCode::NOT_FOUND => {
                         return Poll::Ready(Ok(None));
                     }
                     Poll::Ready(Err(why)) => return Poll::Ready(Err(why)),
@@ -65,10 +69,12 @@ impl Future for GetMember<'_> {
                 };
 
                 let mut bytes = bytes.as_ref().to_vec();
-                let value = crate::json_from_slice::<Value>(&mut bytes)?;
+                let value = crate::json_from_slice::<Value>(&mut bytes).map_err(HttpError::json)?;
 
                 let member_deserializer = MemberDeserializer::new(self.guild_id);
-                let member = member_deserializer.deserialize(value)?;
+                let member = member_deserializer
+                    .deserialize(value)
+                    .map_err(HttpError::json)?;
 
                 return Poll::Ready(Ok(Some(member)));
             }

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -6,22 +6,56 @@ use std::{
 use twilight_model::id::{ChannelId, GuildId, RoleId, UserId};
 
 /// The error created when the member can not be updated as configured.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub enum UpdateGuildMemberError {
-    /// The nickname is either empty or the length is more than 32 UTF-16 characters.
-    NicknameInvalid { nickname: String },
+#[derive(Debug)]
+pub struct UpdateGuildMemberError {
+    kind: UpdateGuildMemberErrorType,
+}
+
+impl UpdateGuildMemberError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &UpdateGuildMemberErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        UpdateGuildMemberErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
 }
 
 impl Display for UpdateGuildMemberError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NicknameInvalid { .. } => f.write_str("the nickname length is invalid"),
+        match &self.kind {
+            UpdateGuildMemberErrorType::NicknameInvalid { .. } => {
+                f.write_str("the nickname length is invalid")
+            }
         }
     }
 }
 
 impl Error for UpdateGuildMemberError {}
+
+/// Type of [`UpdateGuildMemberError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum UpdateGuildMemberErrorType {
+    /// The nickname is either empty or the length is more than 32 UTF-16 characters.
+    NicknameInvalid { nickname: String },
+}
 
 #[derive(Default, Serialize)]
 struct UpdateGuildMemberFields {
@@ -97,8 +131,8 @@ impl<'a> UpdateGuildMember<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`UpdateGuildMemberError::NicknameInvalid`] if the nickname length is too short or
-    /// too long.
+    /// Returns an [`UpdateGuildMemberErrorType::NicknameInvalid`] error type if
+    /// the nickname length is too short or too long.
     pub fn nick(self, nick: impl Into<Option<String>>) -> Result<Self, UpdateGuildMemberError> {
         self._nick(nick.into())
     }
@@ -106,8 +140,10 @@ impl<'a> UpdateGuildMember<'a> {
     fn _nick(mut self, nick: Option<String>) -> Result<Self, UpdateGuildMemberError> {
         if let Some(nick) = nick.as_ref() {
             if !validate::nickname(&nick) {
-                return Err(UpdateGuildMemberError::NicknameInvalid {
-                    nickname: nick.to_owned(),
+                return Err(UpdateGuildMemberError {
+                    kind: UpdateGuildMemberErrorType::NicknameInvalid {
+                        nickname: nick.to_owned(),
+                    },
                 });
             }
         }
@@ -128,7 +164,7 @@ impl<'a> UpdateGuildMember<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::UpdateMember {
                     guild_id: self.guild_id.0,
@@ -137,7 +173,7 @@ impl<'a> UpdateGuildMember<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::UpdateMember {
                     guild_id: self.guild_id.0,
                     user_id: self.user_id.0,

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -77,11 +77,6 @@ struct UpdateGuildMemberFields {
 ///
 /// All fields are optional. Refer to [the discord docs] for more information.
 ///
-/// # Errors
-///
-/// Returns [`UpdateGuildMemberError::NicknameInvalid`] if the nickname length is too short or too
-/// long.
-///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild-member
 pub struct UpdateGuildMember<'a> {
     fields: UpdateGuildMemberFields,

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -20,8 +20,8 @@ impl UpdateGuildMemberError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -13,7 +13,7 @@ pub struct UpdateGuildMemberError {
 
 impl UpdateGuildMemberError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &UpdateGuildMemberErrorType {
         &self.kind
     }

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -97,7 +97,7 @@ impl<'a> CreateRole<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::CreateRole {
                     guild_id: self.guild_id.0,
@@ -105,7 +105,7 @@ impl<'a> CreateRole<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::CreateRole {
                     guild_id: self.guild_id.0,
                 },

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -81,7 +81,7 @@ impl<'a> UpdateRole<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::UpdateRole {
                     guild_id: self.guild_id.0,
@@ -90,7 +90,7 @@ impl<'a> UpdateRole<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::UpdateRole {
                     guild_id: self.guild_id.0,
                     role_id: self.role_id.0,

--- a/http/src/request/guild/role/update_role_positions.rs
+++ b/http/src/request/guild/role/update_role_positions.rs
@@ -30,7 +30,7 @@ impl<'a> UpdateRolePositions<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.roles)?,
+            crate::json_to_vec(&self.roles).map_err(HttpError::json)?,
             Route::UpdateRolePositions {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/guild/update_current_user_nick.rs
+++ b/http/src/request/guild/update_current_user_nick.rs
@@ -26,7 +26,7 @@ impl<'a> UpdateCurrentUserNick<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.verify(Request::from((
-            crate::json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
             Route::UpdateNickname {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -11,9 +11,46 @@ use twilight_model::{
 };
 
 /// The error returned when the guild can not be updated as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct UpdateGuildError {
+    kind: UpdateGuildErrorType,
+}
+
+impl UpdateGuildError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &UpdateGuildErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (UpdateGuildErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
+}
+
+impl Display for UpdateGuildError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            UpdateGuildErrorType::NameInvalid { .. } => f.write_str("the name's length is invalid"),
+        }
+    }
+}
+
+impl Error for UpdateGuildError {}
+
+/// Type of [`UpdateGuildError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum UpdateGuildError {
+pub enum UpdateGuildErrorType {
     /// The name length is either fewer than 2 UTF-16 characters or more than 100 UTF-16
     /// characters.
     NameInvalid {
@@ -21,16 +58,6 @@ pub enum UpdateGuildError {
         name: String,
     },
 }
-
-impl Display for UpdateGuildError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NameInvalid { .. } => f.write_str("the name's length is invalid"),
-        }
-    }
-}
-
-impl Error for UpdateGuildError {}
 
 #[derive(Default, Serialize)]
 struct UpdateGuildFields {
@@ -173,17 +200,19 @@ impl<'a> UpdateGuild<'a> {
     /// The minimum length is 2 UTF-16 characters and the maximum is 100 UTF-16
     /// characters.
     ///
-    /// # Erroors
+    /// # Errors
     ///
-    /// Returns [`UpdateGuildError::NameInvalid`] if the name length is too
-    /// short or too long.
+    /// Returns an [`UpdateGuildErrorType::NameInvalid`] error type if the name
+    /// length is too short or too long.
     pub fn name(self, name: impl Into<String>) -> Result<Self, UpdateGuildError> {
         self._name(name.into())
     }
 
     fn _name(mut self, name: String) -> Result<Self, UpdateGuildError> {
         if !validate::guild_name(&name) {
-            return Err(UpdateGuildError::NameInvalid { name });
+            return Err(UpdateGuildError {
+                kind: UpdateGuildErrorType::NameInvalid { name },
+            });
         }
 
         self.fields.name.replace(name);
@@ -284,7 +313,7 @@ impl<'a> UpdateGuild<'a> {
         let request = if let Some(reason) = &self.reason {
             let headers = audit_header(&reason)?;
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 headers,
                 Route::UpdateGuild {
                     guild_id: self.guild_id.0,
@@ -292,7 +321,7 @@ impl<'a> UpdateGuild<'a> {
             ))
         } else {
             Request::from((
-                crate::json_to_vec(&self.fields)?,
+                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
                 Route::UpdateGuild {
                     guild_id: self.guild_id.0,
                 },

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -25,8 +25,8 @@ impl UpdateGuildError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -18,7 +18,7 @@ pub struct UpdateGuildError {
 
 impl UpdateGuildError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &UpdateGuildErrorType {
         &self.kind
     }

--- a/http/src/request/guild/update_guild_channel_positions.rs
+++ b/http/src/request/guild/update_guild_channel_positions.rs
@@ -37,7 +37,7 @@ impl<'a> UpdateGuildChannelPositions<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.verify(Request::from((
-            crate::json_to_vec(&self.positions)?,
+            crate::json_to_vec(&self.positions).map_err(HttpError::json)?,
             Route::UpdateGuildChannels {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/guild/update_guild_widget.rs
+++ b/http/src/request/guild/update_guild_widget.rs
@@ -47,7 +47,7 @@ impl<'a> UpdateGuildWidget<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
             Route::UpdateGuildWidget {
                 guild_id: self.guild_id.0,
             },

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -47,10 +47,10 @@ macro_rules! poll_req {
                         let mut bytes = bytes.as_ref().to_vec();
                         return Poll::Ready(json_from_slice(&mut bytes).map(Some).map_err(
                             |source| crate::Error {
-                                cause: Some(Box::new(source)),
                                 kind: crate::error::ErrorType::Parsing {
                                     body: bytes.to_vec(),
                                 },
+                                source: Some(Box::new(source)),
                             },
                         ));
                     }
@@ -123,10 +123,10 @@ pub(crate) fn audit_header(reason: &str) -> Result<HeaderMap<HeaderValue>> {
     let mut headers = HeaderMap::new();
     let encoded_reason = utf8_percent_encode(reason, NON_ALPHANUMERIC).to_string();
     let header_value = HeaderValue::from_str(&encoded_reason).map_err(|e| Error {
-        cause: Some(Box::new(e)),
         kind: ErrorType::CreatingHeader {
             name: encoded_reason.clone(),
         },
+        source: Some(Box::new(e)),
     })?;
 
     headers.insert(header_name, header_value);

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -35,8 +35,8 @@ macro_rules! poll_req {
                     if let Some(fut) = self.as_mut().fut.as_mut() {
                         let bytes = match fut.as_mut().poll(cx) {
                             Poll::Ready(Ok(bytes)) => bytes,
-                            Poll::Ready(Err(crate::Error::Response { status, .. }))
-                                if status == hyper::StatusCode::NOT_FOUND =>
+                            Poll::Ready(Err(e))
+                                if matches!(e.kind, crate::error::ErrorType::Response { status, .. } if status == hyper::StatusCode::NOT_FOUND) =>
                             {
                                 return Poll::Ready(Ok(None));
                             }
@@ -46,9 +46,11 @@ macro_rules! poll_req {
 
                         let mut bytes = bytes.as_ref().to_vec();
                         return Poll::Ready(json_from_slice(&mut bytes).map(Some).map_err(
-                            |source| crate::Error::Parsing {
-                                body: bytes.to_vec(),
-                                source,
+                            |source| crate::Error {
+                                cause: Some(Box::new(source)),
+                                kind: crate::error::ErrorType::Parsing {
+                                    body: bytes.to_vec(),
+                                },
                             },
                         ));
                     }
@@ -85,7 +87,7 @@ pub use self::{
 
 use self::multipart::Form;
 use crate::{
-    error::{Error, Result},
+    error::{Error, ErrorType, Result},
     routing::{Path, Route},
 };
 use bytes::Bytes;
@@ -120,11 +122,12 @@ pub(crate) fn audit_header(reason: &str) -> Result<HeaderMap<HeaderValue>> {
     let header_name = HeaderName::from_static("x-audit-log-reason");
     let mut headers = HeaderMap::new();
     let encoded_reason = utf8_percent_encode(reason, NON_ALPHANUMERIC).to_string();
-    let header_value =
-        HeaderValue::from_str(&encoded_reason).map_err(|e| Error::CreatingHeader {
+    let header_value = HeaderValue::from_str(&encoded_reason).map_err(|e| Error {
+        cause: Some(Box::new(e)),
+        kind: ErrorType::CreatingHeader {
             name: encoded_reason.clone(),
-            source: e,
-        })?;
+        },
+    })?;
 
     headers.insert(header_name, header_value);
 

--- a/http/src/request/prelude.rs
+++ b/http/src/request/prelude.rs
@@ -8,5 +8,9 @@ pub use super::{
     guild::{ban::*, emoji::*, integration::*, member::*, role::*, *},
     user::*,
 };
-pub(super) use crate::{client::Client, error::Result, routing::Route};
+pub(super) use crate::{
+    client::Client,
+    error::{Error as HttpError, Result},
+    routing::Route,
+};
 pub(super) use serde::Serialize;

--- a/http/src/request/user/create_private_channel.rs
+++ b/http/src/request/user/create_private_channel.rs
@@ -25,7 +25,7 @@ impl<'a> CreatePrivateChannel<'a> {
     }
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
             Route::CreatePrivateChannel,
         )))));
 

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -13,7 +13,7 @@ pub struct GetCurrentUserGuildsError {
 
 impl GetCurrentUserGuildsError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &GetCurrentUserGuildsErrorType {
         &self.kind
     }

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -20,8 +20,8 @@ impl GetCurrentUserGuildsError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -6,25 +6,59 @@ use std::{
 use twilight_model::{id::GuildId, user::CurrentUserGuild};
 
 /// The error created when the current guilds can not be retrieved as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct GetCurrentUserGuildsError {
+    kind: GetCurrentUserGuildsErrorType,
+}
+
+impl GetCurrentUserGuildsError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &GetCurrentUserGuildsErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        GetCurrentUserGuildsErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for GetCurrentUserGuildsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            GetCurrentUserGuildsErrorType::LimitInvalid { .. } => {
+                f.write_str("the limit is invalid")
+            }
+        }
+    }
+}
+
+impl Error for GetCurrentUserGuildsError {}
+
+/// Type of [`GetCurrentUserGuildsError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum GetCurrentUserGuildsError {
+pub enum GetCurrentUserGuildsErrorType {
     /// The maximum number of guilds to retrieve is 0 or more than 100.
     LimitInvalid {
         /// Provided maximum number of guilds to retrieve.
         limit: u64,
     },
 }
-
-impl Display for GetCurrentUserGuildsError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
-        }
-    }
-}
-
-impl Error for GetCurrentUserGuildsError {}
 
 struct GetCurrentUserGuildsFields {
     after: Option<GuildId>,
@@ -95,13 +129,15 @@ impl<'a> GetCurrentUserGuilds<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`GetCurrentUserGuildsError::LimitInvalid`] if the amount is greater
-    /// than 100.
+    /// Returns a [`GetCurrentUserGuildsErrorType::LimitInvalid`] error type if
+    /// the amount is greater than 100.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/user#get-current-user-guilds-query-string-params
     pub fn limit(mut self, limit: u64) -> Result<Self, GetCurrentUserGuildsError> {
         if !validate::get_current_user_guilds_limit(limit) {
-            return Err(GetCurrentUserGuildsError::LimitInvalid { limit });
+            return Err(GetCurrentUserGuildsError {
+                kind: GetCurrentUserGuildsErrorType::LimitInvalid { limit },
+            });
         }
 
         self.fields.limit.replace(limit);

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -49,7 +49,7 @@ impl Display for UpdateCurrentUserError {
 
 impl Error for UpdateCurrentUserError {}
 
-/// Type of [`UpdateCurrentUserEror`] that occurred.
+/// Type of [`UpdateCurrentUserError`] that occurred.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum UpdateCurrentUserErrorType {

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -6,9 +6,53 @@ use std::{
 use twilight_model::user::User;
 
 /// The error created when the user can not be updated as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct UpdateCurrentUserError {
+    kind: UpdateCurrentUserErrorType,
+}
+
+impl UpdateCurrentUserError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &UpdateCurrentUserErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        UpdateCurrentUserErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for UpdateCurrentUserError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            UpdateCurrentUserErrorType::UsernameInvalid { .. } => {
+                f.write_str("the username length is invalid")
+            }
+        }
+    }
+}
+
+impl Error for UpdateCurrentUserError {}
+
+/// Type of [`UpdateCurrentUserEror`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum UpdateCurrentUserError {
+pub enum UpdateCurrentUserErrorType {
     /// The length of the username is either fewer than 2 UTF-16 characters or more than 32 UTF-16
     /// characters.
     UsernameInvalid {
@@ -16,16 +60,6 @@ pub enum UpdateCurrentUserError {
         username: String,
     },
 }
-
-impl Display for UpdateCurrentUserError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::UsernameInvalid { .. } => f.write_str("the username length is invalid"),
-        }
-    }
-}
-
-impl Error for UpdateCurrentUserError {}
 
 #[derive(Default, Serialize)]
 struct UpdateCurrentUserFields {
@@ -74,15 +108,17 @@ impl<'a> UpdateCurrentUser<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`UpdateCurrentUserError::UsernameInvalid`] if the username length is too short or
-    /// too long.
+    /// Returns an [`UpdateCurrentUserErrorType::UsernameInvalid`] error type if
+    /// the username length is too short or too long.
     pub fn username(self, username: impl Into<String>) -> Result<Self, UpdateCurrentUserError> {
         self._username(username.into())
     }
 
     fn _username(mut self, username: String) -> Result<Self, UpdateCurrentUserError> {
         if !validate::username(&username) {
-            return Err(UpdateCurrentUserError::UsernameInvalid { username });
+            return Err(UpdateCurrentUserError {
+                kind: UpdateCurrentUserErrorType::UsernameInvalid { username },
+            });
         }
 
         self.fields.username.replace(username);
@@ -92,7 +128,7 @@ impl<'a> UpdateCurrentUser<'a> {
 
     fn start(&mut self) -> Result<()> {
         self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields)?,
+            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
             Route::UpdateCurrentUser,
         )))));
 

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -13,7 +13,7 @@ pub struct UpdateCurrentUserError {
 
 impl UpdateCurrentUserError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &UpdateCurrentUserErrorType {
         &self.kind
     }

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -20,8 +20,8 @@ impl UpdateCurrentUserError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -52,8 +52,8 @@ impl EmbedValidationError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -45,7 +45,7 @@ impl EmbedValidationError {
     pub const TITLE_LENGTH: usize = 256;
 
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &EmbedValidationErrorType {
         &self.kind
     }

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -14,9 +14,122 @@ use twilight_model::channel::embed::Embed;
 /// Referenced values are used from [the Discord docs][docs].
 ///
 /// [docs]: https://discord.com/developers/docs/resources/channel#embed-limits
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct EmbedValidationError {
+    kind: EmbedValidationErrorType,
+}
+
+impl EmbedValidationError {
+    /// The maximum embed author name length in codepoints.
+    pub const AUTHOR_NAME_LENGTH: usize = 256;
+
+    /// The maximum embed description length in codepoints.
+    pub const DESCRIPTION_LENGTH: usize = 2048;
+
+    /// The maximum combined embed length in codepoints.
+    pub const EMBED_TOTAL_LENGTH: usize = 6000;
+
+    /// The maximum number of fields in an embed.
+    pub const FIELD_COUNT: usize = 25;
+
+    /// The maximum length of an embed field name in codepoints.
+    pub const FIELD_NAME_LENGTH: usize = 256;
+
+    /// The maximum length of an embed field value in codepoints.
+    pub const FIELD_VALUE_LENGTH: usize = 1024;
+
+    /// The maximum embed footer length in codepoints.
+    pub const FOOTER_TEXT_LENGTH: usize = 2048;
+
+    /// The maximum embed title length in codepoints.
+    pub const TITLE_LENGTH: usize = 256;
+
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &EmbedValidationErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        EmbedValidationErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for EmbedValidationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            EmbedValidationErrorType::AuthorNameTooLarge { chars } => write!(
+                f,
+                "the author name is {} characters long, but the max is {}",
+                chars,
+                Self::AUTHOR_NAME_LENGTH
+            ),
+            EmbedValidationErrorType::DescriptionTooLarge { chars } => write!(
+                f,
+                "the description is {} characters long, but the max is {}",
+                chars,
+                Self::DESCRIPTION_LENGTH
+            ),
+            EmbedValidationErrorType::EmbedTooLarge { chars } => write!(
+                f,
+                "the combined total length of the embed is {} characters long, but the max is {}",
+                chars,
+                Self::EMBED_TOTAL_LENGTH
+            ),
+            EmbedValidationErrorType::FieldNameTooLarge { chars } => write!(
+                f,
+                "a field name is {} characters long, but the max is {}",
+                chars,
+                Self::FIELD_NAME_LENGTH
+            ),
+            EmbedValidationErrorType::FieldValueTooLarge { chars } => write!(
+                f,
+                "a field value is {} characters long, but the max is {}",
+                chars,
+                Self::FIELD_VALUE_LENGTH
+            ),
+            EmbedValidationErrorType::FooterTextTooLarge { chars } => write!(
+                f,
+                "the footer's text is {} characters long, but the max is {}",
+                chars,
+                Self::FOOTER_TEXT_LENGTH
+            ),
+            EmbedValidationErrorType::TitleTooLarge { chars } => write!(
+                f,
+                "the title's length is {} characters long, but the max is {}",
+                chars,
+                Self::TITLE_LENGTH
+            ),
+            EmbedValidationErrorType::TooManyFields { amount } => write!(
+                f,
+                "there are {} fields, but the maximum amount is {}",
+                amount,
+                Self::FIELD_COUNT
+            ),
+        }
+    }
+}
+
+impl Error for EmbedValidationError {}
+
+/// Type of [`EmbedValidationError`] that occurred.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum EmbedValidationError {
+pub enum EmbedValidationErrorType {
     /// The embed author's name is larger than
     /// [the maximum][`AUTHOR_NAME_LENGTH`].
     ///
@@ -80,89 +193,6 @@ pub enum EmbedValidationError {
     },
 }
 
-impl EmbedValidationError {
-    /// The maximum embed author name length in codepoints.
-    pub const AUTHOR_NAME_LENGTH: usize = 256;
-
-    /// The maximum embed description length in codepoints.
-    pub const DESCRIPTION_LENGTH: usize = 2048;
-
-    /// The maximum combined embed length in codepoints.
-    pub const EMBED_TOTAL_LENGTH: usize = 6000;
-
-    /// The maximum number of fields in an embed.
-    pub const FIELD_COUNT: usize = 25;
-
-    /// The maximum length of an embed field name in codepoints.
-    pub const FIELD_NAME_LENGTH: usize = 256;
-
-    /// The maximum length of an embed field value in codepoints.
-    pub const FIELD_VALUE_LENGTH: usize = 1024;
-
-    /// The maximum embed footer length in codepoints.
-    pub const FOOTER_TEXT_LENGTH: usize = 2048;
-
-    /// The maximum embed title length in codepoints.
-    pub const TITLE_LENGTH: usize = 256;
-}
-
-impl Display for EmbedValidationError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::AuthorNameTooLarge { chars } => write!(
-                f,
-                "the author name is {} characters long, but the max is {}",
-                chars,
-                Self::AUTHOR_NAME_LENGTH
-            ),
-            Self::DescriptionTooLarge { chars } => write!(
-                f,
-                "the description is {} characters long, but the max is {}",
-                chars,
-                Self::DESCRIPTION_LENGTH
-            ),
-            Self::EmbedTooLarge { chars } => write!(
-                f,
-                "the combined total length of the embed is {} characters long, but the max is {}",
-                chars,
-                Self::EMBED_TOTAL_LENGTH
-            ),
-            Self::FieldNameTooLarge { chars } => write!(
-                f,
-                "a field name is {} characters long, but the max is {}",
-                chars,
-                Self::FIELD_NAME_LENGTH
-            ),
-            Self::FieldValueTooLarge { chars } => write!(
-                f,
-                "a field value is {} characters long, but the max is {}",
-                chars,
-                Self::FIELD_VALUE_LENGTH
-            ),
-            Self::FooterTextTooLarge { chars } => write!(
-                f,
-                "the footer's text is {} characters long, but the max is {}",
-                chars,
-                Self::FOOTER_TEXT_LENGTH
-            ),
-            Self::TitleTooLarge { chars } => write!(
-                f,
-                "the title's length is {} characters long, but the max is {}",
-                chars,
-                Self::TITLE_LENGTH
-            ),
-            Self::TooManyFields { amount } => write!(
-                f,
-                "there are {} fields, but the maximum amount is {}",
-                amount,
-                Self::FIELD_COUNT
-            ),
-        }
-    }
-}
-
-impl Error for EmbedValidationError {}
-
 pub fn ban_delete_message_days(value: u64) -> bool {
     // <https://discordapp.com/developers/docs/resources/guild#create-guild-ban-query-string-params>
     value <= 7
@@ -192,8 +222,10 @@ pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
     let mut total = 0;
 
     if embed.fields.len() > EmbedValidationError::FIELD_COUNT {
-        return Err(EmbedValidationError::TooManyFields {
-            amount: embed.fields.len(),
+        return Err(EmbedValidationError {
+            kind: EmbedValidationErrorType::TooManyFields {
+                amount: embed.fields.len(),
+            },
         });
     }
 
@@ -205,7 +237,9 @@ pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
         let chars = name.chars().count();
 
         if chars > EmbedValidationError::AUTHOR_NAME_LENGTH {
-            return Err(EmbedValidationError::AuthorNameTooLarge { chars });
+            return Err(EmbedValidationError {
+                kind: EmbedValidationErrorType::AuthorNameTooLarge { chars },
+            });
         }
 
         total += chars;
@@ -215,7 +249,9 @@ pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
         let chars = description.chars().count();
 
         if chars > EmbedValidationError::DESCRIPTION_LENGTH {
-            return Err(EmbedValidationError::DescriptionTooLarge { chars });
+            return Err(EmbedValidationError {
+                kind: EmbedValidationErrorType::DescriptionTooLarge { chars },
+            });
         }
 
         total += chars;
@@ -225,7 +261,9 @@ pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
         let chars = footer.text.chars().count();
 
         if chars > EmbedValidationError::FOOTER_TEXT_LENGTH {
-            return Err(EmbedValidationError::FooterTextTooLarge { chars });
+            return Err(EmbedValidationError {
+                kind: EmbedValidationErrorType::FooterTextTooLarge { chars },
+            });
         }
 
         total += chars;
@@ -235,13 +273,17 @@ pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
         let name_chars = field.name.chars().count();
 
         if name_chars > EmbedValidationError::FIELD_NAME_LENGTH {
-            return Err(EmbedValidationError::FieldNameTooLarge { chars: name_chars });
+            return Err(EmbedValidationError {
+                kind: EmbedValidationErrorType::FieldNameTooLarge { chars: name_chars },
+            });
         }
 
         let value_chars = field.value.chars().count();
 
         if value_chars > EmbedValidationError::FIELD_VALUE_LENGTH {
-            return Err(EmbedValidationError::FieldValueTooLarge { chars: value_chars });
+            return Err(EmbedValidationError {
+                kind: EmbedValidationErrorType::FieldValueTooLarge { chars: value_chars },
+            });
         }
 
         total += name_chars + value_chars;
@@ -251,14 +293,18 @@ pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
         let chars = title.chars().count();
 
         if chars > EmbedValidationError::TITLE_LENGTH {
-            return Err(EmbedValidationError::TitleTooLarge { chars });
+            return Err(EmbedValidationError {
+                kind: EmbedValidationErrorType::TitleTooLarge { chars },
+            });
         }
 
         total += chars;
     }
 
     if total > EmbedValidationError::EMBED_TOTAL_LENGTH {
-        return Err(EmbedValidationError::EmbedTooLarge { chars: total });
+        return Err(EmbedValidationError {
+            kind: EmbedValidationErrorType::EmbedTooLarge { chars: total },
+        });
     }
 
     Ok(())
@@ -423,8 +469,8 @@ mod tests {
             url: None,
         });
         assert!(matches!(
-            super::embed(&embed),
-            Err(EmbedValidationError::AuthorNameTooLarge { chars: 257 })
+            super::embed(&embed).unwrap_err().kind(),
+            EmbedValidationErrorType::AuthorNameTooLarge { chars: 257 }
         ));
     }
 
@@ -436,8 +482,8 @@ mod tests {
 
         embed.description.replace(str::repeat("a", 2049));
         assert!(matches!(
-            super::embed(&embed),
-            Err(EmbedValidationError::DescriptionTooLarge { chars: 2049 })
+            super::embed(&embed).unwrap_err().kind(),
+            EmbedValidationErrorType::DescriptionTooLarge { chars: 2049 }
         ));
     }
 
@@ -454,8 +500,8 @@ mod tests {
         }
 
         assert!(matches!(
-            super::embed(&embed),
-            Err(EmbedValidationError::TooManyFields { amount: 26 })
+            super::embed(&embed).unwrap_err().kind(),
+            EmbedValidationErrorType::TooManyFields { amount: 26 }
         ));
     }
 
@@ -475,8 +521,8 @@ mod tests {
             value: "a".to_owned(),
         });
         assert!(matches!(
-            super::embed(&embed),
-            Err(EmbedValidationError::FieldNameTooLarge { chars: 257 })
+            super::embed(&embed).unwrap_err().kind(),
+            EmbedValidationErrorType::FieldNameTooLarge { chars: 257 }
         ));
     }
 
@@ -496,8 +542,8 @@ mod tests {
             value: str::repeat("a", 1025),
         });
         assert!(matches!(
-            super::embed(&embed),
-            Err(EmbedValidationError::FieldValueTooLarge { chars: 1025 })
+            super::embed(&embed).unwrap_err().kind(),
+            EmbedValidationErrorType::FieldValueTooLarge { chars: 1025 }
         ));
     }
 
@@ -517,8 +563,8 @@ mod tests {
             text: str::repeat("a", 2049),
         });
         assert!(matches!(
-            super::embed(&embed),
-            Err(EmbedValidationError::FooterTextTooLarge { chars: 2049 })
+            super::embed(&embed).unwrap_err().kind(),
+            EmbedValidationErrorType::FooterTextTooLarge { chars: 2049 }
         ));
     }
 
@@ -530,8 +576,8 @@ mod tests {
 
         embed.title.replace(str::repeat("a", 257));
         assert!(matches!(
-            super::embed(&embed),
-            Err(EmbedValidationError::TitleTooLarge { chars: 257 })
+            super::embed(&embed).unwrap_err().kind(),
+            EmbedValidationErrorType::TitleTooLarge { chars: 257 }
         ));
     }
 
@@ -559,8 +605,8 @@ mod tests {
         });
 
         assert!(matches!(
-            super::embed(&embed),
-            Err(EmbedValidationError::EmbedTooLarge { chars: 6304 })
+            super::embed(&embed).unwrap_err().kind(),
+            EmbedValidationErrorType::EmbedTooLarge { chars: 6304 }
         ));
     }
 

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -15,7 +15,7 @@ pub struct PathParseError {
 
 impl PathParseError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &PathParseErrorType {
         &self.kind
     }

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -2,20 +2,64 @@ use hyper::Method;
 use std::{
     borrow::Cow,
     convert::TryFrom,
-    error::Error as StdError,
+    error::Error,
     fmt::{Display, Formatter, Result as FmtResult, Write},
-    num::ParseIntError,
     str::FromStr,
 };
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
+pub struct PathParseError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: PathParseErrorType,
+}
+
+impl PathParseError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &PathParseErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (PathParseErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, self.cause)
+    }
+}
+
+impl Display for PathParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            PathParseErrorType::IntegerParsing { .. } => {
+                f.write_str("An ID in a segment was invalid")
+            }
+            PathParseErrorType::MessageIdWithoutMethod { .. } => {
+                f.write_str("A message path was detected but the method wasn't given")
+            }
+            PathParseErrorType::NoMatch => f.write_str("There was no matched path"),
+        }
+    }
+}
+
+impl Error for PathParseError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
+    }
+}
+
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum PathParseError {
+pub enum PathParseErrorType {
     /// The ID couldn't be parsed as an integer.
-    IntegerParsing {
-        /// Additional information about the parsing failure.
-        source: ParseIntError,
-    },
+    IntegerParsing,
     /// When parsing into a [`Path::ChannelsIdMessagesId`] variant, the method
     /// must also be specified via its `TryFrom` impl.
     MessageIdWithoutMethod {
@@ -24,33 +68,6 @@ pub enum PathParseError {
     },
     /// A static path for the provided path string wasn't found.
     NoMatch,
-}
-
-impl From<ParseIntError> for PathParseError {
-    fn from(source: ParseIntError) -> Self {
-        Self::IntegerParsing { source }
-    }
-}
-
-impl Display for PathParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::IntegerParsing { .. } => f.write_str("An ID in a segment was invalid"),
-            Self::MessageIdWithoutMethod { .. } => {
-                f.write_str("A message path was detected but the method wasn't given")
-            }
-            Self::NoMatch => f.write_str("There was no matched path"),
-        }
-    }
-}
-
-impl StdError for PathParseError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::IntegerParsing { source } => Some(source),
-            Self::MessageIdWithoutMethod { .. } | Self::NoMatch => None,
-        }
-    }
 }
 
 /// An enum representing a path, most useful for ratelimiting implementations.
@@ -160,59 +177,69 @@ impl FromStr for Path {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use Path::*;
 
+        fn parse_id(id: &str) -> Result<u64, PathParseError> {
+            id.parse().map_err(|source| PathParseError {
+                cause: Some(Box::new(source)),
+                kind: PathParseErrorType::IntegerParsing,
+            })
+        }
+
         let skip = usize::from(s.starts_with('/'));
 
         let parts = s.split('/').skip(skip).collect::<Vec<&str>>();
 
         Ok(match parts.as_slice() {
-            ["channels", id] => ChannelsId(id.parse()?),
-            ["channels", id, "followers"] => ChannelsIdFollowers(id.parse()?),
-            ["channels", id, "invites"] => ChannelsIdInvites(id.parse()?),
-            ["channels", id, "messages"] => ChannelsIdMessages(id.parse()?),
+            ["channels", id] => ChannelsId(parse_id(id)?),
+            ["channels", id, "followers"] => ChannelsIdFollowers(parse_id(id)?),
+            ["channels", id, "invites"] => ChannelsIdInvites(parse_id(id)?),
+            ["channels", id, "messages"] => ChannelsIdMessages(parse_id(id)?),
             ["channels", id, "messages", _] => {
-                return Err(PathParseError::MessageIdWithoutMethod {
-                    channel_id: id.parse()?,
+                return Err(PathParseError {
+                    cause: None,
+                    kind: PathParseErrorType::MessageIdWithoutMethod {
+                        channel_id: parse_id(id)?,
+                    },
                 });
             }
             ["channels", id, "messages", _, "crosspost"] => {
-                ChannelsIdMessagesIdCrosspost(id.parse()?)
+                ChannelsIdMessagesIdCrosspost(parse_id(id)?)
             }
             ["channels", id, "messages", _, "reactions"] => {
-                ChannelsIdMessagesIdReactions(id.parse()?)
+                ChannelsIdMessagesIdReactions(parse_id(id)?)
             }
             ["channels", id, "messages", _, "reactions", _, _] => {
-                ChannelsIdMessagesIdReactionsUserIdType(id.parse()?)
+                ChannelsIdMessagesIdReactionsUserIdType(parse_id(id)?)
             }
-            ["channels", id, "permissions", _] => ChannelsIdPermissionsOverwriteId(id.parse()?),
-            ["channels", id, "pins"] => ChannelsIdPins(id.parse()?),
-            ["channels", id, "pins", _] => ChannelsIdPinsMessageId(id.parse()?),
-            ["channels", id, "typing"] => ChannelsIdTyping(id.parse()?),
-            ["channels", id, "webhooks"] => ChannelsIdWebhooks(id.parse()?),
+            ["channels", id, "permissions", _] => ChannelsIdPermissionsOverwriteId(parse_id(id)?),
+            ["channels", id, "pins"] => ChannelsIdPins(parse_id(id)?),
+            ["channels", id, "pins", _] => ChannelsIdPinsMessageId(parse_id(id)?),
+            ["channels", id, "typing"] => ChannelsIdTyping(parse_id(id)?),
+            ["channels", id, "webhooks"] => ChannelsIdWebhooks(parse_id(id)?),
             ["gateway"] => Gateway,
             ["gateway", "bot"] => GatewayBot,
             ["guilds"] => Guilds,
-            ["guilds", id] => GuildsId(id.parse()?),
-            ["guilds", id, "bans"] => GuildsIdBans(id.parse()?),
-            ["guilds", id, "bans", _] => GuildsIdBansUserId(id.parse()?),
-            ["guilds", id, "channels"] => GuildsIdChannels(id.parse()?),
-            ["guilds", id, "widget"] => GuildsIdWidget(id.parse()?),
-            ["guilds", id, "emojis"] => GuildsIdEmojis(id.parse()?),
-            ["guilds", id, "emojis", _] => GuildsIdEmojisId(id.parse()?),
-            ["guilds", id, "integrations"] => GuildsIdIntegrations(id.parse()?),
-            ["guilds", id, "integrations", _] => GuildsIdIntegrationsId(id.parse()?),
-            ["guilds", id, "integrations", _, "sync"] => GuildsIdIntegrationsIdSync(id.parse()?),
-            ["guilds", id, "invites"] => GuildsIdInvites(id.parse()?),
-            ["guilds", id, "members"] => GuildsIdMembers(id.parse()?),
-            ["guilds", id, "members", _] => GuildsIdMembersId(id.parse()?),
-            ["guilds", id, "members", _, "roles", _] => GuildsIdMembersIdRolesId(id.parse()?),
-            ["guilds", id, "members", "@me", "nick"] => GuildsIdMembersMeNick(id.parse()?),
-            ["guilds", id, "preview"] => GuildsIdPreview(id.parse()?),
-            ["guilds", id, "prune"] => GuildsIdPrune(id.parse()?),
-            ["guilds", id, "regions"] => GuildsIdRegions(id.parse()?),
-            ["guilds", id, "roles"] => GuildsIdRoles(id.parse()?),
-            ["guilds", id, "roles", _] => GuildsIdRolesId(id.parse()?),
-            ["guilds", id, "vanity-url"] => GuildsIdVanityUrl(id.parse()?),
-            ["guilds", id, "webhooks"] => GuildsIdWebhooks(id.parse()?),
+            ["guilds", id] => GuildsId(parse_id(id)?),
+            ["guilds", id, "bans"] => GuildsIdBans(parse_id(id)?),
+            ["guilds", id, "bans", _] => GuildsIdBansUserId(parse_id(id)?),
+            ["guilds", id, "channels"] => GuildsIdChannels(parse_id(id)?),
+            ["guilds", id, "widget"] => GuildsIdWidget(parse_id(id)?),
+            ["guilds", id, "emojis"] => GuildsIdEmojis(parse_id(id)?),
+            ["guilds", id, "emojis", _] => GuildsIdEmojisId(parse_id(id)?),
+            ["guilds", id, "integrations"] => GuildsIdIntegrations(parse_id(id)?),
+            ["guilds", id, "integrations", _] => GuildsIdIntegrationsId(parse_id(id)?),
+            ["guilds", id, "integrations", _, "sync"] => GuildsIdIntegrationsIdSync(parse_id(id)?),
+            ["guilds", id, "invites"] => GuildsIdInvites(parse_id(id)?),
+            ["guilds", id, "members"] => GuildsIdMembers(parse_id(id)?),
+            ["guilds", id, "members", _] => GuildsIdMembersId(parse_id(id)?),
+            ["guilds", id, "members", _, "roles", _] => GuildsIdMembersIdRolesId(parse_id(id)?),
+            ["guilds", id, "members", "@me", "nick"] => GuildsIdMembersMeNick(parse_id(id)?),
+            ["guilds", id, "preview"] => GuildsIdPreview(parse_id(id)?),
+            ["guilds", id, "prune"] => GuildsIdPrune(parse_id(id)?),
+            ["guilds", id, "regions"] => GuildsIdRegions(parse_id(id)?),
+            ["guilds", id, "roles"] => GuildsIdRoles(parse_id(id)?),
+            ["guilds", id, "roles", _] => GuildsIdRolesId(parse_id(id)?),
+            ["guilds", id, "vanity-url"] => GuildsIdVanityUrl(parse_id(id)?),
+            ["guilds", id, "webhooks"] => GuildsIdWebhooks(parse_id(id)?),
             ["invites", _] => InvitesCode,
             ["oauth2", "applications", "@me"] => OauthApplicationsMe,
             ["users", _] => UsersId,
@@ -221,8 +248,13 @@ impl FromStr for Path {
             ["users", _, "guilds"] => UsersIdGuilds,
             ["users", _, "guilds", _] => UsersIdGuildsId,
             ["voice", "regions"] => VoiceRegions,
-            ["webhooks", id] | ["webhooks", id, _] => WebhooksId(id.parse()?),
-            _ => return Err(PathParseError::NoMatch),
+            ["webhooks", id] | ["webhooks", id, _] => WebhooksId(parse_id(id)?),
+            _ => {
+                return Err(PathParseError {
+                    cause: None,
+                    kind: PathParseErrorType::NoMatch,
+                })
+            }
         })
     }
 }
@@ -233,10 +265,13 @@ impl TryFrom<(Method, &str)> for Path {
     fn try_from((method, s): (Method, &str)) -> Result<Self, Self::Error> {
         match Self::from_str(s) {
             Ok(v) => Ok(v),
-            Err(PathParseError::MessageIdWithoutMethod { channel_id }) => {
-                Ok(Self::ChannelsIdMessagesId(method, channel_id))
+            Err(why) => {
+                if let PathParseErrorType::MessageIdWithoutMethod { channel_id } = why.kind() {
+                    Ok(Self::ChannelsIdMessagesId(method, *channel_id))
+                } else {
+                    Err(why)
+                }
             }
-            Err(why) => Err(why),
         }
     }
 }
@@ -1528,7 +1563,7 @@ impl Route {
 
 #[cfg(test)]
 mod tests {
-    use super::{Path, PathParseError};
+    use super::{Path, PathParseErrorType};
     use hyper::Method;
     use std::{convert::TryFrom, error::Error, str::FromStr};
 
@@ -1551,10 +1586,12 @@ mod tests {
 
     #[test]
     fn test_path_message_id() -> Result<(), Box<dyn Error>> {
-        assert_eq!(
-            PathParseError::MessageIdWithoutMethod { channel_id: 123 },
-            Path::from_str("channels/123/messages/456").unwrap_err()
-        );
+        assert!(matches!(
+            Path::from_str("channels/123/messages/456")
+                .unwrap_err()
+                .kind(),
+            PathParseErrorType::MessageIdWithoutMethod { channel_id: 123 },
+        ));
         assert_eq!(
             Path::ChannelsIdMessagesId(Method::GET, 123),
             Path::try_from((Method::GET, "/channels/123/messages/456"))?,

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -24,8 +24,8 @@ use twilight_model::{
 /// An error that can occur while interacting with the client.
 #[derive(Debug)]
 pub struct ClientError {
-    cause: Option<Box<dyn Error + Send + Sync>>,
     kind: ClientErrorType,
+    source: Option<Box<dyn Error + Send + Sync>>,
 }
 
 impl ClientError {
@@ -35,8 +35,8 @@ impl ClientError {
     }
 
     /// Consume the error, returning the source error if there is any.
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
-        self.cause
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.source
     }
 }
 
@@ -53,9 +53,9 @@ impl Display for ClientError {
 
 impl Error for ClientError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.cause
+        self.source
             .as_ref()
-            .map(|cause| &**cause as &(dyn Error + 'static))
+            .map(|source| &**source as &(dyn Error + 'static))
     }
 }
 
@@ -278,8 +278,8 @@ impl Lavalink {
         let player = self.player(guild_id).await?;
         tracing::debug!("sending voice update for guild {}: {:?}", guild_id, update);
         player.send(update).map_err(|source| ClientError {
-            cause: Some(Box::new(source)),
             kind: ClientErrorType::SendingVoiceUpdate,
+            source: Some(Box::new(source)),
         })?;
         tracing::debug!("sent voice update for guild {}", guild_id);
 
@@ -342,8 +342,8 @@ impl Lavalink {
         }
 
         best.ok_or(ClientError {
-            cause: None,
             kind: ClientErrorType::NodesUnconfigured,
+            source: None,
         })
     }
 

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -38,6 +38,12 @@ impl ClientError {
     pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         self.source
     }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (ClientErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, self.source)
+    }
 }
 
 impl Display for ClientError {

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -33,8 +33,7 @@ use futures_util::{
     sink::SinkExt,
     stream::StreamExt,
 };
-use http::{header::HeaderName, Error as HttpError, Request, Response, StatusCode};
-use serde_json::Error as JsonError;
+use http::{header::HeaderName, Request, Response, StatusCode};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -48,45 +47,42 @@ use twilight_model::id::UserId;
 /// An error occurred while either initializing a connection or while running
 /// its event loop.
 #[derive(Debug)]
-#[non_exhaustive]
-pub enum NodeError {
-    /// Building the HTTP request to initialize a connection failed.
-    BuildingConnectionRequest {
-        /// The source of the error from the `http` crate.
-        source: HttpError,
-    },
-    /// Connecting to the Lavalink server failed after several backoff attempts.
-    Connecting {
-        /// The source of the error from the `tungstenite` crate.
-        source: TungsteniteError,
-    },
-    /// Serializing a JSON message to be sent to a Lavalink node failed.
-    SerializingMessage {
-        /// The message that couldn't be serialized.
-        message: OutgoingEvent,
-        /// The source of the error from the `serde_json` crate.
-        source: JsonError,
-    },
-    /// The given authorization for the node is incorrect.
-    Unauthorized {
-        /// The address of the node that failed to authorize.
-        address: SocketAddr,
-        /// The authorization used to connect to the node.
-        authorization: String,
-    },
+pub struct NodeError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: NodeErrorType,
+}
+
+impl NodeError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &NodeErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (NodeErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, self.cause)
+    }
 }
 
 impl Display for NodeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::BuildingConnectionRequest { .. } => {
+        match &self.kind {
+            NodeErrorType::BuildingConnectionRequest { .. } => {
                 f.write_str("failed to build connection request")
             }
-            Self::Connecting { .. } => f.write_str("Failed to connect to the node"),
-            Self::SerializingMessage { .. } => {
+            NodeErrorType::Connecting { .. } => f.write_str("Failed to connect to the node"),
+            NodeErrorType::SerializingMessage { .. } => {
                 f.write_str("failed to serialize outgoing message as json")
             }
-            Self::Unauthorized { address, .. } => write!(
+            NodeErrorType::Unauthorized { address, .. } => write!(
                 f,
                 "the authorization used to connect to node {} is invalid",
                 address
@@ -97,13 +93,32 @@ impl Display for NodeError {
 
 impl Error for NodeError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::BuildingConnectionRequest { source } => Some(source),
-            Self::Connecting { source } => Some(source),
-            Self::SerializingMessage { source, .. } => Some(source),
-            Self::Unauthorized { .. } => None,
-        }
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
     }
+}
+
+/// Type of [`NodeError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum NodeErrorType {
+    /// Building the HTTP request to initialize a connection failed.
+    BuildingConnectionRequest,
+    /// Connecting to the Lavalink server failed after several backoff attempts.
+    Connecting,
+    /// Serializing a JSON message to be sent to a Lavalink node failed.
+    SerializingMessage {
+        /// The message that couldn't be serialized.
+        message: OutgoingEvent,
+    },
+    /// The given authorization for the node is incorrect.
+    Unauthorized {
+        /// The address of the node that failed to authorize.
+        address: SocketAddr,
+        /// The authorization used to connect to the node.
+        authorization: String,
+    },
 }
 
 /// The configuration that a [`Node`] uses to connect to a Lavalink server.
@@ -373,11 +388,9 @@ impl Connection {
                         outgoing
                     );
 
-                    let payload = serde_json::to_string(&outgoing).map_err(|source| {
-                        NodeError::SerializingMessage {
-                            message: outgoing,
-                            source,
-                        }
+                    let payload = serde_json::to_string(&outgoing).map_err(|source| NodeError {
+                        cause: Some(Box::new(source)),
+                        kind: NodeErrorType::SerializingMessage { message: outgoing },
                     })?;
                     let msg = Message::Text(payload);
                     self.connection.send(msg).await.unwrap();
@@ -485,9 +498,10 @@ fn connect_request(state: &NodeConfig) -> Result<Request<()>, NodeError> {
         builder = builder.header("Resume-Key", state.address.to_string());
     }
 
-    builder
-        .body(())
-        .map_err(|source| NodeError::BuildingConnectionRequest { source })
+    builder.body(()).map_err(|source| NodeError {
+        cause: Some(Box::new(source)),
+        kind: NodeErrorType::BuildingConnectionRequest,
+    })
 }
 
 async fn reconnect(config: &NodeConfig) -> Result<WebSocketStream<ConnectStream>, NodeError> {
@@ -534,16 +548,22 @@ async fn backoff(
 
                 if matches!(source, TungsteniteError::Http(ref resp) if resp.status() == StatusCode::UNAUTHORIZED)
                 {
-                    return Err(NodeError::Unauthorized {
-                        address: config.address,
-                        authorization: config.authorization.to_owned(),
+                    return Err(NodeError {
+                        cause: None,
+                        kind: NodeErrorType::Unauthorized {
+                            address: config.address,
+                            authorization: config.authorization.to_owned(),
+                        },
                     });
                 }
 
                 if seconds > 64 {
                     tracing::debug!("no longer trying to connect to node {}", config.address);
 
-                    return Err(NodeError::Connecting { source });
+                    return Err(NodeError {
+                        cause: Some(Box::new(source)),
+                        kind: NodeErrorType::Connecting,
+                    });
                 }
 
                 tracing::debug!(
@@ -563,7 +583,7 @@ async fn backoff(
 
 #[cfg(test)]
 mod tests {
-    use super::{Node, NodeConfig, NodeError, Resume};
+    use super::{Node, NodeConfig, NodeError, NodeErrorType, Resume};
     use static_assertions::{assert_fields, assert_impl_all};
     use std::{error::Error, fmt::Debug};
 
@@ -575,11 +595,10 @@ mod tests {
         user_id
     );
     assert_impl_all!(NodeConfig: Clone, Debug, Send, Sync);
-    assert_fields!(NodeError::BuildingConnectionRequest: source);
-    assert_fields!(NodeError::Connecting: source);
-    assert_fields!(NodeError::SerializingMessage: message, source);
-    assert_fields!(NodeError::Unauthorized: address, authorization);
-    assert_impl_all!(NodeError: Debug, Error, Send, Sync);
+    assert_fields!(NodeErrorType::SerializingMessage: message);
+    assert_fields!(NodeErrorType::Unauthorized: address, authorization);
+    assert_impl_all!(NodeErrorType: Debug, Send, Sync);
+    assert_impl_all!(NodeError: Error, Send, Sync);
     assert_impl_all!(Node: Clone, Debug, Send, Sync);
     assert_fields!(Resume: timeout);
     assert_impl_all!(Resume: Clone, Debug, Default, Eq, PartialEq, Send, Sync);

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -54,7 +54,7 @@ pub struct NodeError {
 
 impl NodeError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &NodeErrorType {
         &self.kind
     }

--- a/mention/src/parse/error.rs
+++ b/mention/src/parse/error.rs
@@ -1,18 +1,109 @@
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
-    num::ParseIntError,
 };
 
 /// Parsing a mention failed due to invalid syntax.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum ParseMentionError<'a> {
+#[derive(Debug)]
+pub struct ParseMentionError<'a> {
+    pub(super) cause: Option<Box<dyn Error + Send + Sync>>,
+    pub(super) kind: ParseMentionErrorType<'a>,
+}
+
+impl<'a> ParseMentionError<'a> {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &ParseMentionErrorType<'_> {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        ParseMentionErrorType<'a>,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, self.cause)
+    }
+}
+
+impl Display for ParseMentionError<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            ParseMentionErrorType::IdNotU64 { found, .. } => f.write_fmt(format_args!(
+                "id portion ('{}') of mention is not a u64",
+                found,
+            )),
+            ParseMentionErrorType::LeadingArrow { found } => {
+                f.write_str("expected to find a leading arrow ('<') but instead ")?;
+
+                if let Some(c) = found {
+                    f.write_fmt(format_args!("found '{}'", c))
+                } else {
+                    f.write_str("found nothing")
+                }
+            }
+            ParseMentionErrorType::PartMissing { expected, found } => f.write_fmt(format_args!(
+                "
+                    expected {} parts but only found {}",
+                expected, found,
+            )),
+            ParseMentionErrorType::Sigil { expected, found } => {
+                f.write_str("expected to find a mention sigil (")?;
+
+                for (idx, sigil) in expected.iter().enumerate() {
+                    f.write_fmt(format_args!("'{}'", sigil))?;
+
+                    if idx < expected.len() - 1 {
+                        f.write_str(", ")?;
+                    }
+                }
+
+                f.write_str(") but instead found ")?;
+
+                if let Some(c) = found {
+                    f.write_fmt(format_args!("'{}'", c))
+                } else {
+                    f.write_str("nothing")
+                }
+            }
+            ParseMentionErrorType::TrailingArrow { found } => {
+                f.write_str("expected to find a trailing arrow ('>') but instead ")?;
+
+                if let Some(c) = found {
+                    f.write_fmt(format_args!("found '{}'", c))
+                } else {
+                    f.write_str("found nothing")
+                }
+            }
+        }
+    }
+}
+
+impl Error for ParseMentionError<'_> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
+    }
+}
+
+/// Type of [`ParseMentionError`] that occurred.
+#[derive(Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ParseMentionErrorType<'a> {
     /// ID portion of the mention isn't a u64.
     IdNotU64 {
         /// String that could not be parsed into a u64.
         found: &'a str,
-        /// Reason for the error.
-        source: ParseIntError,
     },
     /// Leading arrow (`<`) is not present.
     LeadingArrow {
@@ -46,112 +137,59 @@ pub enum ParseMentionError<'a> {
     },
 }
 
-impl Display for ParseMentionError<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::IdNotU64 { found, .. } => f.write_fmt(format_args!(
-                "id portion ('{}') of mention is not a u64",
-                found,
-            )),
-            Self::LeadingArrow { found } => {
-                f.write_str("expected to find a leading arrow ('<') but instead ")?;
-
-                if let Some(c) = found {
-                    f.write_fmt(format_args!("found '{}'", c))
-                } else {
-                    f.write_str("found nothing")
-                }
-            }
-            Self::PartMissing { expected, found } => f.write_fmt(format_args!(
-                "
-                    expected {} parts but only found {}",
-                expected, found,
-            )),
-            Self::Sigil { expected, found } => {
-                f.write_str("expected to find a mention sigil (")?;
-
-                for (idx, sigil) in expected.iter().enumerate() {
-                    f.write_fmt(format_args!("'{}'", sigil))?;
-
-                    if idx < expected.len() - 1 {
-                        f.write_str(", ")?;
-                    }
-                }
-
-                f.write_str(") but instead found ")?;
-
-                if let Some(c) = found {
-                    f.write_fmt(format_args!("'{}'", c))
-                } else {
-                    f.write_str("nothing")
-                }
-            }
-            Self::TrailingArrow { found } => {
-                f.write_str("expected to find a trailing arrow ('>') but instead ")?;
-
-                if let Some(c) = found {
-                    f.write_fmt(format_args!("found '{}'", c))
-                } else {
-                    f.write_str("found nothing")
-                }
-            }
-        }
-    }
-}
-
-impl Error for ParseMentionError<'_> {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::IdNotU64 { source, .. } => Some(source),
-            Self::LeadingArrow { .. }
-            | Self::PartMissing { .. }
-            | Self::Sigil { .. }
-            | Self::TrailingArrow { .. } => None,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::ParseMentionError;
+    use super::{ParseMentionError, ParseMentionErrorType};
     use static_assertions::{assert_fields, assert_impl_all};
     use std::{error::Error, fmt::Debug};
 
-    assert_fields!(ParseMentionError::IdNotU64: found, source);
-    assert_fields!(ParseMentionError::LeadingArrow: found);
-    assert_fields!(ParseMentionError::Sigil: expected, found);
-    assert_fields!(ParseMentionError::TrailingArrow: found);
-    assert_impl_all!(ParseMentionError<'_>: Clone, Debug, Error, Eq, PartialEq, Send, Sync);
+    assert_fields!(ParseMentionErrorType::IdNotU64: found);
+    assert_fields!(ParseMentionErrorType::LeadingArrow: found);
+    assert_fields!(ParseMentionErrorType::Sigil: expected, found);
+    assert_fields!(ParseMentionErrorType::TrailingArrow: found);
+    assert_impl_all!(ParseMentionErrorType<'_>: Debug, Send, Sync);
+    assert_impl_all!(ParseMentionError<'_>: Debug, Error, Send, Sync);
 
     #[test]
     fn test_display() {
         let mut expected = "id portion ('abcd') of mention is not a u64";
         assert_eq!(
             expected,
-            ParseMentionError::IdNotU64 {
-                found: "abcd",
-                source: "abcd".parse::<u64>().unwrap_err(),
+            ParseMentionError {
+                cause: Some(Box::new("abcd".parse::<u64>().unwrap_err())),
+                kind: ParseMentionErrorType::IdNotU64 { found: "abcd" }
             }
             .to_string(),
         );
         expected = "expected to find a leading arrow ('<') but instead found 'a'";
         assert_eq!(
             expected,
-            ParseMentionError::LeadingArrow { found: Some('a') }.to_string(),
+            ParseMentionError {
+                cause: None,
+                kind: ParseMentionErrorType::LeadingArrow { found: Some('a') }
+            }
+            .to_string(),
         );
 
         expected = "expected to find a leading arrow ('<') but instead found nothing";
         assert_eq!(
             expected,
-            ParseMentionError::LeadingArrow { found: None }.to_string(),
+            ParseMentionError {
+                cause: None,
+                kind: ParseMentionErrorType::LeadingArrow { found: None }
+            }
+            .to_string(),
         );
 
         expected = "expected to find a mention sigil ('@') but instead found '#'";
         assert_eq!(
             expected,
-            ParseMentionError::Sigil {
-                expected: &["@"],
-                found: Some('#')
+            ParseMentionError {
+                cause: None,
+                kind: ParseMentionErrorType::Sigil {
+                    expected: &["@"],
+                    found: Some('#')
+                }
             }
             .to_string(),
         );
@@ -159,9 +197,12 @@ mod tests {
         expected = "expected to find a mention sigil ('@') but instead found nothing";
         assert_eq!(
             expected,
-            ParseMentionError::Sigil {
-                expected: &["@"],
-                found: None
+            ParseMentionError {
+                cause: None,
+                kind: ParseMentionErrorType::Sigil {
+                    expected: &["@"],
+                    found: None
+                }
             }
             .to_string(),
         );
@@ -169,9 +210,12 @@ mod tests {
         expected = "expected to find a mention sigil ('@!', '@') but instead found '#'";
         assert_eq!(
             expected,
-            ParseMentionError::Sigil {
-                expected: &["@!", "@"],
-                found: Some('#'),
+            ParseMentionError {
+                cause: None,
+                kind: ParseMentionErrorType::Sigil {
+                    expected: &["@!", "@"],
+                    found: Some('#'),
+                }
             }
             .to_string(),
         );
@@ -179,9 +223,12 @@ mod tests {
         expected = "expected to find a mention sigil ('@!', '@') but instead found nothing";
         assert_eq!(
             expected,
-            ParseMentionError::Sigil {
-                expected: &["@!", "@"],
-                found: None
+            ParseMentionError {
+                cause: None,
+                kind: ParseMentionErrorType::Sigil {
+                    expected: &["@!", "@"],
+                    found: None
+                }
             }
             .to_string(),
         );
@@ -189,13 +236,21 @@ mod tests {
         expected = "expected to find a trailing arrow ('>') but instead found 'a'";
         assert_eq!(
             expected,
-            ParseMentionError::TrailingArrow { found: Some('a') }.to_string(),
+            ParseMentionError {
+                cause: None,
+                kind: ParseMentionErrorType::TrailingArrow { found: Some('a') }
+            }
+            .to_string(),
         );
 
         expected = "expected to find a trailing arrow ('>') but instead found nothing";
         assert_eq!(
             expected,
-            ParseMentionError::TrailingArrow { found: None }.to_string(),
+            ParseMentionError {
+                cause: None,
+                kind: ParseMentionErrorType::TrailingArrow { found: None }
+            }
+            .to_string(),
         );
     }
 }

--- a/mention/src/parse/error.rs
+++ b/mention/src/parse/error.rs
@@ -6,8 +6,8 @@ use std::{
 /// Parsing a mention failed due to invalid syntax.
 #[derive(Debug)]
 pub struct ParseMentionError<'a> {
-    pub(super) cause: Option<Box<dyn Error + Send + Sync>>,
     pub(super) kind: ParseMentionErrorType<'a>,
+    pub(super) source: Option<Box<dyn Error + Send + Sync>>,
 }
 
 impl<'a> ParseMentionError<'a> {
@@ -18,9 +18,9 @@ impl<'a> ParseMentionError<'a> {
     }
 
     /// Consume the error, returning the source error if there is any.
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
-        self.cause
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.source
     }
 
     /// Consume the error, returning the owned error type and the source error.
@@ -31,7 +31,7 @@ impl<'a> ParseMentionError<'a> {
         ParseMentionErrorType<'a>,
         Option<Box<dyn Error + Send + Sync>>,
     ) {
-        (self.kind, self.cause)
+        (self.kind, self.source)
     }
 }
 
@@ -90,9 +90,9 @@ impl Display for ParseMentionError<'_> {
 
 impl Error for ParseMentionError<'_> {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.cause
+        self.source
             .as_ref()
-            .map(|cause| &**cause as &(dyn Error + 'static))
+            .map(|source| &**source as &(dyn Error + 'static))
     }
 }
 
@@ -156,8 +156,8 @@ mod tests {
         assert_eq!(
             expected,
             ParseMentionError {
-                cause: Some(Box::new("abcd".parse::<u64>().unwrap_err())),
-                kind: ParseMentionErrorType::IdNotU64 { found: "abcd" }
+                kind: ParseMentionErrorType::IdNotU64 { found: "abcd" },
+                source: Some(Box::new("abcd".parse::<u64>().unwrap_err())),
             }
             .to_string(),
         );
@@ -165,8 +165,8 @@ mod tests {
         assert_eq!(
             expected,
             ParseMentionError {
-                cause: None,
-                kind: ParseMentionErrorType::LeadingArrow { found: Some('a') }
+                kind: ParseMentionErrorType::LeadingArrow { found: Some('a') },
+                source: None,
             }
             .to_string(),
         );
@@ -175,8 +175,8 @@ mod tests {
         assert_eq!(
             expected,
             ParseMentionError {
-                cause: None,
-                kind: ParseMentionErrorType::LeadingArrow { found: None }
+                kind: ParseMentionErrorType::LeadingArrow { found: None },
+                source: None,
             }
             .to_string(),
         );
@@ -185,11 +185,11 @@ mod tests {
         assert_eq!(
             expected,
             ParseMentionError {
-                cause: None,
                 kind: ParseMentionErrorType::Sigil {
                     expected: &["@"],
                     found: Some('#')
-                }
+                },
+                source: None,
             }
             .to_string(),
         );
@@ -198,11 +198,11 @@ mod tests {
         assert_eq!(
             expected,
             ParseMentionError {
-                cause: None,
                 kind: ParseMentionErrorType::Sigil {
                     expected: &["@"],
                     found: None
-                }
+                },
+                source: None,
             }
             .to_string(),
         );
@@ -211,11 +211,11 @@ mod tests {
         assert_eq!(
             expected,
             ParseMentionError {
-                cause: None,
                 kind: ParseMentionErrorType::Sigil {
                     expected: &["@!", "@"],
                     found: Some('#'),
-                }
+                },
+                source: None,
             }
             .to_string(),
         );
@@ -224,11 +224,11 @@ mod tests {
         assert_eq!(
             expected,
             ParseMentionError {
-                cause: None,
                 kind: ParseMentionErrorType::Sigil {
                     expected: &["@!", "@"],
                     found: None
-                }
+                },
+                source: None,
             }
             .to_string(),
         );
@@ -237,8 +237,8 @@ mod tests {
         assert_eq!(
             expected,
             ParseMentionError {
-                cause: None,
-                kind: ParseMentionErrorType::TrailingArrow { found: Some('a') }
+                kind: ParseMentionErrorType::TrailingArrow { found: Some('a') },
+                source: None,
             }
             .to_string(),
         );
@@ -247,8 +247,8 @@ mod tests {
         assert_eq!(
             expected,
             ParseMentionError {
-                cause: None,
-                kind: ParseMentionErrorType::TrailingArrow { found: None }
+                kind: ParseMentionErrorType::TrailingArrow { found: None },
+                source: None,
             }
             .to_string(),
         );

--- a/mention/src/parse/error.rs
+++ b/mention/src/parse/error.rs
@@ -12,7 +12,7 @@ pub struct ParseMentionError<'a> {
 
 impl<'a> ParseMentionError<'a> {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &ParseMentionErrorType<'_> {
         &self.kind
     }

--- a/mention/src/parse/impl.rs
+++ b/mention/src/parse/impl.rs
@@ -1,4 +1,4 @@
-use super::{MentionIter, MentionType, ParseMentionError};
+use super::{MentionIter, MentionType, ParseMentionError, ParseMentionErrorType};
 use std::str::Chars;
 use twilight_model::id::{ChannelId, EmojiId, RoleId, UserId};
 
@@ -37,14 +37,14 @@ pub trait ParseMention: private::Sealed {
     ///
     /// # Errors
     ///
-    /// Returns [`ParseMentionError::LeadingArrow`] if the leading arrow is not
-    /// present.
+    /// Returns a [`ParseMentionErrorType::LeadingArrow`] error type if the
+    /// leading arrow is not present.
     ///
-    /// Returns [`ParseMentionError::Sigil`] if the mention type's sigil is not
-    /// present after the leading arrow.
+    /// Returns a [`ParseMentionErrorType::Sigil`] error type if the mention
+    /// type's sigil is not present after the leading arrow.
     ///
-    /// Returns [`ParseMentionError::TrailingArrow`] if the trailing arrow is
-    /// not present after the ID.
+    /// Returns a [`ParseMentionErrorType::TrailingArrow`] error type if the
+    /// trailing arrow is not present after the ID.
     fn parse(buf: &str) -> Result<Self, ParseMentionError<'_>>
     where
         Self: Sized;
@@ -171,7 +171,10 @@ fn parse_id<'a>(
     let c = chars.next();
 
     if c.map_or(true, |c| c != '<') {
-        return Err(ParseMentionError::LeadingArrow { found: c });
+        return Err(ParseMentionError {
+            cause: None,
+            kind: ParseMentionErrorType::LeadingArrow { found: c },
+        });
     }
 
     let maybe_sigil = sigils.iter().find(|sigil| {
@@ -189,16 +192,22 @@ fn parse_id<'a>(
     let sigil = if let Some(sigil) = maybe_sigil {
         *sigil
     } else {
-        return Err(ParseMentionError::Sigil {
-            expected: sigils,
-            found: chars.next(),
+        return Err(ParseMentionError {
+            cause: None,
+            kind: ParseMentionErrorType::Sigil {
+                expected: sigils,
+                found: chars.next(),
+            },
         });
     };
 
     if sigil == ":" && !emoji_sigil_present(&mut chars) {
-        return Err(ParseMentionError::PartMissing {
-            found: 1,
-            expected: 2,
+        return Err(ParseMentionError {
+            cause: None,
+            kind: ParseMentionErrorType::PartMissing {
+                found: 1,
+                expected: 2,
+            },
         });
     }
 
@@ -206,14 +215,17 @@ fn parse_id<'a>(
         .as_str()
         .find('>')
         .and_then(|idx| chars.as_str().get(..idx))
-        .ok_or(ParseMentionError::TrailingArrow { found: None })?;
+        .ok_or(ParseMentionError {
+            cause: None,
+            kind: ParseMentionErrorType::TrailingArrow { found: None },
+        })?;
 
     remaining
         .parse()
         .map(|id| (id, sigil))
-        .map_err(|source| ParseMentionError::IdNotU64 {
-            found: remaining,
-            source,
+        .map_err(|source| ParseMentionError {
+            cause: Some(Box::new(source)),
+            kind: ParseMentionErrorType::IdNotU64 { found: remaining },
         })
 }
 
@@ -252,7 +264,7 @@ mod private {
 #[cfg(test)]
 mod tests {
     use super::{
-        super::{MentionType, ParseMentionError},
+        super::{MentionType, ParseMentionErrorType},
         private::Sealed,
         ParseMention,
     };
@@ -278,11 +290,11 @@ mod tests {
     fn test_parse_channel_id() {
         assert_eq!(ChannelId(123), ChannelId::parse("<#123>").unwrap());
         assert_eq!(
-            ParseMentionError::Sigil {
+            &ParseMentionErrorType::Sigil {
                 expected: &["#"],
                 found: Some('@'),
             },
-            ChannelId::parse("<@123>").unwrap_err(),
+            ChannelId::parse("<@123>").unwrap_err().kind(),
         );
     }
 
@@ -290,11 +302,11 @@ mod tests {
     fn test_parse_emoji_id() {
         assert_eq!(EmojiId(123), EmojiId::parse("<:name:123>").unwrap());
         assert_eq!(
-            ParseMentionError::Sigil {
+            &ParseMentionErrorType::Sigil {
                 expected: &[":"],
                 found: Some('@'),
             },
-            EmojiId::parse("<@123>").unwrap_err(),
+            EmojiId::parse("<@123>").unwrap_err().kind(),
         );
     }
 
@@ -317,11 +329,11 @@ mod tests {
             MentionType::parse("<@123>").unwrap()
         );
         assert_eq!(
-            ParseMentionError::Sigil {
+            &ParseMentionErrorType::Sigil {
                 expected: &["#", ":", "@&", "@!", "@"],
                 found: Some(';'),
             },
-            MentionType::parse("<;123>").unwrap_err(),
+            MentionType::parse("<;123>").unwrap_err().kind(),
         );
     }
 
@@ -329,11 +341,11 @@ mod tests {
     fn test_parse_role_id() {
         assert_eq!(RoleId(123), RoleId::parse("<@&123>").unwrap());
         assert_eq!(
-            ParseMentionError::Sigil {
+            &ParseMentionErrorType::Sigil {
                 expected: &["@&"],
                 found: Some('@'),
             },
-            RoleId::parse("<@123>").unwrap_err(),
+            RoleId::parse("<@123>").unwrap_err().kind(),
         );
     }
 
@@ -341,36 +353,33 @@ mod tests {
     fn test_parse_user_id() {
         assert_eq!(UserId(123), UserId::parse("<@123>").unwrap());
         assert_eq!(
-            ParseMentionError::IdNotU64 {
-                found: "&123",
-                source: "&123".parse::<u64>().unwrap_err(),
-            },
-            UserId::parse("<@&123>").unwrap_err(),
+            &ParseMentionErrorType::IdNotU64 { found: "&123" },
+            UserId::parse("<@&123>").unwrap_err().kind(),
         );
     }
 
     #[test]
     fn test_parse_id_wrong_sigil() {
         assert_eq!(
-            ParseMentionError::Sigil {
+            &ParseMentionErrorType::Sigil {
                 expected: &["@"],
                 found: Some('#'),
             },
-            super::parse_id("<#123>", &["@"]).unwrap_err(),
+            super::parse_id("<#123>", &["@"]).unwrap_err().kind(),
         );
         assert_eq!(
-            ParseMentionError::Sigil {
+            &ParseMentionErrorType::Sigil {
                 expected: &["#"],
                 found: None,
             },
-            super::parse_id("<", &["#"]).unwrap_err(),
+            super::parse_id("<", &["#"]).unwrap_err().kind(),
         );
         assert_eq!(
-            ParseMentionError::Sigil {
+            &ParseMentionErrorType::Sigil {
                 expected: &["#"],
                 found: None,
             },
-            super::parse_id("<", &["#"]).unwrap_err(),
+            super::parse_id("<", &["#"]).unwrap_err().kind(),
         );
     }
 }

--- a/mention/src/parse/impl.rs
+++ b/mention/src/parse/impl.rs
@@ -172,8 +172,8 @@ fn parse_id<'a>(
 
     if c.map_or(true, |c| c != '<') {
         return Err(ParseMentionError {
-            cause: None,
             kind: ParseMentionErrorType::LeadingArrow { found: c },
+            source: None,
         });
     }
 
@@ -193,21 +193,21 @@ fn parse_id<'a>(
         *sigil
     } else {
         return Err(ParseMentionError {
-            cause: None,
             kind: ParseMentionErrorType::Sigil {
                 expected: sigils,
                 found: chars.next(),
             },
+            source: None,
         });
     };
 
     if sigil == ":" && !emoji_sigil_present(&mut chars) {
         return Err(ParseMentionError {
-            cause: None,
             kind: ParseMentionErrorType::PartMissing {
                 found: 1,
                 expected: 2,
             },
+            source: None,
         });
     }
 
@@ -216,16 +216,16 @@ fn parse_id<'a>(
         .find('>')
         .and_then(|idx| chars.as_str().get(..idx))
         .ok_or(ParseMentionError {
-            cause: None,
             kind: ParseMentionErrorType::TrailingArrow { found: None },
+            source: None,
         })?;
 
     remaining
         .parse()
         .map(|id| (id, sigil))
         .map_err(|source| ParseMentionError {
-            cause: Some(Box::new(source)),
             kind: ParseMentionErrorType::IdNotU64 { found: remaining },
+            source: Some(Box::new(source)),
         })
 }
 

--- a/mention/src/parse/mod.rs
+++ b/mention/src/parse/mod.rs
@@ -41,7 +41,11 @@ mod error;
 mod r#impl;
 mod iter;
 
-pub use self::{error::ParseMentionError, iter::MentionIter, r#impl::ParseMention};
+pub use self::{
+    error::{ParseMentionError, ParseMentionErrorType},
+    iter::MentionIter,
+    r#impl::ParseMention,
+};
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use twilight_model::id::{ChannelId, EmojiId, RoleId, UserId};

--- a/model/src/gateway/payload/request_guild_members.rs
+++ b/model/src/gateway/payload/request_guild_members.rs
@@ -25,8 +25,8 @@ impl UserIdsError {
 
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
     }
 

--- a/model/src/gateway/payload/request_guild_members.rs
+++ b/model/src/gateway/payload/request_guild_members.rs
@@ -11,20 +11,42 @@ use std::{
 /// Provided IDs is invalid for the request.
 ///
 /// Returned by [`RequestGuildMembersBuilder::user_ids`].
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub enum UserIdsError {
-    /// More than 100 user IDs were provided.
-    TooMany {
-        /// Provided list of user IDs.
-        ids: Vec<UserId>,
-    },
+#[derive(Debug)]
+pub struct UserIdsError {
+    kind: UserIdsErrorType,
+}
+
+impl UserIdsError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &UserIdsErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (UserIdsErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
+
+    fn too_many(ids: Vec<UserId>) -> Self {
+        Self {
+            kind: UserIdsErrorType::TooMany { ids },
+        }
+    }
 }
 
 impl Display for UserIdsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::TooMany { ids } => f.write_fmt(format_args!(
+        match &self.kind {
+            UserIdsErrorType::TooMany { ids } => f.write_fmt(format_args!(
                 "{} user IDs were provided when only a maximum of 100 is allowed",
                 ids.len(),
             )),
@@ -33,6 +55,17 @@ impl Display for UserIdsError {
 }
 
 impl Error for UserIdsError {}
+
+/// Type of [`UserIdsError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum UserIdsErrorType {
+    /// More than 100 user IDs were provided.
+    TooMany {
+        /// Provided list of user IDs.
+        ids: Vec<UserId>,
+    },
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct RequestGuildMembers {
@@ -193,8 +226,8 @@ impl RequestGuildMembersBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`UserIdsError::TooMany`] if more than 100 user IDs were
-    /// provided.
+    /// Returns a [`UserIdsErrorType::TooMany`] error type if more than 100 user
+    /// IDs were provided.
     pub fn user_ids(
         self,
         user_ids: impl Into<Vec<UserId>>,
@@ -204,7 +237,7 @@ impl RequestGuildMembersBuilder {
 
     fn _user_ids(self, user_ids: Vec<UserId>) -> Result<RequestGuildMembers, UserIdsError> {
         if user_ids.len() > 100 {
-            return Err(UserIdsError::TooMany { ids: user_ids });
+            return Err(UserIdsError::too_many(user_ids));
         }
 
         Ok(RequestGuildMembers {

--- a/model/src/gateway/payload/request_guild_members.rs
+++ b/model/src/gateway/payload/request_guild_members.rs
@@ -18,7 +18,7 @@ pub struct UserIdsError {
 
 impl UserIdsError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &UserIdsErrorType {
         &self.kind
     }

--- a/standby/src/futures.rs
+++ b/standby/src/futures.rs
@@ -1,12 +1,14 @@
 use futures_channel::{
     mpsc::UnboundedReceiver as MpscReceiver,
-    oneshot::{Canceled, Receiver},
+    oneshot::{Canceled as ChannelCanceled, Receiver},
 };
 use futures_util::{
     future::FutureExt,
     stream::{Stream, StreamExt},
 };
 use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
     future::Future,
     pin::Pin,
     task::{Context, Poll},
@@ -15,6 +17,30 @@ use twilight_model::gateway::{
     event::Event,
     payload::{MessageCreate, ReactionAdd},
 };
+
+/// Future canceled due to Standby being dropped.
+#[derive(Debug)]
+pub struct Canceled(ChannelCanceled);
+
+impl Canceled {
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::must_use_candidate)]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        Some(Box::new(self.0))
+    }
+}
+
+impl Display for Canceled {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Error for Canceled {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.0)
+    }
+}
 
 /// The future returned from [`Standby::wait_for_event`].
 ///
@@ -29,7 +55,7 @@ impl Future for WaitForEventFuture {
     type Output = Result<Event, Canceled>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.rx.poll_unpin(cx)
+        self.rx.poll_unpin(cx).map_err(Canceled)
     }
 }
 
@@ -63,7 +89,7 @@ impl Future for WaitForGuildEventFuture {
     type Output = Result<Event, Canceled>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.rx.poll_unpin(cx)
+        self.rx.poll_unpin(cx).map_err(Canceled)
     }
 }
 
@@ -97,7 +123,7 @@ impl Future for WaitForMessageFuture {
     type Output = Result<MessageCreate, Canceled>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.rx.poll_unpin(cx)
+        self.rx.poll_unpin(cx).map_err(Canceled)
     }
 }
 
@@ -131,7 +157,7 @@ impl Future for WaitForReactionFuture {
     type Output = Result<ReactionAdd, Canceled>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.rx.poll_unpin(cx)
+        self.rx.poll_unpin(cx).map_err(Canceled)
     }
 }
 

--- a/standby/src/futures.rs
+++ b/standby/src/futures.rs
@@ -25,7 +25,7 @@ pub struct Canceled(ChannelCanceled);
 impl Canceled {
     /// Consume the error, returning the source error if there is any.
     #[allow(clippy::must_use_candidate)]
-    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         Some(Box::new(self.0))
     }
 }

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -1024,7 +1024,7 @@ mod tests {
         assert!(!standby.0.events.is_empty());
         standby.process(&event);
 
-        assert_eq!(Ok(event), wait.await);
+        assert_eq!(event, wait.await.unwrap());
         assert!(standby.0.events.is_empty());
     }
 
@@ -1052,7 +1052,7 @@ mod tests {
         });
         standby.process(&event);
 
-        assert_eq!(Ok(MessageId(3)), wait.await.map(|msg| msg.id));
+        assert_eq!(MessageId(3), wait.await.map(|msg| msg.id).unwrap());
         assert!(standby.0.messages.is_empty());
     }
 
@@ -1082,7 +1082,10 @@ mod tests {
 
         standby.process(&event);
 
-        assert_eq!(Ok(UserId(3)), wait.await.map(|reaction| reaction.user_id));
+        assert_eq!(
+            UserId(3),
+            wait.await.map(|reaction| reaction.user_id).unwrap()
+        );
         assert!(standby.0.reactions.is_empty());
     }
 
@@ -1110,7 +1113,7 @@ mod tests {
         standby.process(&Event::PresencesReplace);
         standby.process(&Event::Resumed);
 
-        assert_eq!(Ok(Event::Resumed), wait.await);
+        assert_eq!(Event::Resumed, wait.await.unwrap());
     }
 
     /// Test that generic event handlers will be given the opportunity to

--- a/util/src/link/webhook.rs
+++ b/util/src/link/webhook.rs
@@ -6,7 +6,6 @@
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
-    num::ParseIntError,
 };
 use twilight_model::id::WebhookId;
 
@@ -14,34 +13,62 @@ use twilight_model::id::WebhookId;
 ///
 /// [parsing]: parse
 #[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum WebhookParseError {
-    /// ID segment in the URL path is not an integer.
-    IdInvalid {
-        /// Reason for the error.
-        source: ParseIntError,
-    },
-    /// Required segment of the URL path is missing.
-    SegmentMissing,
+#[derive(Debug)]
+pub struct WebhookParseError {
+    cause: Option<Box<dyn Error + Send + Sync>>,
+    kind: WebhookParseErrorType,
+}
+
+impl WebhookParseError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &WebhookParseErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
+    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.cause
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (WebhookParseErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, self.cause)
+    }
 }
 
 impl Display for WebhookParseError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::IdInvalid { .. } => f.write_str("url path segment isn't a valid ID"),
-            Self::SegmentMissing => f.write_str("url is missing a required path segment"),
+        match self.kind {
+            WebhookParseErrorType::IdInvalid { .. } => {
+                f.write_str("url path segment isn't a valid ID")
+            }
+            WebhookParseErrorType::SegmentMissing => {
+                f.write_str("url is missing a required path segment")
+            }
         }
     }
 }
 
 impl Error for WebhookParseError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::IdInvalid { source } => Some(source),
-            Self::SegmentMissing => None,
-        }
+        self.cause
+            .as_ref()
+            .map(|cause| &**cause as &(dyn Error + 'static))
     }
+}
+
+/// Type of [`WebhookParseError`] that occurred.
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum WebhookParseErrorType {
+    /// ID segment in the URL path is not an integer.
+    IdInvalid,
+    /// Required segment of the URL path is missing.
+    SegmentMissing,
 }
 
 /// Parse the webhook ID and token from a webhook URL, if it exists in the
@@ -84,30 +111,40 @@ impl Error for WebhookParseError {
 ///
 /// # Errors
 ///
-/// Returns [`WebhookParseError::IdInvalid`] if the ID segment of the URL is not
-/// a valid integer.
+/// Returns [`WebhookParseErrorType::IdInvalid`] error type if the ID segment of
+/// the URL is not a valid integer.
 ///
-/// Returns [`WebhookParseError::SegmentMissing`] if one of the required
-/// segments is missing. This can be the "api" or "webhooks" standard segment
-/// of the URL or the segment containing the webhook ID.
+/// Returns [`WebhookParseErrorType::SegmentMissing`] error type if one of the
+/// required segments is missing. This can be the "api" or "webhooks" standard
+/// segment of the URL or the segment containing the webhook ID.
 pub fn parse(url: &str) -> Result<(WebhookId, Option<&str>), WebhookParseError> {
     let mut segments = {
         let mut start = url.split("discord.com/api/webhooks/");
-        let path = start.nth(1).ok_or(WebhookParseError::SegmentMissing)?;
+        let path = start.nth(1).ok_or(WebhookParseError {
+            cause: None,
+            kind: WebhookParseErrorType::SegmentMissing,
+        })?;
 
         path.split('/')
     };
 
-    let id_segment = segments.next().ok_or(WebhookParseError::SegmentMissing)?;
+    let id_segment = segments.next().ok_or(WebhookParseError {
+        cause: None,
+        kind: WebhookParseErrorType::SegmentMissing,
+    })?;
 
     // If we don't have this check it'll return `IdInvalid`, which isn't right.
     if id_segment.is_empty() {
-        return Err(WebhookParseError::SegmentMissing);
+        return Err(WebhookParseError {
+            cause: None,
+            kind: WebhookParseErrorType::SegmentMissing,
+        });
     }
 
-    let id = id_segment
-        .parse()
-        .map_err(|source| WebhookParseError::IdInvalid { source })?;
+    let id = id_segment.parse().map_err(|source| WebhookParseError {
+        cause: Some(Box::new(source)),
+        kind: WebhookParseErrorType::IdInvalid,
+    })?;
     let mut token = segments.next();
 
     // Don't return an empty token if the segment is empty.
@@ -120,22 +157,12 @@ pub fn parse(url: &str) -> Result<(WebhookId, Option<&str>), WebhookParseError> 
 
 #[cfg(test)]
 mod tests {
-    use super::{WebhookId, WebhookParseError};
-    use static_assertions::{assert_fields, assert_impl_all};
-    use std::{
-        error::Error,
-        fmt::{Debug, Display},
-    };
+    use super::{WebhookId, WebhookParseError, WebhookParseErrorType};
+    use static_assertions::assert_impl_all;
+    use std::{error::Error, fmt::Debug};
 
-    assert_fields!(WebhookParseError::IdInvalid: source);
-    assert_impl_all!(
-        WebhookParseError: Clone,
-        Debug,
-        Display,
-        Eq,
-        Error,
-        PartialEq
-    );
+    assert_impl_all!(WebhookParseErrorType: Debug, Send, Sync);
+    assert_impl_all!(WebhookParseError: Debug, Error, Send, Sync);
 
     #[test]
     fn test_parse_no_token() {
@@ -183,19 +210,23 @@ mod tests {
     #[test]
     fn test_parse_invalid() {
         // Base URL is improper.
-        assert_eq!(
-            WebhookParseError::SegmentMissing,
-            super::parse("https://discord.com/foo/bar/456").unwrap_err(),
-        );
+        assert!(matches!(
+            super::parse("https://discord.com/foo/bar/456")
+                .unwrap_err()
+                .kind(),
+            &WebhookParseErrorType::SegmentMissing,
+        ));
         // No ID is present.
-        assert_eq!(
-            WebhookParseError::SegmentMissing,
-            super::parse("https://discord.com/api/webhooks/").unwrap_err(),
-        );
+        assert!(matches!(
+            super::parse("https://discord.com/api/webhooks/")
+                .unwrap_err()
+                .kind(),
+            &WebhookParseErrorType::SegmentMissing,
+        ));
         // ID segment isn't an integer.
         assert!(matches!(
-            super::parse("https://discord.com/api/webhooks/notaninteger").unwrap_err(),
-            WebhookParseError::IdInvalid { .. },
+            super::parse("https://discord.com/api/webhooks/notaninteger").unwrap_err().kind(),
+            &WebhookParseErrorType::IdInvalid { .. },
         ));
     }
 }

--- a/util/src/link/webhook.rs
+++ b/util/src/link/webhook.rs
@@ -21,7 +21,7 @@ pub struct WebhookParseError {
 
 impl WebhookParseError {
     /// Immutable reference to the type of error that occurred.
-    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
+    #[must_use = "retrieving the type has no effect if left unused"]
     pub fn kind(&self) -> &WebhookParseErrorType {
         &self.kind
     }


### PR DESCRIPTION
Hide the inner sources of errors from the API. Error enums contain variants and often contain a `source` field with the underlying error, along with other detailed information. This source error can be something like a `serde_json::Error`, a `futures_channel::mpsc::TrySendError`, and so on.

Instead, the cause of an error and the type of the error are hidden behind error types.

### Motivation

Through these `source` fields we expose many of our dependencies' error types. As a result, we're exposing our dependencies through our public API. This results in us being unable to upgrade our dependencies to new major versions. If `async-tungstenite` upgrades from 0.11 to 0.12, then we can not upgrade it as the error type from version 0.11 is incompatible with the "same type" from version 0.12. By hiding our dependencies, we can upgrade to new major versions.

Additionally, as we're somewhat aiming for a stable 1.0 release, hiding our dependencies from the API is a necessity. If we expose dependencies in our public API then the project will slowly become out of date until we release a new major version.

### API

An error has always, typically, looked like this:

```rust
/// Sending a command failed.
#[derive(Debug)]
#[non_exhaustive]
pub enum CommandError {
    /// Sending the payload over the WebSocket failed. This is indicative of a
    /// shutdown shard.
    Sending {
        /// Reason for the error.
        source: TrySendError<TungsteniteMessage>,
    },
    /// Serializing the payload as JSON failed.
    Serializing {
        /// Reason for the error.
        source: JsonError,
    },
    /// Shard's session is inactive because the shard hasn't been started.
    SessionInactive {
        /// Reason for the error.
        source: SessionInactiveError,
    },
}
```

Users can consume the error to know its type and the underlying cause (if available) by matching on it, like so:

```rust
match command_error {
    CommandError::Sending { source } => {
        println!("source error: {:?}", source);
    }
    CommandError::Serializing { .. } => {
        println!("invalid json");
    },
    _ => {},
}
```

The problem, like mentioned above, is that now the underlying error is in the public API. To solve that, we can design our enums like this:

```rust
/// Starting a shard and connecting to the gateway failed.
#[derive(Debug)]
pub struct ShardStartError {
    cause: Option<Box<dyn Error + Send + Sync>>,
    kind: ShardStartErrorType,
}

impl ShardStartError {
    /// Immutable reference to the type of error that occurred.
    #[must_use = "consuming the error and retrieving the type has no effect if left unused"]
    pub fn kind(&self) -> &ShardStartErrorType {
        &self.kind
    }

    /// Consume the error, returning the source error if there is any.
    #[must_use = "consuming the error and retrieving the cause has no effect if left unused"]
    pub fn into_cause(self) -> Option<Box<dyn Error + Send + Sync>> {
        self.cause
    }

    /// Consume the error, returning the owned error type and the source error.
    #[must_use = "consuming the error into its parts has no effect if left unused"]
    pub fn into_parts(self) -> (ShardStartErrorType, Option<Box<dyn Error + Send + Sync>>) {
        (self.kind, None)
    }
}

/// Type of [`ShardStartError`] that occurred.
#[derive(Debug)]
#[non_exhaustive]
pub enum ShardStartErrorType {
    /// Establishing a connection to the gateway failed.
    Establishing,
    /// Parsing the gateway URL provided by Discord to connect to the gateway
    /// failed due to an invalid URL.
    ParsingGatewayUrl {
        /// URL that couldn't be parsed.
        url: String,
    },
    /// Retrieving the gateway URL via the Twilight HTTP client failed.
    RetrievingGatewayUrl,
}
```

**Note**: `std::error::Error` and `std::fmt::Display` are implemented for `LargeThresholdError`.

There are a few details to note here:

1. when using `LargeThresholdError::into_cause` and `LargeThresholdError::into_parts`, the concrete type is not returned, but rather a trait object is;
2. `LargeThresholdError::kind` is used to retrieve the type of error that occurred, and this does not contain the underlying type but most often just empty variants;
3. in addition to `std::error::Error::source` which returns an immutable reference to the underlying error, `into_cause` and `into_parts` consume the error and return the owned underlying error.

Using this API can look like:

```rust
match shard_start_error.kind() {
    ShardStartErrorType::Establishing => {
        println!("failed to establish connection");
    }
    ShardStartErrorType::ParsingGatewayUrl { url } => {
        println!("couldn't parse url: {}", url);
    }
    _ => {}
}
```

If the underlying error type is required, then there are 3 options:

1. call `std::error::Error::source` on the error;
2. call `ShardStartError::into_cause` to retrieve the owned source error
3. call `ShardStartError::into_parts` to retrieve the owned source error and type of error

### Case studies

`hyper` does something similar, but less powerful and even less committed to a public API.

Its error type also has the `into_cause` method, but instead of returning a type enum it contains methods returning booleans for determining the type of error:

<https://docs.rs/hyper/0.14.2/hyper/struct.Error.html>

`futures-channel` has a similar API to `hyper` with methods, but instead only exposes methods for determining the type of error:

<https://docs.rs/futures-channel/0.3.12/futures_channel/mpsc/struct.SendError.html>

`serde_json`'s error type contains methods to retrieve information that's always available as well as methods to determine the underlying variant:

<https://docs.rs/serde_json/1.0.61/serde_json/struct.Error.html>

Unlike these examples, the proposed API includes a type enum for each error. This is so that additional information can be included for a specific variant, which isn't cleanly possible in these case studies.