### PR TITLE
Fixes #726: Adds mutable volume and channel IDs for players

### DIFF
--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -175,6 +175,11 @@ impl Lavalink {
                     return Ok(());
                 }
 
+                // Update player if it exists and update the connected channel ID.
+                e.0.guild_id
+                 .and_then(|id| self.0.players.get(&id))
+                 .map(|kv| kv.value().set_channel_id(e.0.channel_id));
+
                 (e.0.guild_id, VoiceStateHalf::State(e.clone()))
             }
             _ => return Ok(()),

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -176,9 +176,9 @@ impl Lavalink {
                 }
 
                 // Update player if it exists and update the connected channel ID.
-                e.0.guild_id
-                 .and_then(|id| self.0.players.get(&id))
-                 .map(|kv| kv.value().set_channel_id(e.0.channel_id));
+                if let Some(kv) = e.0.guild_id.and_then(|id| self.0.players.get(&id)) {
+                    kv.value().set_channel_id(e.0.channel_id);
+                }
 
                 (e.0.guild_id, VoiceStateHalf::State(e.clone()))
             }

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -263,7 +263,7 @@ impl Node {
     }
 
     /// Retrieve an immutable reference to the player manager used by the node.
-    pub async fn players(&self) -> &PlayerManager {
+    pub fn players(&self) -> &PlayerManager {
         &self.0.players
     }
 

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -263,7 +263,7 @@ impl Node {
     }
 
     /// Retrieve an immutable reference to the player manager used by the node.
-    pub fn players(&self) -> &PlayerManager {
+    pub async fn players(&self) -> &PlayerManager {
         &self.0.players
     }
 

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -18,7 +18,7 @@ use futures_channel::mpsc::TrySendError;
 use std::{
     fmt::Debug,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering},
         Arc,
     },
 };
@@ -56,6 +56,16 @@ impl PlayerManager {
             .entry(guild_id)
             .or_insert_with(|| Player::new(guild_id, node))
     }
+
+    /// Destroys a player on the remote node and removes it from the PlayerManager.
+    /// Returns an error if the associated node no longer is connected.
+    pub fn destroy(&self, guild_id: GuildId) -> Result<(),  TrySendError<OutgoingEvent>> {
+        if let Some(node) = self.get(&guild_id).map(|kv| kv.value().node().clone()) {
+            node.send(OutgoingEvent::from(Destroy::new(guild_id)))?;
+            self.players.remove(&guild_id);
+        }
+        Ok(())
+    }
 }
 
 /// A player for a guild connected to a node.
@@ -64,27 +74,25 @@ impl PlayerManager {
 /// player for a guild.
 #[derive(Debug)]
 pub struct Player {
-    channel_id: Option<ChannelId>,
     guild_id: GuildId,
+    channel_id: AtomicU64,
     node: Node,
-    paused: AtomicBool,
-    playing: Option<()>,
     position: i64,
     time: i64,
-    volume: u16,
+    paused: AtomicBool,
+    volume: AtomicU16,
 }
 
 impl Player {
     pub(crate) fn new(guild_id: GuildId, node: Node) -> Self {
         Self {
-            channel_id: None,
             guild_id,
+            channel_id: AtomicU64::new(0),
             node,
-            paused: AtomicBool::new(false),
-            playing: None,
             position: 0,
             time: 0,
-            volume: 0,
+            paused: AtomicBool::new(false),
+            volume: AtomicU16::new(100),
         }
     }
 
@@ -126,8 +134,12 @@ impl Player {
             event
         );
 
-        if let OutgoingEvent::Pause(ref event) = event {
-            self.paused.store(event.pause, Ordering::Release);
+        match event {
+            OutgoingEvent::Pause(ref evt) =>
+                self.paused.store(evt.pause, Ordering::Release),
+            OutgoingEvent::Volume(ref evt) =>
+                self.volume.store(evt.volume as u16, Ordering::Release),
+            _ => {},
         }
 
         self.node.send(event)
@@ -140,7 +152,17 @@ impl Player {
 
     /// Return a copy of the player's channel ID.
     pub fn channel_id(&self) -> Option<ChannelId> {
-        self.channel_id.as_ref().copied()
+        let channel_id = self.channel_id.load(Ordering::Acquire);
+        if channel_id == 0 {
+            None
+        } else {
+            Some(ChannelId(channel_id))
+        }
+    }
+
+    /// Sets the channel ID the player is currently connected to.
+    pub(crate) fn set_channel_id(&self, channel_id: Option<ChannelId>) {
+        self.channel_id.store(channel_id.map(|id| id.0).unwrap_or(0_u64), Ordering::Release);
     }
 
     /// Return an copy of the player's guild ID.
@@ -164,7 +186,7 @@ impl Player {
     }
 
     /// Return a copy of the player's time.
-    pub fn time_ref(&mut self) -> i64 {
+    pub fn time_ref(&self) -> i64 {
         self.time
     }
 
@@ -175,7 +197,7 @@ impl Player {
 
     /// Return a copy of the player's volume.
     pub fn volume_ref(&self) -> u16 {
-        self.volume
+        self.volume.load(Ordering::Acquire)
     }
 }
 

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -59,7 +59,7 @@ impl PlayerManager {
 
     /// Destroys a player on the remote node and removes it from the PlayerManager.
     /// Returns an error if the associated node no longer is connected.
-    pub fn destroy(&self, guild_id: GuildId) -> Result<(),  TrySendError<OutgoingEvent>> {
+    pub fn destroy(&self, guild_id: GuildId) -> Result<(), TrySendError<OutgoingEvent>> {
         if let Some(node) = self.get(&guild_id).map(|kv| kv.value().node().clone()) {
             node.send(OutgoingEvent::from(Destroy::new(guild_id)))?;
             self.players.remove(&guild_id);
@@ -135,11 +135,11 @@ impl Player {
         );
 
         match event {
-            OutgoingEvent::Pause(ref evt) =>
-                self.paused.store(evt.pause, Ordering::Release),
-            OutgoingEvent::Volume(ref evt) =>
-                self.volume.store(evt.volume as u16, Ordering::Release),
-            _ => {},
+            OutgoingEvent::Pause(ref evt) => self.paused.store(evt.pause, Ordering::Release),
+            OutgoingEvent::Volume(ref evt) => {
+                self.volume.store(evt.volume as u16, Ordering::Release)
+            }
+            _ => {}
         }
 
         self.node.send(event)
@@ -162,7 +162,10 @@ impl Player {
 
     /// Sets the channel ID the player is currently connected to.
     pub(crate) fn set_channel_id(&self, channel_id: Option<ChannelId>) {
-        self.channel_id.store(channel_id.map(|id| id.0).unwrap_or(0_u64), Ordering::Release);
+        self.channel_id.store(
+            channel_id.map(|id| id.0).unwrap_or(0_u64),
+            Ordering::Release,
+        );
     }
 
     /// Return an copy of the player's guild ID.


### PR DESCRIPTION
Also added PlayerManager::destroy to provide a managed way to destroy players both locally and on remote nodes, and cleaned up several methods that shouldn't be asynchronous or require mutable references.