### PR TITLE
gateway: Update metrics to v0.14

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -37,7 +37,7 @@ dashmap = { default-features = false, version = "4.0" }
 # it does not seem to update the total_in of the function to have an offset
 # https://github.com/alexcrichton/flate2-rs/issues/217
 flate2 = { default-features = false, optional = true, version = "1.0" }
-metrics = { default-features = false, optional = true, version = "0.12.1" }
+metrics = { default-features = false, optional = true, version = "0.14", features = ["std"] }
 simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.3" }
 
 [dev-dependencies]

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -270,9 +270,7 @@ impl Cluster {
 
         #[cfg(feature = "metrics")]
         {
-            use std::convert::TryInto;
-
-            metrics::gauge!("Cluster-Shard-Count", total.try_into().unwrap_or(-1));
+            metrics::gauge!("Cluster-Shard-Count", total as f64);
         }
 
         let shards = iter

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -269,6 +269,7 @@ impl Cluster {
         let total = scheme.total().expect("shard scheme is not auto");
 
         #[cfg(feature = "metrics")]
+        #[allow(clippy::cast_precision_loss)]
         {
             metrics::gauge!("Cluster-Shard-Count", total as f64);
         }

--- a/gateway/src/shard/processor/inflater.rs
+++ b/gateway/src/shard/processor/inflater.rs
@@ -139,6 +139,7 @@ impl Inflater {
 
     /// Log metrics about the inflater.
     #[cfg(feature = "metrics")]
+    #[allow(clippy::cast_precision_loss)]
     fn inflater_metrics(&self) {
         metrics::gauge!(
             format!("Inflater-Capacity-{}", self.shard[0]),

--- a/gateway/src/shard/processor/inflater.rs
+++ b/gateway/src/shard/processor/inflater.rs
@@ -142,15 +142,15 @@ impl Inflater {
     fn inflater_metrics(&self) {
         metrics::gauge!(
             format!("Inflater-Capacity-{}", self.shard[0]),
-            self.buffer.capacity().try_into().unwrap_or(-1)
+            self.buffer.capacity() as f64
         );
         metrics::gauge!(
             format!("Inflater-In-{}", self.shard[0]),
-            self.decompress.total_in().try_into().unwrap_or(-1)
+            self.decompress.total_in() as f64
         );
         metrics::gauge!(
             format!("Inflater-Out-{}", self.shard[0]),
-            self.decompress.total_out().try_into().unwrap_or(-1)
+            self.decompress.total_out() as f64
         );
     }
 


### PR DESCRIPTION
Existing metrics exporters currently rely on 0.14. This PR bumps the gateway's dependency to match these crates.