### PR TITLE
Deprecate HTTP Result type

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -4,7 +4,7 @@ pub use self::builder::ClientBuilder;
 
 use crate::{
     api_error::{ApiError, ErrorCode},
-    error::{Error, ErrorType, Result},
+    error::{Error, ErrorType},
     ratelimiting::{RatelimitHeaders, Ratelimiter},
     request::{
         channel::stage::{
@@ -28,7 +28,6 @@ use serde::de::DeserializeOwned;
 use std::{
     convert::TryFrom,
     fmt::{Debug, Formatter, Result as FmtResult},
-    result::Result as StdResult,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -639,7 +638,7 @@ impl Client {
     pub fn create_guild(
         &self,
         name: impl Into<String>,
-    ) -> StdResult<CreateGuild<'_>, CreateGuildError> {
+    ) -> Result<CreateGuild<'_>, CreateGuildError> {
         CreateGuild::new(self, name)
     }
 
@@ -690,7 +689,7 @@ impl Client {
         &self,
         guild_id: GuildId,
         name: impl Into<String>,
-    ) -> StdResult<CreateGuildChannel<'_>, CreateGuildChannelError> {
+    ) -> Result<CreateGuildChannel<'_>, CreateGuildChannelError> {
         CreateGuildChannel::new(self, guild_id, name)
     }
 
@@ -1387,7 +1386,7 @@ impl Client {
         &self,
         template_code: impl Into<String>,
         name: impl Into<String>,
-    ) -> StdResult<CreateGuildFromTemplate<'_>, CreateGuildFromTemplateError> {
+    ) -> Result<CreateGuildFromTemplate<'_>, CreateGuildFromTemplateError> {
         CreateGuildFromTemplate::new(self, template_code, name)
     }
 
@@ -1405,7 +1404,7 @@ impl Client {
         &self,
         guild_id: GuildId,
         name: impl Into<String>,
-    ) -> StdResult<CreateTemplate<'_>, CreateTemplateError> {
+    ) -> Result<CreateTemplate<'_>, CreateTemplateError> {
         CreateTemplate::new(self, guild_id, name)
     }
 
