### PR TITLE
Move JSON utilities to own module

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1800,7 +1800,7 @@ impl Client {
         let mut bytes = vec![0; buf.remaining()];
         buf.copy_to_slice(&mut bytes);
 
-        let result = crate::json_from_slice(&mut bytes);
+        let result = crate::json::from_slice(&mut bytes);
 
         result.map_err(|source| Error {
             kind: ErrorType::Parsing {
@@ -1868,7 +1868,7 @@ impl Client {
         let mut bytes = vec![0; buf.remaining()];
         buf.copy_to_slice(&mut bytes);
 
-        let error = crate::json_from_slice::<ApiError>(&mut bytes).map_err(|source| Error {
+        let error = crate::json::from_slice::<ApiError>(&mut bytes).map_err(|source| Error {
             kind: ErrorType::Parsing {
                 body: bytes.clone(),
             },

--- a/http/src/json.rs
+++ b/http/src/json.rs
@@ -1,0 +1,17 @@
+#[cfg(not(feature = "simd-json"))]
+pub use serde_json::to_vec;
+#[cfg(feature = "simd-json")]
+pub use simd_json::to_vec;
+
+use serde::Deserialize;
+
+#[cfg(not(feature = "simd-json"))]
+use serde_json::{from_slice as inner_from_slice, Result as JsonResult};
+#[cfg(feature = "simd-json")]
+use simd_json::{from_slice as inner_from_slice, Result as JsonResult};
+
+// Function will automatically cast mutable references to immutable for
+// `serde_json`.
+pub fn from_slice<'a, T: Deserialize<'a>>(s: &'a mut [u8]) -> JsonResult<T> {
+    inner_from_slice(s)
+}

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -99,6 +99,8 @@ pub mod ratelimiting;
 pub mod request;
 pub mod routing;
 
+mod json;
+
 /// Discord API version used by this crate.
 pub const API_VERSION: u8 = 8;
 
@@ -106,23 +108,6 @@ pub use crate::{
     client::Client,
     error::{Error, Result},
 };
-
-#[cfg(not(feature = "simd-json"))]
-use serde_json::Result as JsonResult;
-#[cfg(feature = "simd-json")]
-use simd_json::Result as JsonResult;
-
-pub(crate) fn json_from_slice<'a, T: serde::de::Deserialize<'a>>(s: &'a mut [u8]) -> JsonResult<T> {
-    #[cfg(not(feature = "simd-json"))]
-    return serde_json::from_slice(s);
-    #[cfg(feature = "simd-json")]
-    return simd_json::from_slice(s);
-}
-
-#[cfg(not(feature = "simd-json"))]
-pub(crate) use serde_json::to_vec as json_to_vec;
-#[cfg(feature = "simd-json")]
-pub(crate) use simd_json::to_vec as json_to_vec;
 
 #[cfg(not(any(
     feature = "native",

--- a/http/src/request/base.rs
+++ b/http/src/request/base.rs
@@ -74,7 +74,7 @@ impl RequestBuilder {
     /// [`ErrorType::Json`]: crate::error::ErrorType::Json
     #[must_use = "request has not been fully built"]
     pub fn json(self, to: &impl Serialize) -> Result<Self> {
-        let bytes = crate::json_to_vec(to).map_err(Error::json)?;
+        let bytes = crate::json::to_vec(to).map_err(Error::json)?;
 
         Ok(self.body(bytes))
     }

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -318,7 +318,7 @@ impl<'a> CreateMessage<'a> {
             if let Some(payload_json) = &self.fields.payload_json {
                 form.payload_json(&payload_json);
             } else {
-                let body = crate::json_to_vec(&self.fields).map_err(HttpError::json)?;
+                let body = crate::json::to_vec(&self.fields).map_err(HttpError::json)?;
                 form.payload_json(&body);
             }
 

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -285,8 +285,7 @@ impl<'a> UpdateChannel<'a> {
     fn start(&mut self) -> Result<()> {
         let mut request = Request::builder(Route::UpdateChannel {
             channel_id: self.channel_id.0,
-        })
-        .json(&self.fields)?;
+        });
 
         if let Some(reason) = &self.reason {
             request = request.headers(audit_header(reason)?);

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -110,7 +110,7 @@ mod tests {
         );
         let actual = builder.request().expect("failed to create request");
 
-        let body = crate::json_to_vec(&UpdateChannelPermissionConfiguredFields {
+        let body = crate::json::to_vec(&UpdateChannelPermissionConfiguredFields {
             allow: Permissions::empty(),
             deny: Permissions::SEND_MESSAGES,
             kind: PermissionOverwriteTargetType::Member,

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -223,7 +223,7 @@ impl<'a> ExecuteWebhook<'a> {
             if let Some(payload_json) = &self.fields.payload_json {
                 form.payload_json(&payload_json);
             } else {
-                let body = crate::json_to_vec(&self.fields).map_err(HttpError::json)?;
+                let body = crate::json::to_vec(&self.fields).map_err(HttpError::json)?;
                 form.payload_json(&body);
             }
 

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -375,7 +375,7 @@ impl<'a> UpdateWebhookMessage<'a> {
                 form.file(format!("{}", index).as_bytes(), name.as_bytes(), &file);
             }
 
-            let body = crate::json_to_vec(&self.fields).map_err(HttpError::json)?;
+            let body = crate::json::to_vec(&self.fields).map_err(HttpError::json)?;
             form.payload_json(&body);
 
             request = request.form(form);

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -63,7 +63,7 @@ impl Future for GetGuildVanityUrl<'_> {
 
                 let mut bytes = bytes.as_ref().to_vec();
                 let vanity_url =
-                    crate::json_from_slice::<VanityUrl>(&mut bytes).map_err(|source| Error {
+                    crate::json::from_slice::<VanityUrl>(&mut bytes).map_err(|source| Error {
                         kind: ErrorType::Parsing {
                             body: bytes.clone(),
                         },

--- a/http/src/request/guild/member/add_guild_member.rs
+++ b/http/src/request/guild/member/add_guild_member.rs
@@ -198,7 +198,7 @@ impl Future for AddGuildMember<'_> {
                     return Poll::Ready(Ok(None));
                 }
 
-                return Poll::Ready(crate::json_from_slice(&mut bytes).map(Some).map_err(
+                return Poll::Ready(crate::json::from_slice(&mut bytes).map(Some).map_err(
                     |source| HttpError {
                         kind: ErrorType::Parsing { body: bytes },
                         source: Some(Box::new(source)),

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -182,7 +182,7 @@ impl Future for GetGuildMembers<'_> {
 
                 let mut bytes = bytes.as_ref().to_vec();
                 let values =
-                    crate::json_from_slice::<Vec<Value>>(&mut bytes).map_err(HttpError::json)?;
+                    crate::json::from_slice::<Vec<Value>>(&mut bytes).map_err(HttpError::json)?;
 
                 for value in values {
                     let member_deserializer = MemberDeserializer::new(self.guild_id);

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -68,7 +68,8 @@ impl Future for GetMember<'_> {
                 };
 
                 let mut bytes = bytes.as_ref().to_vec();
-                let value = crate::json_from_slice::<Value>(&mut bytes).map_err(HttpError::json)?;
+                let value =
+                    crate::json::from_slice::<Value>(&mut bytes).map_err(HttpError::json)?;
 
                 let member_deserializer = MemberDeserializer::new(self.guild_id);
                 let member = member_deserializer

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -141,7 +141,7 @@ impl Future for SearchGuildMembers<'_> {
 
                 let mut bytes = bytes.as_ref().to_vec();
                 let values =
-                    crate::json_from_slice::<Vec<Value>>(&mut bytes).map_err(HttpError::json)?;
+                    crate::json::from_slice::<Vec<Value>>(&mut bytes).map_err(HttpError::json)?;
 
                 for value in values {
                     let member_deserializer = MemberDeserializer::new(self.guild_id);

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -212,7 +212,8 @@ impl Future for UpdateGuildMember<'_> {
                 };
 
                 let mut bytes = bytes.as_ref().to_vec();
-                let value = crate::json_from_slice::<Value>(&mut bytes).map_err(HttpError::json)?;
+                let value =
+                    crate::json::from_slice::<Value>(&mut bytes).map_err(HttpError::json)?;
 
                 let member_deserializer = MemberDeserializer::new(self.guild_id);
                 let member = member_deserializer

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -28,7 +28,6 @@ macro_rules! poll_req {
                 mut self: std::pin::Pin<&mut Self>,
                 cx: &mut std::task::Context<'_>,
             ) -> ::std::task::Poll<Self::Output> {
-                use crate::json_from_slice;
                 use std::task::Poll;
 
                 loop {
@@ -45,7 +44,7 @@ macro_rules! poll_req {
                         };
 
                         let mut bytes = bytes.as_ref().to_vec();
-                        return Poll::Ready(json_from_slice(&mut bytes).map(Some).map_err(
+                        return Poll::Ready(crate::json::from_slice(&mut bytes).map(Some).map_err(
                             |source| crate::Error {
                                 kind: crate::error::ErrorType::Parsing {
                                     body: bytes.to_vec(),


### PR DESCRIPTION
Avoid polluting the crate root by moving the JSON utilities to their own module. Additionally, simplify their definitions.