### PR TITLE
feat(http): add missing create/update guild fields

### DIFF
--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -288,7 +288,7 @@ impl<'a> CreateGuild<'a> {
     /// This must be an ID specified in [`channels`].
     ///
     /// [`channels`]: Self::channels
-    pub fn afk_chanel_id(mut self, afk_channel_id: ChannelId) -> Self {
+    pub fn afk_channel_id(mut self, afk_channel_id: ChannelId) -> Self {
         self.fields.afk_channel_id.replace(afk_channel_id);
 
         self

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -435,7 +435,9 @@ impl<'a> CreateGuild<'a> {
 
     /// Set the guild's [`SystemChannelFlags`].
     pub fn system_channel_flags(mut self, system_channel_flags: SystemChannelFlags) -> Self {
-        self.fields.system_channel_flags.replace(system_channel_flags);
+        self.fields
+            .system_channel_flags
+            .replace(system_channel_flags);
 
         self
     }

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -7,7 +7,7 @@ use twilight_model::{
     channel::{permission_overwrite::PermissionOverwrite, ChannelType},
     guild::{
         DefaultMessageNotificationLevel, ExplicitContentFilter, PartialGuild, Permissions,
-        VerificationLevel,
+        SystemChannelFlags, VerificationLevel,
     },
     id::{ChannelId, RoleId},
 };
@@ -88,6 +88,10 @@ pub enum CreateGuildErrorType {
 #[derive(Serialize)]
 struct CreateGuildFields {
     #[serde(skip_serializing_if = "Option::is_none")]
+    afk_channel_id: Option<ChannelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    afk_timeout: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     channels: Option<Vec<GuildChannelFields>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_message_notifications: Option<DefaultMessageNotificationLevel>,
@@ -100,6 +104,10 @@ struct CreateGuildFields {
     region: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     roles: Option<Vec<RoleFields>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_channel_id: Option<ChannelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_channel_flags: Option<SystemChannelFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]
     verification_level: Option<VerificationLevel>,
 }
@@ -243,6 +251,8 @@ impl<'a> CreateGuild<'a> {
 
         Ok(Self {
             fields: CreateGuildFields {
+                afk_channel_id: None,
+                afk_timeout: None,
                 channels: None,
                 default_message_notifications: None,
                 explicit_content_filter: None,
@@ -250,6 +260,8 @@ impl<'a> CreateGuild<'a> {
                 name,
                 region: None,
                 roles: None,
+                system_channel_id: None,
+                system_channel_flags: None,
                 verification_level: None,
             },
             fut: None,
@@ -267,6 +279,24 @@ impl<'a> CreateGuild<'a> {
         if let Some(roles) = self.fields.roles.as_mut() {
             roles.push(role.into());
         }
+
+        self
+    }
+
+    /// Set the ID of the AFK voice channel.
+    ///
+    /// This must be an ID specified in [`channels`].
+    ///
+    /// [`channels`]: Self::channels
+    pub fn afk_chanel_id(mut self, afk_channel_id: ChannelId) -> Self {
+        self.fields.afk_channel_id.replace(afk_channel_id);
+
+        self
+    }
+
+    /// Set the AFK timeout, in seconds.
+    pub fn afk_timeout(mut self, afk_timeout: u64) -> Self {
+        self.fields.afk_timeout.replace(afk_timeout);
 
         self
     }
@@ -388,6 +418,24 @@ impl<'a> CreateGuild<'a> {
     /// [the discord docs]: https://discord.com/developers/docs/resources/voice#voice-region-object
     pub fn region(mut self, region: impl Into<String>) -> Self {
         self.fields.region.replace(region.into());
+
+        self
+    }
+
+    /// Set the channel where system messages will be posted.
+    ///
+    /// This must be an ID specified in [`channels`].
+    ///
+    /// [`channels`]: Self::channels
+    pub fn system_channel_id(mut self, system_channel_id: ChannelId) -> Self {
+        self.fields.system_channel_id.replace(system_channel_id);
+
+        self
+    }
+
+    /// Set the guild's [`SystemChannelFlags`].
+    pub fn system_channel_flags(mut self, system_channel_flags: SystemChannelFlags) -> Self {
+        self.fields.system_channel_flags.replace(system_channel_flags);
 
         self
     }

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -5,7 +5,8 @@ use std::{
 };
 use twilight_model::{
     guild::{
-        DefaultMessageNotificationLevel, ExplicitContentFilter, PartialGuild, VerificationLevel,
+        DefaultMessageNotificationLevel, ExplicitContentFilter, PartialGuild, SystemChannelFlags,
+        VerificationLevel,
     },
     id::{ChannelId, GuildId, UserId},
 };
@@ -74,7 +75,13 @@ struct UpdateGuildFields {
     default_message_notifications: Option<Option<DefaultMessageNotificationLevel>>,
     #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
+    discovery_splash: Option<Option<String>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     explicit_content_filter: Option<Option<ExplicitContentFilter>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    features: Option<Option<Vec<String>>>,
     #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
     icon: Option<Option<String>>,
@@ -91,6 +98,9 @@ struct UpdateGuildFields {
     #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
     system_channel_id: Option<Option<ChannelId>>,
+    #[allow(clippy::option_option)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_channel_flags: Option<Option<SystemChannelFlags>>,
     #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
     verification_level: Option<Option<VerificationLevel>>,
@@ -170,6 +180,17 @@ impl<'a> UpdateGuild<'a> {
         self
     }
 
+    /// Set the guild's discovery splash image.
+    ///
+    /// Requires the guild to have the `DISCOVERABLE` feature enabled.
+    pub fn discovery_splash(mut self, discovery_splash: impl Into<Option<String>>) -> Self {
+        self.fields
+            .discovery_splash
+            .replace(discovery_splash.into());
+
+        self
+    }
+
     /// Set the explicit content filter level.
     pub fn explicit_content_filter(
         mut self,
@@ -178,6 +199,15 @@ impl<'a> UpdateGuild<'a> {
         self.fields
             .explicit_content_filter
             .replace(explicit_content_filter.into());
+
+        self
+    }
+
+    /// Set the enabled features of the guild.
+    pub fn features(mut self, features: impl IntoIterator<Item = String>) -> Self {
+        self.fields
+            .features
+            .replace(Some(features.into_iter().collect()));
 
         self
     }
@@ -253,6 +283,18 @@ impl<'a> UpdateGuild<'a> {
         self.fields
             .system_channel_id
             .replace(system_channel_id.into());
+
+        self
+    }
+
+    /// Set the guild's [`SystemChannelFlags`].
+    pub fn system_channel_flags(
+        mut self,
+        system_channel_flags: impl Into<Option<SystemChannelFlags>>,
+    ) -> Self {
+        self.fields
+            .system_channel_flags
+            .replace(system_channel_flags.into());
 
         self
     }


### PR DESCRIPTION
Adds:
* `http` `CreateGuild::afk_channel_id`
* `http` `CreateGuild::afk_timeout`
* `http` `CreateGuild::system_chanel_id`
* `http` `CreateGuild::system_chanel_flags`
* `http` `UpdateGuild::discovery_splash`
* `http` `UpdateGuild::features`
* `http` `UpdateGuild::system_chanel_flags`

https://github.com/discord/discord-api-docs/commit/5b63daebe35a8c0e9d313186f0de5fcf30304057#
