### PR TITLE
v0.4 Lavalink: Remove unnecessary async.

### DIFF
--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -278,7 +278,7 @@ impl Node {
     }
 
     /// Retrieve an immutable reference to the player manager used by the node.
-    pub async fn players(&self) -> &PlayerManager {
+    pub fn players(&self) -> &PlayerManager {
         &self.0.players
     }
 


### PR DESCRIPTION
#729, but targeting the right branch. orz

Removes an unnecessary async from Node::players.