### PR TITLE
Percent encode reason

### DIFF
--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -937,7 +937,7 @@ impl Route {
                 }
 
                 if let Some(reason) = reason {
-                    let encoded_reason = utf8_percent_encode(reason).to_string();
+                    let encoded_reason = utf8_percent_encode(&reason, NON_ALPHANUMERIC).to_string();
                     let _ = write!(path, "reason={}", encoded_reason);
                 }
 

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -1,4 +1,5 @@
 use hyper::Method;
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use std::{
     borrow::Cow,
     convert::TryFrom,
@@ -936,7 +937,8 @@ impl Route {
                 }
 
                 if let Some(reason) = reason {
-                    let _ = write!(path, "reason={}", reason);
+                    let encoded_reason = utf8_percent_encode(reason).to_string();
+                    let _ = write!(path, "reason={}", encoded_reason);
                 }
 
                 (Method::PUT, Path::GuildsIdBansUserId(guild_id), path.into())


### PR DESCRIPTION
Percent encode reason, as it would else fail with symbols like space
as they may not be in a url.