### PR TITLE
Add builder for HTTP Request type

### DIFF
--- a/http/src/request/base.rs
+++ b/http/src/request/base.rs
@@ -279,4 +279,3 @@ impl From<(Form, HeaderMap<HeaderValue>, Route)> for Request {
         }
     }
 }
-

--- a/http/src/request/base.rs
+++ b/http/src/request/base.rs
@@ -1,0 +1,266 @@
+use super::{Form, Method};
+use crate::{
+    error::{Error, Result},
+    routing::{Path, Route},
+};
+use hyper::header::{HeaderMap, HeaderName, HeaderValue};
+use serde::Serialize;
+use std::borrow::Cow;
+
+/// Builder to create a customized request.
+///
+/// # Examples
+///
+/// Create a request to create a message with a content of "test" in a
+/// channel with an ID of 1:
+///
+/// ```
+/// use twilight_http::{request::Request, routing::Route};
+///
+/// let body = br#"{
+///     "content": "test"
+/// }"#.to_vec();
+///
+/// let request = Request::builder(Route::CreateMessage {
+///     channel_id: 1,
+/// }).body(body).build();
+/// ```
+pub struct RequestBuilder(Request);
+
+impl RequestBuilder {
+    /// Create a new request builder.
+    #[must_use = "request has not been fully built"]
+    pub fn new(route: Route) -> Self {
+        Self(Request::from_route(route))
+    }
+
+    /// Consume the builder, returning the built request.
+    #[must_use = "request information is not useful on its own and must be acted on"]
+    pub fn build(self) -> Request {
+        self.0
+    }
+
+    /// Set the contents of the body.
+    #[must_use = "request has not been fully built"]
+    pub fn body(mut self, body: Vec<u8>) -> Self {
+        self.0.body.replace(body);
+
+        self
+    }
+
+    /// Set the multipart form.
+    #[must_use = "request has not been fully built"]
+    pub fn form(mut self, form: Form) -> Self {
+        self.0.form.replace(form);
+
+        self
+    }
+
+    /// Set the headers to add.
+    #[must_use = "request has not been fully built"]
+    pub fn headers(mut self, iter: impl Iterator<Item = (HeaderName, HeaderValue)>) -> Self {
+        self.0.headers.replace(iter.collect());
+
+        self
+    }
+
+    /// Set the body, to be serialized as JSON.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`ErrorType::Json`] error type if the value could not be
+    /// serialized as JSON.
+    ///
+    /// [`ErrorType::Json`]: crate::error::ErrorType::Json
+    #[must_use = "request has not been fully built"]
+    pub fn json(self, to: &impl Serialize) -> Result<Self> {
+        let bytes = crate::json_to_vec(to).map_err(Error::json)?;
+
+        Ok(self.body(bytes))
+    }
+}
+
+#[derive(Debug)]
+pub struct Request {
+    /// The body of the request, if any.
+    pub body: Option<Vec<u8>>,
+    /// The multipart form of the request, if any.
+    pub form: Option<Form>,
+    /// The headers to set in the request, if any.
+    pub headers: Option<HeaderMap<HeaderValue>>,
+    /// The method of the request.
+    pub method: Method,
+    /// The ratelimiting bucket path.
+    pub path: Path,
+    /// The URI path to request.
+    pub path_str: Cow<'static, str>,
+}
+
+impl Request {
+    /// Create a simple `Request` with basic information.
+    ///
+    /// Use the [`RequestBuilder`] if you need to set a combination of
+    /// configurations in the request.
+    #[deprecated(since = "0.4.0", note = "Use `Request::builder` instead")]
+    pub fn new(
+        body: Option<Vec<u8>>,
+        headers: Option<HeaderMap<HeaderValue>>,
+        route: Route,
+    ) -> Self {
+        let (method, path, path_str) = route.into_parts();
+
+        Self {
+            body,
+            form: None,
+            headers,
+            method,
+            path,
+            path_str,
+        }
+    }
+
+    /// Create a new request builder.
+    ///
+    /// # Examples
+    ///
+    /// Create a request to create a message with a content of "test" in a
+    /// channel with an ID of 1:
+    ///
+    /// ```
+    /// use twilight_http::{request::Request, routing::Route};
+    ///
+    /// let body = br#"{
+    ///     "content": "test"
+    /// }"#.to_vec();
+    ///
+    /// let request = Request::builder(Route::CreateMessage {
+    ///     channel_id: 1,
+    /// }).body(body).build();
+    /// ```
+    pub fn builder(route: Route) -> RequestBuilder {
+        RequestBuilder::new(route)
+    }
+
+    /// Create a request from only its route information.
+    ///
+    /// If you need to set additional configurations like the body then use
+    /// [`builder`].
+    ///
+    /// # Examples
+    ///
+    /// Create a request to get a message with an ID of 2 in a channel with an
+    /// ID of 1:
+    ///
+    /// ```
+    /// use twilight_http::{request::Request, routing::Route};
+    ///
+    /// let request = Request::from_route(Route::GetMessage {
+    ///     channel_id: 1,
+    ///     message_id: 2,
+    /// });
+    /// ```
+    ///
+    /// [`builder`]: Self::builder
+    pub fn from_route(route: Route) -> Self {
+        let (method, path, path_str) = route.into_parts();
+
+        Self {
+            body: None,
+            form: None,
+            headers: None,
+            method,
+            path,
+            path_str,
+        }
+    }
+}
+
+impl From<Route> for Request {
+    fn from(route: Route) -> Self {
+        let (method, path, path_str) = route.into_parts();
+
+        Self {
+            body: None,
+            form: None,
+            headers: None,
+            method,
+            path,
+            path_str,
+        }
+    }
+}
+
+impl From<(Vec<u8>, Route)> for Request {
+    fn from((body, route): (Vec<u8>, Route)) -> Self {
+        let (method, path, path_str) = route.into_parts();
+
+        Self {
+            body: Some(body),
+            form: None,
+            headers: None,
+            method,
+            path,
+            path_str,
+        }
+    }
+}
+
+impl From<(Form, Route)> for Request {
+    fn from((form, route): (Form, Route)) -> Self {
+        let (method, path, path_str) = route.into_parts();
+
+        Self {
+            body: None,
+            form: Some(form),
+            headers: None,
+            method,
+            path,
+            path_str,
+        }
+    }
+}
+
+impl From<(Vec<u8>, Form, Route)> for Request {
+    fn from((body, form, route): (Vec<u8>, Form, Route)) -> Self {
+        let (method, path, path_str) = route.into_parts();
+
+        Self {
+            body: Some(body),
+            form: Some(form),
+            headers: None,
+            method,
+            path,
+            path_str,
+        }
+    }
+}
+
+impl From<(HeaderMap<HeaderValue>, Route)> for Request {
+    fn from((headers, route): (HeaderMap<HeaderValue>, Route)) -> Self {
+        let (method, path, path_str) = route.into_parts();
+
+        Self {
+            body: None,
+            form: None,
+            headers: Some(headers),
+            method,
+            path,
+            path_str,
+        }
+    }
+}
+
+impl From<(Vec<u8>, HeaderMap<HeaderValue>, Route)> for Request {
+    fn from((body, headers, route): (Vec<u8>, HeaderMap<HeaderValue>, Route)) -> Self {
+        let (method, path, path_str) = route.into_parts();
+
+        Self {
+            body: Some(body),
+            form: None,
+            headers: Some(headers),
+            method,
+            path,
+            path_str,
+        }
+    }
+}

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -22,23 +22,17 @@ impl<'a> CreatePin<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::PinMessage {
-                    channel_id: self.channel_id.0,
-                    message_id: self.message_id.0,
-                },
-            ))
-        } else {
-            Request::from(Route::PinMessage {
-                channel_id: self.channel_id.0,
-                message_id: self.message_id.0,
-            })
-        };
+        let mut request = Request::builder(Route::PinMessage {
+            channel_id: self.channel_id.0,
+            message_id: self.message_id.0,
+        });
 
