### PR TITLE
Implement Ord and PartialOrd on Role

### DIFF
--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -23,10 +23,7 @@ impl Ord for Role {
     /// positions are unique, positive, or contiguous. In the case of equal positions, order is
     /// based on the roles' IDs instead.
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.position.cmp(&other.position) {
-            Ordering::Equal => self.id.0.cmp(&other.id.0),
-            ordering => ordering,
-        }
+        self.position.cmp(&other.position).then(self.id.0.cmp(&other.id.0))
     }
 }
 

--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -19,11 +19,90 @@ pub struct Role {
 }
 
 impl Ord for Role {
-    /// Roles are ordered primarily by position. Discord does not provide guarentees that role
-    /// positions are unique, positive, or contiguous. In the case of equal positions, order is
-    /// based on the roles' IDs instead.
+    /// Compare two roles to each other using their position and ID.
+    ///
+    /// Roles are primarily ordered by their position in descending order. For example,
+    /// a role with a position of 17 is considered a higher role than one with a
+    /// position of 12.
+    ///
+    /// Discord does not guarantee that role positions are positive, unique, or contiguous. When
+    /// two or more roles have the same position then the order is based on the roles' IDs in
+    /// ascending order. For example, given two roles with positions of 10 then a role
+    /// with an ID of 1 would be considered a higher role than one with an ID of 20.
+    ///
+    /// ### Examples
+    ///
+    /// Compare the position of two roles:
+    ///
+    /// ```rust
+    /// # use twilight_model::{guild::{Permissions, Role}, id::RoleId};
+    /// # use std::cmp::Ordering;
+    /// let role_a = Role {
+    ///     id: RoleId(123),
+    ///     position: 12,
+    ///#    color: 0,
+    ///#    hoist: true,
+    ///#    managed: false,
+    ///#    mentionable: true,
+    ///#    name: "test".to_owned(),
+    ///#    permissions: Permissions::ADMINISTRATOR,
+    ///#    tags: None,
+    ///     // ...
+    /// };
+    /// let role_b = Role {
+    ///     id: RoleId(456),
+    ///     position: 13,
+    ///#    color: 0,
+    ///#    hoist: true,
+    ///#    managed: false,
+    ///#    mentionable: true,
+    ///#    name: "test".to_owned(),
+    ///#    permissions: Permissions::ADMINISTRATOR,
+    ///#    tags: None,
+    ///     // ...
+    /// };
+    /// assert_eq!(Ordering::Less, role_a.cmp(&role_b));
+    /// assert_eq!(Ordering::Greater, role_b.cmp(&role_a));
+    /// assert_eq!(Ordering::Equal, role_a.cmp(&role_a));
+    /// assert_eq!(Ordering::Equal, role_b.cmp(&role_b));
+    /// ```
+    ///
+    /// Compare the position of two roles with the same position:
+    ///
+    /// ```rust
+    /// # use twilight_model::{guild::{Permissions, Role}, id::RoleId};
+    /// # use std::cmp::Ordering;
+    /// let role_a = Role {
+    ///     id: RoleId(123),
+    ///     position: 12,
+    ///#    color: 0,
+    ///#    hoist: true,
+    ///#    managed: false,
+    ///#    mentionable: true,
+    ///#    name: "test".to_owned(),
+    ///#    permissions: Permissions::ADMINISTRATOR,
+    ///#    tags: None,
+    /// };
+    /// let role_b = Role {
+    ///     id: RoleId(456),
+    ///     position: 12,
+    ///#    color: 0,
+    ///#    hoist: true,
+    ///#    managed: false,
+    ///#    mentionable: true,
+    ///#    name: "test".to_owned(),
+    ///#    permissions: Permissions::ADMINISTRATOR,
+    ///#    tags: None,
+    /// };
+    /// assert_eq!(Ordering::Less, role_a.cmp(&role_b));
+    /// assert_eq!(Ordering::Greater, role_b.cmp(&role_a));
+    /// assert_eq!(Ordering::Equal, role_a.cmp(&role_a));
+    /// assert_eq!(Ordering::Equal, role_b.cmp(&role_b));
+    /// ```
     fn cmp(&self, other: &Self) -> Ordering {
-        self.position.cmp(&other.position).then(self.id.0.cmp(&other.id.0))
+        self.position
+            .cmp(&other.position)
+            .then(self.id.0.cmp(&other.id.0))
     }
 }
 
