### PR TITLE
Remove internal usage of HTTP request prelude

### DIFF
--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -10,7 +10,26 @@ pub trait AuditLogReason: private::Sealed {
 }
 
 mod private {
-    use crate::request::prelude::*;
+    use crate::request::{
+        channel::{
+            invite::{CreateInvite, DeleteInvite},
+            message::{DeleteMessage, DeleteMessages},
+            webhook::{
+                CreateWebhook, DeleteWebhook, DeleteWebhookMessage, UpdateWebhook,
+                UpdateWebhookMessage,
+            },
+            CreatePin, DeleteChannel, DeleteChannelPermissionConfigured, DeletePin, UpdateChannel,
+            UpdateChannelPermissionConfigured,
+        },
+        guild::{
+            ban::{CreateBan, DeleteBan},
+            emoji::{CreateEmoji, DeleteEmoji, UpdateEmoji},
+            integration::DeleteGuildIntegration,
+            member::{AddRoleToMember, RemoveMember, RemoveRoleFromMember, UpdateGuildMember},
+            role::{CreateRole, DeleteRole, UpdateRole},
+            CreateGuildChannel, CreateGuildPrune, UpdateGuild,
+        },
+    };
 
     /// Sealed stops crates other crates implementing the trait.
     pub trait Sealed {}
@@ -119,7 +138,24 @@ pub enum AuditLogReasonErrorType {
 
 #[cfg(test)]
 mod test {
-    use crate::request::prelude::*;
+    use super::AuditLogReason;
+    use crate::request::{
+        channel::{
+            invite::{CreateInvite, DeleteInvite},
+            message::{DeleteMessage, DeleteMessages},
+            webhook::{CreateWebhook, DeleteWebhook, UpdateWebhook},
+            CreatePin, DeleteChannel, DeleteChannelPermissionConfigured, DeletePin, UpdateChannel,
+            UpdateChannelPermissionConfigured,
+        },
+        guild::{
+            ban::{CreateBan, DeleteBan},
+            emoji::{CreateEmoji, DeleteEmoji, UpdateEmoji},
+            integration::DeleteGuildIntegration,
+            member::{AddRoleToMember, RemoveMember, RemoveRoleFromMember, UpdateGuildMember},
+            role::{CreateRole, DeleteRole, UpdateRole},
+            CreateGuildChannel, CreateGuildPrune, UpdateGuild,
+        },
+    };
     use static_assertions::{assert_impl_all, assert_obj_safe};
 
     assert_obj_safe!(AuditLogReason);

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Create a new pin in a channel.
@@ -21,14 +26,14 @@ impl<'a> CreatePin<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::PinMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/channel/create_typing_trigger.rs
+++ b/http/src/request/channel/create_typing_trigger.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::ChannelId;
 
 /// Fire a Typing Start event in the channel.
@@ -17,7 +22,7 @@ impl<'a> CreateTypingTrigger<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::CreateTypingTrigger {
             channel_id: self.channel_id.0,
         });

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::{channel::Channel, id::ChannelId};
 
 /// Delete a channel by ID.
@@ -19,13 +24,13 @@ impl<'a> DeleteChannel<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::DeleteChannel {
             channel_id: self.channel_id.0,
         });
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/channel/delete_channel_permission.rs
+++ b/http/src/request/channel/delete_channel_permission.rs
@@ -1,5 +1,5 @@
 use super::DeleteChannelPermissionConfigured;
-use crate::request::prelude::*;
+use crate::client::Client;
 use twilight_model::id::{ChannelId, RoleId, UserId};
 
 /// Clear the permissions for a target ID in a channel.

--- a/http/src/request/channel/delete_channel_permission_configured.rs
+++ b/http/src/request/channel/delete_channel_permission_configured.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::ChannelId;
 
 /// Clear the permissions for a target ID in a channel.
@@ -23,14 +28,14 @@ impl<'a> DeleteChannelPermissionConfigured<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::DeletePermissionOverwrite {
             channel_id: self.channel_id.0,
             target_id: self.target_id,
         });
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Delete a pin in a channel, by ID.
@@ -21,14 +26,14 @@ impl<'a> DeletePin<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::UnpinMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/channel/follow_news_channel.rs
+++ b/http/src/request/channel/follow_news_channel.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use serde::Serialize;
 use twilight_model::{channel::FollowedChannel, id::ChannelId};
 
@@ -29,7 +34,7 @@ impl<'a> FollowNewsChannel<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::builder(Route::FollowNewsChannel {
             channel_id: self.channel_id.0,
         })

--- a/http/src/request/channel/get_channel.rs
+++ b/http/src/request/channel/get_channel.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{PendingOption, Request},
+    routing::Route,
+};
 use twilight_model::{channel::Channel, id::ChannelId};
 
 /// Get a channel by its ID.
@@ -35,7 +40,7 @@ impl<'a> GetChannel<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetChannel {
             channel_id: self.channel_id.0,
         });

--- a/http/src/request/channel/get_pins.rs
+++ b/http/src/request/channel/get_pins.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{channel::Message, id::ChannelId};
 
 /// Get the pins of a channel.
