### PR TITLE
fix(http): Set request headers & default headers after content headers

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1470,14 +1470,13 @@ impl Client {
 
         if let Some(headers) = builder.headers_mut() {
             if let Some(form) = &form {
-                let content_type = HeaderValue::try_from(form.content_type());
-                if let Ok(content_type) = content_type {
+                if let Ok(content_type) = HeaderValue::try_from(form.content_type()) {
                     headers.insert(CONTENT_TYPE, content_type);
                 }
             } else if let Some(bytes) = &body {
                 let len = bytes.len();
-
                 headers.insert(CONTENT_LENGTH, len.into());
+
                 let content_type = HeaderValue::from_static("application/json");
                 headers.insert(CONTENT_TYPE, content_type);
             }

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1469,6 +1469,19 @@ impl Client {
         ));
 
         if let Some(headers) = builder.headers_mut() {
+            if let Some(form) = &form {
+                let content_type = HeaderValue::try_from(form.content_type());
+                if let Ok(content_type) = content_type {
+                    headers.insert(CONTENT_TYPE, content_type);
+                }
+            } else if let Some(bytes) = &body {
+                let len = bytes.len();
+
+                headers.insert(CONTENT_LENGTH, len.into());
+                let content_type = HeaderValue::from_static("application/json");
+                headers.insert(CONTENT_TYPE, content_type);
+            }
+
             headers.insert(USER_AGENT, user_agent);
 
             if let Some(req_headers) = req_headers {
@@ -1478,37 +1491,23 @@ impl Client {
                     }
                 }
             }
-        }
 
-        if let (Some(default_headers), Some(headers)) =
-            (&self.state.default_headers, &mut builder.headers_mut())
-        {
-            for (name, value) in default_headers {
-                headers.insert(name, HeaderValue::from(value));
+            if let Some(default_headers) = &self.state.default_headers {
+                for (name, value) in default_headers {
+                    headers.insert(name, HeaderValue::from(value));
+                }
             }
         }
 
         let req = if let Some(form) = form {
-            let content_type = HeaderValue::try_from(form.content_type());
             let form_bytes = form.build();
             if let Some(headers) = builder.headers_mut() {
-                if let Ok(content_type) = content_type {
-                    headers.insert(CONTENT_TYPE, content_type);
-                }
                 headers.insert(CONTENT_LENGTH, form_bytes.len().into());
             };
             builder
                 .body(Body::from(form_bytes))
                 .map_err(|source| Error::BuildingRequest { source })?
         } else if let Some(bytes) = body {
-            let len = bytes.len();
-
-            if let Some(headers) = builder.headers_mut() {
-                headers.insert(CONTENT_LENGTH, len.into());
-                let content_type = HeaderValue::from_static("application/json");
-                headers.insert(CONTENT_TYPE, content_type);
-            }
-
             builder
                 .body(Body::from(bytes))
                 .map_err(|source| Error::BuildingRequest { source })?


### PR DESCRIPTION
This PR fixes setting the request & default headers after the content headers so that when the raw method is invoked with a `CONTENT-TYPE` header, it is not incorrectly overwritten. This also fixes sending attachments with the http-proxy.