### PR TITLE
`Client#edit_webhook_message` now returns a `Message`

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.3.2"
 
 [dependencies]
-async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.12" }
+async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.13" }
 bitflags = { default-features = false, version = "1" }
 twilight-gateway-queue = { default-features = false, path = "./queue" }
 twilight-http = { default-features = false, path = "../http" }

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -15,7 +15,7 @@ use std::{
     fmt::{Display, Formatter, Result as FmtResult},
 };
 use twilight_model::{
-    channel::embed::Embed,
+    channel::{embed::Embed, Message},
     id::{MessageId, WebhookId},
 };
 
@@ -149,7 +149,7 @@ struct UpdateWebhookMessageFields {
 /// [`DeleteWebhookMessage`]: super::DeleteWebhookMessage
 pub struct UpdateWebhookMessage<'a> {
     fields: UpdateWebhookMessageFields,
-    fut: Option<Pending<'a, ()>>,
+    fut: Option<Pending<'a, Message>>,
     http: &'a Client,
     message_id: MessageId,
     reason: Option<String>,
@@ -311,7 +311,7 @@ impl<'a> UpdateWebhookMessage<'a> {
 
     fn start(&mut self) -> Result<()> {
         let request = self.request()?;
-        self.fut.replace(Box::pin(self.http.verify(request)));
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }
@@ -326,7 +326,7 @@ impl<'a> AuditLogReason for UpdateWebhookMessage<'a> {
     }
 }
 
-poll_req!(UpdateWebhookMessage<'_>, ());
+poll_req!(UpdateWebhookMessage<'_>, Message);
 
 #[cfg(test)]
 mod tests {

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.3.0"
 
 [dependencies]
-async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.12" }
+async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.13" }
 dashmap = { default-features = false, version = "4.0" }
 futures-channel = { default-features = false, features = ["std"], version = "0.3" }
 futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -331,6 +331,7 @@ mod tests {
                 channel_id: Some(ChannelId(1)),
                 guild_id: None,
                 message_id: None,
+                fail_if_not_exists: None,
             }),
             stickers: vec![Sticker {
                 asset: "foo1".to_owned(),

--- a/model/src/channel/message/reference.rs
+++ b/model/src/channel/message/reference.rs
@@ -9,6 +9,8 @@ pub struct MessageReference {
     pub guild_id: Option<GuildId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<MessageId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fail_if_not_exists: Option<bool>,
 }
 
 #[cfg(test)]
@@ -22,6 +24,7 @@ mod tests {
             channel_id: Some(ChannelId(1)),
             guild_id: None,
             message_id: None,
+            fail_if_not_exists: None,
         };
 
         serde_test::assert_tokens(
@@ -46,6 +49,7 @@ mod tests {
             channel_id: Some(ChannelId(1)),
             guild_id: Some(GuildId(2)),
             message_id: Some(MessageId(3)),
+            fail_if_not_exists: Some(false),
         };
 
         serde_test::assert_tokens(
@@ -53,7 +57,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "MessageReference",
-                    len: 3,
+                    len: 4,
                 },
                 Token::Str("channel_id"),
                 Token::Some,
@@ -67,6 +71,9 @@ mod tests {
                 Token::Some,
                 Token::NewtypeStruct { name: "MessageId" },
                 Token::Str("3"),
+                Token::Str("fail_if_not_exists"),
+                Token::Some,
+                Token::Bool(false),
                 Token::StructEnd,
             ],
         );


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/commit/0345b9fc3332d54820c0f728c7377a36b19a846f#diff-0ff2c21918d49c00288388fd5c26de5eb0018abbdeeeac03739e0b961ecda155

Signed-off-by: Cassandra McCarthy <cassie@7596ff.com>