@@ -37,7 +116,6 @@ impl PartialOrd for Role {
 mod tests {
     use super::{Permissions, Role, RoleId};
     use serde_test::Token;
-    use std::cmp::Ordering;
 
     #[test]
     fn test_role() {
@@ -80,77 +158,5 @@ mod tests {
                 Token::StructEnd,
             ],
         );
-    }
-
-    #[test]
-    fn test_role_ordering() {
-        let role_a = Role {
-            color: 0,
-            hoist: true,
-            id: RoleId(123),
-            managed: false,
-            mentionable: true,
-            name: "test".to_owned(),
-            permissions: Permissions::ADMINISTRATOR,
-            position: 12,
-            tags: None,
-        };
-
-        let role_b = Role {
-            color: 0,
-            hoist: true,
-            id: RoleId(456),
-            managed: false,
-            mentionable: true,
-            name: "test".to_owned(),
-            permissions: Permissions::ADMINISTRATOR,
-            position: 120,
-            tags: None,
-        };
-
-        assert_eq!(Ordering::Less, role_a.cmp(&role_b));
-        assert_eq!(Ordering::Greater, role_b.cmp(&role_a));
-        assert_eq!(Ordering::Equal, role_a.cmp(&role_a));
-        assert_eq!(Ordering::Equal, role_b.cmp(&role_b));
-        assert_eq!(Some(Ordering::Less), role_a.partial_cmp(&role_b));
-        assert_eq!(Some(Ordering::Greater), role_b.partial_cmp(&role_a));
-        assert_eq!(Some(Ordering::Equal), role_a.partial_cmp(&role_a));
-        assert_eq!(Some(Ordering::Equal), role_b.partial_cmp(&role_b));
-    }
-
-    #[test]
-    fn test_role_ordering_equal_position() {
-        let role_a = Role {
-            color: 0,
-            hoist: true,
-            id: RoleId(123),
-            managed: false,
-            mentionable: true,
-            name: "test".to_owned(),
-            permissions: Permissions::ADMINISTRATOR,
-            position: 12,
-            tags: None,
-        };
-
-        let role_b = Role {
-            color: 0,
-            hoist: true,
-            id: RoleId(456),
-            managed: false,
-            mentionable: true,
-            name: "test".to_owned(),
-            permissions: Permissions::ADMINISTRATOR,
-            position: 12,
-            tags: None,
-        };
-
-        assert_eq!(Ordering::Less, role_a.cmp(&role_b));
-        assert_eq!(Ordering::Greater, role_b.cmp(&role_a));
-        assert_eq!(Ordering::Equal, role_a.cmp(&role_a));
-        assert_eq!(Ordering::Equal, role_b.cmp(&role_b));
-        assert_eq!(Some(Ordering::Less), role_a.partial_cmp(&role_b));
-        assert_eq!(Some(Ordering::Greater), role_b.partial_cmp(&role_a));
-        assert_eq!(Some(Ordering::Equal), role_a.partial_cmp(&role_a));
-        assert_eq!(Some(Ordering::Equal), role_b.partial_cmp(&role_b));
     }
 }


### PR DESCRIPTION
Role ordering can be done `position`, but Discord provides zero guarantees that positions are unique, positive, or contiguous. In the case of positions being equal, order is deferred to an ordering based on ID. This is not immediately apparent, nor easy to replicate where needed. 

This PR implements both `Ord` and `PartialOrd` on Role to provide a consistent implementation for ordering roles.

Added appropriate unit tests.

There is one thing missing from this PR. The `@everyone` role is always at the bottom of the role list and has an ID equal to the guild's ID. In the odd case that the role doesn't have a position of 0, this implementation might be wrong. However, adding this will require access to the guild ID in some way (changing the actual contents of the model), or using less efficient and hackier checks (i.e. checking if the role name is "@everyone". For these reasons, this check is currently intentionally omitted from this PR.