### PR TITLE
feat(http, model): implement stage instances

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1303,8 +1303,14 @@ impl Client {
 
     /// Create a new stage instance associated with a stage channel.
     ///
-    /// Requires the user to be a moderator of the stage channel. The topic must
-    /// be between 1 and 120 characters in length.
+    /// Requires the user to be a moderator of the stage channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`CreateStageInstanceError`] of type [`InvalidTopic`] when the
+    /// topic is not between 1 and 120 characters in length.
+    ///
+    /// [`InvalidTopic`]: crate::request::channel::stage::create_stage_instance::CreateStageInstanceErrorType::InvalidTopic
     pub fn create_stage_instance(
         &self,
         channel_id: ChannelId,
@@ -1320,8 +1326,14 @@ impl Client {
 
     /// Update fields of an existing stage instance.
     ///
-    /// Requires the user to be a moderator of the stage channel. The topic must
-    /// be between 1 and 120 characters in length.
+    /// Requires the user to be a moderator of the stage channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`UpdateStageInstanceError`] of type [`InvalidTopic`] when the
+    ///
+    /// [`InvalidTopic`]: crate::request::channel::stage::update_stage_instance::UpdateStageInstanceErrorType::InvalidTopic
+    /// topic is not between 1 and 120 characters in length.
     pub fn update_stage_instance(
         &self,
         channel_id: ChannelId,

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -7,6 +7,10 @@ use crate::{
     error::{Error, ErrorType, Result},
     ratelimiting::{RatelimitHeaders, Ratelimiter},
     request::{
+        channel::stage::{
+            create_stage_instance::CreateStageInstanceError,
+            update_stage_instance::UpdateStageInstanceError,
+        },
         guild::{create_guild::CreateGuildError, create_guild_channel::CreateGuildChannelError},
         prelude::*,
         GetUserApplicationInfo, Method, Request,
@@ -1295,6 +1299,42 @@ impl Client {
         roles: impl Iterator<Item = (RoleId, u64)>,
     ) -> UpdateRolePositions<'_> {
         UpdateRolePositions::new(self, guild_id, roles)
+    }
+
+    /// Create a new stage instance associated with a stage channel.
+    ///
+    /// Requires the user to be a moderator of the stage channel. The topic must
+    /// be between 1 and 120 characters in length.
+    pub fn create_stage_instance(
+        &self,
+        channel_id: ChannelId,
+        topic: impl Into<String>,
+    ) -> Result<CreateStageInstance<'_>, CreateStageInstanceError> {
+        CreateStageInstance::new(self, channel_id, topic)
+    }
+
+    /// Gets the stage instance associated with a stage channel, if it exists.
+    pub fn stage_instance(&self, channel_id: ChannelId) -> GetStageInstance<'_> {
+        GetStageInstance::new(self, channel_id)
+    }
+
+    /// Update fields of an existing stage instance.
+    ///
+    /// Requires the user to be a moderator of the stage channel. The topic must
+    /// be between 1 and 120 characters in length.
+    pub fn update_stage_instance(
+        &self,
+        channel_id: ChannelId,
+        topic: impl Into<String>,
+    ) -> Result<UpdateStageInstance<'_>, UpdateStageInstanceError> {
+        UpdateStageInstance::new(self, channel_id, topic)
+    }
+
+    /// Delete the stage instance of a stage channel.
+    ///
+    /// Requires the user to be a moderator of the stage channel.
+    pub fn delete_stage_instance(&self, channel_id: ChannelId) -> DeleteStageInstance<'_> {
+        DeleteStageInstance::new(self, channel_id)
     }
 
     /// Create a new guild based on a template.

--- a/http/src/request/channel/mod.rs
+++ b/http/src/request/channel/mod.rs
@@ -1,6 +1,7 @@
 pub mod invite;
 pub mod message;
 pub mod reaction;
+pub mod stage;
 pub mod update_channel;
 pub mod webhook;
 

--- a/http/src/request/channel/stage/create_stage_instance.rs
+++ b/http/src/request/channel/stage/create_stage_instance.rs
@@ -65,13 +65,6 @@ pub enum CreateStageInstanceErrorType {
 /// Create a new stage instance associated with a stage channel.
 ///
 /// Requires the user to be a moderator of the stage channel.
-///
-/// # Errors
-///
-/// Returns a [`CreateStageInstanceError`] of type [`InvalidTopic`] when the
-/// topic is not between 1 and 120 characters in length.
-///
-/// [`InvalidTopic`]: CreateStageInstanceErrorType::InvalidTopic
 pub struct CreateStageInstance<'a> {
     channel_id: ChannelId,
     fut: Option<Pending<'a, ()>>,

--- a/http/src/request/channel/stage/create_stage_instance.rs
+++ b/http/src/request/channel/stage/create_stage_instance.rs
@@ -1,0 +1,115 @@
+use crate::request::prelude::*;
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+use twilight_model::id::ChannelId;
+
+/// The request can not be created as configured.
+#[derive(Debug)]
+pub struct CreateStageInstanceError {
+    kind: CreateStageInstanceErrorType,
+}
+
+impl CreateStageInstanceError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &CreateStageInstanceErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        CreateStageInstanceErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for CreateStageInstanceError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            CreateStageInstanceErrorType::InvalidTopic { .. } => {
+                f.write_fmt(format_args!("invalid topic"))
+            }
+        }
+    }
+}
+
+impl Error for CreateStageInstanceError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
+
+#[derive(Debug)]
+pub enum CreateStageInstanceErrorType {
+    /// Topic is not between 1 and 120 characters in length.
+    InvalidTopic {
+        /// Invalid topic.
+        topic: String
+    },
+}
+
+/// Create a new stage instance associated with a stage channel.
+///
+/// Requires the user to be a moderator of the stage channel. The topic must be
+/// between 1 and 120 characters in length.
+pub struct CreateStageInstance<'a> {
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, ()>>,
+    http: &'a Client,
+    topic: String,
+}
+
+impl<'a> CreateStageInstance<'a> {
+    pub(crate) fn new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        topic: impl Into<String>,
+    ) -> Result<Self, CreateStageInstanceError> {
+        Self::_new(http, channel_id, topic.into())
+    }
+
+    fn _new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        topic: String,
+    ) -> Result<Self, CreateStageInstanceError> {
+        if !validate::stage_topic(&topic) {
+            return Err(CreateStageInstanceError {
+                kind: CreateStageInstanceErrorType::InvalidTopic { topic },
+            });
+        }
+
+        Ok(Self {
+            channel_id,
+            fut: None,
+            http,
+            topic,
+        })
+    }
+
+    fn start(&mut self) -> Result<()> {
+        self.fut.replace(Box::pin(self.http.verify(Request::from(
+            Route::CreateStageInstance {
+                channel_id: self.channel_id.0,
+                topic: self.topic.clone(),
+            },
+        ))));
+
+        Ok(())
+    }
+}
+
+poll_req!(CreateStageInstance<'_>, ());

--- a/http/src/request/channel/stage/create_stage_instance.rs
+++ b/http/src/request/channel/stage/create_stage_instance.rs
@@ -9,6 +9,7 @@ use twilight_model::id::ChannelId;
 #[derive(Debug)]
 pub struct CreateStageInstanceError {
     kind: CreateStageInstanceErrorType,
+    source: Option<Box<dyn Error + Send + Sync>>,
 }
 
 impl CreateStageInstanceError {
@@ -21,7 +22,7 @@ impl CreateStageInstanceError {
     /// Consume the error, returning the source error if there is any.
     #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
     pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
-        None
+        self.source
     }
 
     /// Consume the error, returning the owned error type and the source error.
@@ -32,7 +33,7 @@ impl CreateStageInstanceError {
         CreateStageInstanceErrorType,
         Option<Box<dyn Error + Send + Sync>>,
     ) {
-        (self.kind, None)
+        (self.kind, self.source)
     }
 }
 
@@ -48,7 +49,9 @@ impl Display for CreateStageInstanceError {
 
 impl Error for CreateStageInstanceError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        None
+        self.source
+            .as_ref()
+            .map(|source| &**source as &(dyn Error + 'static))
     }
 }
 
@@ -57,7 +60,7 @@ pub enum CreateStageInstanceErrorType {
     /// Topic is not between 1 and 120 characters in length.
     InvalidTopic {
         /// Invalid topic.
-        topic: String
+        topic: String,
     },
 }
 
@@ -89,6 +92,7 @@ impl<'a> CreateStageInstance<'a> {
         if !validate::stage_topic(&topic) {
             return Err(CreateStageInstanceError {
                 kind: CreateStageInstanceErrorType::InvalidTopic { topic },
+                source: None,
             });
         }
 

--- a/http/src/request/channel/stage/create_stage_instance.rs
+++ b/http/src/request/channel/stage/create_stage_instance.rs
@@ -40,9 +40,7 @@ impl CreateStageInstanceError {
 impl Display for CreateStageInstanceError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            CreateStageInstanceErrorType::InvalidTopic { .. } => {
-                f.write_str("invalid topic")
-            }
+            CreateStageInstanceErrorType::InvalidTopic { .. } => f.write_str("invalid topic"),
         }
     }
 }

--- a/http/src/request/channel/stage/create_stage_instance.rs
+++ b/http/src/request/channel/stage/create_stage_instance.rs
@@ -41,7 +41,7 @@ impl Display for CreateStageInstanceError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
             CreateStageInstanceErrorType::InvalidTopic { .. } => {
-                f.write_fmt(format_args!("invalid topic"))
+                f.write_str("invalid topic")
             }
         }
     }
