### PR TITLE
Rename HTTP path variant variant for consistency

### DIFF
--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -147,7 +147,7 @@ pub enum Path {
     /// Operating on the voice regions available to the current user.
     VoiceRegions,
     /// Operating on a message created by a webhook.
-    WebhooksIdTokenMessageId(u64),
+    WebhooksIdTokenMessagesId(u64),
     /// Operating on a webhook.
     WebhooksId(u64),
 }

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -1091,7 +1091,7 @@ impl Route {
                 webhook_id,
             } => (
                 Method::DELETE,
-                Path::WebhooksIdTokenMessageId(webhook_id),
+                Path::WebhooksIdTokenMessagesId(webhook_id),
                 format!("webhooks/{}/{}/messages/{}", webhook_id, token, message_id).into(),
             ),
             Self::DeleteWebhook { token, webhook_id } => {
@@ -1544,7 +1544,7 @@ impl Route {
                 webhook_id,
             } => (
                 Method::PATCH,
-                Path::WebhooksIdTokenMessageId(webhook_id),
+                Path::WebhooksIdTokenMessagesId(webhook_id),
                 format!("webhooks/{}/{}/messages/{}", webhook_id, token, message_id).into(),
             ),
             Self::UpdateWebhook { token, webhook_id } => {


### PR DESCRIPTION
Rename the `Path::WebhooksIdTokenMessageId` enum variant to `Path::WebhooksIdTokenMessagesId` for consistency.

Relates to #743 where a TODO was initially written in.