### PR TITLE
Correctly parse global ratelimit headers

### DIFF
--- a/http/src/ratelimiting/headers.rs
+++ b/http/src/ratelimiting/headers.rs
@@ -83,10 +83,17 @@ impl TryFrom<&'_ HeaderMap<HeaderValue>> for RatelimitHeaders {
 
 #[allow(clippy::cast_possible_truncation)]
 fn parse_map(map: &HeaderMap<HeaderValue>) -> RatelimitResult<RatelimitHeaders> {
+    if let Ok(true) = header_bool(map, "x-ratelimit-global") {
+        let retry_after = header_int(map, "retry-after")?;
+
+        return Ok(RatelimitHeaders::GlobalLimited {
+            reset_after: retry_after,
+        });
+    }
+
     let bucket = header_str(map, "x-ratelimit-bucket")
         .ok()
         .map(ToOwned::to_owned);
-    let global = header_bool(map, "x-ratelimit-global").unwrap_or(false);
     let limit = header_int(map, "x-ratelimit-limit")?;
     let remaining = header_int(map, "x-ratelimit-remaining")?;
     let reset = header_float(map, "x-ratelimit-reset")?;
@@ -98,7 +105,7 @@ fn parse_map(map: &HeaderMap<HeaderValue>) -> RatelimitResult<RatelimitHeaders> 
 
     Ok(RatelimitHeaders::Present {
         bucket,
-        global,
+        global: false,
         limit,
         remaining,
         reset,
@@ -192,4 +199,35 @@ fn header_str<'a>(map: &'a HeaderMap<HeaderValue>, name: &'static str) -> Rateli
         })?;
 
     Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RatelimitHeaders;
+    use hyper::header::{HeaderMap, HeaderName, HeaderValue};
+    use std::{convert::TryFrom, error::Error};
+
+    #[test]
+    fn test_global() -> Result<(), Box<dyn Error>> {
+        let map = {
+            let mut map = HeaderMap::new();
+            map.insert(
+                HeaderName::from_static("x-ratelimit-global"),
+                HeaderValue::from_static("true"),
+            );
+            map.insert(
+                HeaderName::from_static("retry-after"),
+                HeaderValue::from_static("65"),
+            );
+
+            map
+        };
+
+        let headers = RatelimitHeaders::try_from(&map)?;
+        assert!(
+            matches!(headers, RatelimitHeaders::GlobalLimited { reset_after } if reset_after == 65)
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Global ratelimits were not being parsed prior to other headers, meaning that the absense of other headers would cause all parsing to fail. By parsing the `x-ratelimit-global` header as the first step we short-circuit on global ratelimits.

Notably `x-ratelimit-reset-after` is not in the response but `retry-after` is.