### PR TITLE
cache: use VecDeque instead of BTreeMap for messages

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -385,7 +385,10 @@ impl InMemoryCache {
     ) -> Option<Arc<CachedMessage>> {
         let channel = self.0.messages.get(&channel_id)?;
 
-        channel.iter().find(|msg| msg.id == message_id).map(Arc::clone)
+        channel
+            .iter()
+            .find(|msg| msg.id == message_id)
+            .map(Arc::clone)
     }
 
     /// Gets a presence by, optionally, guild ID, and user ID.


### PR DESCRIPTION
Storing the cached messages in a VecDeque instead of a BTreeMap has some performance implications:
- `MessageDelete`, `MessageDeleteBulk`, `MessageUpdate`, `ReactionAdd`, `ReactionRemove`, `ReactionRemoveAll`, and `ReactionRemoveEmoji` events now have a message lookup of O(n) instead of O(log n).
- `MessageCreate` now performs in O(1) instead of O(log n)

Additionally, the cache's `message` method now operates in O(n) instead of O(log n).

Another thing to note is the message order:
- In a BTreeMap messages are ordered by their id. This would be incorrect in case an older message has a larger id than a newer message.
- In a VecDeque messages are ordered by the `MessageCreate` arrival order. This would be incorrect in case older messages arrive after newer messages. It also prevents using a binary search lookup for the now O(n) events.


Personally, I'm observing ~6 times more `MessageCreate`s than those other events combined so I'm happy with the performance tradeoff. The issue with the message order is a little sad but still no dealbreaker imo.

PS: Instead of inserting `VecDeque::default()` on new channels, it is also possible to insert `VecDeque::with_capacity(msg_cache_size)` but I wasn't sure if it improves things so I didn't include it.