-        self.fut.replace(Box::pin(self.http.verify(request)));
+        if let Some(reason) = &self.reason {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.verify(request.build())));
 
         Ok(())
     }

--- a/http/src/request/channel/create_typing_trigger.rs
+++ b/http/src/request/channel/create_typing_trigger.rs
@@ -18,11 +18,11 @@ impl<'a> CreateTypingTrigger<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::CreateTypingTrigger {
-                channel_id: self.channel_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::CreateTypingTrigger {
+            channel_id: self.channel_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -20,21 +20,16 @@ impl<'a> DeleteChannel<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::DeleteChannel {
-                    channel_id: self.channel_id.0,
-                },
-            ))
-        } else {
-            Request::from(Route::DeleteChannel {
-                channel_id: self.channel_id.0,
-            })
-        };
+        let mut request = Request::builder(Route::DeleteChannel {
+            channel_id: self.channel_id.0,
+        });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        if let Some(reason) = &self.reason {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
 
         Ok(())
     }

--- a/http/src/request/channel/delete_channel_permission_configured.rs
+++ b/http/src/request/channel/delete_channel_permission_configured.rs
@@ -24,23 +24,17 @@ impl<'a> DeleteChannelPermissionConfigured<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::DeletePermissionOverwrite {
-                    channel_id: self.channel_id.0,
-                    target_id: self.target_id,
-                },
-            ))
-        } else {
-            Request::from(Route::DeletePermissionOverwrite {
-                channel_id: self.channel_id.0,
-                target_id: self.target_id,
-            })
-        };
+        let mut request = Request::builder(Route::DeletePermissionOverwrite {
+            channel_id: self.channel_id.0,
+            target_id: self.target_id,
+        });
 
-        self.fut.replace(Box::pin(self.http.verify(request)));
+        if let Some(reason) = &self.reason {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.verify(request.build())));
 
         Ok(())
     }

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -22,23 +22,17 @@ impl<'a> DeletePin<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::UnpinMessage {
-                    channel_id: self.channel_id.0,
-                    message_id: self.message_id.0,
-                },
-            ))
-        } else {
-            Request::from(Route::UnpinMessage {
-                channel_id: self.channel_id.0,
-                message_id: self.message_id.0,
-            })
-        };
+        let mut request = Request::builder(Route::UnpinMessage {
+            channel_id: self.channel_id.0,
+            message_id: self.message_id.0,
+        });
 
-        self.fut.replace(Box::pin(self.http.verify(request)));
+        if let Some(reason) = &self.reason {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.verify(request.build())));
 
         Ok(())
     }

--- a/http/src/request/channel/follow_news_channel.rs
+++ b/http/src/request/channel/follow_news_channel.rs
@@ -30,12 +30,11 @@ impl<'a> FollowNewsChannel<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::FollowNewsChannel {
-                channel_id: self.channel_id.0,
-            },
-        ));
+        let request = Request::builder(Route::FollowNewsChannel {
+            channel_id: self.channel_id.0,
+        })
+        .json(&self.fields)?
+        .build();
 
         self.fut.replace(Box::pin(self.http.request(request)));
 

--- a/http/src/request/channel/get_channel.rs
+++ b/http/src/request/channel/get_channel.rs
@@ -36,12 +36,11 @@ impl<'a> GetChannel<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetChannel {
-                    channel_id: self.channel_id.0,
-                },
-            ))));
+        let request = Request::from_route(Route::GetChannel {
+            channel_id: self.channel_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/get_pins.rs
+++ b/http/src/request/channel/get_pins.rs
@@ -18,10 +18,11 @@ impl<'a> GetPins<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request(Request::from(Route::GetPins {
-                channel_id: self.channel_id.0,
-            }))));
+        let request = Request::from_route(Route::GetPins {
+            channel_id: self.channel_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -226,25 +226,17 @@ impl<'a> CreateInvite<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                headers,
-                Route::CreateInvite {
-                    channel_id: self.channel_id.0,
-                },
-            ))
-        } else {
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                Route::CreateInvite {
-                    channel_id: self.channel_id.0,
-                },
-            ))
-        };
+        let mut request = Request::builder(Route::CreateInvite {
+            channel_id: self.channel_id.0,
+        })
+        .json(&self.fields)?;
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        if let Some(reason) = &self.reason {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
 
         Ok(())
     }

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -19,21 +19,16 @@ impl<'a> DeleteInvite<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::DeleteInvite {
-                    code: self.code.clone(),
-                },
-            ))
-        } else {
-            Request::from(Route::DeleteInvite {
-                code: self.code.clone(),
-            })
-        };
+        let mut request = Request::builder(Route::DeleteInvite {
+            code: self.code.clone(),
+        });
 
-        self.fut.replace(Box::pin(self.http.verify(request)));
+        if let Some(reason) = &self.reason {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.verify(request.build())));
 
         Ok(())
     }