@@ -17,7 +22,7 @@ impl<'a> GetPins<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetPins {
             channel_id: self.channel_id.0,
         });

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -252,14 +258,14 @@ impl<'a> CreateInvite<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let mut request = Request::builder(Route::CreateInvite {
             channel_id: self.channel_id.0,
         })
         .json(&self.fields)?;
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 
 /// Delete an invite by its code.
 ///
@@ -24,13 +29,13 @@ impl<'a> DeleteInvite<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::DeleteInvite {
             code: self.code.clone(),
         });
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/channel/invite/get_channel_invites.rs
+++ b/http/src/request/channel/invite/get_channel_invites.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{id::ChannelId, invite::Invite};
 
 /// Get the invites for a guild channel.
@@ -23,7 +28,7 @@ impl<'a> GetChannelInvites<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetChannelInvites {
             channel_id: self.channel_id.0,
         });

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{PendingOption, Request},
+    routing::Route,
+};
 use twilight_model::invite::Invite;
 
 #[derive(Default)]
@@ -62,7 +67,7 @@ impl<'a> GetInvite<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetInviteWithExpiration {
             code: self.code.clone(),
             with_counts: self.fields.with_counts,

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -1,4 +1,10 @@
-use crate::request::{multipart::Form, prelude::*};
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{multipart::Form, validate, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -303,7 +309,7 @@ impl<'a> CreateMessage<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let mut request = Request::builder(Route::CreateMessage {
             channel_id: self.channel_id.0,
         });

--- a/http/src/request/channel/message/crosspost_message.rs
+++ b/http/src/request/channel/message/crosspost_message.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{
     channel::Message,
     id::{ChannelId, MessageId},
@@ -22,7 +27,7 @@ impl<'a> CrosspostMessage<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::CrosspostMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Delete a message by [`ChannelId`] and [`MessageId`].
@@ -21,14 +26,14 @@ impl<'a> DeleteMessage<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::DeleteMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::id::{ChannelId, MessageId};
 
 #[derive(Serialize)]
@@ -38,14 +44,14 @@ impl<'a> DeleteMessages<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::DeleteMessages {
             channel_id: self.channel_id.0,
         })
         .json(&self.fields)?;
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -1,5 +1,10 @@
 use super::GetChannelMessagesConfigured;
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -170,7 +175,7 @@ impl<'a> GetChannelMessages<'a> {
         Ok(self)
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::from_route(Route::GetMessages {
             after: None,
             around: None,

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -124,7 +129,7 @@ impl<'a> GetChannelMessagesConfigured<'a> {
         Ok(self)
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::from_route(Route::GetMessages {
             after: self.after.map(|x| x.0),
             around: self.around.map(|x| x.0),

--- a/http/src/request/channel/message/get_message.rs
+++ b/http/src/request/channel/message/get_message.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{PendingOption, Request},
+    routing::Route,
+};
 use twilight_model::{
     channel::Message,
     id::{ChannelId, MessageId},
@@ -22,7 +27,7 @@ impl<'a> GetMessage<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -261,7 +267,7 @@ impl<'a> UpdateMessage<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::builder(Route::UpdateMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use super::RequestReactionType;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Create a reaction in a [`ChannelId`] on a [`MessageId`].
@@ -57,7 +63,7 @@ impl<'a> CreateReaction<'a> {
         })
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = self.request();
 
         self.fut.replace(Box::pin(self.http.verify(request)));

--- a/http/src/request/channel/reaction/delete_all_reaction.rs
+++ b/http/src/request/channel/reaction/delete_all_reaction.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use super::RequestReactionType;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Remove all reactions of a specified emoji from a message.
@@ -26,7 +32,7 @@ impl<'a> DeleteAllReaction<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::DeleteMessageSpecficReaction {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,

--- a/http/src/request/channel/reaction/delete_all_reactions.rs
+++ b/http/src/request/channel/reaction/delete_all_reactions.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Delete all reactions by all users on a message.
@@ -19,7 +24,7 @@ impl<'a> DeleteAllReactions<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::DeleteMessageReactions {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,

--- a/http/src/request/channel/reaction/delete_reaction.rs
+++ b/http/src/request/channel/reaction/delete_reaction.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use super::RequestReactionType;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Delete one reaction by a user on a message.
@@ -29,7 +35,7 @@ impl<'a> DeleteReaction<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::DeleteReaction {
             channel_id: self.channel_id.0,
             emoji: self.emoji.clone(),

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use super::RequestReactionType;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -128,7 +134,7 @@ impl<'a> GetReactions<'a> {
         Ok(self)
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::from_route(Route::GetReactionUsers {
             after: self.fields.after.map(|x| x.0),
             before: self.fields.before.map(|x| x.0),

--- a/http/src/request/channel/stage/create_stage_instance.rs
+++ b/http/src/request/channel/stage/create_stage_instance.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -101,7 +106,7 @@ impl<'a> CreateStageInstance<'a> {
         })
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::from_route(Route::CreateStageInstance {
             channel_id: self.channel_id.0,
             topic: self.topic.clone(),

--- a/http/src/request/channel/stage/delete_stage_instance.rs
+++ b/http/src/request/channel/stage/delete_stage_instance.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::ChannelId;
 
 /// Delete the stage instance of a stage channel.
@@ -19,7 +24,7 @@ impl<'a> DeleteStageInstance<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::DeleteStageInstance {
             channel_id: self.channel_id.0,
         });

--- a/http/src/request/channel/stage/get_stage_instance.rs
+++ b/http/src/request/channel/stage/get_stage_instance.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{channel::StageInstance, id::ChannelId};
 
 /// Gets the stage instance associated with a stage channel, if it exists.
@@ -17,7 +22,7 @@ impl<'a> GetStageInstance<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetStageInstance {
             channel_id: self.channel_id.0,
         });

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -108,7 +114,7 @@ impl<'a> UpdateStageInstance<'a> {
         })
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::builder(Route::UpdateStageInstance {
             channel_id: self.channel_id.0,
         })

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -282,13 +288,13 @@ impl<'a> UpdateChannel<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let mut request = Request::builder(Route::UpdateChannel {
             channel_id: self.channel_id.0,
         });
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -1,5 +1,5 @@
 use super::UpdateChannelPermissionConfigured;
-use crate::request::prelude::*;
+use crate::client::Client;
 use twilight_model::{
     channel::permission_overwrite::PermissionOverwriteType,
     guild::Permissions,

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::{channel::Webhook, id::ChannelId};
 
 #[derive(Serialize)]
@@ -61,14 +67,14 @@ impl<'a> CreateWebhook<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::CreateWebhook {
             channel_id: self.channel_id.0,
         })
         .json(&self.fields)?;
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/channel/webhook/delete_webhook.rs
+++ b/http/src/request/channel/webhook/delete_webhook.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::WebhookId;
 
 struct DeleteWebhookParams {
@@ -32,14 +37,14 @@ impl<'a> DeleteWebhook<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::DeleteWebhook {
             webhook_id: self.id.0,
             token: self.fields.token.clone(),
         });
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/channel/webhook/delete_webhook_message.rs
+++ b/http/src/request/channel/webhook/delete_webhook_message.rs
@@ -1,6 +1,6 @@
 use crate::{
     client::Client,
-    error::Result,
+    error::Error,
     request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
     routing::Route,
 };
@@ -50,7 +50,7 @@ impl<'a> DeleteWebhookMessage<'a> {
         }
     }
 