@@ -66,8 +66,14 @@ pub enum CreateStageInstanceErrorType {
 
 /// Create a new stage instance associated with a stage channel.
 ///
-/// Requires the user to be a moderator of the stage channel. The topic must be
-/// between 1 and 120 characters in length.
+/// Requires the user to be a moderator of the stage channel.
+///
+/// # Errors
+///
+/// Returns a [`CreateStageInstanceError`] of type [`InvalidTopic`] when the
+/// topic is not between 1 and 120 characters in length.
+///
+/// [`InvalidTopic`]: CreateStageInstanceErrorType::InvalidTopic
 pub struct CreateStageInstance<'a> {
     channel_id: ChannelId,
     fut: Option<Pending<'a, ()>>,

--- a/http/src/request/channel/stage/delete_stage_instance.rs
+++ b/http/src/request/channel/stage/delete_stage_instance.rs
@@ -1,0 +1,33 @@
+use crate::request::prelude::*;
+use twilight_model::id::ChannelId;
+
+/// Delete the stage instance of a stage channel.
+///
+/// Requires the user to be a moderator of the stage channel.
+pub struct DeleteStageInstance<'a> {
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, ()>>,
+    http: &'a Client,
+}
+
+impl<'a> DeleteStageInstance<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self {
+            channel_id,
+            fut: None,
+            http,
+        }
+    }
+
+    fn start(&mut self) -> Result<()> {
+        self.fut.replace(Box::pin(self.http.verify(Request::from(
+            Route::DeleteStageInstance {
+                channel_id: self.channel_id.0,
+            },
+        ))));
+
+        Ok(())
+    }
+}
+
+poll_req!(DeleteStageInstance<'_>, ());

--- a/http/src/request/channel/stage/get_stage_instance.rs
+++ b/http/src/request/channel/stage/get_stage_instance.rs
@@ -1,0 +1,31 @@
+use crate::request::prelude::*;
+use twilight_model::{channel::StageInstance, id::ChannelId};
+
+/// Gets the stage instance associated with a stage channel, if it exists.
+pub struct GetStageInstance<'a> {
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, Option<StageInstance>>>,
+    http: &'a Client,
+}
+
+impl<'a> GetStageInstance<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self {
+            channel_id,
+            fut: None,
+            http,
+        }
+    }
+
+    fn start(&mut self) -> Result<()> {
+        self.fut.replace(Box::pin(self.http.request(Request::from(
+            Route::GetStageInstance {
+                channel_id: self.channel_id.0,
+            },
+        ))));
+
+        Ok(())
+    }
+}
+
+poll_req!(GetStageInstance<'_>, Option<StageInstance>);

--- a/http/src/request/channel/stage/mod.rs
+++ b/http/src/request/channel/stage/mod.rs
@@ -1,0 +1,10 @@
+pub mod create_stage_instance;
+pub mod update_stage_instance;
+
+mod delete_stage_instance;
+mod get_stage_instance;
+
+pub use self::{
+    create_stage_instance::CreateStageInstance, delete_stage_instance::DeleteStageInstance,
+    get_stage_instance::GetStageInstance, update_stage_instance::UpdateStageInstance,
+};

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -72,12 +72,6 @@ struct UpdateStageInstanceFields {
 /// Update fields of an existing stage instance.
 ///
 /// Requires the user to be a moderator of the stage channel.
-///
-/// # Errors
-///
-/// Returns a [`UpdateStageInstanceError`] of type [`InvalidTopic`] when the
-///
-/// [`InvalidTopic`]: UpdateStageInstanceErrorType::InvalidTopic
 pub struct UpdateStageInstance<'a> {
     channel_id: ChannelId,
     fields: UpdateStageInstanceFields,

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -1,0 +1,120 @@
+use crate::request::prelude::*;
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+use twilight_model::id::ChannelId;
+
+/// The request can not be created as configured.
+#[derive(Debug)]
+pub struct UpdateStageInstanceError {
+    kind: UpdateStageInstanceErrorType,
+}
+
+impl UpdateStageInstanceError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "retrieving the type has no effect if left unused"]
+    pub fn kind(&self) -> &UpdateStageInstanceErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        UpdateStageInstanceErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for UpdateStageInstanceError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            UpdateStageInstanceErrorType::InvalidTopic { .. } => {
+                f.write_fmt(format_args!("invalid topic"))
+            }
+        }
+    }
+}
+
+impl Error for UpdateStageInstanceError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
+
+#[derive(Debug)]
+pub enum UpdateStageInstanceErrorType {
+    /// Topic is not between 1 and 120 characters in length.
+    InvalidTopic {
+        /// Invalid topic.
+        topic: String,
+    },
+}
+
+#[derive(Serialize)]
+struct UpdateStageInstanceFields {
+    topic: String,
+}
+
+/// Update fields of an existing stage instance.
+///
+/// Requires the user to be a moderator of the stage channel. The topic must
+/// be between 1 and 120 characters in length.
+pub struct UpdateStageInstance<'a> {
+    channel_id: ChannelId,
+    fields: UpdateStageInstanceFields,
+    fut: Option<Pending<'a, ()>>,
+    http: &'a Client,
+}
+
+impl<'a> UpdateStageInstance<'a> {
+    pub(crate) fn new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        topic: impl Into<String>,
+    ) -> Result<Self, UpdateStageInstanceError> {
+        Self::_new(http, channel_id, topic.into())
+    }
+
+    fn _new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        topic: String,
+    ) -> Result<Self, UpdateStageInstanceError> {
+        if !validate::stage_topic(&topic) {
+            return Err(UpdateStageInstanceError {
+                kind: UpdateStageInstanceErrorType::InvalidTopic { topic },
+            });
+        }
+
+        Ok(Self {
+            channel_id,
+            fields: UpdateStageInstanceFields { topic },
+            fut: None,
+            http,
+        })
+    }
+
+    fn start(&mut self) -> Result<()> {
+        self.fut.replace(Box::pin(self.http.verify(Request::from((
+            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
+            Route::UpdateStageInstance {
+                channel_id: self.channel_id.0,
+            },
+        )))));
+
+        Ok(())
+    }
+}
+
+poll_req!(UpdateStageInstance<'_>, ());

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -9,6 +9,7 @@ use twilight_model::id::ChannelId;
 #[derive(Debug)]
 pub struct UpdateStageInstanceError {
     kind: UpdateStageInstanceErrorType,
+    source: Option<Box<dyn Error + Send + Sync>>,
 }
 
 impl UpdateStageInstanceError {
@@ -21,7 +22,7 @@ impl UpdateStageInstanceError {
     /// Consume the error, returning the source error if there is any.
     #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
     pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
-        None
+        self.source
     }
 
     /// Consume the error, returning the owned error type and the source error.
@@ -48,7 +49,9 @@ impl Display for UpdateStageInstanceError {
 
 impl Error for UpdateStageInstanceError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        None
+        self.source
+            .as_ref()
+            .map(|source| &**source as &(dyn Error + 'static))
     }
 }
 
@@ -94,6 +97,7 @@ impl<'a> UpdateStageInstance<'a> {
         if !validate::stage_topic(&topic) {
             return Err(UpdateStageInstanceError {
                 kind: UpdateStageInstanceErrorType::InvalidTopic { topic },
+                source: None,
             });
         }
 

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -71,8 +71,13 @@ struct UpdateStageInstanceFields {
 
 /// Update fields of an existing stage instance.
 ///
-/// Requires the user to be a moderator of the stage channel. The topic must
-/// be between 1 and 120 characters in length.
+/// Requires the user to be a moderator of the stage channel.
+///
+/// # Errors
+///
+/// Returns a [`UpdateStageInstanceError`] of type [`InvalidTopic`] when the
+///
+/// [`InvalidTopic`]: UpdateStageInstanceErrorType::InvalidTopic
 pub struct UpdateStageInstance<'a> {
     channel_id: ChannelId,
     fields: UpdateStageInstanceFields,

--- a/http/src/request/prelude.rs
+++ b/http/src/request/prelude.rs
@@ -1,7 +1,7 @@
 pub(super) use super::{audit_header, validate, Pending, PendingOption, Request};
 pub use super::{
     audit_reason::{AuditLogReason, AuditLogReasonError},
-    channel::{invite::*, message::*, reaction::*, webhook::*, *},
+    channel::{invite::*, message::*, reaction::*, stage::*, webhook::*, *},
     get_gateway::GetGateway,
     get_gateway_authed::GetGatewayAuthed,
     get_voice_regions::GetVoiceRegions,

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -409,6 +409,17 @@ fn _template_description(value: &str) -> bool {
     (0..=120).contains(&len)
 }
 
+pub fn stage_topic(value: impl AsRef<str>) -> bool {
+    _stage_topic(value.as_ref())
+}
+
+fn _stage_topic(value: &str) -> bool {
+    let len = value.chars().count();
+
+    // <https://github.com/discord/discord-api-docs/commit/f019fc358047050513c623f3639b6e96809f9280>
+    (0..=120).contains(&len)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -1746,7 +1746,7 @@ impl Route {
             Self::UpdateStageInstance { channel_id } => (
                 Method::Patch,
                 Path::StageInstances,
-                format!("stage-instances/{}", channel_id).into()
+                format!("stage-instances/{}", channel_id).into(),
             ),
             Self::UpdateTemplate {
                 guild_id,

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -144,6 +144,7 @@ pub enum Path {
     GuildsIdWelcomeScreen(u64),
     GuildsIdWebhooks(u64),
     InvitesCode,
+    StageInstances,
     UsersId,
     OauthApplicationsMe,
     UsersIdConnections,
@@ -267,6 +268,7 @@ impl FromStr for Path {
             ["guilds", id, "welcome-screen"] => GuildsIdWelcomeScreen(parse_id(id)?),
             ["guilds", id, "webhooks"] => GuildsIdWebhooks(parse_id(id)?),
             ["invites", _] => InvitesCode,
+            ["stage-instances", _] => StageInstances,
             ["oauth2", "applications", "@me"] => OauthApplicationsMe,
             ["users", _] => UsersId,
             ["users", _, "connections"] => UsersIdConnections,
@@ -392,6 +394,13 @@ pub enum Route {
         /// The ID of the guild.
         guild_id: u64,
     },
+    /// Route information to create a stage instance.
+    CreateStageInstance {
+        /// ID of the channel.
+        channel_id: u64,
+        /// Topic of the stage instance.
+        topic: String,
+    },
     /// Route information to create a guild template.
     CreateTemplate {
         /// The ID of the guild.
@@ -504,6 +513,11 @@ pub enum Route {
         guild_id: u64,
         /// The ID of the role.
         role_id: u64,
+    },
+    /// Route information to delete a stage instance.
+    DeleteStageInstance {
+        /// ID of the stage channel.
+        channel_id: u64,
     },
     /// Route information to delete a guild template.
     DeleteTemplate {
@@ -745,6 +759,11 @@ pub enum Route {
         /// The ID of the message.
         message_id: u64,
     },
+    /// Route information to get a stage instance.
+    GetStageInstance {
+        /// ID of the stage channel.
+        channel_id: u64,
+    },
     /// Route information to get a template.
     GetTemplate {
         /// The template code.
@@ -918,6 +937,11 @@ pub enum Route {
         /// The ID of the guild.
         guild_id: u64,
     },
+    /// Route information to update an existing stage instance.
+    UpdateStageInstance {
+        /// ID of the stage channel.
+        channel_id: u64,
+    },
     /// Route information to update a template.
     UpdateTemplate {
         /// The ID of the guild.
@@ -1078,6 +1102,9 @@ impl Route {
                 Path::GuildsIdRoles(guild_id),
                 format!("guilds/{}/roles", guild_id).into(),
             ),
+            Self::CreateStageInstance { .. } => {
+                (Method::Post, Path::StageInstances, "stage-instances".into())
+            }
             Self::CreateTemplate { guild_id } => (
                 Method::Post,
                 Path::GuildsIdTemplates(guild_id),
@@ -1194,6 +1221,11 @@ impl Route {
                 Method::Delete,
                 Path::GuildsIdRolesId(guild_id),
                 format!("guilds/{}/roles/{}", guild_id, role_id).into(),
+            ),
+            Self::DeleteStageInstance { channel_id } => (
+                Method::Delete,
+                Path::StageInstances,
+                format!("stage-instances/{}", channel_id).into(),
             ),
             Self::DeleteTemplate {
                 guild_id,
@@ -1522,6 +1554,11 @@ impl Route {
                     path.into(),
                 )
             }
+            Self::GetStageInstance { channel_id } => (
+                Method::Get,
+                Path::StageInstances,
+                format!("stage-instances/{}", channel_id).into(),
+            ),
             Self::GetTemplate { template_code } => (
                 Method::Get,
                 Path::Guilds,
@@ -1705,6 +1742,11 @@ impl Route {
                 Method::Patch,
                 Path::GuildsIdRolesId(guild_id),
                 format!("guilds/{}/roles", guild_id).into(),
+            ),
+            Self::UpdateStageInstance { channel_id } => (
+                Method::Patch,
+                Path::StageInstances,
+                format!("stage-instances/{}", channel_id).into()
             ),
             Self::UpdateTemplate {
                 guild_id,

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -11,6 +11,7 @@ mod group;
 mod private_channel;
 mod reaction;
 mod reaction_type;
+mod stage_instance;
 mod text_channel;
 mod video_quality_mode;
 mod voice_channel;
@@ -21,8 +22,8 @@ pub use self::{
     attachment::Attachment, category_channel::CategoryChannel, channel_mention::ChannelMention,
     channel_type::ChannelType, followed_channel::FollowedChannel, group::Group, message::Message,
     private_channel::PrivateChannel, reaction::Reaction, reaction_type::ReactionType,
-    text_channel::TextChannel, video_quality_mode::VideoQualityMode, voice_channel::VoiceChannel,
-    webhook::Webhook, webhook_type::WebhookType,
+    stage_instance::StageInstance, text_channel::TextChannel, video_quality_mode::VideoQualityMode,
+    voice_channel::VoiceChannel, webhook::Webhook, webhook_type::WebhookType,
 };
 
 use crate::id::{ChannelId, GuildId, MessageId};

--- a/model/src/channel/stage_instance.rs
+++ b/model/src/channel/stage_instance.rs
@@ -1,0 +1,46 @@
+use crate::id::{ChannelId, GuildId, StageId};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct StageInstance {
+    pub channel_id: ChannelId,
+    pub guild_id: GuildId,
+    pub id: StageId,
+    pub topic: String,
+}
+
+#[cfg(test)]
+mod test {
+    use super::StageInstance;
+    use crate::id::{ChannelId, GuildId, StageId};
+    use serde_test::Token;
+
+    #[test]
+    fn test_stage_instance() {
+        let value = StageInstance {
+            channel_id: ChannelId(100),
+            guild_id: GuildId(200),
+            id: StageId(300),
+            topic: "a topic".into(),
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct { name: "StageInstance", len: 4 },
+                Token::Str("channel_id"),
+                Token::NewtypeStruct { name: "ChannelId" },
+                Token::Str("100"),
+                Token::Str("guild_id"),
+                Token::NewtypeStruct { name: "GuildId" },
+                Token::Str("200"),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "StageId" },
+                Token::Str("300"),
+                Token::Str("topic"),
+                Token::Str("a topic"),
+                Token::StructEnd,
+            ]
+        );
+    }
+}

--- a/model/src/channel/stage_instance.rs
+++ b/model/src/channel/stage_instance.rs
@@ -27,7 +27,10 @@ mod test {
         serde_test::assert_tokens(
             &value,
             &[
-                Token::Struct { name: "StageInstance", len: 4 },
+                Token::Struct {
+                    name: "StageInstance",
+                    len: 4,
+                },
                 Token::Str("channel_id"),
                 Token::NewtypeStruct { name: "ChannelId" },
                 Token::Str("100"),
@@ -40,7 +43,7 @@ mod test {
                 Token::Str("topic"),
                 Token::Str("a topic"),
                 Token::StructEnd,
-            ]
+            ],
         );
     }
 }

--- a/model/src/id.rs
+++ b/model/src/id.rs
@@ -224,6 +224,23 @@ impl From<u64> for RoleId {
 #[derive(
     Clone, Copy, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
 )]
+pub struct StageId(#[serde(with = "string")] pub u64);
+
+impl Display for StageId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl From<u64> for StageId {
+    fn from(id: u64) -> Self {
+        StageId(id)
+    }
+}
+
+#[derive(
+    Clone, Copy, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
+)]
 pub struct UserId(#[serde(with = "string")] pub u64);
 
 impl Display for UserId {
@@ -259,7 +276,7 @@ impl From<u64> for WebhookId {
 mod tests {
     use super::{
         ApplicationId, AttachmentId, AuditLogEntryId, ChannelId, EmojiId, GenericId, GuildId,
-        IntegrationId, MessageId, RoleId, UserId, WebhookId,
+        IntegrationId, MessageId, RoleId, StageId, UserId, WebhookId,
     };
     use serde_test::Token;
 
@@ -419,6 +436,20 @@ mod tests {
             &RoleId(114_941_315_417_899_012),
             &[
                 Token::NewtypeStruct { name: "RoleId" },
+                Token::U64(114_941_315_417_899_012),
+            ],
+        );
+        serde_test::assert_tokens(
+            &StageId(114_941_315_417_899_012),
+            &[
+                Token::NewtypeStruct { name: "StageId" },
+                Token::Str("114941315417899012"),
+            ],
+        );
+        serde_test::assert_de_tokens(
+            &StageId(114_941_315_417_899_012),
+            &[
+                Token::NewtypeStruct { name: "StageId" },
                 Token::U64(114_941_315_417_899_012),
             ],
         );


### PR DESCRIPTION
Adds:
* `http` `Client::create_stage_instance`
* `http` `Client::delete_stage_instance`
* `http` `Client::stage_instance`
* `http` `Client::update_stage_instance`
* `model` `StageId`
* `model` `StageInstance`

https://github.com/discord/discord-api-docs/commit/f019fc358047050513c623f3639b6e96809f9280
