### PR TITLE
fix(http, model): bring invites up to date

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -328,7 +328,11 @@ impl Client {
 
     /// Get the invites for a guild channel.
     ///
-    /// This method only works if the channel is of type `GuildChannel`.
+    /// Requires the [`MANAGE_CHANNELS`] permission. This method only works if
+    /// the channel is of type [`GuildChannel`].
+    ///
+    /// [`MANAGE_CHANNELS`]: twilight_model::guild::permissions::Permissions::MANAGE_CHANNELS
+    /// [`GuildChannel`]: twilight_model::channel::GuildChannel
     pub fn channel_invites(&self, channel_id: ChannelId) -> GetChannelInvites<'_> {
         GetChannelInvites::new(self, channel_id)
     }
@@ -723,6 +727,10 @@ impl Client {
     }
 
     /// Get information about the invites of a guild.
+    ///
+    /// Requires the [`MANAGE_GUILD`] permission.
+    ///
+    /// [`MANAGE_GUILD`]: twilight_model::guild::permissions::Permissions::MANAGE_GUILD
     pub fn guild_invites(&self, guild_id: GuildId) -> GetGuildInvites<'_> {
         GetGuildInvites::new(self, guild_id)
     }
@@ -958,7 +966,9 @@ impl Client {
 
     /// Get information about an invite by its code.
     ///
-    /// If [`with_counts`] is called, the returned invite will contain approximate member counts.
+    /// If [`with_counts`] is called, the returned invite will contain
+    /// approximate member counts.  If [`with_expiration`] is called, it will
+    /// contain the expiration date.
     ///
     /// # Examples
     ///
@@ -977,11 +987,14 @@ impl Client {
     /// ```
     ///
     /// [`with_counts`]: crate::request::channel::invite::GetInvite::with_counts
+    /// [`with_expiration`]: crate::request::channel::invite::GetInvite::with_expiration
     pub fn invite(&self, code: impl Into<String>) -> GetInvite<'_> {
         GetInvite::new(self, code)
     }
 
     /// Create an invite, with options.
+    ///
+    /// Requires the [`CREATE_INVITE`] permission.
     ///
     /// # Examples
     ///
@@ -1000,11 +1013,19 @@ impl Client {
     ///     .await?;
     /// # Ok(()) }
     /// ```
+    ///
+    /// [`CREATE_INVITE`]: twilight_model::guild::permissions::Permissions::CREATE_INVITE
     pub fn create_invite(&self, channel_id: ChannelId) -> CreateInvite<'_> {
         CreateInvite::new(self, channel_id)
     }
 
     /// Delete an invite by its code.
+    ///
+    /// Requires the [`MANAGE_CHANNELS`] permission on the channel this invite
+    /// belongs to, or [`MANAGE_GUILD`] to remove any invite across the guild.
+    ///
+    /// [`MANAGE_CHANNELS`]: twilight_model::guild::permissions::Permissions::MANAGE_CHANNELS
+    /// [`MANAGE_GUILD`]: twilight_model::guild::permissions::Permissions::MANAGE_GUILD
     pub fn delete_invite(&self, code: impl Into<String>) -> DeleteInvite<'_> {
         DeleteInvite::new(self, code)
     }

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -331,7 +331,7 @@ impl Client {
     /// Requires the [`MANAGE_CHANNELS`] permission. This method only works if
     /// the channel is of type [`GuildChannel`].
     ///
-    /// [`MANAGE_CHANNELS`]: twilight_model::guild::permissions::Permissions::MANAGE_CHANNELS
+    /// [`MANAGE_CHANNELS`]: twilight_model::guild::Permissions::MANAGE_CHANNELS
     /// [`GuildChannel`]: twilight_model::channel::GuildChannel
     pub fn channel_invites(&self, channel_id: ChannelId) -> GetChannelInvites<'_> {
         GetChannelInvites::new(self, channel_id)
@@ -730,7 +730,7 @@ impl Client {
     ///
     /// Requires the [`MANAGE_GUILD`] permission.
     ///
-    /// [`MANAGE_GUILD`]: twilight_model::guild::permissions::Permissions::MANAGE_GUILD
+    /// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
     pub fn guild_invites(&self, guild_id: GuildId) -> GetGuildInvites<'_> {
         GetGuildInvites::new(self, guild_id)
     }
@@ -1014,7 +1014,7 @@ impl Client {
     /// # Ok(()) }
     /// ```
     ///
-    /// [`CREATE_INVITE`]: twilight_model::guild::permissions::Permissions::CREATE_INVITE
+    /// [`CREATE_INVITE`]: twilight_model::guild::Permissions::CREATE_INVITE
     pub fn create_invite(&self, channel_id: ChannelId) -> CreateInvite<'_> {
         CreateInvite::new(self, channel_id)
     }
@@ -1024,8 +1024,8 @@ impl Client {
     /// Requires the [`MANAGE_CHANNELS`] permission on the channel this invite
     /// belongs to, or [`MANAGE_GUILD`] to remove any invite across the guild.
     ///
-    /// [`MANAGE_CHANNELS`]: twilight_model::guild::permissions::Permissions::MANAGE_CHANNELS
-    /// [`MANAGE_GUILD`]: twilight_model::guild::permissions::Permissions::MANAGE_GUILD
+    /// [`MANAGE_CHANNELS`]: twilight_model::guild::Permissions::MANAGE_CHANNELS
+    /// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
     pub fn delete_invite(&self, code: impl Into<String>) -> DeleteInvite<'_> {
         DeleteInvite::new(self, code)
     }

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -218,11 +218,17 @@ impl<'a> CreateInvite<'a> {
         self.target_user_id(target_user_id)
     }
 
-    /// Set the target user type for this invite.
+    /// Set the target type for this invite.
     pub fn target_type(mut self, target_type: TargetType) -> Self {
         self.fields.target_type.replace(target_type);
 
         self
+    }
+
+    /// Set the target user type for this invite.
+    #[deprecated(since = "0.4.1", note = "Use `target_type` instead")]
+    pub fn target_user_type(self, target_user_type: TargetType) -> Self {
+        Self::target_type(self, target_user_type)
     }
 
     /// Specify true if the invite should grant temporary membership.

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -3,9 +3,10 @@ use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
+#[allow(deprecated)]
 use twilight_model::{
     id::{ApplicationId, ChannelId, UserId},
-    invite::{Invite, TargetType},
+    invite::{Invite, TargetType, TargetUserType},
 };
 
 /// Error created when an invite can not be created as configured.
@@ -227,7 +228,8 @@ impl<'a> CreateInvite<'a> {
 
     /// Set the target user type for this invite.
     #[deprecated(since = "0.4.1", note = "Use `target_type` instead")]
-    pub fn target_user_type(self, target_user_type: TargetType) -> Self {
+    #[allow(deprecated)]
+    pub fn target_user_type(self, target_user_type: TargetUserType) -> Self {
         Self::target_type(self, target_user_type)
     }
 

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -4,8 +4,8 @@ use std::{
     fmt::{Display, Formatter, Result as FmtResult},
 };
 use twilight_model::{
-    id::{ChannelId, UserId},
-    invite::{Invite, TargetUserType},
+    id::{ApplicationId, ChannelId, UserId},
+    invite::{Invite, TargetType},
 };
 
 /// Error created when an invite can not be created as configured.
@@ -71,14 +71,18 @@ struct CreateInviteFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     temporary: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    unique: Option<bool>,
+    target_application_id: Option<ApplicationId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_user_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    target_user_type: Option<TargetUserType>,
+    target_type: Option<TargetType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unique: Option<bool>,
 }
 
 /// Create an invite, with options.
+///
+/// Requires the [`CREATE_INVITE`] permission.
 ///
 /// # Examples
 ///
@@ -97,6 +101,8 @@ struct CreateInviteFields {
 ///     .await?;
 /// # Ok(()) }
 /// ```
+///
+/// [`CREATE_INVITE`]: twilight_model::guild::permissions::Permissions::CREATE_INVITE
 pub struct CreateInvite<'a> {
     channel_id: ChannelId,
     fields: CreateInviteFields,
@@ -184,26 +190,20 @@ impl<'a> CreateInvite<'a> {
         Ok(self)
     }
 
-    /// Specify true if the invite should grant temporary membership. Defaults to false.
-    pub fn temporary(mut self, temporary: bool) -> Self {
-        self.fields.temporary.replace(temporary);
+    /// Set the target application ID for this invite.
+    ///
+    /// This only works if [`target_type`] is set to [`TargetType::EmbeddedApplication`].
+    ///
+    /// [`target_type`]: Self::target_type
+    pub fn target_application_id(mut self, target_application_id: ApplicationId) -> Self {
+        self.fields
+            .target_application_id
+            .replace(target_application_id);
 
         self
     }
 
-    /// Specify true if the invite should be unique. Defaults to false.
-    ///
-    /// If true, don't try to reuse a similar invite (useful for creating many unique one time use
-    /// invites). Refer to [the discord docs] for more information.
-    ///
-    /// [the discord docs]: https://discord.com/developers/docs/resources/channel#create-channel-invite
-    pub fn unique(mut self, unique: bool) -> Self {
-        self.fields.unique.replace(unique);
-
-        self
-    }
-
-    /// Set the target user for this invite.
+    /// Set the target user id for this invite.
     pub fn target_user_id(mut self, target_user_id: UserId) -> Self {
         self.fields
             .target_user_id
@@ -219,8 +219,29 @@ impl<'a> CreateInvite<'a> {
     }
 
     /// Set the target user type for this invite.
-    pub fn target_user_type(mut self, target_user_type: TargetUserType) -> Self {
-        self.fields.target_user_type.replace(target_user_type);
+    pub fn target_type(mut self, target_type: TargetType) -> Self {
+        self.fields.target_type.replace(target_type);
+
+        self
+    }
+
+    /// Specify true if the invite should grant temporary membership.
+    ///
+    /// Defaults to false.
+    pub fn temporary(mut self, temporary: bool) -> Self {
+        self.fields.temporary.replace(temporary);
+
+        self
+    }
+
+    /// Specify true if the invite should be unique. Defaults to false.
+    ///
+    /// If true, don't try to reuse a similar invite (useful for creating many unique one time use
+    /// invites). Refer to [the discord docs] for more information.
+    ///
+    /// [the discord docs]: https://discord.com/developers/docs/resources/channel#create-channel-invite
+    pub fn unique(mut self, unique: bool) -> Self {
+        self.fields.unique.replace(unique);
 
         self
     }

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -3,10 +3,9 @@ use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
-#[allow(deprecated)]
 use twilight_model::{
     id::{ApplicationId, ChannelId, UserId},
-    invite::{Invite, TargetType, TargetUserType},
+    invite::{Invite, TargetType},
 };
 
 /// Error created when an invite can not be created as configured.
@@ -228,8 +227,7 @@ impl<'a> CreateInvite<'a> {
 
     /// Set the target user type for this invite.
     #[deprecated(since = "0.4.1", note = "Use `target_type` instead")]
-    #[allow(deprecated)]
-    pub fn target_user_type(self, target_user_type: TargetUserType) -> Self {
+    pub fn target_user_type(self, target_user_type: TargetType) -> Self {
         Self::target_type(self, target_user_type)
     }
 

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -226,7 +226,7 @@ impl<'a> CreateInvite<'a> {
     }
 
     /// Set the target user type for this invite.
-    #[deprecated(since = "0.4.1", note = "Use `target_type` instead")]
+    #[deprecated(since = "0.4.2", note = "Use `target_type` instead")]
     pub fn target_user_type(self, target_user_type: TargetType) -> Self {
         Self::target_type(self, target_user_type)
     }

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -102,7 +102,7 @@ struct CreateInviteFields {
 /// # Ok(()) }
 /// ```
 ///
-/// [`CREATE_INVITE`]: twilight_model::guild::permissions::Permissions::CREATE_INVITE
+/// [`CREATE_INVITE`]: twilight_model::guild::Permissions::CREATE_INVITE
 pub struct CreateInvite<'a> {
     channel_id: ChannelId,
     fields: CreateInviteFields,

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -1,9 +1,16 @@
 use crate::request::prelude::*;
+use twilight_model::invite::Invite;
 
 /// Delete an invite by its code.
+///
+/// Requires the [`MANAGE_CHANNELS`] permission on the channel this invite
+/// belongs to, or [`MANAGE_GUILD`] to remove any invite across the guild.
+///
+/// [`MANAGE_CHANNELS`]: twilight_model::guild::permissions::Permissions::MANAGE_CHANNELS
+/// [`MANAGE_GUILD`]: twilight_model::guild::permissions::Permissions::MANAGE_GUILD
 pub struct DeleteInvite<'a> {
     code: String,
-    fut: Option<Pending<'a, ()>>,
+    fut: Option<Pending<'a, Invite>>,
     http: &'a Client,
     reason: Option<String>,
 }
@@ -33,7 +40,7 @@ impl<'a> DeleteInvite<'a> {
             })
         };
 
-        self.fut.replace(Box::pin(self.http.verify(request)));
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }
@@ -48,4 +55,4 @@ impl<'a> AuditLogReason for DeleteInvite<'a> {
     }
 }
 
-poll_req!(DeleteInvite<'_>, ());
+poll_req!(DeleteInvite<'_>, Invite);

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -6,8 +6,8 @@ use twilight_model::invite::Invite;
 /// Requires the [`MANAGE_CHANNELS`] permission on the channel this invite
 /// belongs to, or [`MANAGE_GUILD`] to remove any invite across the guild.
 ///
-/// [`MANAGE_CHANNELS`]: twilight_model::guild::permissions::Permissions::MANAGE_CHANNELS
-/// [`MANAGE_GUILD`]: twilight_model::guild::permissions::Permissions::MANAGE_GUILD
+/// [`MANAGE_CHANNELS`]: twilight_model::guild::Permissions::MANAGE_CHANNELS
+/// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
 pub struct DeleteInvite<'a> {
     code: String,
     fut: Option<Pending<'a, Invite>>,

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -1,5 +1,4 @@
 use crate::request::prelude::*;
-use twilight_model::invite::Invite;
 
 /// Delete an invite by its code.
 ///
@@ -10,7 +9,7 @@ use twilight_model::invite::Invite;
 /// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
 pub struct DeleteInvite<'a> {
     code: String,
-    fut: Option<Pending<'a, Invite>>,
+    fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     reason: Option<String>,
 }
@@ -40,7 +39,7 @@ impl<'a> DeleteInvite<'a> {
             })
         };
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }
@@ -55,4 +54,4 @@ impl<'a> AuditLogReason for DeleteInvite<'a> {
     }
 }
 
-poll_req!(DeleteInvite<'_>, Invite);
+poll_req!(DeleteInvite<'_>, ());

--- a/http/src/request/channel/invite/get_channel_invites.rs
+++ b/http/src/request/channel/invite/get_channel_invites.rs
@@ -3,7 +3,11 @@ use twilight_model::{id::ChannelId, invite::Invite};
 
 /// Get the invites for a guild channel.
 ///
-/// This method only works if the channel is of type `GuildChannel`.
+/// Requires the [`MANAGE_CHANNELS`] permission. This method only works if the
+/// channel is of type [`GuildChannel`].
+///
+/// [`MANAGE_CHANNELS`]: twilight_model::guild::permissions::Permissions::MANAGE_CHANNELS
+/// [`GuildChannel`]: twilight_model::channel::GuildChannel
 pub struct GetChannelInvites<'a> {
     channel_id: ChannelId,
     fut: Option<Pending<'a, Vec<Invite>>>,

--- a/http/src/request/channel/invite/get_channel_invites.rs
+++ b/http/src/request/channel/invite/get_channel_invites.rs
@@ -6,7 +6,7 @@ use twilight_model::{id::ChannelId, invite::Invite};
 /// Requires the [`MANAGE_CHANNELS`] permission. This method only works if the
 /// channel is of type [`GuildChannel`].
 ///
-/// [`MANAGE_CHANNELS`]: twilight_model::guild::permissions::Permissions::MANAGE_CHANNELS
+/// [`MANAGE_CHANNELS`]: twilight_model::guild::Permissions::MANAGE_CHANNELS
 /// [`GuildChannel`]: twilight_model::channel::GuildChannel
 pub struct GetChannelInvites<'a> {
     channel_id: ChannelId,

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -4,11 +4,14 @@ use twilight_model::invite::Invite;
 #[derive(Default)]
 struct GetInviteFields {
     with_counts: bool,
+    with_expiration: bool,
 }
 
 /// Get information about an invite by its code.
 ///
-/// If [`with_counts`] is called, the returned invite will contain approximate member counts.
+/// If [`with_counts`] is called, the returned invite will contain approximate
+/// member counts. If [`with_expiration`] is called, it will contain the
+/// expiration date.
 ///
 /// # Examples
 ///
@@ -27,6 +30,7 @@ struct GetInviteFields {
 /// ```
 ///
 /// [`with_counts`]: Self::with_counts
+/// [`with_counts`]: Self::with_expiration
 pub struct GetInvite<'a> {
     code: String,
     fields: GetInviteFields,
@@ -51,12 +55,20 @@ impl<'a> GetInvite<'a> {
         self
     }
 
+    /// Whether the invite returned should contain its expiration date.
+    pub fn with_expiration(mut self) -> Self {
+        self.fields.with_expiration = true;
+
+        self
+    }
+
     fn start(&mut self) -> Result<()> {
         self.fut
             .replace(Box::pin(self.http.request_bytes(Request::from(
                 Route::GetInvite {
                     code: self.code.clone(),
                     with_counts: self.fields.with_counts,
+                    with_expiration: self.fields.with_expiration,
                 },
             ))));
 

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -65,7 +65,7 @@ impl<'a> GetInvite<'a> {
     fn start(&mut self) -> Result<()> {
         self.fut
             .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetInvite {
+                Route::GetInviteWithExpiration {
                     code: self.code.clone(),
                     with_counts: self.fields.with_counts,
                     with_expiration: self.fields.with_expiration,

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -30,7 +30,7 @@ struct GetInviteFields {
 /// ```
 ///
 /// [`with_counts`]: Self::with_counts
-/// [`with_counts`]: Self::with_expiration
+/// [`with_expiration`]: Self::with_expiration
 pub struct GetInvite<'a> {
     code: String,
     fields: GetInviteFields,

--- a/http/src/request/guild/get_guild_invites.rs
+++ b/http/src/request/guild/get_guild_invites.rs
@@ -2,6 +2,10 @@ use crate::request::prelude::*;
 use twilight_model::{id::GuildId, invite::Invite};
 
 /// Get information about the invites of a guild.
+///
+/// Requires the [`MANAGE_GUILD`] permission.
+///
+/// [`MANAGE_GUILD`]: twilight_model::guild::permissions::Permissions::MANAGE_GUILD
 pub struct GetGuildInvites<'a> {
     fut: Option<Pending<'a, Vec<Invite>>>,
     guild_id: GuildId,

--- a/http/src/request/guild/get_guild_invites.rs
+++ b/http/src/request/guild/get_guild_invites.rs
@@ -5,7 +5,7 @@ use twilight_model::{id::GuildId, invite::Invite};
 ///
 /// Requires the [`MANAGE_GUILD`] permission.
 ///
-/// [`MANAGE_GUILD`]: twilight_model::guild::permissions::Permissions::MANAGE_GUILD
+/// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
 pub struct GetGuildInvites<'a> {
     fut: Option<Pending<'a, Vec<Invite>>>,
     guild_id: GuildId,

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -696,6 +696,8 @@ pub enum Route {
         code: String,
         /// Whether to retrieve statistics about the invite.
         with_counts: bool,
+        /// Whether to retrieve the expiration date of the invite.
+        with_expiration: bool,
     },
     /// Route information to get a member.
     GetMember {
@@ -1437,11 +1439,22 @@ impl Route {
 
                 (Method::Get, Path::UsersIdGuilds, path.into())
             }
-            Self::GetInvite { code, with_counts } => (
-                Method::Get,
-                Path::InvitesCode,
-                format!("invites/{}?with-counts={}", code, with_counts).into(),
-            ),
+            Self::GetInvite {
+                code,
+                with_counts,
+                with_expiration,
+            } => {
+                let query_params = match (with_counts, with_expiration) {
+                    (true, true) => "?with-counts=true&with-expiration=true",
+                    (true, false) => "?with-counts=true",
+                    (false, true) => "?with-expiration=true",
+                    (false, false) => "",
+                };
+
+                let route = format!("invites/{}{}", code, query_params);
+
+                (Method::Get, Path::InvitesCode, route.into())
+            }
             Self::GetMember { guild_id, user_id } => (
                 Method::Get,
                 Path::GuildsIdMembersId(guild_id),

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -696,6 +696,13 @@ pub enum Route {
         code: String,
         /// Whether to retrieve statistics about the invite.
         with_counts: bool,
+    },
+    /// Route information to get an invite with an expiration.
+    GetInviteWithExpiration {
+        /// The unique invite code.
+        code: String,
+        /// Whether to retrieve statistics about the invite.
+        with_counts: bool,
         /// Whether to retrieve the expiration date of the invite.
         with_expiration: bool,
     },
@@ -1439,7 +1446,12 @@ impl Route {
 
                 (Method::Get, Path::UsersIdGuilds, path.into())
             }
-            Self::GetInvite {
+            Self::GetInvite { code, with_counts } => (
+                Method::Get,
+                Path::InvitesCode,
+                format!("invites/{}?with-counts={}", code, with_counts).into(),
+            ),
+            Self::GetInviteWithExpiration {
                 code,
                 with_counts,
                 with_expiration,

--- a/model/src/gateway/payload/invite_create.rs
+++ b/model/src/gateway/payload/invite_create.rs
@@ -1,6 +1,6 @@
 use crate::{
     id::{ChannelId, GuildId, UserId},
-    invite::TargetUserType,
+    invite::TargetType,
     user::User,
 };
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,7 @@ pub struct InviteCreate {
     pub max_age: u64,
     pub max_uses: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_user_type: Option<TargetUserType>,
+    pub target_user_type: Option<TargetType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_user: Option<PartialUser>,
     pub temporary: bool,

--- a/model/src/invite/mod.rs
+++ b/model/src/invite/mod.rs
@@ -1,14 +1,14 @@
 mod channel;
 mod guild;
 mod metadata;
-mod target_user_type;
+mod target_type;
 mod welcome_screen;
 
 pub use self::{
     channel::InviteChannel,
     guild::InviteGuild,
     metadata::InviteMetadata,
-    target_user_type::TargetUserType,
+    target_type::TargetType,
     welcome_screen::{WelcomeScreen, WelcomeScreenChannel},
 };
 
@@ -24,11 +24,13 @@ pub struct Invite {
     pub channel: InviteChannel,
     pub code: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub guild: Option<InviteGuild>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inviter: Option<User>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_user_type: Option<TargetUserType>,
+    pub target_type: Option<TargetType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_user: Option<User>,
 }
@@ -36,8 +38,8 @@ pub struct Invite {
 #[cfg(test)]
 mod tests {
     use super::{
-        welcome_screen::WelcomeScreenChannel, Invite, InviteChannel, InviteGuild, TargetUserType,
-        User, WelcomeScreen,
+        welcome_screen::WelcomeScreenChannel, Invite, InviteChannel, InviteGuild, TargetType, User,
+        WelcomeScreen,
     };
     use crate::{
         channel::ChannelType,
@@ -57,9 +59,10 @@ mod tests {
                 name: None,
             },
             code: "uniquecode".to_owned(),
+            expires_at: None,
             guild: None,
             inviter: None,
-            target_user_type: Some(TargetUserType::Stream),
+            target_type: Some(TargetType::Stream),
             target_user: None,
         };
 
@@ -89,7 +92,7 @@ mod tests {
                 Token::StructEnd,
                 Token::Str("code"),
                 Token::Str("uniquecode"),
-                Token::Str("target_user_type"),
+                Token::Str("target_type"),
                 Token::Some,
                 Token::U8(1),
                 Token::StructEnd,
@@ -137,6 +140,7 @@ mod tests {
                     ],
                 }),
             }),
+            expires_at: Some("expires at timestamp".to_owned()),
             inviter: Some(User {
                 avatar: None,
                 bot: false,
@@ -152,7 +156,7 @@ mod tests {
                 system: None,
                 verified: None,
             }),
-            target_user_type: Some(TargetUserType::Stream),
+            target_type: Some(TargetType::Stream),
             target_user: Some(User {
                 avatar: None,
                 bot: false,
@@ -175,7 +179,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Invite",
-                    len: 8,
+                    len: 9,
                 },
                 Token::Str("approximate_member_count"),
                 Token::Some,
@@ -196,6 +200,9 @@ mod tests {
                 Token::StructEnd,
                 Token::Str("code"),
                 Token::Str("uniquecode"),
+                Token::Str("expires_at"),
+                Token::Some,
+                Token::Str("expires at timestamp"),
                 Token::Str("guild"),
                 Token::Some,
                 Token::Struct {
@@ -292,7 +299,7 @@ mod tests {
                 Token::Str("username"),
                 Token::Str("test"),
                 Token::StructEnd,
-                Token::Str("target_user_type"),
+                Token::Str("target_type"),
                 Token::Some,
                 Token::U8(1),
                 Token::Str("target_user"),

--- a/model/src/invite/mod.rs
+++ b/model/src/invite/mod.rs
@@ -4,11 +4,12 @@ mod metadata;
 mod target_type;
 mod welcome_screen;
 
+#[allow(deprecated)]
 pub use self::{
     channel::InviteChannel,
     guild::InviteGuild,
     metadata::InviteMetadata,
-    target_type::TargetType,
+    target_type::{TargetType, TargetUserType},
     welcome_screen::{WelcomeScreen, WelcomeScreenChannel},
 };
 

--- a/model/src/invite/target_type.rs
+++ b/model/src/invite/target_type.rs
@@ -9,7 +9,7 @@ pub enum TargetType {
     EmbeddedApplication = 2,
 }
 
-#[deprecated(since = "0.4.1", note = "renamed to `TargetType`")]
+#[deprecated(since = "0.4.2", note = "renamed to `TargetType`")]
 pub type TargetUserType = TargetType;
 
 #[cfg(test)]

--- a/model/src/invite/target_type.rs
+++ b/model/src/invite/target_type.rs
@@ -4,17 +4,19 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
     Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
 )]
 #[repr(u8)]
-pub enum TargetUserType {
+pub enum TargetType {
     Stream = 1,
+    EmbeddedApplication = 2,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::TargetUserType;
+    use super::TargetType;
     use serde_test::Token;
 
     #[test]
     fn test_variants() {
-        serde_test::assert_tokens(&TargetUserType::Stream, &[Token::U8(1)]);
+        serde_test::assert_tokens(&TargetType::Stream, &[Token::U8(1)]);
+        serde_test::assert_tokens(&TargetType::EmbeddedApplication, &[Token::U8(2)]);
     }
 }

--- a/model/src/invite/target_type.rs
+++ b/model/src/invite/target_type.rs
@@ -9,6 +9,9 @@ pub enum TargetType {
     EmbeddedApplication = 2,
 }
 
+#[deprecated(since = "0.4.1", note = "renamed to `TargetType`")]
+pub type TargetUserType = TargetType;
+
 #[cfg(test)]
 mod tests {
     use super::TargetType;


### PR DESCRIPTION
This PR brings invite functionality up to date with the current api.

Adds:
* `http` `GetInvite::with_expiration`
* `http` `CreateInvite::target_application_id`

Deprecates:
* `http` `CreateInvite::target_user_type` in favor of `CreateInvite::target_type`
* `model` `TargetUserType` in favor of `TargetType`

Other invite-related documentation has been updated.

Note: The signature of `target_user_type` is technically changed due to the model changes.

https://github.com/discord/discord-api-docs/commit/1b4e363e324eb1f49a47e32cb0108fbe276c8e0e
https://github.com/discord/discord-api-docs/commit/6dc1b2a3e7aad5145420f965e3ec15f3b7ed7074
https://github.com/discord/discord-api-docs/commit/2c9f17887a8e5c95d48b93901f4543beda4c09be