-    fn request(&self) -> Result<Request> {
+    fn request(&self) -> Result<Request, Error> {
         let mut request = Request::builder(Route::DeleteWebhookMessage {
             message_id: self.message_id.0,
             token: self.token.clone(),
@@ -65,7 +65,7 @@ impl<'a> DeleteWebhookMessage<'a> {
         Ok(request.build())
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = self.request()?;
         self.fut.replace(Box::pin(self.http.verify(request)));
 

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -1,5 +1,11 @@
-use crate::request::{prelude::*, Form};
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Form, Pending, Request},
+    routing::Route,
+};
 use futures_util::future::TryFutureExt;
+use serde::Serialize;
 use twilight_model::{
     channel::{embed::Embed, message::AllowedMentions, Message},
     id::WebhookId,
@@ -202,7 +208,7 @@ impl<'a> ExecuteWebhook<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::ExecuteWebhook {
             token: self.token.clone(),
             wait: self.fields.wait,
@@ -223,7 +229,7 @@ impl<'a> ExecuteWebhook<'a> {
             if let Some(payload_json) = &self.fields.payload_json {
                 form.payload_json(&payload_json);
             } else {
-                let body = crate::json::to_vec(&self.fields).map_err(HttpError::json)?;
+                let body = crate::json::to_vec(&self.fields).map_err(Error::json)?;
                 form.payload_json(&body);
             }
 

--- a/http/src/request/channel/webhook/get_channel_webhooks.rs
+++ b/http/src/request/channel/webhook/get_channel_webhooks.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{channel::Webhook, id::ChannelId};
 
 /// Get all the webhooks of a channel.
@@ -17,7 +22,7 @@ impl<'a> GetChannelWebhooks<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetChannelWebhooks {
             channel_id: self.channel_id.0,
         });

--- a/http/src/request/channel/webhook/get_webhook.rs
+++ b/http/src/request/channel/webhook/get_webhook.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{PendingOption, Request},
+    routing::Route,
+};
 use twilight_model::{channel::Webhook, id::WebhookId};
 
 #[derive(Default)]
@@ -32,7 +37,7 @@ impl<'a> GetWebhook<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::GetWebhook {
             token: self.fields.token.clone(),
             webhook_id: self.id.0,

--- a/http/src/request/channel/webhook/get_webhook_message.rs
+++ b/http/src/request/channel/webhook/get_webhook_message.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{PendingOption, Request},
+    routing::Route,
+};
 use twilight_model::{
     channel::Message,
     id::{MessageId, WebhookId},
@@ -32,7 +37,7 @@ impl<'a> GetWebhookMessage<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::builder(Route::GetWebhookMessage {
             message_id: self.message_id.0,
             token: self.token.clone(),

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::{
     channel::Webhook,
     id::{ChannelId, WebhookId},
@@ -65,7 +71,7 @@ impl<'a> UpdateWebhook<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::UpdateWebhook {
             token: None,
             webhook_id: self.webhook_id.0,
@@ -73,7 +79,7 @@ impl<'a> UpdateWebhook<'a> {
         .json(&self.fields)?;
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -3,9 +3,7 @@
 use crate::{
     client::Client,
     error::{Error as HttpError, Result},
-    request::{
-        audit_header, validate, AuditLogReason, AuditLogReasonError, Form, Pending, Request,
-    },
+    request::{self, validate, AuditLogReason, AuditLogReasonError, Form, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -386,13 +384,13 @@ impl<'a> UpdateWebhookMessage<'a> {
         }
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         Ok(request.build())
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = self.request()?;
         self.fut.replace(Box::pin(self.http.verify(request)));
 

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::{channel::Webhook, id::WebhookId};
 
 #[derive(Default, Serialize)]
@@ -51,7 +57,7 @@ impl<'a> UpdateWebhookWithToken<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::builder(Route::UpdateWebhook {
             token: Some(self.token.clone()),
             webhook_id: self.webhook_id.0,

--- a/http/src/request/get_gateway.rs
+++ b/http/src/request/get_gateway.rs
@@ -1,4 +1,9 @@
-use super::{prelude::*, GetGatewayAuthed};
+use crate::{
+    client::Client,
+    error::Error,
+    request::{GetGatewayAuthed, Pending, Request},
+    routing::Route,
+};
 use twilight_model::gateway::connection_info::ConnectionInfo;
 
 /// Get information about the gateway, optionally with additional information detailing the
@@ -53,7 +58,7 @@ impl<'a> GetGateway<'a> {
         GetGatewayAuthed::new(self.http)
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetGateway);
 
         self.fut.replace(Box::pin(self.http.request(request)));

--- a/http/src/request/get_gateway_authed.rs
+++ b/http/src/request/get_gateway_authed.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::gateway::connection_info::BotConnectionInfo;
 
 /// Get information about the gateway, authenticated as a bot user.
@@ -15,7 +20,7 @@ impl<'a> GetGatewayAuthed<'a> {
         Self { fut: None, http }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetGatewayBot);
 
         self.fut.replace(Box::pin(self.http.request(request)));

--- a/http/src/request/get_user_application.rs
+++ b/http/src/request/get_user_application.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::oauth::CurrentApplicationInfo;
 
 pub struct GetUserApplicationInfo<'a> {
@@ -11,7 +16,7 @@ impl<'a> GetUserApplicationInfo<'a> {
         Self { fut: None, http }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetCurrentUserApplicationInfo);
 
         self.fut.replace(Box::pin(self.http.request(request)));

--- a/http/src/request/get_voice_regions.rs
+++ b/http/src/request/get_voice_regions.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::voice::VoiceRegion;
 
 /// Get a list of voice regions that can be used when creating a guild.
@@ -12,7 +17,7 @@ impl<'a> GetVoiceRegions<'a> {
         Self { fut: None, http }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetVoiceRegions);
 
         self.fut.replace(Box::pin(self.http.request(request)));

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -124,7 +129,7 @@ impl<'a> CreateBan<'a> {
         Ok(self)
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::from_route(Route::CreateBan {
             delete_message_days: self.fields.delete_message_days,
             guild_id: self.guild_id.0,

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{GuildId, UserId};
 
 /// Remove a ban from a user in a guild.
@@ -40,14 +45,14 @@ impl<'a> DeleteBan<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::DeleteBan {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
         });
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/ban/get_ban.rs
+++ b/http/src/request/guild/ban/get_ban.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{PendingOption, Request},
+    routing::Route,
+};
 use twilight_model::{
     guild::Ban,
     id::{GuildId, UserId},
@@ -24,7 +29,7 @@ impl<'a> GetBan<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetBan {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,

--- a/http/src/request/guild/ban/get_bans.rs
+++ b/http/src/request/guild/ban/get_bans.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{guild::Ban, id::GuildId};
 
 /// Retrieve the bans for a guild.
@@ -35,7 +40,7 @@ impl<'a> GetBans<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetBans {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -482,7 +488,7 @@ impl<'a> CreateGuild<'a> {
         Ok(self)
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::builder(Route::CreateGuild)
             .json(&self.fields)?
             .build();

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -271,14 +277,14 @@ impl<'a> CreateGuildChannel<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let mut request = Request::builder(Route::CreateChannel {
             guild_id: self.guild_id.0,
         })
         .json(&self.fields)?;
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -127,7 +132,7 @@ impl<'a> CreateGuildPrune<'a> {
         Ok(self)
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let mut request = Request::builder(Route::CreateGuildPrune {
             compute_prune_count: self.fields.compute_prune_count,
             days: self.fields.days,
@@ -136,7 +141,7 @@ impl<'a> CreateGuildPrune<'a> {
         });
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/delete_guild.rs
+++ b/http/src/request/guild/delete_guild.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::GuildId;
 
 /// Delete a guild permanently. The user must be the owner.
@@ -17,7 +22,7 @@ impl<'a> DeleteGuild<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::DeleteGuild {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::{
     guild::Emoji,
     id::{GuildId, RoleId},
@@ -58,14 +64,14 @@ impl<'a> CreateEmoji<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::CreateEmoji {
             guild_id: self.guild_id.0,
         })
         .json(&self.fields)?;
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{EmojiId, GuildId};
 
 /// Delete an emoji in a guild, by id.
@@ -21,14 +26,14 @@ impl<'a> DeleteEmoji<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::DeleteEmoji {
             emoji_id: self.emoji_id.0,
             guild_id: self.guild_id.0,
         });
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/emoji/get_emoji.rs
+++ b/http/src/request/guild/emoji/get_emoji.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{PendingOption, Request},
+    routing::Route,
+};
 use twilight_model::{
     guild::Emoji,
     id::{EmojiId, GuildId},
@@ -41,7 +46,7 @@ impl<'a> GetEmoji<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetEmoji {
             emoji_id: self.emoji_id.0,
             guild_id: self.guild_id.0,

--- a/http/src/request/guild/emoji/get_emojis.rs
+++ b/http/src/request/guild/emoji/get_emojis.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{guild::Emoji, id::GuildId};
 
 /// Get the emojis for a guild, by the guild's id.
@@ -35,7 +40,7 @@ impl<'a> GetEmojis<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetEmojis {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::{
     guild::Emoji,
     id::{EmojiId, GuildId, RoleId},
@@ -48,7 +54,7 @@ impl<'a> UpdateEmoji<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::UpdateEmoji {
             emoji_id: self.emoji_id.0,
             guild_id: self.guild_id.0,
@@ -56,7 +62,7 @@ impl<'a> UpdateEmoji<'a> {
         .json(&self.fields)?;
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -143,7 +148,7 @@ impl<'a> GetAuditLog<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::from_route(Route::GetAuditLogs {
             action_type: self.fields.action_type.map(|x| x as u64),
             before: self.fields.before,

--- a/http/src/request/guild/get_guild.rs
+++ b/http/src/request/guild/get_guild.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{guild::Guild, id::GuildId};
 
 #[derive(Default)]
@@ -32,7 +37,7 @@ impl<'a> GetGuild<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetGuild {
             guild_id: self.guild_id.0,
             with_counts: self.fields.with_counts,

--- a/http/src/request/guild/get_guild_channels.rs
+++ b/http/src/request/guild/get_guild_channels.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{channel::GuildChannel, id::GuildId};
 
 /// Get the channels in a guild.
@@ -17,7 +22,7 @@ impl<'a> GetGuildChannels<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetChannels {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/get_guild_invites.rs
+++ b/http/src/request/guild/get_guild_invites.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{id::GuildId, invite::Invite};
 
 /// Get information about the invites of a guild.
@@ -21,7 +26,7 @@ impl<'a> GetGuildInvites<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetGuildInvites {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/get_guild_preview.rs
+++ b/http/src/request/guild/get_guild_preview.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{guild::GuildPreview, id::GuildId};
 
 /// For public guilds, get the guild preview.
@@ -19,7 +24,7 @@ impl<'a> GetGuildPreview<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetGuildPreview {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -114,7 +119,7 @@ impl<'a> GetGuildPruneCount<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::from_route(Route::GetGuildPruneCount {
             days: self.fields.days,
             guild_id: self.guild_id.0,

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -1,6 +1,8 @@
 use crate::{
+    client::Client,
     error::{Error, ErrorType},
-    request::prelude::*,
+    request::{PendingOption, Request},
+    routing::Route,
 };
 use hyper::StatusCode;
 use serde::Deserialize;
@@ -32,7 +34,7 @@ impl<'a> GetGuildVanityUrl<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetGuildVanityUrl {
             guild_id: self.guild_id.0,
         });
@@ -44,7 +46,7 @@ impl<'a> GetGuildVanityUrl<'a> {
 }
 
 impl Future for GetGuildVanityUrl<'_> {
-    type Output = Result<Option<String>>;
+    type Output = Result<Option<String>, Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {

--- a/http/src/request/guild/get_guild_voice_regions.rs
+++ b/http/src/request/guild/get_guild_voice_regions.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{id::GuildId, voice::VoiceRegion};
 
 /// Get voice region data for the guild.
@@ -19,7 +24,7 @@ impl<'a> GetGuildVoiceRegions<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetGuildVoiceRegions {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/get_guild_webhooks.rs
+++ b/http/src/request/guild/get_guild_webhooks.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{channel::Webhook, id::GuildId};
 
 /// Get the webhooks of a guild.
@@ -17,7 +22,7 @@ impl<'a> GetGuildWebhooks<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetGuildWebhooks {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/get_guild_welcome_screen.rs
+++ b/http/src/request/guild/get_guild_welcome_screen.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{PendingOption, Request},
+    routing::Route,
+};
 use twilight_model::{id::GuildId, invite::WelcomeScreen};
 
 /// Get the guild's welcome screen.
@@ -17,7 +22,7 @@ impl<'a> GetGuildWelcomeScreen<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetGuildWelcomeScreen {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/get_guild_widget.rs
+++ b/http/src/request/guild/get_guild_widget.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{PendingOption, Request},
+    routing::Route,
+};
 use twilight_model::{guild::GuildWidget, id::GuildId};
 
 /// Get the guild widget.
@@ -21,7 +26,7 @@ impl<'a> GetGuildWidget<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetGuildWidget {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{GuildId, IntegrationId};
 
 /// Delete an integration for a guild, by the integration's id.
@@ -21,14 +26,14 @@ impl<'a> DeleteGuildIntegration<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::DeleteGuildIntegration {
             guild_id: self.guild_id.0,
             integration_id: self.integration_id.0,
         });
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/integration/get_guild_integrations.rs
+++ b/http/src/request/guild/integration/get_guild_integrations.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{guild::GuildIntegration, id::GuildId};
 
 /// Get the guild's integrations.
@@ -17,7 +22,7 @@ impl<'a> GetGuildIntegrations<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetGuildIntegrations {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/member/add_guild_member.rs
+++ b/http/src/request/guild/member/add_guild_member.rs
@@ -1,7 +1,10 @@
 use crate::{
+    client::Client,
     error::{Error as HttpError, ErrorType},
-    request::prelude::*,
+    request::{validate, PendingOption, Request},
+    routing::Route,
 };
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -166,7 +169,7 @@ impl<'a> AddGuildMember<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::builder(Route::AddGuildMember {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
@@ -181,7 +184,7 @@ impl<'a> AddGuildMember<'a> {
 }
 
 impl Future for AddGuildMember<'_> {
-    type Output = Result<Option<PartialMember>>;
+    type Output = Result<Option<PartialMember>, HttpError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{GuildId, RoleId, UserId};
 
 /// Add a role to a member in a guild.
@@ -48,7 +53,7 @@ impl<'a> AddRoleToMember<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::AddMemberRole {
             guild_id: self.guild_id.0,
             role_id: self.role_id.0,
@@ -56,7 +61,7 @@ impl<'a> AddRoleToMember<'a> {
         });
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
 use bytes::Bytes;
 use serde::de::DeserializeSeed;
 use std::{
@@ -151,7 +156,7 @@ impl<'a> GetGuildMembers<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::from_route(Route::GetGuildMembers {
             after: self.fields.after.map(|x| x.0),
             guild_id: self.guild_id.0,
@@ -166,7 +171,7 @@ impl<'a> GetGuildMembers<'a> {
 }
 
 impl Future for GetGuildMembers<'_> {
-    type Output = Result<Vec<Member>>;
+    type Output = Result<Vec<Member>, HttpError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.fut.is_none() {

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{GuildId, UserId};
 
 /// Kick a member from a guild, by their id.
@@ -21,14 +26,14 @@ impl<'a> RemoveMember<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::RemoveMember {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
         });
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/member/remove_role_from_member.rs
+++ b/http/src/request/guild/member/remove_role_from_member.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{GuildId, RoleId, UserId};
 
 /// Remove a role from a member in a guild, by id.
