### PR TITLE
Lavalink:  Add methods to close and cleanup connections to Lavalink nodes

### DIFF
--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -326,7 +326,7 @@ impl Lavalink {
     }
 
     /// Determine the "best" node for new players according to available nodes'
-    /// penalty scores. Disconnected nodes are will not be considered.
+    /// penalty scores. Disconnected nodes will not be considered.
     ///
     /// Refer to [`Node::penalty`] for how this is calculated.
     ///

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -282,6 +282,14 @@ impl Node {
         &self.0.players
     }
 
+    /// Closes the connection with the node. All future calls to `[Node::send]` will fail.
+    ///
+    /// Using [`Lavalink::disconnect`] is advised over directly calling this, as it will also
+    /// removing the node from the manager.
+    pub fn close(&self) {
+        self.sender().close_channel();
+    }
+
     /// Retrieve an immutable reference to the node's configuration.
     ///
     /// Note that sending player events through the node's sender won't update
@@ -485,6 +493,13 @@ impl Connection {
         *self.stats.lock().await = stats.clone();
 
         Ok(())
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        // Cleanup local players associated with the node
+        self.players.players.retain(|_, v| v.node().config() != &self.config);
     }
 }
 

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -499,7 +499,9 @@ impl Connection {
 impl Drop for Connection {
     fn drop(&mut self) {
         // Cleanup local players associated with the node
-        self.players.players.retain(|_, v| v.node().config() != &self.config);
+        self.players
+            .players
+            .retain(|_, v| v.node().config() != &self.config);
     }
 }
 

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -282,7 +282,7 @@ impl Node {
         &self.0.players
     }
 
-    /// Closes the connection with the node. All future calls to `[Node::send]` will fail.
+    /// Closes the connection with the node. All future calls to [`Node::send`] will fail.
     ///
     /// Using [`Lavalink::disconnect`] is advised over directly calling this, as it will also
     /// removing the node from the manager.
@@ -501,7 +501,7 @@ impl Drop for Connection {
         // Cleanup local players associated with the node
         self.players
             .players
-            .retain(|_, v| v.node().config() != &self.config);
+            .retain(|_, v| v.node().config().address != self.config.address);
     }
 }
 


### PR DESCRIPTION
 - Added `Node::close` to close terminate the connection.
 - Added `Lavalink::disconnect` to close the websocket connection to a specified node and remove it from the manager.
 - Updated `Lavalink::best` to only consider connected nodes.
 - Implemented `Drop` for `Connection` which removes all players associated  with the connection.