--- a/http/src/request/channel/invite/get_channel_invites.rs
+++ b/http/src/request/channel/invite/get_channel_invites.rs
@@ -20,11 +20,11 @@ impl<'a> GetChannelInvites<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetChannelInvites {
-                channel_id: self.channel_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::GetChannelInvites {
+            channel_id: self.channel_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -52,13 +52,12 @@ impl<'a> GetInvite<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetInvite {
-                    code: self.code.clone(),
-                    with_counts: self.fields.with_counts,
-                },
-            ))));
+        let request = Request::from_route(Route::GetInvite {
+            code: self.code.clone(),
+            with_counts: self.fields.with_counts,
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/message/crosspost_message.rs
+++ b/http/src/request/channel/message/crosspost_message.rs
@@ -23,7 +23,7 @@ impl<'a> CrosspostMessage<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = Request::from(Route::CrosspostMessage {
+        let request = Request::from_route(Route::CrosspostMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -171,15 +171,15 @@ impl<'a> GetChannelMessages<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetMessages {
-                after: None,
-                around: None,
-                before: None,
-                channel_id: self.channel_id.0,
-                limit: self.fields.limit,
-            },
-        ))));
+        let request = Request::from_route(Route::GetMessages {
+            after: None,
+            around: None,
+            before: None,
+            channel_id: self.channel_id.0,
+            limit: self.fields.limit,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -125,15 +125,15 @@ impl<'a> GetChannelMessagesConfigured<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetMessages {
-                after: self.after.map(|x| x.0),
-                around: self.around.map(|x| x.0),
-                before: self.before.map(|x| x.0),
-                channel_id: self.channel_id.0,
-                limit: self.fields.limit,
-            },
-        ))));
+        let request = Request::from_route(Route::GetMessages {
+            after: self.after.map(|x| x.0),
+            around: self.around.map(|x| x.0),
+            before: self.before.map(|x| x.0),
+            channel_id: self.channel_id.0,
+            limit: self.fields.limit,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/message/get_message.rs
+++ b/http/src/request/channel/message/get_message.rs
@@ -23,13 +23,12 @@ impl<'a> GetMessage<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetMessage {
-                    channel_id: self.channel_id.0,
-                    message_id: self.message_id.0,
-                },
-            ))));
+        let request = Request::from_route(Route::GetMessage {
+            channel_id: self.channel_id.0,
+            message_id: self.message_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -238,13 +238,14 @@ impl<'a> UpdateMessage<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::UpdateMessage {
-                channel_id: self.channel_id.0,
-                message_id: self.message_id.0,
-            },
-        )))));
+        let request = Request::builder(Route::UpdateMessage {
+            channel_id: self.channel_id.0,
+            message_id: self.message_id.0,
+        })
+        .json(&self.fields)?
+        .build();
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -50,7 +50,7 @@ impl<'a> CreateReaction<'a> {
     }
 
     fn request(&self) -> Request {
-        Request::from(Route::CreateReaction {
+        Request::from_route(Route::CreateReaction {
             channel_id: self.channel_id.0,
             emoji: self.emoji.clone(),
             message_id: self.message_id.0,
@@ -90,7 +90,7 @@ mod tests {
         let builder = CreateReaction::new(&client, ChannelId(123), MessageId(456), emoji);
         let actual = builder.request();
 
-        let expected = Request::from(Route::CreateReaction {
+        let expected = Request::from_route(Route::CreateReaction {
             channel_id: 123,
             emoji: utf8_percent_encode("\u{1f303}", NON_ALPHANUMERIC).to_string(),
             message_id: 456,

--- a/http/src/request/channel/reaction/delete_all_reaction.rs
+++ b/http/src/request/channel/reaction/delete_all_reaction.rs
@@ -27,13 +27,13 @@ impl<'a> DeleteAllReaction<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::DeleteMessageSpecficReaction {
-                channel_id: self.channel_id.0,
-                message_id: self.message_id.0,
-                emoji: self.emoji.clone(),
-            },
-        ))));
+        let request = Request::from_route(Route::DeleteMessageSpecficReaction {
+            channel_id: self.channel_id.0,
+            message_id: self.message_id.0,
+            emoji: self.emoji.clone(),
+        });
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/reaction/delete_all_reactions.rs
+++ b/http/src/request/channel/reaction/delete_all_reactions.rs
@@ -20,12 +20,12 @@ impl<'a> DeleteAllReactions<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::DeleteMessageReactions {
-                channel_id: self.channel_id.0,
-                message_id: self.message_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::DeleteMessageReactions {
+            channel_id: self.channel_id.0,
+            message_id: self.message_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/reaction/delete_reaction.rs
+++ b/http/src/request/channel/reaction/delete_reaction.rs
@@ -30,14 +30,14 @@ impl<'a> DeleteReaction<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::DeleteReaction {
-                channel_id: self.channel_id.0,
-                emoji: self.emoji.clone(),
-                message_id: self.message_id.0,
-                user: self.target_user.clone(),
-            },
-        ))));
+        let request = Request::from_route(Route::DeleteReaction {
+            channel_id: self.channel_id.0,
+            emoji: self.emoji.clone(),
+            message_id: self.message_id.0,
+            user: self.target_user.clone(),
+        });
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -129,16 +129,16 @@ impl<'a> GetReactions<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetReactionUsers {
-                after: self.fields.after.map(|x| x.0),
-                before: self.fields.before.map(|x| x.0),
-                channel_id: self.channel_id.0,
-                emoji: self.emoji.clone(),
-                limit: self.fields.limit,
-                message_id: self.message_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::GetReactionUsers {
+            after: self.fields.after.map(|x| x.0),
+            before: self.fields.before.map(|x| x.0),
+            channel_id: self.channel_id.0,
+            emoji: self.emoji.clone(),
+            limit: self.fields.limit,
+            message_id: self.message_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -283,25 +283,16 @@ impl<'a> UpdateChannel<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                headers,
-                Route::UpdateChannel {
-                    channel_id: self.channel_id.0,
-                },
-            ))
-        } else {
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                Route::UpdateChannel {
-                    channel_id: self.channel_id.0,
-                },
-            ))
-        };
+        let mut request = Request::builder(Route::UpdateChannel {
+            channel_id: self.channel_id.0,
+        });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        if let Some(reason) = &self.reason {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
 
         Ok(())
     }

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -55,25 +55,17 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
     }
 
     fn request(&self) -> Result<Request> {
-        Ok(if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                headers,
-                Route::UpdatePermissionOverwrite {
-                    channel_id: self.channel_id.0,
-                    target_id: self.target_id,
-                },
-            ))
-        } else {
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                Route::UpdatePermissionOverwrite {
-                    channel_id: self.channel_id.0,
-                    target_id: self.target_id,
-                },
-            ))
+        let mut request = Request::builder(Route::UpdatePermissionOverwrite {
+            channel_id: self.channel_id.0,
+            target_id: self.target_id,
         })
