### PR TITLE
Update async-tungstenite to 0.13

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.3.4"
 
 [dependencies]
-async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.11" }
+async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.13" }
 bitflags = { default-features = false, version = "1" }
 twilight-gateway-queue = { default-features = false, path = "./queue" }
 twilight-http = { default-features = false, path = "../http" }

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.3.2"
 
 [dependencies]
-async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.11" }
+async-tungstenite = { default-features = false, features = ["tokio-runtime"], version = "0.13" }
 dashmap = { default-features = false, version = "4.0" }
 futures-channel = { default-features = false, features = ["std"], version = "0.3" }
 futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -532,7 +532,7 @@ async fn backoff(
             Err(source) => {
                 tracing::warn!("failed to connect to node {}: {:?}", source, config.address);
 
-                if matches!(source, TungsteniteError::Http(status) if status == StatusCode::UNAUTHORIZED)
+                if matches!(source, TungsteniteError::Http(ref response) if response.status() == StatusCode::UNAUTHORIZED)
                 {
                     return Err(NodeError::Unauthorized {
                         address: config.address,


### PR DESCRIPTION
See title. Two two major version of `async-tungstenite` have came out since 0.11, which can cause some duplicated dependencies in projects.