### PR TITLE
`AuditLogEntry::user_id` is now nullable

### DIFF
--- a/model/src/guild/audit_log/entry.rs
+++ b/model/src/guild/audit_log/entry.rs
@@ -15,5 +15,5 @@ pub struct AuditLogEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
     pub target_id: Option<String>,
-    pub user_id: UserId,
+    pub user_id: Option<UserId>,
 }


### PR DESCRIPTION
The `AuditLogEntry::user_id` field is now nullable, per <https://github.com/discord/discord-api-docs/commit/367ea81704dd089481e9865678355a5a8b422088>.

Although this is a breaking change our semver policy on the `model` crate is different, so this can go on `trunk`.