+        .json(&self.fields)?;
+
+        if let Some(reason) = &self.reason {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        Ok(request.build())
     }
 
     fn start(&mut self) -> Result<()> {
@@ -128,7 +120,7 @@ mod tests {
             channel_id: 1,
             target_id: 2,
         };
-        let expected = Request::from((body, route));
+        let expected = Request::builder(route).body(body).build();
 
         assert_eq!(expected.body, actual.body);
         assert_eq!(expected.path, actual.path);

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -62,25 +62,17 @@ impl<'a> CreateWebhook<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                headers,
-                Route::CreateWebhook {
-                    channel_id: self.channel_id.0,
-                },
-            ))
-        } else {
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                Route::CreateWebhook {
-                    channel_id: self.channel_id.0,
-                },
-            ))
-        };
+        let mut request = Request::builder(Route::CreateWebhook {
+            channel_id: self.channel_id.0,
+        })
+        .json(&self.fields)?;
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        if let Some(reason) = self.reason.as_ref() {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
 
         Ok(())
     }

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -142,14 +142,13 @@ impl<'a> ExecuteWebhook<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::ExecuteWebhook {
-                token: self.token.clone(),
-                wait: self.fields.wait,
-                webhook_id: self.webhook_id.0,
-            },
-        ));
+        let request = Request::builder(Route::ExecuteWebhook {
+            token: self.token.clone(),
+            wait: self.fields.wait,
+            webhook_id: self.webhook_id.0,
+        })
+        .json(&self.fields)?
+        .build();
 
         match self.fields.wait {
             Some(true) => {

--- a/http/src/request/channel/webhook/get_channel_webhooks.rs
+++ b/http/src/request/channel/webhook/get_channel_webhooks.rs
@@ -18,11 +18,11 @@ impl<'a> GetChannelWebhooks<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetChannelWebhooks {
-                channel_id: self.channel_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::GetChannelWebhooks {
+            channel_id: self.channel_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/webhook/get_webhook.rs
+++ b/http/src/request/channel/webhook/get_webhook.rs
@@ -32,13 +32,12 @@ impl<'a> GetWebhook<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetWebhook {
-                    token: self.fields.token.clone(),
-                    webhook_id: self.id.0,
-                },
-            ))));
+        let request = Request::from_route(Route::GetWebhook {
+            token: self.fields.token.clone(),
+            webhook_id: self.id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -66,27 +66,18 @@ impl<'a> UpdateWebhook<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                headers,
-                Route::UpdateWebhook {
-                    token: None,
-                    webhook_id: self.webhook_id.0,
-                },
-            ))
-        } else {
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                Route::UpdateWebhook {
-                    token: None,
-                    webhook_id: self.webhook_id.0,
-                },
-            ))
-        };
+        let mut request = Request::builder(Route::UpdateWebhook {
+            token: None,
+            webhook_id: self.webhook_id.0,
+        })
+        .json(&self.fields)?;
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        if let Some(reason) = self.reason.as_ref() {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
 
         Ok(())
     }

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -52,13 +52,14 @@ impl<'a> UpdateWebhookWithToken<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::UpdateWebhook {
-                token: Some(self.token.clone()),
-                webhook_id: self.webhook_id.0,
-            },
-        )))));
+        let request = Request::builder(Route::UpdateWebhook {
+            token: Some(self.token.clone()),
+            webhook_id: self.webhook_id.0,
+        })
+        .json(&self.fields)?
+        .build();
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/get_gateway.rs
+++ b/http/src/request/get_gateway.rs
@@ -54,9 +54,9 @@ impl<'a> GetGateway<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(
-            self.http.request(Request::from(Route::GetGateway)),
-        ));
+        let request = Request::from_route(Route::GetGateway);
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/get_gateway_authed.rs
+++ b/http/src/request/get_gateway_authed.rs
@@ -16,9 +16,9 @@ impl<'a> GetGatewayAuthed<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(
-            self.http.request(Request::from(Route::GetGatewayBot)),
-        ));
+        let request = Request::from_route(Route::GetGatewayBot);
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/get_user_application.rs
+++ b/http/src/request/get_user_application.rs
@@ -12,10 +12,9 @@ impl<'a> GetUserApplicationInfo<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(
-            self.http
-                .request(Request::from(Route::GetCurrentUserApplicationInfo)),
-        ));
+        let request = Request::from_route(Route::GetCurrentUserApplicationInfo);
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/get_voice_regions.rs
+++ b/http/src/request/get_voice_regions.rs
@@ -13,9 +13,9 @@ impl<'a> GetVoiceRegions<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(
-            self.http.request(Request::from(Route::GetVoiceRegions)),
-        ));
+        let request = Request::from_route(Route::GetVoiceRegions);
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -125,14 +125,14 @@ impl<'a> CreateBan<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::CreateBan {
-                delete_message_days: self.fields.delete_message_days,
-                guild_id: self.guild_id.0,
-                reason: self.fields.reason.clone(),
-                user_id: self.user_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::CreateBan {
+            delete_message_days: self.fields.delete_message_days,
+            guild_id: self.guild_id.0,
+            reason: self.fields.reason.clone(),
+            user_id: self.user_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -41,23 +41,17 @@ impl<'a> DeleteBan<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::DeleteBan {
-                    guild_id: self.guild_id.0,
-                    user_id: self.user_id.0,
-                },
-            ))
-        } else {
-            Request::from(Route::DeleteBan {
-                guild_id: self.guild_id.0,
-                user_id: self.user_id.0,
-            })
-        };
+        let mut request = Request::builder(Route::DeleteBan {
+            guild_id: self.guild_id.0,
+            user_id: self.user_id.0,
+        });
 
-        self.fut.replace(Box::pin(self.http.verify(request)));
+        if let Some(reason) = self.reason.as_ref() {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.verify(request.build())));
 
         Ok(())
     }

--- a/http/src/request/guild/ban/get_ban.rs
+++ b/http/src/request/guild/ban/get_ban.rs
@@ -25,13 +25,12 @@ impl<'a> GetBan<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetBan {
-                    guild_id: self.guild_id.0,
-                    user_id: self.user_id.0,
-                },
-            ))));
+        let request = Request::from_route(Route::GetBan {
+            guild_id: self.guild_id.0,
+            user_id: self.user_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/ban/get_bans.rs
+++ b/http/src/request/guild/ban/get_bans.rs
@@ -36,10 +36,11 @@ impl<'a> GetBans<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request(Request::from(Route::GetBans {
-                guild_id: self.guild_id.0,
-            }))));
+        let request = Request::from_route(Route::GetBans {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -432,10 +432,11 @@ impl<'a> CreateGuild<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::CreateGuild,
-        )))));
+        let request = Request::builder(Route::CreateGuild)
+            .json(&self.fields)?
+            .build();
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -272,25 +272,17 @@ impl<'a> CreateGuildChannel<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                headers,
-                Route::CreateChannel {
-                    guild_id: self.guild_id.0,
-                },
-            ))
-        } else {
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                Route::CreateChannel {
-                    guild_id: self.guild_id.0,
-                },
-            ))
-        };
+        let mut request = Request::builder(Route::CreateChannel {
+            guild_id: self.guild_id.0,
+        })
+        .json(&self.fields)?;
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        if let Some(reason) = self.reason.as_ref() {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
 
         Ok(())
     }

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -128,27 +128,19 @@ impl<'a> CreateGuildPrune<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::CreateGuildPrune {
-                    compute_prune_count: self.fields.compute_prune_count,
-                    days: self.fields.days,
-                    guild_id: self.guild_id.0,
-                    include_roles: self.fields.include_roles.clone(),
-                },
-            ))
-        } else {
-            Request::from(Route::CreateGuildPrune {
-                compute_prune_count: self.fields.compute_prune_count,
-                days: self.fields.days,
-                guild_id: self.guild_id.0,
-                include_roles: self.fields.include_roles.clone(),
-            })
-        };
+        let mut request = Request::builder(Route::CreateGuildPrune {
+            compute_prune_count: self.fields.compute_prune_count,
+            days: self.fields.days,
+            guild_id: self.guild_id.0,
+            include_roles: self.fields.include_roles.clone(),
+        });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        if let Some(reason) = self.reason.as_ref() {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
 
         Ok(())
     }

