### PR TITLE
Add `VoiceChannel::rtc_region`

### DIFF
--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -345,6 +345,7 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
                     parent_id,
                     permission_overwrites,
                     position,
+                    rtc_region: None,
                     user_limit,
                 })
             }
@@ -449,6 +450,7 @@ mod tests {
             permission_overwrites: Vec::new(),
             parent_id: None,
             position: 2,
+            rtc_region: None,
             user_limit: None,
         }
     }

--- a/model/src/channel/voice_channel.rs
+++ b/model/src/channel/voice_channel.rs
@@ -17,6 +17,11 @@ pub struct VoiceChannel {
     pub parent_id: Option<ChannelId>,
     pub permission_overwrites: Vec<PermissionOverwrite>,
     pub position: i64,
+    /// ID of the voice channel's region.
+    ///
+    /// Automatic when not present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtc_region: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_limit: Option<u64>,
 }
@@ -37,6 +42,7 @@ mod tests {
             permission_overwrites: Vec::new(),
             parent_id: None,
             position: 3,
+            rtc_region: None,
             user_limit: Some(7),
         };
 
@@ -85,15 +91,16 @@ mod tests {
                 permission_overwrites: Vec::new(),
                 parent_id: Some(ChannelId(3)),
                 position: 3,
+                rtc_region: Some("a".to_owned()),
                 user_limit: Some(7),
             }
         }
 
-        fn tokens(kind: ChannelType) -> [Token; 27] {
+        fn tokens(kind: ChannelType) -> [Token; 30] {
             [
                 Token::Struct {
                     name: "VoiceChannel",
-                    len: 9,
+                    len: 10,
                 },
                 Token::Str("bitrate"),
                 Token::U64(124_000),
@@ -117,6 +124,9 @@ mod tests {
                 Token::SeqEnd,
                 Token::Str("position"),
                 Token::I64(3),
+                Token::Str("rtc_region"),
+                Token::Some,
+                Token::Str("a"),
                 Token::Str("user_limit"),
                 Token::Some,
                 Token::U64(7),


### PR DESCRIPTION
Add the `VoiceChannel::rtc_region` field.

Docs: <https://github.com/discord/discord-api-docs/commit/fd7c6e44a6fdf8c1b0ca88de1faffb2b2b91bb53>