### PR TITLE
fix(gateway): remove useless version param from identity payload

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -242,9 +242,6 @@ pub struct ShardProcessor {
 }
 
 impl ShardProcessor {
-    /// Gateway version to use in the URL to connect to the gateway.
-    const GATEWAY_VERSION: u64 = 6;
-
     pub async fn new(
         config: Arc<Config>,
         mut url: String,
@@ -747,7 +744,6 @@ impl ShardProcessor {
             shard: Some(self.config.shard()),
             presence: self.config.presence().cloned(),
             token: self.config.token().to_owned(),
-            v: Self::GATEWAY_VERSION,
         });
         self.emitter.event(Event::ShardIdentifying(Identifying {
             shard_id: self.config.shard()[0],

--- a/model/src/gateway/payload/identify.rs
+++ b/model/src/gateway/payload/identify.rs
@@ -26,7 +26,6 @@ pub struct IdentifyInfo {
     pub properties: IdentifyProperties,
     pub shard: Option<[u64; 2]>,
     pub token: String,
-    pub v: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]


### PR DESCRIPTION
Removes the defunct version param from the identify payload