--- a/http/src/request/guild/delete_guild.rs
+++ b/http/src/request/guild/delete_guild.rs
@@ -18,11 +18,11 @@ impl<'a> DeleteGuild<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::DeleteGuild {
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::DeleteGuild {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -59,25 +59,17 @@ impl<'a> CreateEmoji<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                headers,
-                Route::CreateEmoji {
-                    guild_id: self.guild_id.0,
-                },
-            ))
-        } else {
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                Route::CreateEmoji {
-                    guild_id: self.guild_id.0,
-                },
-            ))
-        };
+        let mut request = Request::builder(Route::CreateEmoji {
+            guild_id: self.guild_id.0,
+        })
+        .json(&self.fields)?;
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        if let Some(reason) = self.reason.as_ref() {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
 
         Ok(())
     }

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -22,23 +22,17 @@ impl<'a> DeleteEmoji<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::DeleteEmoji {
-                    emoji_id: self.emoji_id.0,
-                    guild_id: self.guild_id.0,
-                },
-            ))
-        } else {
-            Request::from(Route::DeleteEmoji {
-                emoji_id: self.emoji_id.0,
-                guild_id: self.guild_id.0,
-            })
-        };
+        let mut request = Request::builder(Route::DeleteEmoji {
+            emoji_id: self.emoji_id.0,
+            guild_id: self.guild_id.0,
+        });
 
-        self.fut.replace(Box::pin(self.http.verify(request)));
+        if let Some(reason) = self.reason.as_ref() {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.verify(request.build())));
 
         Ok(())
     }

--- a/http/src/request/guild/emoji/get_emoji.rs
+++ b/http/src/request/guild/emoji/get_emoji.rs
@@ -42,13 +42,12 @@ impl<'a> GetEmoji<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetEmoji {
-                    emoji_id: self.emoji_id.0,
-                    guild_id: self.guild_id.0,
-                },
-            ))));
+        let request = Request::from_route(Route::GetEmoji {
+            emoji_id: self.emoji_id.0,
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/emoji/get_emojis.rs
+++ b/http/src/request/guild/emoji/get_emojis.rs
@@ -36,11 +36,11 @@ impl<'a> GetEmojis<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetEmojis {
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::GetEmojis {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -144,15 +144,15 @@ impl<'a> GetAuditLog<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetAuditLogs {
-                action_type: self.fields.action_type.map(|x| x as u64),
-                before: self.fields.before,
-                guild_id: self.guild_id.0,
-                limit: self.fields.limit,
-                user_id: self.fields.user_id.map(|x| x.0),
-            },
-        ))));
+        let request = Request::from_route(Route::GetAuditLogs {
+            action_type: self.fields.action_type.map(|x| x as u64),
+            before: self.fields.before,
+            guild_id: self.guild_id.0,
+            limit: self.fields.limit,
+            user_id: self.fields.user_id.map(|x| x.0),
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/get_guild.rs
+++ b/http/src/request/guild/get_guild.rs
@@ -33,12 +33,12 @@ impl<'a> GetGuild<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetGuild {
-                guild_id: self.guild_id.0,
-                with_counts: self.fields.with_counts,
-            },
-        ))));
+        let request = Request::from_route(Route::GetGuild {
+            guild_id: self.guild_id.0,
+            with_counts: self.fields.with_counts,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/get_guild_channels.rs
+++ b/http/src/request/guild/get_guild_channels.rs
@@ -18,11 +18,11 @@ impl<'a> GetGuildChannels<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetChannels {
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::GetChannels {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/get_guild_invites.rs
+++ b/http/src/request/guild/get_guild_invites.rs
@@ -18,11 +18,11 @@ impl<'a> GetGuildInvites<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetGuildInvites {
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::GetGuildInvites {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/get_guild_preview.rs
+++ b/http/src/request/guild/get_guild_preview.rs
@@ -20,11 +20,11 @@ impl<'a> GetGuildPreview<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetGuildPreview {
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::GetGuildPreview {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -115,13 +115,13 @@ impl<'a> GetGuildPruneCount<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetGuildPruneCount {
-                days: self.fields.days,
-                guild_id: self.guild_id.0,
-                include_roles: self.fields.include_roles.clone(),
-            },
-        ))));
+        let request = Request::from_route(Route::GetGuildPruneCount {
+            days: self.fields.days,
+            guild_id: self.guild_id.0,
+            include_roles: self.fields.include_roles.clone(),
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -33,12 +33,11 @@ impl<'a> GetGuildVanityUrl<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let fut = self
-            .http
-            .request_bytes(Request::from(Route::GetGuildVanityUrl {
-                guild_id: self.guild_id.0,
-            }));
-        self.fut.replace(Box::pin(fut));
+        let request = Request::from_route(Route::GetGuildVanityUrl {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/get_guild_voice_regions.rs
+++ b/http/src/request/guild/get_guild_voice_regions.rs
@@ -20,11 +20,11 @@ impl<'a> GetGuildVoiceRegions<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetGuildVoiceRegions {
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::GetGuildVoiceRegions {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/get_guild_webhooks.rs
+++ b/http/src/request/guild/get_guild_webhooks.rs
@@ -18,11 +18,11 @@ impl<'a> GetGuildWebhooks<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetGuildWebhooks {
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::GetGuildWebhooks {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/get_guild_welcome_screen.rs
+++ b/http/src/request/guild/get_guild_welcome_screen.rs
@@ -18,12 +18,11 @@ impl<'a> GetGuildWelcomeScreen<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetGuildWelcomeScreen {
-                    guild_id: self.guild_id.0,
-                },
-            ))));
+        let request = Request::from_route(Route::GetGuildWelcomeScreen {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/get_guild_widget.rs
+++ b/http/src/request/guild/get_guild_widget.rs
@@ -22,12 +22,11 @@ impl<'a> GetGuildWidget<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetGuildWidget {
-                    guild_id: self.guild_id.0,
-                },
-            ))));
+        let request = Request::from_route(Route::GetGuildWidget {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -22,23 +22,17 @@ impl<'a> DeleteGuildIntegration<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::DeleteGuildIntegration {
-                    guild_id: self.guild_id.0,
-                    integration_id: self.integration_id.0,
-                },
-            ))
-        } else {
-            Request::from(Route::DeleteGuildIntegration {
-                guild_id: self.guild_id.0,
-                integration_id: self.integration_id.0,
-            })
-        };
+        let mut request = Request::builder(Route::DeleteGuildIntegration {
+            guild_id: self.guild_id.0,
+            integration_id: self.integration_id.0,
+        });
 
-        self.fut.replace(Box::pin(self.http.verify(request)));
+        if let Some(reason) = self.reason.as_ref() {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.verify(request.build())));
 
         Ok(())
     }

