### PR TITLE
fix(http/bucket): sleep in seconds on global lock

### DIFF
--- a/http/src/ratelimiting/headers.rs
+++ b/http/src/ratelimiting/headers.rs
@@ -6,6 +6,7 @@ use std::convert::TryFrom;
 #[non_exhaustive]
 pub enum RatelimitHeaders {
     GlobalLimited {
+        /// Number of seconds until the global ratelimit resets.
         reset_after: u64,
     },
     None,
@@ -16,7 +17,7 @@ pub enum RatelimitHeaders {
         remaining: u64,
         // when the bucket resets in unix ms
         reset: u64,
-        // how long until it resets in ms
+        /// Number of seconds until the bucket resets.
         reset_after: u64,
     },
 }


### PR DESCRIPTION
When a global ratelimit is received and the global lock is locked, sleep for the provided number of seconds instead of milliseconds. These headers with these values are not in milliseconds.