### PR TITLE
Remove the limit on frame size on the websocket

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -807,7 +807,7 @@ impl ShardProcessor {
 
         let config = WebSocketConfig {
             max_frame_size: None,
-            ..Default::default()
+            ..WebSocketConfig::default()
         };
 
         let (stream, _) = connect_async_with_config(url, Some(config))

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -796,12 +796,21 @@ impl ShardProcessor {
     }
 
     async fn connect(url: &str) -> Result<ShardStream, ConnectingError> {
+        use async_tungstenite::{
+            tokio::connect_async_with_config, tungstenite::protocol::WebSocketConfig,
+        };
+
         let url = Url::parse(url).map_err(|source| ConnectingError::ParsingUrl {
             source,
             url: url.to_owned(),
         })?;
 
-        let (stream, _) = async_tungstenite::tokio::connect_async(url)
+        let config = WebSocketConfig {
+            max_frame_size: None,
+            ..Default::default()
+        };
+
+        let (stream, _) = connect_async_with_config(url, Some(config))
             .await
             .map_err(|source| ConnectingError::Establishing { source })?;
 


### PR DESCRIPTION
This is safe as we know that discord is not a malicious actor.

Also see https://github.com/serenity-rs/serenity/pull/618