--- a/http/src/request/guild/integration/get_guild_integrations.rs
+++ b/http/src/request/guild/integration/get_guild_integrations.rs
@@ -18,11 +18,11 @@ impl<'a> GetGuildIntegrations<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetGuildIntegrations {
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::GetGuildIntegrations {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/member/add_guild_member.rs
+++ b/http/src/request/guild/member/add_guild_member.rs
@@ -167,13 +167,12 @@ impl<'a> AddGuildMember<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::AddGuildMember {
-                guild_id: self.guild_id.0,
-                user_id: self.user_id.0,
-            },
-        ));
+        let request = Request::builder(Route::AddGuildMember {
+            guild_id: self.guild_id.0,
+            user_id: self.user_id.0,
+        })
+        .json(&self.fields)?
+        .build();
 
         self.fut.replace(Box::pin(self.http.request_bytes(request)));
 

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -152,15 +152,14 @@ impl<'a> GetGuildMembers<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetGuildMembers {
-                    after: self.fields.after.map(|x| x.0),
-                    guild_id: self.guild_id.0,
-                    limit: self.fields.limit,
-                    presences: self.fields.presences,
-                },
-            ))));
+        let request = Request::from_route(Route::GetGuildMembers {
+            after: self.fields.after.map(|x| x.0),
+            guild_id: self.guild_id.0,
+            limit: self.fields.limit,
+            presences: self.fields.presences,
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -38,13 +38,12 @@ impl<'a> GetMember<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetMember {
-                    guild_id: self.guild_id.0,
-                    user_id: self.user_id.0,
-                },
-            ))));
+        let request = Request::from_route(Route::GetMember {
+            guild_id: self.guild_id.0,
+            user_id: self.user_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -22,23 +22,17 @@ impl<'a> RemoveMember<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::RemoveMember {
-                    guild_id: self.guild_id.0,
-                    user_id: self.user_id.0,
-                },
-            ))
-        } else {
-            Request::from(Route::RemoveMember {
-                guild_id: self.guild_id.0,
-                user_id: self.user_id.0,
-            })
-        };
+        let mut request = Request::builder(Route::RemoveMember {
+            guild_id: self.guild_id.0,
+            user_id: self.user_id.0,
+        });
 
-        self.fut.replace(Box::pin(self.http.verify(request)));
+        if let Some(reason) = self.reason.as_ref() {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.verify(request.build())));
 
         Ok(())
     }

--- a/http/src/request/guild/member/remove_role_from_member.rs
+++ b/http/src/request/guild/member/remove_role_from_member.rs
@@ -29,25 +29,18 @@ impl<'a> RemoveRoleFromMember<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::RemoveMemberRole {
-                    guild_id: self.guild_id.0,
-                    role_id: self.role_id.0,
-                    user_id: self.user_id.0,
-                },
-            ))
-        } else {
-            Request::from(Route::RemoveMemberRole {
-                guild_id: self.guild_id.0,
-                role_id: self.role_id.0,
-                user_id: self.user_id.0,
-            })
-        };
+        let mut request = Request::builder(Route::RemoveMemberRole {
+            guild_id: self.guild_id.0,
+            role_id: self.role_id.0,
+            user_id: self.user_id.0,
+        });
 
-        self.fut.replace(Box::pin(self.http.verify(request)));
+        if let Some(reason) = self.reason.as_ref() {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.verify(request.build())));
 
         Ok(())
     }

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -112,14 +112,13 @@ impl<'a> SearchGuildMembers<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::SearchGuildMembers {
-                    guild_id: self.guild_id.0,
-                    limit: self.fields.limit,
-                    query: self.fields.query.clone(),
-                },
-            ))));
+        let request = Request::from_route(Route::SearchGuildMembers {
+            guild_id: self.guild_id.0,
+            limit: self.fields.limit,
+            query: self.fields.query.clone(),
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -94,25 +94,17 @@ impl<'a> CreateRole<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                headers,
-                Route::CreateRole {
-                    guild_id: self.guild_id.0,
-                },
-            ))
-        } else {
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                Route::CreateRole {
-                    guild_id: self.guild_id.0,
-                },
-            ))
-        };
+        let mut request = Request::builder(Route::CreateRole {
+            guild_id: self.guild_id.0,
+        })
+        .json(&self.fields)?;
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        if let Some(reason) = &self.reason {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
 
         Ok(())
     }

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -22,23 +22,17 @@ impl<'a> DeleteRole<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                headers,
-                Route::DeleteRole {
-                    guild_id: self.guild_id.0,
-                    role_id: self.role_id.0,
-                },
-            ))
-        } else {
-            Request::from(Route::DeleteRole {
-                guild_id: self.guild_id.0,
-                role_id: self.role_id.0,
-            })
-        };
+        let mut request = Request::builder(Route::DeleteRole {
+            guild_id: self.guild_id.0,
+            role_id: self.role_id.0,
+        });
 
-        self.fut.replace(Box::pin(self.http.verify(request)));
+        if let Some(reason) = &self.reason {
+            request = request.headers(audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.verify(request.build())));
 
         Ok(())
     }

--- a/http/src/request/guild/role/get_guild_roles.rs
+++ b/http/src/request/guild/role/get_guild_roles.rs
@@ -18,11 +18,11 @@ impl<'a> GetGuildRoles<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetGuildRoles {
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::GetGuildRoles {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/role/update_role_positions.rs
+++ b/http/src/request/guild/role/update_role_positions.rs
@@ -29,12 +29,13 @@ impl<'a> UpdateRolePositions<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.roles).map_err(HttpError::json)?,
-            Route::UpdateRolePositions {
-                guild_id: self.guild_id.0,
-            },
-        )))));
+        let request = Request::builder(Route::UpdateRolePositions {
+            guild_id: self.guild_id.0,
+        })
+        .json(&self.roles)?
+        .build();
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/update_current_user_nick.rs
+++ b/http/src/request/guild/update_current_user_nick.rs
@@ -25,12 +25,13 @@ impl<'a> UpdateCurrentUserNick<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::UpdateNickname {
-                guild_id: self.guild_id.0,
-            },
-        )))));
+        let request = Request::builder(Route::UpdateNickname {
+            guild_id: self.guild_id.0,
+        })
+        .json(&self.fields)?
+        .build();
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -310,25 +310,17 @@ impl<'a> UpdateGuild<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = if let Some(reason) = &self.reason {
-            let headers = audit_header(&reason)?;
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                headers,
-                Route::UpdateGuild {
-                    guild_id: self.guild_id.0,
-                },
-            ))
-        } else {
-            Request::from((
-                crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-                Route::UpdateGuild {
-                    guild_id: self.guild_id.0,
-                },
-            ))
-        };
+        let mut request = Request::builder(Route::UpdateGuild {
+            guild_id: self.guild_id.0,
+        })
+        .json(&self.fields)?;
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        if let Some(reason) = &self.reason {
+            request = request.headers(audit_header(reason)?)
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
 
         Ok(())
     }