@@ -28,7 +33,7 @@ impl<'a> RemoveRoleFromMember<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::RemoveMemberRole {
             guild_id: self.guild_id.0,
             role_id: self.role_id.0,
@@ -36,7 +41,7 @@ impl<'a> RemoveRoleFromMember<'a> {
         });
 
         if let Some(reason) = self.reason.as_ref() {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
 use bytes::Bytes;
 use serde::de::DeserializeSeed;
 use std::{
@@ -111,7 +116,7 @@ impl<'a> SearchGuildMembers<'a> {
         Ok(self)
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::from_route(Route::SearchGuildMembers {
             guild_id: self.guild_id.0,
             limit: self.fields.limit,
@@ -125,7 +130,7 @@ impl<'a> SearchGuildMembers<'a> {
 }
 
 impl Future for SearchGuildMembers<'_> {
-    type Output = Result<Vec<Member>>;
+    type Output = Result<Vec<Member>, HttpError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.fut.is_none() {

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::{
     guild::{Permissions, Role},
     id::GuildId,
@@ -93,14 +99,14 @@ impl<'a> CreateRole<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::CreateRole {
             guild_id: self.guild_id.0,
         })
         .json(&self.fields)?;
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::{GuildId, RoleId};
 
 /// Delete a role in a guild, by id.
@@ -21,14 +26,14 @@ impl<'a> DeleteRole<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::DeleteRole {
             guild_id: self.guild_id.0,
             role_id: self.role_id.0,
         });
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/role/get_guild_roles.rs
+++ b/http/src/request/guild/role/get_guild_roles.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{guild::Role, id::GuildId};
 
 /// Get the roles of a guild.
@@ -17,7 +22,7 @@ impl<'a> GetGuildRoles<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetGuildRoles {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::{
     guild::{Permissions, Role},
     id::{GuildId, RoleId},
@@ -77,7 +83,7 @@ impl<'a> UpdateRole<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let mut request = Request::builder(Route::UpdateRole {
             guild_id: self.guild_id.0,
             role_id: self.role_id.0,
@@ -85,7 +91,7 @@ impl<'a> UpdateRole<'a> {
         .json(&self.fields)?;
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?);
+            request = request.headers(request::audit_header(reason)?);
         }
 
         self.fut

--- a/http/src/request/guild/role/update_role_positions.rs
+++ b/http/src/request/guild/role/update_role_positions.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{
     guild::Role,
     id::{GuildId, RoleId},
@@ -28,7 +33,7 @@ impl<'a> UpdateRolePositions<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::builder(Route::UpdateRolePositions {
             guild_id: self.guild_id.0,
         })

--- a/http/src/request/guild/update_current_user_nick.rs
+++ b/http/src/request/guild/update_current_user_nick.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::id::GuildId;
 
 #[derive(Serialize)]
@@ -24,7 +30,7 @@ impl<'a> UpdateCurrentUserNick<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::builder(Route::UpdateNickname {
             guild_id: self.guild_id.0,
         })

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -351,14 +357,14 @@ impl<'a> UpdateGuild<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let mut request = Request::builder(Route::UpdateGuild {
             guild_id: self.guild_id.0,
         })
         .json(&self.fields)?;
 
         if let Some(reason) = &self.reason {
-            request = request.headers(audit_header(reason)?)
+            request = request.headers(request::audit_header(reason)?)
         }
 
         self.fut

