### PR TITLE
Release v0.4.0

### DIFF
--- a/cache/in-memory/CHANGELOG.md
+++ b/cache/in-memory/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `twilight-cache-inmemory`.
 
-## [0.4.0] - 2021-05-??
+## [0.4.0] - 2021-05-12
 
 ### Upgrade Path
 

--- a/cache/in-memory/CHANGELOG.md
+++ b/cache/in-memory/CHANGELOG.md
@@ -214,7 +214,7 @@ Initial release.
 [#528]: https://github.com/twilight-rs/twilight/pull/528
 [#524]: https://github.com/twilight-rs/twilight/pull/524
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/cache-in-memory-v0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/cache-in-memory-0.4.0
 [0.3.6]: https://github.com/twilight-rs/twilight/releases/tag/cache-in-memory-v0.3.6
 [0.3.5]: https://github.com/twilight-rs/twilight/releases/tag/cache-in-memory-v0.3.5
 [0.3.4]: https://github.com/twilight-rs/twilight/releases/tag/cache-in-memory-v0.3.4

--- a/cache/in-memory/CHANGELOG.md
+++ b/cache/in-memory/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Changelog for `twilight-cache-inmemory`.
 
+## [0.4.0] - 2021-05-??
+
+### Upgrade Path
+
+The MSRV is now Rust 1.49.
+
 ## [0.3.6] - 2021-04-27
 
 ### Additions
@@ -208,6 +214,7 @@ Initial release.
 [#528]: https://github.com/twilight-rs/twilight/pull/528
 [#524]: https://github.com/twilight-rs/twilight/pull/524
 
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/cache-in-memory-v0.4.0
 [0.3.6]: https://github.com/twilight-rs/twilight/releases/tag/cache-in-memory-v0.3.6
 [0.3.5]: https://github.com/twilight-rs/twilight/releases/tag/cache-in-memory-v0.3.5
 [0.3.4]: https://github.com/twilight-rs/twilight/releases/tag/cache-in-memory-v0.3.4

--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -12,7 +12,7 @@ name = "twilight-cache-inmemory"
 publish = false
 repository = "https://github.com/twilight-rs/twilight"
 readme = "README.md"
-version = "0.3.6"
+version = "0.4.0"
 
 [dependencies]
 bitflags = { default-features = false, version = "1" }

--- a/command-parser/CHANGELOG.md
+++ b/command-parser/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 Changelog for `twilight-command-parser`.
 
+## [0.4.0] - 2021-05-??
+
+### Upgrade Path
+
+The MSRV is now Rust 1.49.
+
+Create an `Arguments` instance via `Arguments::new` instead of using the `From`
+implementation.
+
+When checking if a command is case-sensitive use
+`CaseSensitivity::is_sensitive`.
+
+### Changes
+
+Remove `From<&str>` implementation for `Arguments` ([#763] - [@vivian]).
+
+Hide the `unicase` dependency by offering alternatives in the API:
+
+- Add `CaseSensitivity::is_sensitive` to check if the command is case-sensitive
+- Implement `AsMut<str>` for `CaseSensitivity`
+- `Commands` now iterates over `(&str, bool)` instead of `&CaseSensitivity`
+- `CommandsMut` now iterates over `(&mut str, bool)` instead of
+`&mut CaseSensitivity`
+
+([#692] - [@vivian]).
+
+[#763]: https://github.com/twilight-rs/twilight/pull/692
+[#692]: https://github.com/twilight-rs/twilight/pull/763
+
 ## [0.3.0] - 2021-01-08
 
 This major version bump of the Command Parser crate is done to match all of the
@@ -73,6 +102,7 @@ Initial release.
 [#515]: https://github.com/twilight-rs/twilight/pull/515
 [#511]: https://github.com/twilight-rs/twilight/pull/511
 
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-v0.3.0
 [0.2.2]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-v0.2.2
 [0.2.1]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-v0.2.1

--- a/command-parser/CHANGELOG.md
+++ b/command-parser/CHANGELOG.md
@@ -102,7 +102,7 @@ Initial release.
 [#515]: https://github.com/twilight-rs/twilight/pull/515
 [#511]: https://github.com/twilight-rs/twilight/pull/511
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-v0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-v0.3.0
 [0.2.2]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-v0.2.2
 [0.2.1]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-v0.2.1

--- a/command-parser/CHANGELOG.md
+++ b/command-parser/CHANGELOG.md
@@ -102,7 +102,7 @@ Initial release.
 [#515]: https://github.com/twilight-rs/twilight/pull/515
 [#511]: https://github.com/twilight-rs/twilight/pull/511
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-v0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-v0.3.0
 [0.2.2]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-v0.2.2
 [0.2.1]: https://github.com/twilight-rs/twilight/releases/tag/command-parser-v0.2.1

--- a/command-parser/CHANGELOG.md
+++ b/command-parser/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `twilight-command-parser`.
 
-## [0.4.0] - 2021-05-??
+## [0.4.0] - 2021-05-12
 
 ### Upgrade Path
 

--- a/command-parser/CHANGELOG.md
+++ b/command-parser/CHANGELOG.md
@@ -28,8 +28,8 @@ Hide the `unicase` dependency by offering alternatives in the API:
 
 ([#692] - [@vivian]).
 
-[#763]: https://github.com/twilight-rs/twilight/pull/692
 [#692]: https://github.com/twilight-rs/twilight/pull/763
+[#763]: https://github.com/twilight-rs/twilight/pull/692
 
 ## [0.3.0] - 2021-01-08
 

--- a/command-parser/CHANGELOG.md
+++ b/command-parser/CHANGELOG.md
@@ -28,8 +28,8 @@ Hide the `unicase` dependency by offering alternatives in the API:
 
 ([#692] - [@vivian]).
 
-[#692]: https://github.com/twilight-rs/twilight/pull/763
-[#763]: https://github.com/twilight-rs/twilight/pull/692
+[#692]: https://github.com/twilight-rs/twilight/pull/692
+[#763]: https://github.com/twilight-rs/twilight/pull/763
 
 ## [0.3.0] - 2021-01-08
 

--- a/command-parser/Cargo.toml
+++ b/command-parser/Cargo.toml
@@ -12,7 +12,7 @@ name = "twilight-command-parser"
 publish = false
 readme = "README.md"
 repository = "https://github.com/twilight-rs/twilight.git"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 unicase = { default-features = false, version = "2" }

--- a/embed-builder/CHANGELOG.md
+++ b/embed-builder/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 Changelog for `twilight-embed-builder`.
 
+## [0.4.0] - 2021-05-??
+
+### Upgrade Path
+
+The MSRV is now Rust 1.49.
+
+Individual builder methods' errors have been combined into one and now lazily
+error when calling `EmbedBuilder::build`. The following code:
+
+```rust
+use twilight_embed_builder::{EmbedBuilder, ImageSource};
+
+let embed = EmbedBuilder::new()
+    .description("Here's a cool image of Twilight Sparkle")?
+    .image(ImageSource::attachment("bestpony.png")?)
+    .build();
+```
+
+is now written like:
+
+```rust
+use twilight_embed_builder::{EmbedBuilder, ImageSource};
+
+let embed = EmbedBuilder::new()
+    .description("Here's a cool image of Twilight Sparkle")
+    .image(ImageSource::attachment("bestpony.png")?)
+    .build()?;
+```
+
+This is much more concise with larger embed builders.
+
+Errors are no longer enums and don't expose their concrete underlying error
+source. You can access the underlying error via the implemented
+`std::error::Error::source` method or the `into_parts` or `into_source` methods
+on each error struct, which will return a boxed `std::error::Error`. To access
+the reason for the error use the `kind` or `into_parts` method on error structs;
+the returned error type is an enum with variants for each potential reason the
+error occurred.
+
+### Changes
+
+Simplify error handling by moving all results into the final
+`EmbedBuilder::build` method ([#687] - [@vivian]).
+
+[#687]: https://github.com/twilight-rs/twilight/pull/687
+
 ## [0.3.0] - 2020-01-08
 
 This major version bump of the Embed Builder is done to match all of the other
@@ -25,6 +71,7 @@ crates in the ecosystem receiving a major version bump. There are no changes.
 
 Initial release.
 
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/embed-builder-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/v0.3.0
 [0.2.0]: https://github.com/twilight-rs/twilight/releases/tag/v0.2.0
 [0.1.0]: https://github.com/twilight-rs/twilight/releases/tag/v0.1.0

--- a/embed-builder/CHANGELOG.md
+++ b/embed-builder/CHANGELOG.md
@@ -71,7 +71,7 @@ crates in the ecosystem receiving a major version bump. There are no changes.
 
 Initial release.
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/embed-builder-v0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/embed-builder-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/v0.3.0
 [0.2.0]: https://github.com/twilight-rs/twilight/releases/tag/v0.2.0
 [0.1.0]: https://github.com/twilight-rs/twilight/releases/tag/v0.1.0

--- a/embed-builder/CHANGELOG.md
+++ b/embed-builder/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `twilight-embed-builder`.
 
-## [0.4.0] - 2021-05-??
+## [0.4.0] - 2021-05-12
 
 ### Upgrade Path
 

--- a/embed-builder/CHANGELOG.md
+++ b/embed-builder/CHANGELOG.md
@@ -71,7 +71,7 @@ crates in the ecosystem receiving a major version bump. There are no changes.
 
 Initial release.
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/embed-builder-0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/embed-builder-v0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/v0.3.0
 [0.2.0]: https://github.com/twilight-rs/twilight/releases/tag/v0.2.0
 [0.1.0]: https://github.com/twilight-rs/twilight/releases/tag/v0.1.0

--- a/embed-builder/Cargo.toml
+++ b/embed-builder/Cargo.toml
@@ -12,7 +12,7 @@ name = "twilight-embed-builder"
 publish = false
 readme = "README.md"
 repository = "https://github.com/twilight-rs/twilight.git"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 twilight-model = { path = "../model", default-features = false }

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 Changelog for `twilight-gateway`.
 
+## [0.4.0] - 2021-05-??
+
+### Upgrade Path
+
+The MSRV is now Rust 1.49.
+
+Errors are no longer enums and don't expose their concrete underlying error
+source. You can access the underlying error via the implemented
+`std::error::Error::source` method or the `into_parts` or `into_source` methods
+on each error struct, which will return a boxed `std::error::Error`. To access
+the reason for the error use the `kind` or `into_parts` method on error structs;
+the returned error type is an enum with variants for each potential reason the
+error occurred.
+
+### Additions
+
+Add `rustls-webki-roots` feature to use WebPKI roots for RusTLS
+([#720] - [@Gelbpunkt]).
+
+### Enhancements
+
+Update `simd-json` to 0.4 ([#786] - [@Gekbpunkt]).
+
+Update `metrics` to v0.14 ([#789] - [@james7132]).
+
+The `futures-channel` and `futures-timer` dependencies have been removed while
+the `async-tungstenite` dependency has been switched out for `tokio-tungstenite`
+to decrease the dependency tree ([#785] - [@Gelbpunkt]).
+
+[#789]: https://github.com/twilight-rs/twilight/pull/789
+[#786]: https://github.com/twilight-rs/twilight/pull/786
+[#785]: https://github.com/twilight-rs/twilight/pull/785
+[#720]: https://github.com/twilight-rs/twilight/pull/720
+
 ## [0.3.4] - 2021-04-04
 
 ### Additions
@@ -230,6 +264,7 @@ Initial release.
 [@dvtkrlbs]: https://github.com/dvtkrlbs
 [@Erk-]: https://github.com/Erk-
 [@Gelbpunkt]: https://github.com/Gelbpunkt
+[@james7132]: https://github.com/james7132
 [@nickelc]: https://github.com/nickelc
 [@tbnritzdoge]: https://github.com/tbnritzdoge
 [@vivian]: https://github.com/vivian
@@ -252,6 +287,7 @@ Initial release.
 [#515]: https://github.com/twilight-rs/twilight/pull/515
 [#512]: https://github.com/twilight-rs/twilight/pull/512
 
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-0.4.0
 [0.3.4]: https://github.com/twilight-rs/twilight/releases/tag/gateway-v0.3.4
 [0.3.3]: https://github.com/twilight-rs/twilight/releases/tag/gateway-v0.3.3
 [0.3.2]: https://github.com/twilight-rs/twilight/releases/tag/gateway-v0.3.2

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -287,7 +287,7 @@ Initial release.
 [#515]: https://github.com/twilight-rs/twilight/pull/515
 [#512]: https://github.com/twilight-rs/twilight/pull/512
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-v0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-0.4.0
 [0.3.4]: https://github.com/twilight-rs/twilight/releases/tag/gateway-v0.3.4
 [0.3.3]: https://github.com/twilight-rs/twilight/releases/tag/gateway-v0.3.3
 [0.3.2]: https://github.com/twilight-rs/twilight/releases/tag/gateway-v0.3.2

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -287,7 +287,7 @@ Initial release.
 [#515]: https://github.com/twilight-rs/twilight/pull/515
 [#512]: https://github.com/twilight-rs/twilight/pull/512
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-v0.4.0
 [0.3.4]: https://github.com/twilight-rs/twilight/releases/tag/gateway-v0.3.4
 [0.3.3]: https://github.com/twilight-rs/twilight/releases/tag/gateway-v0.3.3
 [0.3.2]: https://github.com/twilight-rs/twilight/releases/tag/gateway-v0.3.2

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -18,12 +18,12 @@ error occurred.
 
 ### Additions
 
-Add `rustls-webki-roots` feature to use WebPKI roots for RusTLS
+Add `rustls-webpki-roots` feature to use WebPKI roots for `rustls`
 ([#720] - [@Gelbpunkt]).
 
 ### Enhancements
 
-Update `simd-json` to 0.4 ([#786] - [@Gekbpunkt]).
+Update `simd-json` to 0.4 ([#786] - [@Gelbpunkt]).
 
 Update `metrics` to v0.14 ([#789] - [@james7132]).
 

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `twilight-gateway`.
 
-## [0.4.0] - 2021-05-??
+## [0.4.0] - 2021-05-12
 
 ### Upgrade Path
 

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -12,7 +12,7 @@ name = "twilight-gateway"
 publish = false
 readme = "README.md"
 repository = "https://github.com/twilight-rs/twilight.git"
-version = "0.3.4"
+version = "0.4.0"
 
 [dependencies]
 tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.14" }

--- a/gateway/queue/CHANGELOG.md
+++ b/gateway/queue/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 Changelog for `twilight-gateway-queue`.
 
+## [0.4.0] - 2021-05-??
+
+### Upgrade Path
+
+The MSRV is now Rust 1.49.
+
+Errors are no longer enums and don't expose their concrete underlying error
+source. You can access the underlying error via the implemented
+`std::error::Error::source` method or the `into_parts` or `into_source` methods
+on each error struct, which will return a boxed `std::error::Error`. To access
+the reason for the error use the `kind` or `into_parts` method on error structs;
+the returned error type is an enum with variants for each potential reason the
+error occurred.
+
+### Enhancements
+
+The `futures-channel` and `futures-util` dependencies have been removed
+([#785] - [@Gelbpunkt]).
+
+[#785]: https://github.com/twilight-rs/twilight/pull/785
+
 ## [0.3.0] - 2021-01-08
 
 This major version bump of the Gateway Queue is done to match all of the other
@@ -29,10 +50,12 @@ changes.
 
 Initial release.
 
+[@Gelbpunkt]: https://github.com/Gelbpunkt
 [@vivian]: https://github.com/vivian
 
 [#595]: https://github.com/twilight-rs/twilight/pull/595
 
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-v0.3.0
 [0.2.1]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-v0.2.1
 [0.2.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-v0.2.0

--- a/gateway/queue/CHANGELOG.md
+++ b/gateway/queue/CHANGELOG.md
@@ -55,7 +55,7 @@ Initial release.
 
 [#595]: https://github.com/twilight-rs/twilight/pull/595
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-v0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-v0.3.0
 [0.2.1]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-v0.2.1
 [0.2.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-v0.2.0

--- a/gateway/queue/CHANGELOG.md
+++ b/gateway/queue/CHANGELOG.md
@@ -55,7 +55,7 @@ Initial release.
 
 [#595]: https://github.com/twilight-rs/twilight/pull/595
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-v0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-v0.3.0
 [0.2.1]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-v0.2.1
 [0.2.0]: https://github.com/twilight-rs/twilight/releases/tag/gateway-queue-v0.2.0

--- a/gateway/queue/CHANGELOG.md
+++ b/gateway/queue/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `twilight-gateway-queue`.
 
-## [0.4.0] - 2021-05-??
+## [0.4.0] - 2021-05-12
 
 ### Upgrade Path
 

--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -40,6 +40,18 @@ error occurred.
 When specifying a method in a custom request use `request::Method` instead of
 `hyper`'s.
 
+The Allowed Mentions API has been reworked and moved to `twilight-model`. Use it
+like so:
+
+```rust
+use twilight_model::channel::message::AllowedMentions;
+
+let allowed_mentions = AllowedMentions::builder()
+    .replied_user()
+    .user_ids(user_ids)
+    .build();
+```
+
 ### Additions
 
 Support `CreateMessage::fail_if_not_exists` which will fail creating the message

--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -614,7 +614,7 @@ Initial release.
 
 [0.2.0-beta.1:app integrations]: https://github.com/discord/discord-api-docs/commit/a926694e2f8605848bda6b57d21c8817559e5cec
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/http-0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/http-v0.4.0
 [0.3.9]: https://github.com/twilight-rs/twilight/releases/tag/http-v0.3.9
 [0.3.8]: https://github.com/twilight-rs/twilight/releases/tag/http-v0.3.8
 [0.3.6]: https://github.com/twilight-rs/twilight/releases/tag/http-v0.3.6

--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -614,7 +614,7 @@ Initial release.
 
 [0.2.0-beta.1:app integrations]: https://github.com/discord/discord-api-docs/commit/a926694e2f8605848bda6b57d21c8817559e5cec
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/http-v0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/http-0.4.0
 [0.3.9]: https://github.com/twilight-rs/twilight/releases/tag/http-v0.3.9
 [0.3.8]: https://github.com/twilight-rs/twilight/releases/tag/http-v0.3.8
 [0.3.6]: https://github.com/twilight-rs/twilight/releases/tag/http-v0.3.6

--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -2,6 +2,90 @@
 
 Changelog for `twilight-http`.
 
+## [0.4.0] - 2021-05-??
+
+### Upgrade Path
+
+The MSRV is now Rust 1.49.
+
+Remove calls to:
+
+- `Client::create_guild_integration`
+- `Client::current_user_private_channels`
+- `Client::delete_guild_integration`
+- `Client::sync_guild_integration`
+
+Remove references to:
+
+- `request::guild::integration`
+- `request::user::GetCurrentUserPrivateChannels`
+
+Replace references to `Path::WebhooksIdTokenMessageId` with
+`Path::WebhooksIdTokenMessagesId`.
+
+`CreateInvite::{max_age, max_uses}` now return validation errors, so the results
+returned from them need to be handled.
+
+Don't re-use `hyper` clients via the builder. If you need to configure the
+underlying `hyper` client please create an issue with the reason why.
+
+Errors are no longer enums and don't expose their concrete underlying error
+source. You can access the underlying error via the implemented
+`std::error::Error::source` method or the `into_parts` or `into_source` methods
+on each error struct, which will return a boxed `std::error::Error`. To access
+the reason for the error use the `kind` or `into_parts` method on error structs;
+the returned error type is an enum with variants for each potential reason the
+error occurred.
+
+When specifying a method in a custom request use `request::Method` instead of
+`hyper`'s.
+
+### Additions
+
+Support `CreateMessage::fail_if_not_exists` which will fail creating the message
+if the referenced message does not exist ([#708] - [@7596ff]).
+
+### Enhancements
+
+Update `simd-json` to 0.4 ([#786] - [@Gekbpunkt]).
+
+The `futures-channel` dependency has been removed ([#785] - [@Gelbpunkt]).
+
+### Changes
+
+Remove support for guild integration calls, which are blocked for bots due to a
+Discord API change ([#751] - [@vivian]).
+
+Rename `Path::WebhooksIdTokenMessageId` to `Path::WebhooksIdTokenMessagesId`
+([#755] - [@vivian]).
+
+Return validation errors for `CreateInvite::max_age` and
+`CreateInvite::max_uses` ([#757] - [@vivian]).
+
+Remove ability to get current user's DM channels ([#782] - [@vivian]).
+
+Remove `ClientBuilder::hyper_client` and `From<HyperClient> for Client` which
+were available to re-use `hyper` clients ([#768] - [@vivian]).
+
+Return updated copy of member when updating a member ([#758] - [@vivian]).
+
+The `request::channel::message::allowed_mentions` API has been reworked and
+moved to the `twilight-model` crate ([#760] - [@7596ff]).
+
+Add custom method enum type for use rather than `hyper`'s ([#767] - [@vivian]).
+
+[#786]: https://github.com/twilight-rs/twilight/pull/786
+[#785]: https://github.com/twilight-rs/twilight/pull/785
+[#782]: https://github.com/twilight-rs/twilight/pull/782
+[#768]: https://github.com/twilight-rs/twilight/pull/768
+[#767]: https://github.com/twilight-rs/twilight/pull/767
+[#760]: https://github.com/twilight-rs/twilight/pull/760
+[#758]: https://github.com/twilight-rs/twilight/pull/758
+[#757]: https://github.com/twilight-rs/twilight/pull/757
+[#755]: https://github.com/twilight-rs/twilight/pull/755
+[#751]: https://github.com/twilight-rs/twilight/pull/751
+[#708]: https://github.com/twilight-rs/twilight/pull/708
+
 ## [0.3.9] - 2021-05-09
 
 ### Additions
@@ -518,6 +602,7 @@ Initial release.
 
 [0.2.0-beta.1:app integrations]: https://github.com/discord/discord-api-docs/commit/a926694e2f8605848bda6b57d21c8817559e5cec
 
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/http-0.4.0
 [0.3.9]: https://github.com/twilight-rs/twilight/releases/tag/http-v0.3.9
 [0.3.8]: https://github.com/twilight-rs/twilight/releases/tag/http-v0.3.8
 [0.3.6]: https://github.com/twilight-rs/twilight/releases/tag/http-v0.3.6

--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `twilight-http`.
 
-## [0.4.0] - 2021-05-??
+## [0.4.0] - 2021-05-12
 
 ### Upgrade Path
 

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -12,7 +12,7 @@ name = "twilight-http"
 publish = false
 readme = "README.md"
 repository = "https://github.com/twilight-rs/twilight.git"
-version = "0.3.9"
+version = "0.4.0"
 
 [dependencies]
 bytes = { default-features = false, version = "1.0" }

--- a/lavalink/CHANGELOG.md
+++ b/lavalink/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 Changelog for `twilight-lavalink`.
 
+## [0.4.0] - 2021-05-??
+
+### Upgrade Path
+
+The MSRV is now Rust 1.49.
+
+`Lavalink::player`, `PlayerManager::get`, and `PlayerManager::get_or_insert` now
+return `Player`s instead of `DashMap` references.
+
+`Player` has had some methods renamed:
+
+- `position_mut` has been renamed to `set_position` and accepts an `i64`
+- `time_ref` has been renamed to `time`
+- `time_mut` has been renamed to `set_time` and accepts an `i64`
+- `volume_ref` has been renamed to `volume`
+
+`Node::players` is no longer an async method.
+
+Errors are no longer enums and don't expose their concrete underlying error
+source. You can access the underlying error via the implemented
+`std::error::Error::source` method or the `into_parts` or `into_source` methods
+on each error struct, which will return a boxed `std::error::Error`. To access
+the reason for the error use the `kind` or `into_parts` method on error structs;
+the returned error type is an enum with variants for each potential reason the
+error occurred.
+
+### Additions
+
+Add `WebsocketClosed` incoming event ([#734] - [@james7132]).
+
+Add `Lavalink::disconnect` to disconnect from a given node, `Node::close` to
+close the connection to a node ([#742] - [@james7132]).
+
+### Enhancements
+
+The `futures-channel` dependency has been removed while the `async-tungstenite`
+dependency has been switched out for `tokio-tungstenite` to decrease the
+dependency tree ([#785] - [@Gelbpunkt]).
+
+### Changes
+
+Simplify player API by not exposing DashMap references and returning Players
+instead ([#693] - [@vivian]).
+
+Remove unnecessary `async` qualifier from `Node::players`
+([#731] - [@james7132]).
+
+`Node::drop` now removes the node from the Lavalink client
+([#742] - [@james7132]).
+
+[#785]: https://github.com/twilight-rs/twilight/pull/785
+[#742]: https://github.com/twilight-rs/twilight/pull/742
+[#734]: https://github.com/twilight-rs/twilight/pull/734
+[#731]: https://github.com/twilight-rs/twilight/pull/731
+[#693]: https://github.com/twilight-rs/twilight/pull/693
+
 ## [0.3.2] - 2021-04-12
 
 ### Fixes
@@ -82,6 +138,7 @@ crates in the ecosystem receiving a major version bump. There are no changes.
 
 Initial release.
 
+[@Gelbpunkt]: https://github.com/Gelbpunkt
 [@MOZGIII]: https://github.com/MOZGIII
 [@james7132]: https://github.com/james7132
 [@nickelc]: https://github.com/nickelc
@@ -92,6 +149,7 @@ Initial release.
 [#548]: https://github.com/twilight-rs/twilight/pull/548
 [#518]: https://github.com/twilight-rs/twilight/pull/518
 
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-0.4.0
 [0.3.2]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-v0.3.2
 [0.3.1]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-v0.3.1
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-v0.3.0

--- a/lavalink/CHANGELOG.md
+++ b/lavalink/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `twilight-lavalink`.
 
-## [0.4.0] - 2021-05-??
+## [0.4.0] - 2021-05-12
 
 ### Upgrade Path
 

--- a/lavalink/CHANGELOG.md
+++ b/lavalink/CHANGELOG.md
@@ -149,7 +149,7 @@ Initial release.
 [#548]: https://github.com/twilight-rs/twilight/pull/548
 [#518]: https://github.com/twilight-rs/twilight/pull/518
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-v0.4.0
 [0.3.2]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-v0.3.2
 [0.3.1]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-v0.3.1
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-v0.3.0

--- a/lavalink/CHANGELOG.md
+++ b/lavalink/CHANGELOG.md
@@ -149,7 +149,7 @@ Initial release.
 [#548]: https://github.com/twilight-rs/twilight/pull/548
 [#518]: https://github.com/twilight-rs/twilight/pull/518
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-v0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-0.4.0
 [0.3.2]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-v0.3.2
 [0.3.1]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-v0.3.1
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/lavalink-v0.3.0

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -12,7 +12,7 @@ name = "twilight-lavalink"
 publish = false
 readme = "README.md"
 repository = "https://github.com/twilight-rs/twilight.git"
-version = "0.3.2"
+version = "0.4.0"
 
 [dependencies]
 tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.14" }

--- a/mention/CHANGELOG.md
+++ b/mention/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 Changelog for `twilight-mention`.
 
+## [0.4.0] - 2020-05-??
+
+### Upgrade Path
+
+The MSRV is now Rust 1.49.
+
+Instead of importing `twilight_mention::MentionFormat` import
+`twilight_mention::fmt::MentionFormat`.
+
+Errors are no longer enums and don't expose their concrete underlying error
+source. You can access the underlying error via the implemented
+`std::error::Error::source` method or the `into_parts` or `into_source` methods
+on each error struct, which will return a boxed `std::error::Error`. To access
+the reason for the error use the `kind` or `into_parts` method on error structs;
+the returned error type is an enum with variants for each potential reason the
+error occurred.
+
+### Enhancements
+
+Remove the `Debug` bound on the `parse::MentionIter`'s `Iterator` implementation
+([#764] - [@vivian]).
+
+### Changes
+
+Remove `fmt::MentionFormat` re-export from crate root
+([#735] - [@BlackHoleFox]).
+
+[#764]: https://github.com/twilight-rs/twilight/pull/764
+[#735]: https://github.com/twilight-rs/twilight/pull/735
+
 ## [0.3.0] - 2021-01-08
 
 This major version bump of the Mention crate is done to match all of the other
@@ -27,10 +57,12 @@ crates in the ecosystem receiving a major version bump. There are no changes.
 
 Initial release.
 
+[@BlackHoleFox]: https://github.com/BlackHoleFox
 [@vivian]: https://github.com/vivian
 
 [#513]: https://github.com/twilight-rs/twilight/pull/513
 
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-v0.3.0
 [0.2.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-v0.2.0
 [0.2.0-beta.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-v0.2.0-beta.0

--- a/mention/CHANGELOG.md
+++ b/mention/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `twilight-mention`.
 
-## [0.4.0] - 2020-05-??
+## [0.4.0] - 2020-05-12
 
 ### Upgrade Path
 

--- a/mention/CHANGELOG.md
+++ b/mention/CHANGELOG.md
@@ -62,7 +62,7 @@ Initial release.
 
 [#513]: https://github.com/twilight-rs/twilight/pull/513
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-v0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-v0.3.0
 [0.2.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-v0.2.0
 [0.2.0-beta.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-v0.2.0-beta.0

--- a/mention/CHANGELOG.md
+++ b/mention/CHANGELOG.md
@@ -62,7 +62,7 @@ Initial release.
 
 [#513]: https://github.com/twilight-rs/twilight/pull/513
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-v0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-v0.3.0
 [0.2.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-v0.2.0
 [0.2.0-beta.0]: https://github.com/twilight-rs/twilight/releases/tag/mention-v0.2.0-beta.0

--- a/mention/Cargo.toml
+++ b/mention/Cargo.toml
@@ -12,7 +12,7 @@ name = "twilight-mention"
 publish = false
 repository = "https://github.com/twilight-rs/twilight.git"
 readme = "README.md"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 twilight-model = { default-features = false, path = "../model" }

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -475,7 +475,7 @@ Initial release.
 
 [0.2.0-beta.1:app integrations]: https://github.com/discord/discord-api-docs/commit/a926694e2f8605848bda6b57d21c8817559e5cec
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/model-0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/model-v0.4.0
 [0.3.7]: https://github.com/twilight-rs/twilight/releases/tag/model-v0.3.7
 [0.3.5]: https://github.com/twilight-rs/twilight/releases/tag/model-v0.3.5
 [0.3.4]: https://github.com/twilight-rs/twilight/releases/tag/model-v0.3.4

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 Changelog for `twilight-model`.
 
+## [0.4.0] - 2021-05-??
+
+### Upgrade Path
+
+The MSRV is now Rust 1.49.
+
+Don't reference `GuildStatus`. `Ready::guilds` is now a `Vec<UnavailableGuild>`.
+
+Don't reference `Guild::lazy`.
+
+Errors are no longer enums and don't expose their concrete underlying error
+source. You can access the underlying error via the implemented
+`std::error::Error::source` method or the `into_parts` or `into_source` methods
+on each error struct, which will return a boxed `std::error::Error`. To access
+the reason for the error use the `kind` or `into_parts` method on error structs;
+the returned error type is an enum with variants for each potential reason the
+error occurred.
+
+### Additions
+
+Support `MessageReference::fail_if_not_exists`, which will fail sending a
+message if the referenced message does not exist ([#708] - [@7596ff]).
+
+Implement `Ord` for roles based on position and ID ([#762] - [@james7132]).
+
+Add a reworked Allowed Mentions model and builder, moved from the
+`twilight-http` crate ([#760] - [@7596ff]).
+
+### Changes
+
+Remove the `guild::GuildStatus` enum because guilds are never online in `Ready`
+payloads ([#688] - [@vivian]).
+
+`MessageUpdate::mentions` is now a `Vec<Mention>` instead of a `Vec<User>`
+([#699] - [@chamburr]).
+
+Remove the `Guild::lazy` field ([#724] - [@7596ff]).
+
+[#762]: https://github.com/twilight-rs/twilight/pull/762
+[#724]: https://github.com/twilight-rs/twilight/pull/724
+[#708]: https://github.com/twilight-rs/twilight/pull/708
+[#699]: https://github.com/twilight-rs/twilight/pull/699
+[#688]: https://github.com/twilight-rs/twilight/pull/688
+
 ## [0.3.7] - 2021-04-27
 
 ### Additions
@@ -394,6 +438,7 @@ Initial release.
 
 [@7596ff]: https://github.com/7596ff
 [@AsianIntel]: https://github.com/AsianIntel
+[@chamburr]: https://github.com/chamburr
 [@DusterTheFirst]: https://github.com/DusterTheFirst
 [@Erk-]: https://github.com/Erk-
 [@Gelbpunkt]: https://github.com/Gelbpunkt
@@ -430,6 +475,7 @@ Initial release.
 
 [0.2.0-beta.1:app integrations]: https://github.com/discord/discord-api-docs/commit/a926694e2f8605848bda6b57d21c8817559e5cec
 
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/model-0.4.0
 [0.3.7]: https://github.com/twilight-rs/twilight/releases/tag/model-v0.3.7
 [0.3.5]: https://github.com/twilight-rs/twilight/releases/tag/model-v0.3.5
 [0.3.4]: https://github.com/twilight-rs/twilight/releases/tag/model-v0.3.4

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -475,7 +475,7 @@ Initial release.
 
 [0.2.0-beta.1:app integrations]: https://github.com/discord/discord-api-docs/commit/a926694e2f8605848bda6b57d21c8817559e5cec
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/model-v0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/model-0.4.0
 [0.3.7]: https://github.com/twilight-rs/twilight/releases/tag/model-v0.3.7
 [0.3.5]: https://github.com/twilight-rs/twilight/releases/tag/model-v0.3.5
 [0.3.4]: https://github.com/twilight-rs/twilight/releases/tag/model-v0.3.4

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `twilight-model`.
 
-## [0.4.0] - 2021-05-??
+## [0.4.0] - 2021-05-12
 
 ### Upgrade Path
 

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -12,7 +12,7 @@ name = "twilight-model"
 publish = false
 readme = "README.md"
 repository = "https://github.com/twilight-rs/twilight.git"
-version = "0.3.7"
+version = "0.4.0"
 
 [dependencies]
 bitflags = { default-features = false, version = "1" }

--- a/standby/CHANGELOG.md
+++ b/standby/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 Changelog for `twilight-standby`.
 
+## [0.4.0] - 2021-05-??
+
+### Upgrade Path
+
+The MSRV is now Rust 1.49.
+
+Errors are no longer enums and don't expose their concrete underlying error
+source. You can access the underlying error via the implemented
+`std::error::Error::source` method or the `into_parts` or `into_source` methods
+on each error struct, which will return a boxed `std::error::Error`. To access
+the reason for the error use the `kind` or `into_parts` method on error structs;
+the returned error type is an enum with variants for each potential reason the
+error occurred.
+
+`tokio` is now a required runtime dependency.
+
+### Enhancements
+
+The `futures-channel` dependency has been removed in favor of `tokio` due to the
+dependency of it on other Twilight crates ([#785] - [@Gelbpunkt]).
+
+[#785]: https://github.com/twilight-rs/twilight/pull/785
+
 ## [0.3.0] - 2021-01-08
 
 This major version bump of the Standby crate is done to match all of the other
@@ -44,12 +67,14 @@ the ecosystem receiving a major version bump. There are no changes.
 Initial release.
 
 [@chamburr]: https://github.com/chamburr
+[@Gelbpunkt]: https://github.com/Gelbpunkt
 [@nickelc]: https://github.com/nickelc
 [@vivian]: https://github.com/vivian
 
 [#624]: https://github.com/twilight-rs/twilight/pull/624
 [#523]: https://github.com/twilight-rs/twilight/pull/523
 
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/standby-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/standby-v0.3.0
 [0.2.2]: https://github.com/twilight-rs/twilight/releases/tag/standby-v0.2.2
 [0.2.1]: https://github.com/twilight-rs/twilight/releases/tag/standby-v0.2.1

--- a/standby/CHANGELOG.md
+++ b/standby/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `twilight-standby`.
 
-## [0.4.0] - 2021-05-??
+## [0.4.0] - 2021-05-12
 
 ### Upgrade Path
 

--- a/standby/CHANGELOG.md
+++ b/standby/CHANGELOG.md
@@ -74,7 +74,7 @@ Initial release.
 [#624]: https://github.com/twilight-rs/twilight/pull/624
 [#523]: https://github.com/twilight-rs/twilight/pull/523
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/standby-v0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/standby-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/standby-v0.3.0
 [0.2.2]: https://github.com/twilight-rs/twilight/releases/tag/standby-v0.2.2
 [0.2.1]: https://github.com/twilight-rs/twilight/releases/tag/standby-v0.2.1

--- a/standby/CHANGELOG.md
+++ b/standby/CHANGELOG.md
@@ -74,7 +74,7 @@ Initial release.
 [#624]: https://github.com/twilight-rs/twilight/pull/624
 [#523]: https://github.com/twilight-rs/twilight/pull/523
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/standby-0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/standby-v0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/standby-v0.3.0
 [0.2.2]: https://github.com/twilight-rs/twilight/releases/tag/standby-v0.2.2
 [0.2.1]: https://github.com/twilight-rs/twilight/releases/tag/standby-v0.2.1

--- a/standby/Cargo.toml
+++ b/standby/Cargo.toml
@@ -12,7 +12,7 @@ name = "twilight-standby"
 publish = false
 readme = "README.md"
 repository = "https://github.com/twilight-rs/twilight.git"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 dashmap = { default-features = false, version = "4.0" }

--- a/twilight/CHANGELOG.md
+++ b/twilight/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Changelog for `twilight`.
 
+## [0.4.0] - 2021-05-??
+
+The advertisement crate has been updated to bump development
+dependencies.
+
 ## [0.3.0] - 2021-01-08
 
 The advertisement crate has been updated to bump development
@@ -38,6 +43,7 @@ Initial release.
 [#588]: https://github.com/twilight-rs/twilight/pull/588
 [#498]: https://github.com/twilight-rs/twilight/pull/498
 
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/twilight-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/twilight-v0.3.0
 [0.2.2]: https://github.com/twilight-rs/twilight/releases/tag/twilight-v0.2.2
 [0.2.1]: https://github.com/twilight-rs/twilight/releases/tag/twilight-v0.2.1

--- a/twilight/CHANGELOG.md
+++ b/twilight/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `twilight`.
 
-## [0.4.0] - 2021-05-??
+## [0.4.0] - 2021-05-12
 
 The advertisement crate has been updated to bump development
 dependencies.

--- a/twilight/CHANGELOG.md
+++ b/twilight/CHANGELOG.md
@@ -43,7 +43,7 @@ Initial release.
 [#588]: https://github.com/twilight-rs/twilight/pull/588
 [#498]: https://github.com/twilight-rs/twilight/pull/498
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/twilight-0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/twilight-v0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/twilight-v0.3.0
 [0.2.2]: https://github.com/twilight-rs/twilight/releases/tag/twilight-v0.2.2
 [0.2.1]: https://github.com/twilight-rs/twilight/releases/tag/twilight-v0.2.1

--- a/twilight/CHANGELOG.md
+++ b/twilight/CHANGELOG.md
@@ -43,7 +43,7 @@ Initial release.
 [#588]: https://github.com/twilight-rs/twilight/pull/588
 [#498]: https://github.com/twilight-rs/twilight/pull/498
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/twilight-v0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/twilight-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/twilight-v0.3.0
 [0.2.2]: https://github.com/twilight-rs/twilight/releases/tag/twilight-v0.2.2
 [0.2.1]: https://github.com/twilight-rs/twilight/releases/tag/twilight-v0.2.1

--- a/twilight/Cargo.toml
+++ b/twilight/Cargo.toml
@@ -12,7 +12,7 @@ name = "twilight"
 publish = false
 repository = "https://github.com/twilight-rs/twilight"
 readme = "../README.md"
-version = "0.3.0"
+version = "0.4.0"
 
 [dev-dependencies]
 futures = { default-features = false, version = "0.3" }

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Changelog for `twilight-util`.
 
+## [0.4.0] - 2021-05-??
+
+### Upgrade Path
+
+The MSRV is now Rust 1.49.
+
+Errors are no longer enums and don't expose their concrete underlying error
+source. You can access the underlying error via the implemented
+`std::error::Error::source` method or the `into_parts` or `into_source` methods
+on each error struct, which will return a boxed `std::error::Error`. To access
+the reason for the error use the `kind` or `into_parts` method on error structs;
+the returned error type is an enum with variants for each potential reason the
+error occurred.
+
 ## [0.3.0] - 2021-01-08
 
 This major version bump of the Util crate is done to match all of the other
@@ -35,6 +49,7 @@ Initial release.
 
 [@vivian]: https://github.com/vivian
 
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/util-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/util-v0.3.0
 [0.2.0]: https://github.com/twilight-rs/twilight/releases/tag/util-v0.2.0
 [0.2.0-beta.0]: https://github.com/twilight-rs/twilight/releases/tag/util-v0.2.0-beta.0

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -49,7 +49,7 @@ Initial release.
 
 [@vivian]: https://github.com/vivian
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/util-v0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/util-0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/util-v0.3.0
 [0.2.0]: https://github.com/twilight-rs/twilight/releases/tag/util-v0.2.0
 [0.2.0-beta.0]: https://github.com/twilight-rs/twilight/releases/tag/util-v0.2.0-beta.0

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -49,7 +49,7 @@ Initial release.
 
 [@vivian]: https://github.com/vivian
 
-[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/util-0.4.0
+[0.4.0]: https://github.com/twilight-rs/twilight/releases/tag/util-v0.4.0
 [0.3.0]: https://github.com/twilight-rs/twilight/releases/tag/util-v0.3.0
 [0.2.0]: https://github.com/twilight-rs/twilight/releases/tag/util-v0.2.0
 [0.2.0-beta.0]: https://github.com/twilight-rs/twilight/releases/tag/util-v0.2.0-beta.0

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `twilight-util`.
 
-## [0.4.0] - 2021-05-??
+## [0.4.0] - 2021-05-12
 
 ### Upgrade Path
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -12,7 +12,7 @@ name = "twilight-util"
 publish = false
 readme = "README.md"
 repository = "https://github.com/twilight-rs/twilight.git"
-version = "0.3.0"
+version = "0.4.0"
 
 [features]
 default = []


### PR DESCRIPTION
Crate changelogs for version 0.4.0. I imagine I've missed either a named anchor for the GitHub tag at the bottom of each changelog, an author link, or a commit, so if everyone could take a look for their commits I'd appreciate it.