### PR TITLE
Lavalink: Add missing WebsocketClosed event.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "lavalink/examples/basic-lavalink-bot",
     "mention",
     "model",
+    #"oauth2",
     "standby",
     "twilight",
     "util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ members = [
     "lavalink/examples/basic-lavalink-bot",
     "mention",
     "model",
-    #"oauth2",
     "standby",
     "twilight",
     "util",

--- a/lavalink/src/model.rs
+++ b/lavalink/src/model.rs
@@ -592,7 +592,7 @@ pub mod incoming {
         /// A track for a player started.
         #[serde(rename = "TrackStartEvent")]
         Start,
-        /// A track for a player started.
+        /// The voice websocket connection to Discord has been closed.
         #[serde(rename = "WebSocketClosedEvent")]
         WebsocketClosed,
     }
@@ -638,18 +638,18 @@ pub mod incoming {
     #[non_exhaustive]
     #[serde(rename_all = "camelCase")]
     pub struct WebsocketClosed {
-        /// The guild ID of the player.
+        /// Guild ID of the associated player.
         pub guild_id: GuildId,
-        /// The type of track event.
+        /// Type of track event.
         #[serde(rename = "type")]
         pub kind: TrackEventType,
-        /// The opcode of the event.
+        /// Lavalink websocket opcode of the event.
         pub op: Opcode,
-        /// The Discord websocket opcode
+        /// Discord websocket opcode that closed the connection.
         pub code: u64,
         /// True if Discord closed the connection, false if Lavalink closed it.
         pub by_remote: bool,
-        /// The reason the connection was closed.
+        /// Reason the connection was closed.
         pub reason: String,
     }
 }

--- a/lavalink/src/model.rs
+++ b/lavalink/src/model.rs
@@ -478,6 +478,8 @@ pub mod incoming {
         TrackEnd(TrackEnd),
         /// A track started.
         TrackStart(TrackStart),
+        /// The voice websocket connection was closed.
+        WeboscketClosed(WebsocketClosed),
     }
 
     impl From<PlayerUpdate> for IncomingEvent {
@@ -590,6 +592,9 @@ pub mod incoming {
         /// A track for a player started.
         #[serde(rename = "TrackStartEvent")]
         Start,
+        /// A track for a player started.
+        #[serde(rename = "WebSocketClosedEvent")]
+        WebsocketClosed,
     }
 
     /// A track ended.
@@ -627,12 +632,32 @@ pub mod incoming {
         /// The base64 track that was affected.
         pub track: String,
     }
+
+    /// The voice websocket connection to Discord has been closed.
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[non_exhaustive]
+    #[serde(rename_all = "camelCase")]
+    pub struct WebsocketClosed {
+        /// The guild ID of the player.
+        pub guild_id: GuildId,
+        /// The type of track event.
+        #[serde(rename = "type")]
+        pub kind: TrackEventType,
+        /// The opcode of the event.
+        pub op: Opcode,
+        /// The Discord websocket opcode
+        pub code: u64,
+        /// True if Discord closed the connection, false if Lavalink closed it.
+        pub by_remote: bool,
+        /// The reason the connection was closed.
+        pub reason: String
+    }
 }
 
 pub use self::{
     incoming::{
         IncomingEvent, PlayerUpdate, PlayerUpdateState, Stats, StatsCpu, StatsFrames, StatsMemory,
-        TrackEnd, TrackEventType, TrackStart,
+        TrackEnd, TrackEventType, TrackStart, WebsocketClosed
     },
     outgoing::{
         Destroy, Equalizer, EqualizerBand, OutgoingEvent, Pause, Play, Seek, SlimVoiceServerUpdate,
@@ -645,7 +670,7 @@ mod tests {
     use super::{
         incoming::{
             IncomingEvent, PlayerUpdate, PlayerUpdateState, Stats, StatsCpu, StatsFrames,
-            StatsMemory, TrackEnd, TrackEventType, TrackStart,
+            StatsMemory, TrackEnd, TrackEventType, TrackStart, WebsocketClosed
         },
         outgoing::{
             Destroy, Equalizer, EqualizerBand, OutgoingEvent, Pause, Play, Seek,
@@ -883,6 +908,16 @@ mod tests {
     assert_fields!(TrackStart: guild_id, kind, op, track);
     assert_impl_all!(
         TrackStart: Clone,
+        Debug,
+        Deserialize<'static>,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync,
+    );
+    assert_fields!(WebsocketClosed: guild_id, kind, op, code, reason, by_remote);
+    assert_impl_all!(
+        WebsocketClosed: Clone,
         Debug,
         Deserialize<'static>,
         PartialEq,

--- a/lavalink/src/model.rs
+++ b/lavalink/src/model.rs
@@ -650,14 +650,14 @@ pub mod incoming {
         /// True if Discord closed the connection, false if Lavalink closed it.
         pub by_remote: bool,
         /// The reason the connection was closed.
-        pub reason: String
+        pub reason: String,
     }
 }
 
 pub use self::{
     incoming::{
         IncomingEvent, PlayerUpdate, PlayerUpdateState, Stats, StatsCpu, StatsFrames, StatsMemory,
-        TrackEnd, TrackEventType, TrackStart, WebsocketClosed
+        TrackEnd, TrackEventType, TrackStart, WebsocketClosed,
     },
     outgoing::{
         Destroy, Equalizer, EqualizerBand, OutgoingEvent, Pause, Play, Seek, SlimVoiceServerUpdate,
@@ -670,7 +670,7 @@ mod tests {
     use super::{
         incoming::{
             IncomingEvent, PlayerUpdate, PlayerUpdateState, Stats, StatsCpu, StatsFrames,
-            StatsMemory, TrackEnd, TrackEventType, TrackStart, WebsocketClosed
+            StatsMemory, TrackEnd, TrackEventType, TrackStart, WebsocketClosed,
         },
         outgoing::{
             Destroy, Equalizer, EqualizerBand, OutgoingEvent, Pause, Play, Seek,


### PR DESCRIPTION
This event is fired when either Discord or Lavalink close the voice websocket connection. This may happen , for example, when a moderator forcefully disconnects the bot user from the guild channel, and this would be necessary to clean up local resources in the case of a disconnect (i.e. drop a local player queue).

IncomingEvent is tagged with `#[non_exhaustive]`, so this technically isn't a breaking change. If it would be easier to target trunk, I can retarget this PR if need be.