--- a/http/src/request/guild/update_guild_channel_positions.rs
+++ b/http/src/request/guild/update_guild_channel_positions.rs
@@ -36,12 +36,13 @@ impl<'a> UpdateGuildChannelPositions<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from((
-            crate::json_to_vec(&self.positions).map_err(HttpError::json)?,
-            Route::UpdateGuildChannels {
-                guild_id: self.guild_id.0,
-            },
-        )))));
+        let request = Request::builder(Route::UpdateGuildChannels {
+            guild_id: self.guild_id.0,
+        })
+        .json(&self.positions)?
+        .build();
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/update_guild_welcome_screen.rs
+++ b/http/src/request/guild/update_guild_welcome_screen.rs
@@ -65,12 +65,13 @@ impl<'a> UpdateGuildWelcomeScreen<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::UpdateGuildWelcomeScreen {
-                guild_id: self.guild_id.0,
-            },
-        )))));
+        let request = Request::builder(Route::UpdateGuildWelcomeScreen {
+            guild_id: self.guild_id.0,
+        })
+        .json(&self.fields)?
+        .build();
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/update_guild_widget.rs
+++ b/http/src/request/guild/update_guild_widget.rs
@@ -46,12 +46,13 @@ impl<'a> UpdateGuildWidget<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::UpdateGuildWidget {
-                guild_id: self.guild_id.0,
-            },
-        )))));
+        let request = Request::builder(Route::UpdateGuildWidget {
+            guild_id: self.guild_id.0,
+        })
+        .json(&self.fields)?
+        .build();
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/user/update_current_user_voice_state.rs
+++ b/http/src/request/guild/user/update_current_user_voice_state.rs
@@ -70,12 +70,13 @@ impl<'a> UpdateCurrentUserVoiceState<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::UpdateCurrentUserVoiceState {
-                guild_id: self.guild_id.0,
-            },
-        )))));
+        let request = Request::builder(Route::UpdateCurrentUserVoiceState {
+            guild_id: self.guild_id.0,
+        })
+        .json(&self.fields)?
+        .build();
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/guild/user/update_user_voice_state.rs
+++ b/http/src/request/guild/user/update_user_voice_state.rs
@@ -55,13 +55,14 @@ impl<'a> UpdateUserVoiceState<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::UpdateUserVoiceState {
-                guild_id: self.guild_id.0,
-                user_id: self.user_id.0,
-            },
-        )))));
+        let request = Request::builder(Route::UpdateUserVoiceState {
+            guild_id: self.guild_id.0,
+            user_id: self.user_id.0,
+        })
+        .json(&self.fields)?
+        .build();
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -71,6 +71,7 @@ pub mod template;
 pub mod user;
 
 mod audit_reason;
+mod base;
 mod get_gateway;
 mod get_gateway_authed;
 mod get_user_application;
@@ -80,24 +81,22 @@ mod validate;
 
 pub use self::{
     audit_reason::{AuditLogReason, AuditLogReasonError},
+    base::{Request, RequestBuilder},
     get_gateway::GetGateway,
     get_gateway_authed::GetGatewayAuthed,
     get_user_application::GetUserApplicationInfo,
     get_voice_regions::GetVoiceRegions,
+    multipart::Form,
 };
 
-use self::multipart::Form;
-use crate::{
-    error::{Error, ErrorType, Result},
-    routing::{Path, Route},
-};
+use crate::error::{Error, ErrorType, Result};
 use bytes::Bytes;
 use hyper::{
-    header::{HeaderMap, HeaderName, HeaderValue},
+    header::{HeaderName, HeaderValue},
     Method as HyperMethod,
 };
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
-use std::{borrow::Cow, future::Future, pin::Pin};
+use std::{future::Future, iter, pin::Pin};
 
 type Pending<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
 type PendingOption<'a> = Pin<Box<dyn Future<Output = Result<Bytes>> + Send + 'a>>;
@@ -130,25 +129,10 @@ impl Method {
     }
 }
 
