### PR TITLE
Rename 'trunk' branch references to 'main'

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Deploy documentation
 on:
   push:
     branches:
-      - trunk
+      - main
 
 jobs:
   deploy-docs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ up your topic in the `#support` channel.
 Pull requests must be named with the format `{crate}: {short description of change}`, and should use
 lower case letters. If the change spans more than one crate, separate the crate names with a comma
 and a space: `{crate1}, {crate2}: {short description of change}`. Pull requests must be made from a
-new branch. Please avoid making pull requests from the `trunk` branch. If adding a feature or
+new branch. Please avoid making pull requests from the HEAD branch. If adding a feature or
 enhancement, use the term `add` or something sufficiently similar. If fixing a bug, use the term
 `fix`, or something sufficiently similar. Avoid force-pushing to a pull request branch, as this
 erases review comment history.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/mainLICENSE.md
-[logo]: https://raw.githubusercontent.com/twilight-rs/twilight/mainlogo.png
+[logo]: https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
 [`twilight-cache-inmemory`]: https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ tracing_log::LogTracer::init()?;
 
 All first-party crates are licensed under [ISC][LICENSE.md]
 
-[LICENSE.md]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[LICENSE.md]: https://github.com/twilight-rs/twilight/blob/mainLICENSE.md
 [Lavalink]: https://github.com/freyacodes/Lavalink
 [`http`]: https://crates.io/crates/http
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
@@ -216,8 +216,8 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-[logo]: https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png
+[license link]: https://github.com/twilight-rs/twilight/blob/mainLICENSE.md
+[logo]: https://raw.githubusercontent.com/twilight-rs/twilight/mainlogo.png
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
 [`twilight-cache-inmemory`]: https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ tracing_log::LogTracer::init()?;
 
 All first-party crates are licensed under [ISC][LICENSE.md]
 
-[LICENSE.md]: https://github.com/twilight-rs/twilight/blob/mainLICENSE.md
+[LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [Lavalink]: https://github.com/freyacodes/Lavalink
 [`http`]: https://crates.io/crates/http
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
@@ -216,7 +216,7 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-[license link]: https://github.com/twilight-rs/twilight/blob/mainLICENSE.md
+[license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log

--- a/cache/in-memory/README.md
+++ b/cache/in-memory/README.md
@@ -37,14 +37,14 @@ while let Some(event) = events.next().await {
 
 All first-party crates are licensed under [ISC][LICENSE.md]
 
-[LICENSE.md]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -37,14 +37,14 @@
 //!
 //! All first-party crates are licensed under [ISC][LICENSE.md]
 //!
-//! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(rust_2018_idioms, broken_intra_doc_links, unused, warnings)]

--- a/command-parser/README.md
+++ b/command-parser/README.md
@@ -51,7 +51,7 @@ match parser.parse("!echo a message") {
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 [`twilight-rs`]: https://github.com/twilight-rs/twilight
 

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -49,7 +49,7 @@
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 //! [`twilight-rs`]: https://github.com/twilight-rs/twilight
 

--- a/embed-builder/README.md
+++ b/embed-builder/README.md
@@ -40,7 +40,7 @@ let embed = EmbedBuilder::new()
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 [the discord docs]: https://discord.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
 

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -591,7 +591,7 @@ impl EmbedBuilder {
     /// use twilight_embed_builder::{EmbedBuilder, EmbedFooterBuilder, ImageSource};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let source = ImageSource::url("https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png")?;
+    /// let source = ImageSource::url("https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png")?;
     /// let embed = EmbedBuilder::new()
     ///     .footer(EmbedFooterBuilder::new("twilight"))
     ///     .image(source)
@@ -824,7 +824,7 @@ mod tests {
     #[test]
     fn test_builder() {
         let footer_image = ImageSource::url(
-            "https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png",
+            "https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png",
         )
         .unwrap();
         let embed = EmbedBuilder::new()
@@ -848,7 +848,7 @@ mod tests {
             .to_vec(),
             footer: Some(EmbedFooter {
                 icon_url: Some(
-                    "https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png"
+                    "https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png"
                         .to_string(),
                 ),
                 proxy_icon_url: None,

--- a/embed-builder/src/footer.rs
+++ b/embed-builder/src/footer.rs
@@ -47,7 +47,7 @@ impl EmbedFooterBuilder {
     /// use twilight_embed_builder::{EmbedFooterBuilder, ImageSource};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let icon_url = ImageSource::url("https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png")?;
+    /// let icon_url = ImageSource::url("https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png")?;
     /// let footer = EmbedFooterBuilder::new("Twilight")
     ///     .icon_url(icon_url)
     ///     .build();

--- a/embed-builder/src/lib.rs
+++ b/embed-builder/src/lib.rs
@@ -42,7 +42,7 @@
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 //! [the discord docs]: https://discord.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -108,7 +108,7 @@ This is disabled by default.
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -106,7 +106,7 @@
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(

--- a/http/README.md
+++ b/http/README.md
@@ -72,7 +72,7 @@ This is enabled by default.
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -70,7 +70,7 @@
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -107,7 +107,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [node]: Node
 [process]: Lavalink::process
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -105,7 +105,7 @@
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [node]: Node
 //! [process]: Lavalink::process
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust

--- a/mention/README.md
+++ b/mention/README.md
@@ -28,7 +28,7 @@ let message = format!("Hey there, {}!", user_id.mention());
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/mention/src/lib.rs
+++ b/mention/src/lib.rs
@@ -26,7 +26,7 @@
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(

--- a/model/README.md
+++ b/model/README.md
@@ -27,14 +27,14 @@ or extended by other crates.
 
 [ISC][LICENSE.md]
 
-[LICENSE.md]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [`twilight`]: https://docs.rs/twilight
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -25,14 +25,14 @@
 //!
 //! [ISC][LICENSE.md]
 //!
-//! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [`twilight`]: https://docs.rs/twilight
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(

--- a/standby/README.md
+++ b/standby/README.md
@@ -117,7 +117,7 @@ For more examples, check out each of the methods on [`Standby`].
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -117,7 +117,7 @@
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(rust_2018_idioms, broken_intra_doc_links, unused, warnings)]

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -207,7 +207,7 @@
 //!
 //! All first-party crates are licensed under [ISC][LICENSE.md]
 //!
-//! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [Lavalink]: https://github.com/freyacodes/Lavalink
 //! [`http`]: https://crates.io/crates/http
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
@@ -216,8 +216,8 @@
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
-//! [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/trunk/logo.png
+//! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
+//! [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 //! [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
 //! [`twilight-cache-inmemory`]: https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html

--- a/util/README.md
+++ b/util/README.md
@@ -20,7 +20,7 @@ structured information from [Discord snowflakes].
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-[license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+[license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 [Discord snowflakes]: https://discord.com/developers/docs/reference#snowflakes
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -18,7 +18,7 @@
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
-//! [license link]: https://github.com/twilight-rs/twilight/blob/trunk/LICENSE.md
+//! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 //! [Discord snowflakes]: https://discord.com/developers/docs/reference#snowflakes
 


### PR DESCRIPTION
The primary branch has been renamed from 'trunk' to 'main', so the GitHub workflows, CONTRIBUTING document, and crate and project READMEs need to be updated to reflect that.