### PR TITLE
Hide command parser's unicase dependency

### DIFF
--- a/command-parser/src/casing.rs
+++ b/command-parser/src/casing.rs
@@ -10,11 +10,26 @@ pub enum CaseSensitivity {
     Sensitive(String),
 }
 
+impl CaseSensitivity {
+    pub fn is_sensitive(&self) -> bool {
+        matches!(self, Self::Sensitive(_))
+    }
+}
+
 impl AsRef<str> for CaseSensitivity {
     fn as_ref(&self) -> &str {
         match self {
             Self::Insensitive(u) => u.as_str(),
             Self::Sensitive(s) => s.as_str(),
+        }
+    }
+}
+
+impl AsMut<str> for CaseSensitivity {
+    fn as_mut(&mut self) -> &mut str {
+        match self {
+            Self::Insensitive(u) => u.as_mut_str(),
+            Self::Sensitive(s) => s.as_mut_str(),
         }
     }
 }

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -13,10 +13,9 @@
 //! [`remove_command`]: CommandParserConfig::remove_command
 //! [`remove_prefix`]: CommandParserConfig::remove_prefix
 
+use super::casing::CaseSensitivity;
 use std::borrow::Cow;
 use std::slice::{Iter, IterMut};
-
-use crate::CaseSensitivity;
 
 /// Configuration for a [`Parser`].
 ///
@@ -178,10 +177,12 @@ pub struct Commands<'a> {
 }
 
 impl<'a> Iterator for Commands<'a> {
-    type Item = &'a CaseSensitivity;
+    type Item = (&'a str, bool);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
+        self.iter
+            .next()
+            .map(|casing| (casing.as_ref(), casing.is_sensitive()))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -197,10 +198,13 @@ pub struct CommandsMut<'a> {
 }
 
 impl<'a> Iterator for CommandsMut<'a> {
-    type Item = &'a mut CaseSensitivity;
+    type Item = (&'a mut str, bool);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
+        let casing = self.iter.next()?;
+        let is_sensitive = casing.is_sensitive();
+
+        Some((casing.as_mut(), is_sensitive))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -73,7 +73,6 @@ mod parser;
 
 pub use self::{
     arguments::Arguments,
-    casing::CaseSensitivity,
     config::CommandParserConfig,
     parser::{Command, Parser},
 };


### PR DESCRIPTION
Hide the `unicase` dependency from the API. Our `CaseSensitivity` enum contains two variants, one which contains `unicase::UniCase`. `CaseSensitivity` is exposed through the `config::Commands` and `config::CommandsMut` iterators. Instead of returning it as the item, return a tuple of the string and whether it's case-sensitive.