### PR TITLE
Remove hyper builder method

### DIFF
--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -1,9 +1,6 @@
-use super::{Client, HttpsConnector, State};
+use super::{Client, State};
 use crate::{ratelimiting::Ratelimiter, request::channel::allowed_mentions::AllowedMentions};
-use hyper::{
-    client::{Client as HyperClient, HttpConnector},
-    header::HeaderMap,
-};
+use hyper::header::HeaderMap;
 use std::{
     sync::{atomic::AtomicBool, Arc},
     time::Duration,
@@ -15,7 +12,6 @@ pub struct ClientBuilder {
     pub(crate) default_allowed_mentions: Option<AllowedMentions>,
     pub(crate) proxy: Option<Box<str>>,
     pub(crate) ratelimiter: Option<Ratelimiter>,
-    pub(crate) hyper_client: Option<HyperClient<HttpsConnector<HttpConnector>>>,
     pub(crate) default_headers: Option<HeaderMap>,
     pub(crate) timeout: Duration,
     pub(crate) token: Option<Box<str>>,
@@ -30,20 +26,18 @@ impl ClientBuilder {
 
     /// Build the [`Client`].
     pub fn build(self) -> Client {
-        let http = self.hyper_client.unwrap_or_else(|| {
-            #[cfg(feature = "rustls-native-roots")]
-            let connector = hyper_rustls::HttpsConnector::with_native_roots();
-            #[cfg(all(feature = "rustls-webpki-roots", not(feature = "rustls-native-roots")))]
-            let connector = hyper_rustls::HttpsConnector::with_webpki_roots();
-            #[cfg(all(
-                feature = "hyper-tls",
-                not(feature = "rustls-native-roots"),
-                not(feature = "rustls-webpki-roots")
-            ))]
-            let connector = hyper_tls::HttpsConnector::new();
+        #[cfg(feature = "rustls-native-roots")]
+        let connector = hyper_rustls::HttpsConnector::with_native_roots();
+        #[cfg(all(feature = "rustls-webpki-roots", not(feature = "rustls-native-roots")))]
+        let connector = hyper_rustls::HttpsConnector::with_webpki_roots();
+        #[cfg(all(
+            feature = "hyper-tls",
+            not(feature = "rustls-native-roots"),
+            not(feature = "rustls-webpki-roots")
+        ))]
+        let connector = hyper_tls::HttpsConnector::new();
 
-            hyper::client::Builder::default().build(connector)
-        });
+        let http = hyper::client::Builder::default().build(connector);
 
         Client {
             state: Arc::new(State {
@@ -64,18 +58,6 @@ impl ClientBuilder {
     /// client.
     pub fn default_allowed_mentions(mut self, allowed_mentions: AllowedMentions) -> Self {
         self.default_allowed_mentions.replace(allowed_mentions);
-
-        self
-    }
-
-    /// Set a pre-configured Hyper client builder to build off of.
-    ///
-    /// The proxy and timeout settings in the Hyper client will be overridden by
-    /// those in this builder.
-    ///
-    /// The default client uses Rustls as its TLS backend.
-    pub fn hyper_client(mut self, client: HyperClient<HttpsConnector<HttpConnector>>) -> Self {
-        self.hyper_client.replace(client);
 
         self
     }
@@ -159,7 +141,6 @@ impl Default for ClientBuilder {
     fn default() -> Self {
         Self {
             default_allowed_mentions: None,
-            hyper_client: None,
             default_headers: None,
             proxy: None,
             ratelimiter: Some(Ratelimiter::new()),

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1649,21 +1649,3 @@ impl Client {
         })
     }
 }
-
-impl From<HyperClient<HttpsConnector<HttpConnector>>> for Client {
-    fn from(hyper_client: HyperClient<HttpsConnector<HttpConnector>>) -> Self {
-        Self {
-            state: Arc::new(State {
-                http: hyper_client,
-                default_headers: None,
-                proxy: None,
-                ratelimiter: Some(Ratelimiter::new()),
-                timeout: Duration::from_secs(10),
-                token_invalid: AtomicBool::new(false),
-                token: None,
-                use_http: false,
-                default_allowed_mentions: None,
-            }),
-        }
-    }
-}


### PR DESCRIPTION
Remove the `ClientBuilder::hyper_client` method so that we don't expose `hyper`. This also removes the `From` implementation. We can add an implementation in the future to configure the hyper client if needed.

Part of #714.