### PR TITLE
feat(http/api_error): add code 60003 'two factor'

### DIFF
--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -149,6 +149,8 @@ pub enum ErrorCode {
     InvalidApiVersion,
     /// Invalid sticker sent
     InvalidStickerSent,
+    /// Two factor is required for this operation.
+    TwoFactorRequired,
     /// Reaction was blocked
     ReactionBlocked,
     /// API resource is currently overloaded. Try again a little later
@@ -232,6 +234,7 @@ impl ErrorCode {
             Self::InviteAcceptedToGuildBotNotIn => 50036,
             Self::InvalidApiVersion => 50041,
             Self::InvalidStickerSent => 50081,
+            Self::TwoFactorRequired => 60003,
             Self::ReactionBlocked => 90001,
             Self::ApiResourceOverloaded => 130_000,
             Self::Other(other) => *other,
@@ -312,6 +315,7 @@ impl From<u64> for ErrorCode {
             50036 => Self::InviteAcceptedToGuildBotNotIn,
             50041 => Self::InvalidApiVersion,
             50081 => Self::InvalidStickerSent,
+            60003 => Self::TwoFactorRequired,
             90001 => Self::ReactionBlocked,
             130_000 => Self::ApiResourceOverloaded,
             other => Self::Other(other),
@@ -392,6 +396,7 @@ impl Display for ErrorCode {
             Self::InviteAcceptedToGuildBotNotIn => f.write_str("An invite was accepted to a guild the application's bot is not in"),
             Self::InvalidApiVersion => f.write_str("Invalid API version provided"),
             Self::InvalidStickerSent => f.write_str("Invalid sticker sent"),
+            Self::TwoFactorRequired => f.write_str("Two factor is required for this operation"),
             Self::ReactionBlocked => f.write_str("Reaction was blocked"),
             Self::ApiResourceOverloaded => f.write_str("API resource is currently overloaded. Try again a little later"),
             Self::Other(number) => write!(f, "An error code Twilight doesn't have registered: {}", number),


### PR DESCRIPTION
Add API error code 60003, which is defined as "Two factor is required for this operation."

Per <https://github.com/discord/discord-api-docs/commit/17a2d897ed94f1f67cee1000d561f2dc49a84b4a>.