### PR TITLE
Disable clippy beta

### DIFF
--- a/.github/workflows_disabled/lint.yml
+++ b/.github/workflows_disabled/lint.yml
@@ -1,21 +1,21 @@
-name: Lint
+name: Lint (Beta)
 
 on: [push, pull_request]
 
 jobs:
-  clippy:
-    name: Clippy
+  clippy-beta:
+    name: Clippy (beta)
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: Install beta toolchain
         id: toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: beta
           components: clippy
           profile: minimal
           override: true
@@ -35,21 +35,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --workspace --tests
 
-  rustfmt:
-    name: Format
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: rustfmt
-          profile: minimal
-          override: true
-
-      - name: Run cargo fmt
-        run: cargo fmt --all -- --check


### PR DESCRIPTION
The newest lint we're catching on in beta is still marked as
experimental in stable. This workflow causes PRs to fail while making
fixes for those failures out of scope for the PR.

Signed-off-by: Cassandra McCarthy <cassie@7596ff.com>
