### PR TITLE
models: Implement stage channels

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -536,6 +536,9 @@ impl InMemoryCache {
             GuildChannel::Voice(ref mut c) => {
                 c.guild_id.replace(guild_id);
             }
+            GuildChannel::Stage(ref mut c) => {
+                c.guild_id.replace(guild_id);
+            }
         }
 
         let id = channel.id();
@@ -1074,6 +1077,7 @@ mod tests {
             suppress: false,
             token: None,
             user_id,
+            request_to_speak_timestamp: Some("2021-04-21T22:16:50+0000".to_owned()),
         }
     }
 

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -1037,6 +1037,7 @@ mod tests {
             suppress: false,
             token: None,
             user_id: UserId(1),
+            request_to_speak_timestamp: Some("2021-04-21T22:16:50+0000".to_owned()),
         }));
     }
 
@@ -1084,6 +1085,7 @@ mod tests {
             suppress: false,
             token: None,
             user_id: UserId(3),
+            request_to_speak_timestamp: Some("2021-04-21T22:16:50+0000".to_owned()),
         });
 
         cache.update(&mutation);

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -85,6 +85,7 @@ pub enum GuildChannel {
     Category(CategoryChannel),
     Text(TextChannel),
     Voice(VoiceChannel),
+    Stage(VoiceChannel),
 }
 
 impl GuildChannel {
@@ -94,6 +95,7 @@ impl GuildChannel {
             Self::Category(category) => category.guild_id,
             Self::Text(text) => text.guild_id,
             Self::Voice(voice) => voice.guild_id,
+            Self::Stage(stage) => stage.guild_id,
         }
     }
 
@@ -103,6 +105,7 @@ impl GuildChannel {
             Self::Category(category) => category.id,
             Self::Text(text) => text.id,
             Self::Voice(voice) => voice.id,
+            Self::Stage(stage) => stage.id,
         }
     }
 
@@ -112,6 +115,7 @@ impl GuildChannel {
             Self::Category(category) => category.name.as_ref(),
             Self::Text(text) => text.name.as_ref(),
             Self::Voice(voice) => voice.name.as_ref(),
+            Self::Stage(stage) => stage.name.as_ref(),
         }
     }
 }
@@ -345,11 +349,10 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
                 let user_limit = user_limit.ok_or_else(|| DeError::missing_field("user_limit"))?;
 
                 tracing::trace!(%bitrate, ?user_limit, "handling voice channel");
-
-                GuildChannel::Voice(VoiceChannel {
+                let voice_channel = VoiceChannel {
+                    id,
                     bitrate,
                     guild_id,
-                    id,
                     kind,
                     name,
                     parent_id,
@@ -358,7 +361,13 @@ impl<'de> Visitor<'de> for GuildChannelVisitor {
                     rtc_region: None,
                     user_limit,
                     video_quality_mode,
-                })
+                };
+
+                if kind == ChannelType::GuildVoice {
+                    GuildChannel::Voice(voice_channel)
+                } else {
+                    GuildChannel::Stage(voice_channel)
+                }
             }
             ChannelType::GuildNews | ChannelType::GuildStore | ChannelType::GuildText => {
                 let last_message_id = last_message_id.unwrap_or_default();
@@ -467,6 +476,22 @@ mod tests {
         }
     }
 
+    fn guild_stage() -> VoiceChannel {
+        VoiceChannel {
+            bitrate: 1000,
+            guild_id: Some(GuildId(321)),
+            id: ChannelId(789),
+            kind: ChannelType::GuildStageVoice,
+            name: "stage".to_owned(),
+            permission_overwrites: Vec::new(),
+            parent_id: None,
+            position: 2,
+            rtc_region: None,
+            user_limit: None,
+            video_quality_mode: None,
+        }
+    }
+
     fn private() -> PrivateChannel {
         PrivateChannel {
             id: ChannelId(234),
@@ -492,6 +517,10 @@ mod tests {
             Channel::Guild(GuildChannel::Voice(guild_voice())).id(),
             ChannelId(789)
         );
+        assert_eq!(
+            Channel::Guild(GuildChannel::Stage(guild_stage())).id(),
+            ChannelId(789)
+        );
         assert_eq!(Channel::Private(private()).id(), ChannelId(234));
     }
 
@@ -513,6 +542,10 @@ mod tests {
             Channel::Guild(GuildChannel::Voice(guild_voice())).name(),
             Some("voice")
         );
+        assert_eq!(
+            Channel::Guild(GuildChannel::Stage(guild_stage())).name(),
+            Some("stage")
+        );
         assert!(Channel::Private(private()).name().is_none());
     }
 
