### PR TITLE
fix(model): attachment width/height are optional

### DIFF
--- a/model/src/channel/attachment.rs
+++ b/model/src/channel/attachment.rs
@@ -4,11 +4,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Attachment {
     pub filename: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u64>,
     pub id: AttachmentId,
     pub proxy_url: String,
     pub size: u64,
     pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<u64>,
 }
 


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/commit/b7278cbe36107c0b40487e254a00c17fdf62cbd7

Signed-off-by: Cassandra McCarthy <cassie@7596ff.com>
