### PR TITLE
ci(clippy): fix rust 1.51 clippy lints

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -1087,8 +1087,7 @@ mod tests {
 
     #[test]
     fn test_guild_create_channels_have_guild_ids() {
-        let mut channels = Vec::new();
-        channels.push(GuildChannel::Text(TextChannel {
+        let channels = Vec::from([GuildChannel::Text(TextChannel {
             id: ChannelId(111),
             guild_id: None,
             kind: ChannelType::GuildText,
@@ -1101,7 +1100,7 @@ mod tests {
             position: 1,
             rate_limit_per_user: None,
             topic: None,
-        }));
+        })]);
 
         let guild = Guild {
             id: GuildId(123),

--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -42,6 +42,7 @@ pub enum ErrorCode {
     /// Unknown ban
     UnknownBan,
     /// Unknown SKU
+    #[allow(clippy::upper_case_acronyms)]
     UnknownSKU,
     /// Unknown Store Listing
     UnknownStoreListing,
@@ -96,6 +97,7 @@ pub enum ErrorCode {
     /// Invalid account type
     InvalidAccountType,
     /// Cannot execute action on a DM channel
+    #[allow(clippy::upper_case_acronyms)]
     InvalidDMChannelAction,
     /// Guild widget disabled
     GuildWidgetDisabled,

--- a/http/src/request/channel/allowed_mentions.rs
+++ b/http/src/request/channel/allowed_mentions.rs
@@ -282,6 +282,10 @@ impl<
     > AllowedMentionsBuilder<'a, E, U, R>
 {
     /// Return a [`CreateMessage`] struct with the specified `allowed_mentions`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when no message builder was provided.
     pub fn build(self) -> CreateMessage<'a> {
         match self.create_message {
             Some(mut builder) => {
@@ -300,6 +304,10 @@ impl<
     }
 
     /// Return a [`ExecuteWebhook`] struct with the specified `allowed_mentions`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when no message builder was provided.
     pub fn build_webhook(self) -> ExecuteWebhook<'a> {
         match self.execute_webhook {
             Some(mut builder) => {

--- a/model/src/gateway/payload/member_chunk.rs
+++ b/model/src/gateway/payload/member_chunk.rs
@@ -303,9 +303,7 @@ mod tests {
             chunk_count: 1,
             chunk_index: 0,
             guild_id: GuildId(1),
-            members: {
-                let mut members = Vec::new();
-                members.push(Member {
+            members: Vec::from([Member {
                     deaf: false,
                     guild_id: GuildId(1),
                     hoisted_role: Some(RoleId(6)),
@@ -330,8 +328,7 @@ mod tests {
                         system: None,
                         public_flags: None,
                     },
-                });
-                members.push(Member {
+                }, Member {
                     deaf: false,
                     guild_id: GuildId(1),
                     hoisted_role: Some(RoleId(6)),
@@ -356,8 +353,7 @@ mod tests {
                         system: None,
                         public_flags: None,
                     },
-                });
-                members.push(Member {
+                }, Member {
                     deaf: false,
                     guild_id: GuildId(1),
                     hoisted_role: Some(RoleId(6)),
@@ -382,8 +378,7 @@ mod tests {
                         system: None,
                         public_flags: Some(UserFlags::VERIFIED_BOT_DEVELOPER),
                     },
-                });
-                members.push(Member {
+                }, Member {
                     deaf: false,
                     guild_id: GuildId(1),
                     hoisted_role: Some(RoleId(6)),
@@ -408,15 +403,10 @@ mod tests {
                         system: None,
                         public_flags: None,
                     },
-                });
-
-                members
-            },
+                }]),
             nonce: None,
             not_found: Vec::new(),
-            presences: {
-                let mut presences = Vec::new();
-                presences.push(Presence {
+            presences: Vec::from([Presence {
                     activities: Vec::new(),
                     client_status: ClientStatus {
                         desktop: None,
@@ -426,8 +416,8 @@ mod tests {
                     guild_id: GuildId(1),
                     status: Status::Online,
                     user: UserOrId::UserId { id: UserId(2) },
-                });
-                presences.push(Presence {
+                },
+                Presence {
                     activities: Vec::new(),
                     client_status: ClientStatus {
                         desktop: None,
@@ -437,8 +427,8 @@ mod tests {
                     guild_id: GuildId(1),
                     status: Status::Online,
                     user: UserOrId::UserId { id: UserId(3) },
-                });
-                presences.push(Presence {
+                },
+                Presence {
                     activities: Vec::new(),
                     client_status: ClientStatus {
                         desktop: Some(Status::DoNotDisturb),
@@ -448,10 +438,7 @@ mod tests {
                     guild_id: GuildId(1),
                     status: Status::DoNotDisturb,
                     user: UserOrId::UserId { id: UserId(5) },
-                });
-
-                presences
-            },
+                }]),
         };
 
         let actual = serde_json::from_value::<MemberChunk>(input).unwrap();

--- a/model/src/gateway/payload/member_chunk.rs
+++ b/model/src/gateway/payload/member_chunk.rs
@@ -303,7 +303,8 @@ mod tests {
             chunk_count: 1,
             chunk_index: 0,
             guild_id: GuildId(1),
-            members: Vec::from([Member {
+            members: Vec::from([
+                Member {
                     deaf: false,
                     guild_id: GuildId(1),
                     hoisted_role: Some(RoleId(6)),
@@ -328,7 +329,8 @@ mod tests {
                         system: None,
                         public_flags: None,
                     },
-                }, Member {
+                },
+                Member {
                     deaf: false,
                     guild_id: GuildId(1),
                     hoisted_role: Some(RoleId(6)),
@@ -353,7 +355,8 @@ mod tests {
                         system: None,
                         public_flags: None,
                     },
-                }, Member {
+                },
+                Member {
                     deaf: false,
                     guild_id: GuildId(1),
                     hoisted_role: Some(RoleId(6)),
@@ -378,7 +381,8 @@ mod tests {
                         system: None,
                         public_flags: Some(UserFlags::VERIFIED_BOT_DEVELOPER),
                     },
-                }, Member {
+                },
+                Member {
                     deaf: false,
                     guild_id: GuildId(1),
                     hoisted_role: Some(RoleId(6)),
@@ -403,10 +407,12 @@ mod tests {
                         system: None,
                         public_flags: None,
                     },
-                }]),
+                },
+            ]),
             nonce: None,
             not_found: Vec::new(),
-            presences: Vec::from([Presence {
+            presences: Vec::from([
+                Presence {
                     activities: Vec::new(),
                     client_status: ClientStatus {
                         desktop: None,
@@ -438,7 +444,8 @@ mod tests {
                     guild_id: GuildId(1),
                     status: Status::DoNotDisturb,
                     user: UserOrId::UserId { id: UserId(5) },
-                }]),
+                },
+            ]),
         };
 
         let actual = serde_json::from_value::<MemberChunk>(input).unwrap();

--- a/model/src/gateway/presence/mod.rs
+++ b/model/src/gateway/presence/mod.rs
@@ -274,8 +274,7 @@ mod tests {
             "activities": []
         }]"#;
 
-        let mut expected = Vec::new();
-        expected.push(Presence {
+        let expected = Vec::from([Presence {
             activities: vec![],
             client_status: ClientStatus {
                 desktop: Some(Status::Online),
@@ -285,7 +284,7 @@ mod tests {
             guild_id: GuildId(2),
             status: Status::Online,
             user: UserOrId::UserId { id: UserId(1) },
-        });
+        }]);
 
         let mut json_deserializer = Deserializer::from_str(input);
         let deserializer = PresenceListDeserializer::new(GuildId(2));


### PR DESCRIPTION
Fix Clippy lints introduced in the release of Rust 1.51.

Two enum variants have been marked with an #[allow] to prevent changing their names. These should be renamed at a later major version.