### PR TITLE
Remove MentionIter's Debug bound

### DIFF
--- a/mention/src/parse/iter.rs
+++ b/mention/src/parse/iter.rs
@@ -51,7 +51,7 @@ impl<'a, T> MentionIter<'a, T> {
     }
 }
 
-impl<'a, T: ParseMention + std::fmt::Debug> Iterator for MentionIter<'a, T> {
+impl<'a, T: ParseMention> Iterator for MentionIter<'a, T> {
     /// Found mention followed by the start and ending indexes in the source
     /// string returned by [`as_str`].
     ///


### PR DESCRIPTION
Remove the `Debug` bound on the `mention` crate's `MentionIter` `Iterator` implementation. This isn't necessary as no Debug formatting is performed.