-#[derive(Debug)]
-pub struct Request {
-    /// The body of the request, if any.
-    pub body: Option<Vec<u8>>,
-    /// The multipart form of the request, if any.
-    pub form: Option<Form>,
-    /// The headers to set in the request, if any.
-    pub headers: Option<HeaderMap<HeaderValue>>,
-    /// The method of the request.
-    pub method: Method,
-    /// The ratelimiting bucket path.
-    pub path: Path,
-    /// The URI path to request.
-    pub path_str: Cow<'static, str>,
-}
-
-pub(crate) fn audit_header(reason: &str) -> Result<HeaderMap<HeaderValue>> {
+pub(crate) fn audit_header(
+    reason: &str,
+) -> Result<impl Iterator<Item = (HeaderName, HeaderValue)>> {
     let header_name = HeaderName::from_static("x-audit-log-reason");
-    let mut headers = HeaderMap::new();
     let encoded_reason = utf8_percent_encode(reason, NON_ALPHANUMERIC).to_string();
     let header_value = HeaderValue::from_str(&encoded_reason).map_err(|e| Error {
         kind: ErrorType::CreatingHeader {
@@ -157,122 +141,7 @@ pub(crate) fn audit_header(reason: &str) -> Result<HeaderMap<HeaderValue>> {
         source: Some(Box::new(e)),
     })?;
 
-    headers.insert(header_name, header_value);
-
-    Ok(headers)
-}
-
-impl Request {
-    /// Create a simple `Request` with basic information.
-    ///
-    /// Use the various `From` implementations for different combinations of
-    /// configurations.
-    pub fn new(
-        body: Option<Vec<u8>>,
-        headers: Option<HeaderMap<HeaderValue>>,
-        route: Route,
-    ) -> Self {
-        let (method, path, path_str) = route.into_parts();
-
-        Self {
-            body,
-            form: None,
-            headers,
-            method,
-            path,
-            path_str,
-        }
-    }
-}
-
-impl From<Route> for Request {
-    fn from(route: Route) -> Self {
-        let (method, path, path_str) = route.into_parts();
-
-        Self {
-            body: None,
-            form: None,
-            headers: None,
-            method,
-            path,
-            path_str,
-        }
-    }
-}
-
-impl From<(Vec<u8>, Route)> for Request {
-    fn from((body, route): (Vec<u8>, Route)) -> Self {
-        let (method, path, path_str) = route.into_parts();
-
-        Self {
-            body: Some(body),
-            form: None,
-            headers: None,
-            method,
-            path,
-            path_str,
-        }
-    }
-}
-
-impl From<(Form, Route)> for Request {
-    fn from((form, route): (Form, Route)) -> Self {
-        let (method, path, path_str) = route.into_parts();
-
-        Self {
-            body: None,
-            form: Some(form),
-            headers: None,
-            method,
-            path,
-            path_str,
-        }
-    }
-}
-
-impl From<(Vec<u8>, Form, Route)> for Request {
-    fn from((body, form, route): (Vec<u8>, Form, Route)) -> Self {
-        let (method, path, path_str) = route.into_parts();
-
-        Self {
-            body: Some(body),
-            form: Some(form),
-            headers: None,
-            method,
-            path,
-            path_str,
-        }
-    }
-}
-
-impl From<(HeaderMap<HeaderValue>, Route)> for Request {
-    fn from((headers, route): (HeaderMap<HeaderValue>, Route)) -> Self {
-        let (method, path, path_str) = route.into_parts();
-
-        Self {
-            body: None,
-            form: None,
-            headers: Some(headers),
-            method,
-            path,
-            path_str,
-        }
-    }
-}
-
-impl From<(Vec<u8>, HeaderMap<HeaderValue>, Route)> for Request {
-    fn from((body, headers, route): (Vec<u8>, HeaderMap<HeaderValue>, Route)) -> Self {
-        let (method, path, path_str) = route.into_parts();
-
-        Self {
-            body: Some(body),
-            form: None,
-            headers: Some(headers),
-            method,
-            path,
-            path_str,
-        }
-    }
+    Ok(iter::once((header_name, header_value)))
 }
 
 #[cfg(test)]

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -91,12 +91,13 @@ impl<'a> CreateGuildFromTemplate<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::CreateGuildFromTemplate {
-                template_code: self.template_code.clone(),
-            },
-        )))));
+        let request = Request::builder(Route::CreateGuildFromTemplate {
+            template_code: self.template_code.clone(),
+        })
+        .json(&self.fields)?
+        .build();
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/template/create_template.rs
+++ b/http/src/request/template/create_template.rs
@@ -107,12 +107,13 @@ impl<'a> CreateTemplate<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::CreateTemplate {
-                guild_id: self.guild_id.0,
-            },
-        )))));
+        let request = Request::builder(Route::CreateTemplate {
+            guild_id: self.guild_id.0,
+        })
+        .json(&self.fields)?
+        .build();
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/template/delete_template.rs
+++ b/http/src/request/template/delete_template.rs
@@ -28,12 +28,12 @@ impl<'a> DeleteTemplate<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::DeleteTemplate {
-                guild_id: self.guild_id.0,
-                template_code: self.template_code.clone(),
-            },
-        ))));
+        let request = Request::from_route(Route::DeleteTemplate {
+            guild_id: self.guild_id.0,
+            template_code: self.template_code.clone(),
+        });
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/template/get_template.rs
+++ b/http/src/request/template/get_template.rs
@@ -22,11 +22,11 @@ impl<'a> GetTemplate<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetTemplate {
-                template_code: self.template_code.clone(),
-            },
-        ))));
+        let request = Request::from_route(Route::GetTemplate {
+            template_code: self.template_code.clone(),
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/template/get_templates.rs
+++ b/http/src/request/template/get_templates.rs
@@ -18,11 +18,11 @@ impl<'a> GetTemplates<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetTemplates {
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::GetTemplates {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/template/sync_template.rs
+++ b/http/src/request/template/sync_template.rs
@@ -28,12 +28,12 @@ impl<'a> SyncTemplate<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::SyncTemplate {
-                guild_id: self.guild_id.0,
-                template_code: self.template_code.clone(),
-            },
-        ))));
+        let request = Request::from_route(Route::SyncTemplate {
+            guild_id: self.guild_id.0,
+            template_code: self.template_code.clone(),
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/template/update_template.rs
+++ b/http/src/request/template/update_template.rs
@@ -114,13 +114,14 @@ impl<'a> UpdateTemplate<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::UpdateTemplate {
-                guild_id: self.guild_id.0,
-                template_code: self.template_code.clone(),
-            },
-        )))));
+        let request = Request::builder(Route::UpdateTemplate {
+            guild_id: self.guild_id.0,
+            template_code: self.template_code.clone(),
+        })
+        .json(&self.fields)?
+        .build();
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/user/create_private_channel.rs
+++ b/http/src/request/user/create_private_channel.rs
@@ -24,10 +24,11 @@ impl<'a> CreatePrivateChannel<'a> {
         }
     }
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::CreatePrivateChannel,
-        )))));
+        let request = Request::builder(Route::CreatePrivateChannel)
+            .json(&self.fields)?
+            .build();
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/user/get_current_user.rs
+++ b/http/src/request/user/get_current_user.rs
@@ -13,10 +13,11 @@ impl<'a> GetCurrentUser<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request(Request::from(Route::GetUser {
-                target_user: "@me".to_owned(),
-            }))));
+        let request = Request::from_route(Route::GetUser {
+            target_user: "@me".to_owned(),
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/user/get_current_user_connections.rs
+++ b/http/src/request/user/get_current_user_connections.rs
@@ -15,9 +15,9 @@ impl<'a> GetCurrentUserConnections<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(
-            self.http.request(Request::from(Route::GetUserConnections)),
-        ));
+        let request = Request::from_route(Route::GetUserConnections);
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -146,13 +146,13 @@ impl<'a> GetCurrentUserGuilds<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from(
-            Route::GetGuilds {
-                after: self.fields.after.map(|x| x.0),
-                before: self.fields.before.map(|x| x.0),
-                limit: self.fields.limit,
-            },
-        ))));
+        let request = Request::from_route(Route::GetGuilds {
+            after: self.fields.after.map(|x| x.0),
+            before: self.fields.before.map(|x| x.0),
+            limit: self.fields.limit,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }

--- a/http/src/request/user/get_user.rs
+++ b/http/src/request/user/get_user.rs
@@ -18,12 +18,11 @@ impl<'a> GetUser<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut
-            .replace(Box::pin(self.http.request_bytes(Request::from(
-                Route::GetUser {
-                    target_user: self.target_user.clone(),
-                },
-            ))));
+        let request = Request::from_route(Route::GetUser {
+            target_user: self.target_user.clone(),
+        });
+
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
 
         Ok(())
     }

--- a/http/src/request/user/leave_guild.rs
+++ b/http/src/request/user/leave_guild.rs
@@ -18,11 +18,11 @@ impl<'a> LeaveGuild<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.verify(Request::from(
-            Route::LeaveGuild {
-                guild_id: self.guild_id.0,
-            },
-        ))));
+        let request = Request::from_route(Route::LeaveGuild {
+            guild_id: self.guild_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
 
         Ok(())
     }

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -127,10 +127,11 @@ impl<'a> UpdateCurrentUser<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        self.fut.replace(Box::pin(self.http.request(Request::from((
-            crate::json_to_vec(&self.fields).map_err(HttpError::json)?,
-            Route::UpdateCurrentUser,
-        )))));
+        let request = Request::builder(Route::UpdateCurrentUser)
+            .json(&self.fields)?
+            .build();
+
+        self.fut.replace(Box::pin(self.http.request(request)));
 
         Ok(())
     }


### PR DESCRIPTION
Add a `RequestBuilder` to build into a `Request`. This will allow us to make `Request` non-exhaustive and remove the myriad of `From` impls on `Request` in a future version.

`Request::from_route` has been added to create a request from simply a `Route`. `Request::builder` has been added to create a `RequestBuilder`.

`Request::new` has been deprecated in favor of either of the above two mentioned methods.

The `From` impls would be deprecated, but `#[deprecated]` is not a supported attribute on `From` impls.