--- a/http/src/request/guild/update_guild_channel_positions.rs
+++ b/http/src/request/guild/update_guild_channel_positions.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::id::{ChannelId, GuildId};
 
 #[derive(Serialize)]
@@ -35,7 +41,7 @@ impl<'a> UpdateGuildChannelPositions<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::builder(Route::UpdateGuildChannels {
             guild_id: self.guild_id.0,
         })

--- a/http/src/request/guild/update_guild_welcome_screen.rs
+++ b/http/src/request/guild/update_guild_welcome_screen.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::{
     id::GuildId,
     invite::{WelcomeScreen, WelcomeScreenChannel},
@@ -64,7 +70,7 @@ impl<'a> UpdateGuildWelcomeScreen<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::builder(Route::UpdateGuildWelcomeScreen {
             guild_id: self.guild_id.0,
         })

--- a/http/src/request/guild/update_guild_widget.rs
+++ b/http/src/request/guild/update_guild_widget.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::{
     guild::GuildWidget,
     id::{ChannelId, GuildId},
@@ -45,7 +51,7 @@ impl<'a> UpdateGuildWidget<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::builder(Route::UpdateGuildWidget {
             guild_id: self.guild_id.0,
         })

--- a/http/src/request/guild/user/update_current_user_voice_state.rs
+++ b/http/src/request/guild/user/update_current_user_voice_state.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::id::{ChannelId, GuildId};
 
 #[derive(Serialize)]
