### PR TITLE
chore(command-parser): Get rid of new Clippy warnings

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -1163,7 +1163,7 @@ mod tests {
             GuildChannel::Text(ref c) => {
                 assert_eq!(Some(GuildId(123)), c.guild_id);
             }
-            _ => assert!(false, "{:?}", channel),
+            _ => panic!("{:?}", channel),
         }
     }
 

--- a/command-parser/benches/commands.rs
+++ b/command-parser/benches/commands.rs
@@ -78,7 +78,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     ];
 
     c.bench_function("c: btreeset", |b| {
-        let set = BTreeSet::from_iter(commands.iter().map(|e| Cow::from(*e)));
+        let set = commands.iter().map(|e| Cow::from(*e)).collect();
 
         b.iter(|| {
             for command in commands.iter() {
@@ -88,7 +88,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("c: hashset", |b| {
-        let set = HashSet::from_iter(commands.iter().map(|e| Cow::from(*e)));
+        let set = commands.iter().map(|e| Cow::from(*e)).collect();
 
         b.iter(|| {
             for command in commands.iter() {

--- a/command-parser/src/arguments.rs
+++ b/command-parser/src/arguments.rs
@@ -109,12 +109,11 @@ impl<'a> Iterator for Arguments<'a> {
                     self.idx = i + 1;
 
                     return v.map(str::trim);
-                } else {
-                    self.idx = i;
-                    start_idx = i;
-                    started = true;
-                    continue;
                 }
+                self.idx = i;
+                start_idx = i;
+                started = true;
+                continue;
             } else if ch == '"' {
                 start_idx = i + 1;
                 quoted = true;

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -658,7 +658,7 @@ mod tests {
     assert_impl_all!(Embed: TryFrom<EmbedBuilder>);
 
     #[test]
-    fn test_color_error() -> Result<(), Box<dyn Error>> {
+    fn test_color_error() {
         assert!(matches!(
             EmbedBuilder::new().color(0).unwrap_err(),
             EmbedColorError::Zero
@@ -668,8 +668,6 @@ mod tests {
             EmbedColorError::NotRgb { color }
             if color == u32::MAX
         ));
-
-        Ok(())
     }
 
     #[test]

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -416,7 +416,7 @@ impl Shard {
 
         // We know that these haven't been set, so we can ignore the result.
         let _ = self.0.processor_handle.set(handle);
-        let _ = self.0.session.set(wrx);
+        let _session = self.0.session.set(wrx);
 
         Ok(())
     }

--- a/gateway/src/shard/processor/emitter.rs
+++ b/gateway/src/shard/processor/emitter.rs
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     fn test_event_removes_closed_channels() {
         let listeners = Listeners::default();
-        let _recv = listeners.add(EventTypeFlags::default());
+        listeners.add(EventTypeFlags::default());
         let emitter = Emitter::new(listeners);
         emitter.event(Event::GatewayReconnect);
         assert!(emitter.listeners.all().is_empty());

--- a/gateway/src/shard/processor/emitter.rs
+++ b/gateway/src/shard/processor/emitter.rs
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     fn test_event_removes_closed_channels() {
         let listeners = Listeners::default();
-        let _ = listeners.add(EventTypeFlags::default());
+        let _recv = listeners.add(EventTypeFlags::default());
         let emitter = Emitter::new(listeners);
         emitter.event(Event::GatewayReconnect);
         assert!(emitter.listeners.all().is_empty());

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -87,7 +87,8 @@
     clippy::module_name_repetitions,
     clippy::pub_enum_variant_names,
     clippy::must_use_candidate,
-    clippy::missing_errors_doc
+    clippy::missing_errors_doc,
+    clippy::unnecessary_wraps
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/http/src/ratelimiting/bucket.rs
+++ b/http/src/ratelimiting/bucket.rs
@@ -118,7 +118,7 @@ pub struct BucketQueue {
 
 impl BucketQueue {
     pub fn push(&self, tx: Sender<Sender<Option<RatelimitHeaders>>>) {
-        let _ = self.tx.unbounded_send(tx);
+        let _sent = self.tx.unbounded_send(tx);
     }
 
     pub async fn pop(
@@ -182,7 +182,7 @@ impl BucketQueueTask {
                 self.global.0.lock().await;
             }
 
-            let _ = queue_tx.send(tx);
+            let _sent = queue_tx.send(tx);
 
             tracing::debug!(parent: &span, "starting to wait for response headers",);
 

--- a/model/src/gateway/payload/guild_delete.rs
+++ b/model/src/gateway/payload/guild_delete.rs
@@ -9,6 +9,7 @@ pub struct GuildDelete {
     pub unavailable: bool,
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn nullable_unavailable<'de, D: Deserializer<'de>>(deserializer: D) -> Result<bool, D::Error> {
     Ok(Deserialize::deserialize(deserializer).unwrap_or_default())
 }


### PR DESCRIPTION
Clippy got an upgrade in Rust 1.50 apparently. This should make CI stop failing the lint step.