### PR TITLE
Add note to HTTP client about using bearer tokens

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -71,6 +71,23 @@ impl Debug for State {
 /// Almost all of the client methods require authentication, and as such, the client must be
 /// supplied with a Discord Token. Get yours [here].
 ///
+/// # OAuth
+///
+/// To use Bearer tokens with the client, prefix the token with `"Bearer "`,
+/// including the space at the end:
+///
+/// ```no_run
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::env;
+/// use twilight_http::Client;
+///
+/// let bearer = env::var("BEARER_TOKEN")?;
+/// let token = format!("Bearer {}", bearer);
+///
+/// let client = Client::new(token);
+/// # Ok(()) }
+/// ```
+///
 /// # Cloning
 ///
 /// The client internally wraps its data within an Arc. This means that the

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -73,8 +73,8 @@ impl Debug for State {
 ///
 /// # OAuth
 ///
-/// To use Bearer tokens with the client, prefix the token with `"Bearer "`,
-/// including the space at the end:
+/// To use Bearer tokens prefix the token with `"Bearer "`, including the space
+/// at the end like so:
 ///
 /// ```no_run
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Add a note to the documentation of `twilight_http::client::Client` about the usage of OAuth bearer tokens.