### PR TITLE
v0.4: Remove unnecessary async from Node::players

### DIFF
--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -263,7 +263,7 @@ impl Node {
     }
 
     /// Retrieve an immutable reference to the player manager used by the node.
-    pub async fn players(&self) -> &PlayerManager {
+    pub fn players(&self) -> &PlayerManager {
         &self.0.players
     }
 


### PR DESCRIPTION
Removes an unnecessary async from Node::players.