### PR TITLE
Rename Create Invite payload field `target_user` to `target_user_id`

### DIFF
--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -14,8 +14,8 @@ struct CreateInviteFields {
     temporary: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     unique: Option<bool>,
-    #[serde(rename = "target_user_id", skip_serializing_if = "Option::is_none")]
-    target_user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_user_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_user_type: Option<TargetUserType>,
 }
@@ -97,10 +97,18 @@ impl<'a> CreateInvite<'a> {
     }
 
     /// Set the target user for this invite.
-    pub fn target_user(mut self, target_user: UserId) -> Self {
-        self.fields.target_user.replace(target_user.0.to_string());
+    pub fn target_user_id(mut self, target_user_id: UserId) -> Self {
+        self.fields
+            .target_user_id
+            .replace(target_user_id.0.to_string());
 
         self
+    }
+
+    /// Set the target user for this invite.
+    #[deprecated(since = "0.3.7", note = "Use `target_user_id` instead")]
+    pub fn target_user(mut self, target_user_id: UserId) -> Self {
+        self.target_user_id(target_user_id)
     }
 
     /// Set the target user type for this invite.

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -14,7 +14,7 @@ struct CreateInviteFields {
     temporary: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     unique: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "target_user_id", skip_serializing_if = "Option::is_none")]
     target_user: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_user_type: Option<TargetUserType>,

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -107,7 +107,7 @@ impl<'a> CreateInvite<'a> {
 
     /// Set the target user for this invite.
     #[deprecated(since = "0.3.7", note = "Use `target_user_id` instead")]
-    pub fn target_user(mut self, target_user_id: UserId) -> Self {
+    pub fn target_user(self, target_user_id: UserId) -> Self {
         self.target_user_id(target_user_id)
     }
 


### PR DESCRIPTION
Rename the `target_user` payload field in the Create Invite request to `target_user_id`. The `CreateInvite::target_user` method has been deprecated and `CreateInvite::target_user_id` has been created in its place.

Per <https://github.com/discord/discord-api-docs/commit/ad3a7fd17e8142e086deaa255494be95c7b64635>.