@@ -1624,7 +1623,7 @@ impl Client {
     /// Returns an [`ErrorType::Unauthorized`] error type if the configured
     /// token has become invalid due to expiration, revokation, etc.
     #[allow(clippy::too_many_lines)]
-    pub async fn raw(&self, request: Request) -> Result<Response<Body>> {
+    pub async fn raw(&self, request: Request) -> Result<Response<Body>, Error> {
         if self.state.token_invalid.load(Ordering::Relaxed) {
             return Err(Error {
                 kind: ErrorType::Unauthorized,
@@ -1803,7 +1802,7 @@ impl Client {
     ///
     /// Returns an [`ErrorType::Unauthorized`] error type if the configured
     /// token has become invalid due to expiration, revokation, etc.
-    pub async fn request<T: DeserializeOwned>(&self, request: Request) -> Result<T> {
+    pub async fn request<T: DeserializeOwned>(&self, request: Request) -> Result<T, Error> {
         let resp = self.make_request(request).await?;
 
         let mut buf = body::aggregate(resp.into_body())
@@ -1826,7 +1825,7 @@ impl Client {
         })
     }
 
-    pub(crate) async fn request_bytes(&self, request: Request) -> Result<Bytes> {
+    pub(crate) async fn request_bytes(&self, request: Request) -> Result<Bytes, Error> {
         let resp = self.make_request(request).await?;
 
         hyper::body::to_bytes(resp.into_body())
@@ -1845,13 +1844,13 @@ impl Client {
     ///
     /// Returns an [`ErrorType::Unauthorized`] error type if the configured
     /// token has become invalid due to expiration, revokation, etc.
-    pub async fn verify(&self, request: Request) -> Result<()> {
+    pub async fn verify(&self, request: Request) -> Result<(), Error> {
         self.make_request(request).await?;
 
         Ok(())
     }
 
-    async fn make_request(&self, request: Request) -> Result<Response<Body>> {
+    async fn make_request(&self, request: Request) -> Result<Response<Body>, Error> {
         let resp = self.raw(request).await?;
         let status = resp.status();
 

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -11,7 +11,7 @@ use serde_json::Error as JsonError;
 #[cfg(feature = "simd-json")]
 use simd_json::Error as JsonError;
 
-#[deprecated(since = "0.4.1")]
+#[deprecated(since = "0.4.2")]
 pub type Result<T, E = Error> = StdResult<T, E>;
 
 #[derive(Debug)]

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -11,6 +11,7 @@ use serde_json::Error as JsonError;
 #[cfg(feature = "simd-json")]
 use simd_json::Error as JsonError;
 
+#[deprecated(since = "0.4.1")]
 pub type Result<T, E = Error> = StdResult<T, E>;
 
 #[derive(Debug)]

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -11,7 +11,7 @@ use serde_json::Error as JsonError;
 #[cfg(feature = "simd-json")]
 use simd_json::Error as JsonError;
 
-#[deprecated(since = "0.4.2")]
+#[deprecated(since = "0.4.3")]
 pub type Result<T, E = Error> = StdResult<T, E>;
 
 #[derive(Debug)]

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -105,10 +105,10 @@ mod json;
 /// Discord API version used by this crate.
 pub const API_VERSION: u8 = 8;
 
-pub use crate::{
-    client::Client,
-    error::{Error, Result},
-};
+pub use crate::{client::Client, error::Error};
+
+#[allow(deprecated)]
+pub use crate::error::Result;
 
 #[cfg(not(any(
     feature = "native",

--- a/http/src/request/base.rs
+++ b/http/src/request/base.rs
@@ -1,6 +1,6 @@
 use super::{Form, Method};
 use crate::{
-    error::{Error, Result},
+    error::Error,
     routing::{Path, Route},
 };
 use hyper::header::{HeaderMap, HeaderName, HeaderValue};
@@ -74,7 +74,7 @@ impl RequestBuilder {
     ///
     /// [`ErrorType::Json`]: crate::error::ErrorType::Json
     #[must_use = "request has not been fully built"]
-    pub fn json(self, to: &impl Serialize) -> Result<Self> {
+    pub fn json(self, to: &impl Serialize) -> Result<Self, Error> {
         let bytes = crate::json::to_vec(to).map_err(Error::json)?;
 
         Ok(self.body(bytes))

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     client::Client,
-    error::{Error as HttpError, Result},
+    error::Error as HttpError,
     request::{self, validate, AuditLogReason, AuditLogReasonError, Form, Pending, Request},
     routing::Route,
 };
@@ -356,7 +356,7 @@ impl<'a> UpdateWebhookMessage<'a> {
         self
     }
 
-    fn request(&mut self) -> Result<Request> {
+    fn request(&mut self) -> Result<Request, HttpError> {
         let mut request = Request::builder(Route::UpdateWebhookMessage {
             message_id: self.message_id.0,
             token: self.token.clone(),

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -88,7 +88,7 @@ pub use self::{
     multipart::Form,
 };
 
-use crate::error::{Error, ErrorType, Result};
+use crate::error::{Error, ErrorType};
 use bytes::Bytes;
 use hyper::{
     header::{HeaderName, HeaderValue},
@@ -97,8 +97,8 @@ use hyper::{
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use std::{future::Future, iter, pin::Pin};
 
-type Pending<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
-type PendingOption<'a> = Pin<Box<dyn Future<Output = Result<Bytes>> + Send + 'a>>;
+type Pending<'a, T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>>;
+type PendingOption<'a> = Pin<Box<dyn Future<Output = Result<Bytes, Error>> + Send + 'a>>;
 
 /// Request method.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -130,7 +130,7 @@ impl Method {
 
 pub(crate) fn audit_header(
     reason: &str,
-) -> Result<impl Iterator<Item = (HeaderName, HeaderValue)>> {
+) -> Result<impl Iterator<Item = (HeaderName, HeaderValue)>, Error> {
     let header_name = HeaderName::from_static("x-audit-log-reason");
     let encoded_reason = utf8_percent_encode(reason, NON_ALPHANUMERIC).to_string();
     let header_value = HeaderValue::from_str(&encoded_reason).map_err(|e| Error {


### PR DESCRIPTION
Deprecate the `error::Result` type alias, as it's unnecessary and importing `error::Error` is not much more work. This will make documentation easier to read if it uses `std::result::Result`.