@@ -69,7 +75,7 @@ impl<'a> UpdateCurrentUserVoiceState<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::builder(Route::UpdateCurrentUserVoiceState {
             guild_id: self.guild_id.0,
         })

--- a/http/src/request/guild/user/update_user_voice_state.rs
+++ b/http/src/request/guild/user/update_user_voice_state.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::id::{ChannelId, GuildId, UserId};
 
 #[derive(Serialize)]
@@ -54,7 +60,7 @@ impl<'a> UpdateUserVoiceState<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::builder(Route::UpdateUserVoiceState {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -1,7 +1,7 @@
 macro_rules! poll_req {
     ($ty: ty, $ret: ty) => {
         impl std::future::Future for $ty {
-            type Output = $crate::error::Result<$ret>;
+            type Output = ::std::result::Result<$ret, $crate::error::Error>;
 
             fn poll(
                 mut self: std::pin::Pin<&mut Self>,
@@ -22,7 +22,7 @@ macro_rules! poll_req {
 
     (opt, $ty: ty, $ret: ty) => {
         impl std::future::Future for $ty {
-            type Output = $crate::error::Result<Option<$ret>>;
+            type Output = ::std::result::Result<Option<$ret>, $crate::error::Error>;
 
             fn poll(
                 mut self: std::pin::Pin<&mut Self>,

--- a/http/src/request/prelude.rs
+++ b/http/src/request/prelude.rs
@@ -1,4 +1,3 @@
-pub(super) use super::{audit_header, validate, Pending, PendingOption, Request};
 pub use super::{
     audit_reason::{AuditLogReason, AuditLogReasonError},
     channel::{invite::*, message::*, reaction::*, stage::*, webhook::*, *},
@@ -12,9 +11,3 @@ pub use super::{
     },
     user::*,
 };
-pub(super) use crate::{
-    client::Client,
-    error::{Error as HttpError, Result},
-    routing::Route,
-};
-pub(super) use serde::Serialize;

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -1,4 +1,10 @@
-use crate::request::{prelude::*, validate};
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -90,7 +96,7 @@ impl<'a> CreateGuildFromTemplate<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::builder(Route::CreateGuildFromTemplate {
             template_code: self.template_code.clone(),
         })

--- a/http/src/request/template/create_template.rs
+++ b/http/src/request/template/create_template.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -106,7 +112,7 @@ impl<'a> CreateTemplate<'a> {
         Ok(self)
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::builder(Route::CreateTemplate {
             guild_id: self.guild_id.0,
         })

--- a/http/src/request/template/delete_template.rs
+++ b/http/src/request/template/delete_template.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::GuildId;
 
 /// Delete a template by ID and code.
@@ -27,7 +32,7 @@ impl<'a> DeleteTemplate<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::DeleteTemplate {
             guild_id: self.guild_id.0,
             template_code: self.template_code.clone(),

--- a/http/src/request/template/get_template.rs
+++ b/http/src/request/template/get_template.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::template::Template;
 
 /// Get a template by its code.
@@ -21,7 +26,7 @@ impl<'a> GetTemplate<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetTemplate {
             template_code: self.template_code.clone(),
         });

--- a/http/src/request/template/get_templates.rs
+++ b/http/src/request/template/get_templates.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{id::GuildId, template::Template};
 
 /// Get a list of templates in a guild, by ID.
@@ -17,7 +22,7 @@ impl<'a> GetTemplates<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetTemplates {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/template/sync_template.rs
+++ b/http/src/request/template/sync_template.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::{id::GuildId, template::Template};
 
 /// Sync a template to the current state of the guild, by ID and code.
@@ -27,7 +32,7 @@ impl<'a> SyncTemplate<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::SyncTemplate {
             guild_id: self.guild_id.0,
             template_code: self.template_code.clone(),

--- a/http/src/request/template/update_template.rs
+++ b/http/src/request/template/update_template.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -113,7 +119,7 @@ impl<'a> UpdateTemplate<'a> {
         Ok(self)
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::builder(Route::UpdateTemplate {
             guild_id: self.guild_id.0,
             template_code: self.template_code.clone(),

--- a/http/src/request/user/create_private_channel.rs
+++ b/http/src/request/user/create_private_channel.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::{channel::PrivateChannel, id::UserId};
 
 #[derive(Serialize)]
@@ -23,7 +29,7 @@ impl<'a> CreatePrivateChannel<'a> {
             http,
         }
     }
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::builder(Route::CreatePrivateChannel)
             .json(&self.fields)?
             .build();

--- a/http/src/request/user/get_current_user.rs
+++ b/http/src/request/user/get_current_user.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::user::CurrentUser;
 
 /// Get information about the current user.
@@ -12,7 +17,7 @@ impl<'a> GetCurrentUser<'a> {
         Self { fut: None, http }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetUser {
             target_user: "@me".to_owned(),
         });

--- a/http/src/request/user/get_current_user_connections.rs
+++ b/http/src/request/user/get_current_user_connections.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::user::Connection;
 
 /// Get the current user's connections.
@@ -14,7 +19,7 @@ impl<'a> GetCurrentUserConnections<'a> {
         Self { fut: None, http }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetUserConnections);
 
         self.fut.replace(Box::pin(self.http.request(request)));

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -145,7 +150,7 @@ impl<'a> GetCurrentUserGuilds<'a> {
         Ok(self)
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::from_route(Route::GetGuilds {
             after: self.fields.after.map(|x| x.0),
             before: self.fields.before.map(|x| x.0),

--- a/http/src/request/user/get_user.rs
+++ b/http/src/request/user/get_user.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{PendingOption, Request},
+    routing::Route,
+};
 use twilight_model::user::User;
 
 /// Get a user's information by id.
@@ -17,7 +22,7 @@ impl<'a> GetUser<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::GetUser {
             target_user: self.target_user.clone(),
         });

--- a/http/src/request/user/leave_guild.rs
+++ b/http/src/request/user/leave_guild.rs
@@ -1,4 +1,9 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
 use twilight_model::id::GuildId;
 
 /// Leave a guild by id.
@@ -17,7 +22,7 @@ impl<'a> LeaveGuild<'a> {
         }
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::LeaveGuild {
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -1,4 +1,10 @@
-use crate::request::prelude::*;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -126,7 +132,7 @@ impl<'a> UpdateCurrentUser<'a> {
         Ok(self)
     }
 
-    fn start(&mut self) -> Result<()> {
+    fn start(&mut self) -> Result<(), HttpError> {
         let request = Request::builder(Route::UpdateCurrentUser)
             .json(&self.fields)?
             .build();


### PR DESCRIPTION
Remove crate-private re-exports in `request::prelude` and remove internal usage of it. Preludes make it very difficult to determine where something is being imported from, and ends up making files that use them confusing to read.