### PR TITLE
Fix missing pending field warning on Guild Member Update

### DIFF
--- a/model/src/gateway/payload/member_update.rs
+++ b/model/src/gateway/payload/member_update.rs
@@ -13,7 +13,7 @@ pub struct MemberUpdate {
     /// requirements.
     ///
     /// Note: This field is still under refactoring by Discord. For more info,
-    /// check this [issue] and [pull request] for more info.
+    /// check this [issue] and [pull request].
     ///
     /// [Membership Screening]: https://support.discord.com/hc/en-us/articles/1500000466882
     /// [issue]: https://github.com/discord/discord-api-docs/issues/2567

--- a/model/src/gateway/payload/member_update.rs
+++ b/model/src/gateway/payload/member_update.rs
@@ -13,7 +13,7 @@ pub struct MemberUpdate {
     /// requirements.
     ///
     /// Note: This field is still under refactoring by Discord. For more info,
-    /// check this [issue] & [pull request] for more info.
+    /// check this [issue] and [pull request] for more info.
     ///
     /// [Membership Screening]: https://support.discord.com/hc/en-us/articles/1500000466882
     /// [issue]: https://github.com/discord/discord-api-docs/issues/2567

--- a/model/src/gateway/payload/member_update.rs
+++ b/model/src/gateway/payload/member_update.rs
@@ -16,7 +16,7 @@ pub struct MemberUpdate {
     ///
     /// [Membership Screening]: https://support.discord.com/hc/en-us/articles/1500000466882
     /// [issue]: https://github.com/discord/discord-api-docs/issues/2567
-    /// [pull request]: https://github.com/discord/discord-api-docs/pull/2547 
+    /// [pull request]: https://github.com/discord/discord-api-docs/pull/2547
     #[serde(default)]
     pub pending: bool,
     pub premium_since: Option<String>,

--- a/model/src/gateway/payload/member_update.rs
+++ b/model/src/gateway/payload/member_update.rs
@@ -12,7 +12,8 @@ pub struct MemberUpdate {
     /// Whether the user has yet to pass the guild's [Membership Screening]
     /// requirements.
     ///
-    /// Note: This field is still under refactoring by discord. For more info, check this [issue] & [pull request] for more info.
+    /// Note: This field is still under refactoring by discord. For more info,
+    /// check this [issue] & [pull request] for more info.
     ///
     /// [Membership Screening]: https://support.discord.com/hc/en-us/articles/1500000466882
     /// [issue]: https://github.com/discord/discord-api-docs/issues/2567

--- a/model/src/gateway/payload/member_update.rs
+++ b/model/src/gateway/payload/member_update.rs
@@ -12,7 +12,7 @@ pub struct MemberUpdate {
     /// Whether the user has yet to pass the guild's [Membership Screening]
     /// requirements.
     ///
-    /// Note: This field is still under refactoring by discord. For more info,
+    /// Note: This field is still under refactoring by Discord. For more info,
     /// check this [issue] & [pull request] for more info.
     ///
     /// [Membership Screening]: https://support.discord.com/hc/en-us/articles/1500000466882

--- a/model/src/gateway/payload/member_update.rs
+++ b/model/src/gateway/payload/member_update.rs
@@ -12,7 +12,12 @@ pub struct MemberUpdate {
     /// Whether the user has yet to pass the guild's [Membership Screening]
     /// requirements.
     ///
+    /// Note: This field is still under refactoring by discord. For more info, check this [issue] & [pull request] for more info.
+    ///
     /// [Membership Screening]: https://support.discord.com/hc/en-us/articles/1500000466882
+    /// [issue]: https://github.com/discord/discord-api-docs/issues/2567
+    /// [pull request]: https://github.com/discord/discord-api-docs/pull/2547 
+    #[serde(default)]
     pub pending: bool,
     pub premium_since: Option<String>,
     pub roles: Vec<RoleId>,


### PR DESCRIPTION
In response to https://github.com/discord/discord-api-docs/issues/2567#issuecomment-780844670, a `#[serde(default]` has been added to the `pending` field on Guild Member Update