@@ -530,6 +563,10 @@ mod tests {
             GuildChannel::Voice(guild_voice()).guild_id(),
             Some(GuildId(321))
         );
+        assert_eq!(
+            GuildChannel::Stage(guild_stage()).guild_id(),
+            Some(GuildId(321))
+        );
     }
 
     #[test]
@@ -540,6 +577,7 @@ mod tests {
         );
         assert_eq!(GuildChannel::Text(guild_text()).id(), ChannelId(456));
         assert_eq!(GuildChannel::Voice(guild_voice()).id(), ChannelId(789));
+        assert_eq!(GuildChannel::Stage(guild_stage()).id(), ChannelId(789));
     }
 
     #[test]
@@ -547,6 +585,7 @@ mod tests {
         assert_eq!(GuildChannel::Category(guild_category()).name(), "category");
         assert_eq!(GuildChannel::Text(guild_text()).name(), "text");
         assert_eq!(GuildChannel::Voice(guild_voice()).name(), "voice");
+        assert_eq!(GuildChannel::Stage(guild_stage()).name(), "stage");
     }
 
     // The deserializer for GuildChannel should skip over fields names that

--- a/model/src/gateway/payload/voice_state_update.rs
+++ b/model/src/gateway/payload/voice_state_update.rs
@@ -55,6 +55,7 @@ mod tests {
             suppress: false,
             token: None,
             user_id: UserId(1),
+            request_to_speak_timestamp: None,
         });
 
         serde_test::assert_tokens(
@@ -65,7 +66,7 @@ mod tests {
                 },
                 Token::Struct {
                     name: "VoiceState",
-                    len: 11,
+                    len: 12,
                 },
                 Token::Str("channel_id"),
                 Token::None,
@@ -136,6 +137,8 @@ mod tests {
                 Token::Str("user_id"),
                 Token::NewtypeStruct { name: "UserId" },
                 Token::Str("1"),
+                Token::Str("request_to_speak_timestamp"),
+                Token::None,
                 Token::StructEnd,
             ],
         );
@@ -182,6 +185,7 @@ mod tests {
             suppress: false,
             token: None,
             user_id: UserId(123_213),
+            request_to_speak_timestamp: Some("2021-04-21T22:16:50+0000".to_owned()),
         });
 
         // Token stream here's `Member` has no `guild_id`, which deserialiser
@@ -269,6 +273,9 @@ mod tests {
                 Token::Str("user_id"),
                 Token::NewtypeStruct { name: "UserId" },
                 Token::Str("123213"),
+                Token::Str("request_to_speak_timestamp"),
+                Token::Some,
+                Token::Str("2021-04-21T22:16:50+0000"),
                 Token::StructEnd,
             ],
         );

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -691,7 +691,7 @@ impl<'de> Deserialize<'de> for Guild {
                         GuildChannel::Text(c) => {
                             c.guild_id.replace(id);
                         }
-                        GuildChannel::Voice(c) => {
+                        GuildChannel::Voice(c) | GuildChannel::Stage(c) => {
                             c.guild_id.replace(id);
                         }
                     }

--- a/model/src/guild/permissions.rs
+++ b/model/src/guild/permissions.rs
@@ -38,6 +38,8 @@ bitflags! {
         const MANAGE_ROLES = 0x1000_0000;
         const MANAGE_WEBHOOKS = 0x2000_0000;
         const MANAGE_EMOJIS = 0x4000_0000;
+        const USE_SLASH_COMMANDS = 0x8000_0000;
+        const REQUEST_TO_SPEAK = 0x10000_0000;
     }
 }
 

--- a/model/src/guild/permissions.rs
+++ b/model/src/guild/permissions.rs
@@ -38,7 +38,6 @@ bitflags! {
         const MANAGE_ROLES = 0x1000_0000;
         const MANAGE_WEBHOOKS = 0x2000_0000;
         const MANAGE_EMOJIS = 0x4000_0000;
-        const USE_SLASH_COMMANDS = 0x8000_0000;
         const REQUEST_TO_SPEAK = 0x10000_0000;
     }
 }


### PR DESCRIPTION
As seen in: discord/discord-api-docs#2751.

 * Added `GuildChannel::Stage` variant, containing a  `VoiceChannel`.
 * Added `REQUEST_TO_SPEAK` permission.
 * Added optional `request_to_speak_timestamp` to `VoiceState`
 * ~~Unrelated: Added missing `USE_SLASH_COMMANDS` permission.~~