### PR TITLE
Add webpki-roots feature flags and revert hyper-tls workaround

### DIFF
--- a/embed-builder/src/author.rs
+++ b/embed-builder/src/author.rs
@@ -115,7 +115,8 @@ mod tests {
     fn test_name_empty() {
         let builder = EmbedBuilder::new().author(EmbedAuthorBuilder::new().name(""));
 
-        assert!(matches!(builder.build().unwrap_err().kind(),
+        assert!(matches!(
+            builder.build().unwrap_err().kind(),
             EmbedErrorType::AuthorNameEmpty { .. }
         ));
     }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -49,7 +49,9 @@ tokio = { default-features = false, features = ["macros", "rt-multi-thread"], ve
 default = ["compression", "rustls", "flate2/zlib"]
 compression = ["flate2"]
 native = ["twilight-http/native", "twilight-gateway-queue/native", "async-tungstenite/tokio-native-tls"]
-rustls = ["twilight-http/rustls", "twilight-gateway-queue/rustls", "async-tungstenite/tokio-rustls"]
+rustls = ["rustls-native-roots"]
+rustls-native-roots = ["twilight-http/rustls-native-roots", "twilight-gateway-queue/rustls-native-roots", "async-tungstenite/tokio-rustls"]
+rustls-webpki-roots = ["twilight-http/rustls-webpki-roots", "twilight-gateway-queue/rustls-webpki-roots", "async-tungstenite/tokio-rustls"]
 simd-zlib = ["compression", "flate2/zlib-ng-compat"]
 # if the `zlib` feature is enabled anywhere in the dependency tree it will
 # always use stock zlib instead of zlib-ng.

--- a/gateway/queue/Cargo.toml
+++ b/gateway/queue/Cargo.toml
@@ -27,4 +27,6 @@ static_assertions = { default-features = false, version = "1" }
 [features]
 default = ["rustls"]
 native = ["twilight-http/native"]
-rustls = ["twilight-http/rustls"]
+rustls = ["rustls-native-roots"]
+rustls-native-roots = ["twilight-http/rustls-native-roots"]
+rustls-webpki-roots = ["twilight-http/rustls-webpki-roots"]

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -145,5 +145,11 @@ pub use twilight_gateway_queue as queue;
 #[doc(no_inline)]
 pub use twilight_model::gateway::event::{Event, EventType};
 
-#[cfg(not(any(feature = "native", feature = "rustls")))]
-compile_error!("Either the `native` or `rustls` feature must be enabled");
+#[cfg(not(any(
+    feature = "native",
+    feature = "rustls-native-roots",
+    feature = "rustls-webpki-roots"
+)))]
+compile_error!(
+    "Either the `native`, `rustls-native-roots` or `rustls-webpki-roots` feature must be enabled."
+);

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -385,6 +385,7 @@ impl ShardProcessor {
         self.emitter.into_listeners().remove_all();
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn process(&mut self) -> Result<(), ProcessError> {
         let (op, seq, event_type) = {
             #[cfg(feature = "compression")]

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -95,7 +95,10 @@ struct ProcessError {
 
 impl ProcessError {
     fn fatal(&self) -> bool {
-        matches!(self.kind, ProcessErrorType::SendingClose { .. } | ProcessErrorType::SessionSend { .. })
+        matches!(
+            self.kind,
+            ProcessErrorType::SendingClose { .. } | ProcessErrorType::SessionSend { .. }
+        )
     }
 }
 
@@ -161,8 +164,8 @@ impl ReceivingEventError {
         matches!(
             self.kind,
             ReceivingEventErrorType::AuthorizationInvalid { .. }
-            | ReceivingEventErrorType::IntentsDisallowed { .. }
-            | ReceivingEventErrorType::IntentsInvalid { .. }
+                | ReceivingEventErrorType::IntentsDisallowed { .. }
+                | ReceivingEventErrorType::IntentsInvalid { .. }
         )
     }
 
@@ -498,15 +501,14 @@ impl ShardProcessor {
                 #[cfg(not(feature = "compression"))]
                 let buf_ref = self.buffer.as_mut_slice();
 
-                let ready = json::from_slice::<ReadyMinimal>(buf_ref).map_err(
-                    |source| ProcessError {
+                let ready =
+                    json::from_slice::<ReadyMinimal>(buf_ref).map_err(|source| ProcessError {
                         kind: ProcessErrorType::ParsingPayload,
                         source: Some(Box::new(GatewayEventParsingError {
                             kind: GatewayEventParsingErrorType::Deserializing,
                             source: Some(Box::new(source)),
                         })),
-                    },
-                )?;
+                    })?;
 
                 self.process_ready(&ready.d);
                 emitter.event(Event::Ready(Box::new(ready.d)));

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -19,10 +19,9 @@ bytes = { default-features = false, version = "1.0" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 futures-channel = { default-features = false, version = "0.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
-hyper = { default-features = false, features = ["client", "http2", "runtime"], version = "0.14" }
-hyper-rustls = { default-features = false, features = ["native-tokio"], optional = true, version = "0.22" }
+hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
+hyper-rustls = { default-features = false, optional = true, version = "0.22" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
-native-tls = { default-features = false, features = ["alpn"], optional = true, version = "0.2.7" }
 percent-encoding = { default-features = false, version = "2" }
 tokio = { default-features = false, features = ["time"], version = "1.0" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
@@ -36,8 +35,10 @@ simd-json = { default-features = false, features = ["serde_impl", "swar-number-p
 
 [features]
 default = ["rustls"]
-native = ["hyper-tls", "native-tls"]
-rustls = ["hyper-rustls"]
+native = ["hyper-tls"]
+rustls = ["rustls-native-roots"]
+rustls-native-roots = ["hyper-rustls/native-tokio"]
+rustls-webpki-roots = ["hyper-rustls/webpki-tokio"]
 
 [dev-dependencies]
 serde_test = { default-features = false, version = "1" }

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -124,5 +124,11 @@ pub(crate) use serde_json::to_vec as json_to_vec;
 #[cfg(feature = "simd-json")]
 pub(crate) use simd_json::to_vec as json_to_vec;
 
-#[cfg(not(any(feature = "native", feature = "rustls")))]
-compile_error!("Either the `native` or `rustls` feature must be enabled.");
+#[cfg(not(any(
+    feature = "native",
+    feature = "rustls-native-roots",
+    feature = "rustls-webpki-roots"
+)))]
+compile_error!(
+    "Either the `native`, `rustls-native-roots` or `rustls-webpki-roots` feature must be enabled."
+);

--- a/util/src/link/webhook.rs
+++ b/util/src/link/webhook.rs
@@ -225,7 +225,9 @@ mod tests {
         ));
         // ID segment isn't an integer.
         assert!(matches!(
-            super::parse("https://discord.com/api/webhooks/notaninteger").unwrap_err().kind(),
+            super::parse("https://discord.com/api/webhooks/notaninteger")
+                .unwrap_err()
+                .kind(),
             &WebhookParseErrorType::IdInvalid { .. },
         ));
     }


### PR DESCRIPTION
This cleans up some TLS stuff to make it work in every scenario possible.

It effectively reverts #683 and replaces it with the `http1` feature flag because hyper-tls is not currently in a state where we can use ALPN at all. Enabling http1 would cause it to always handle everything as http1 even when http2 ALPN is negotiated. For that we should keep an eye on https://github.com/hyperium/hyper-tls/pull/85.

It also fixes #703 by adding features for webpki-roots called `rustls-webpki-roots` and renaming `rustls` to `rustls-native-roots` while keeping `rustls` as an alias to preserve backwards compatibility.
It might be worthwhile considering not using native roots at all since async-tungstenite can only use webpki-roots and there's no benefit to using two different certificate roots at once.

Seems that this also fixes rustfmt CI because I ran `cargo +stable fmt` before committing.

This PR should be backported to 0.3 once accepted.