### PR TITLE
Make possible functions constant

### DIFF
--- a/cache/in-memory/src/builder.rs
+++ b/cache/in-memory/src/builder.rs
@@ -9,8 +9,8 @@ pub struct InMemoryCacheBuilder(Config);
 
 impl InMemoryCacheBuilder {
     /// Creates a builder to configure and construct an [`InMemoryCache`].
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self(Config::new())
     }
 
     /// Consume the builder, returning a configured cache.
@@ -21,7 +21,7 @@ impl InMemoryCacheBuilder {
     /// Sets the list of resource types for the cache to handle.
     ///
     /// Defaults to all types.
-    pub fn resource_types(mut self, resource_types: ResourceType) -> Self {
+    pub const fn resource_types(mut self, resource_types: ResourceType) -> Self {
         self.0.resource_types = resource_types;
 
         self
@@ -30,7 +30,7 @@ impl InMemoryCacheBuilder {
     /// Sets the number of messages to cache per channel.
     ///
     /// Defaults to 100.
-    pub fn message_cache_size(mut self, message_cache_size: usize) -> Self {
+    pub const fn message_cache_size(mut self, message_cache_size: usize) -> Self {
         self.0.message_cache_size = message_cache_size;
 
         self

--- a/cache/in-memory/src/config.rs
+++ b/cache/in-memory/src/config.rs
@@ -75,6 +75,9 @@ impl Default for Config {
 #[cfg(test)]
 mod tests {
     use super::{Config, ResourceType};
+    use static_assertions::assert_fields;
+
+    assert_fields!(Config: resource_types, message_cache_size);
 
     #[test]
     #[allow(clippy::cognitive_complexity)]
@@ -101,10 +104,5 @@ mod tests {
         let default = Config::default();
         assert_eq!(conf.resource_types, default.resource_types);
         assert_eq!(conf.message_cache_size, default.message_cache_size);
-    }
-
-    #[test]
-    fn test_config_fields() {
-        static_assertions::assert_fields!(Config: resource_types, message_cache_size);
     }
 }

--- a/cache/in-memory/src/config.rs
+++ b/cache/in-memory/src/config.rs
@@ -32,8 +32,20 @@ pub struct Config {
 }
 
 impl Config {
+    /// Create a new default configuration.
+    ///
+    /// Refer to individual getters for their defaults.
+    pub const fn new() -> Self {
+        Self {
+            resource_types: ResourceType::all(),
+            message_cache_size: 100,
+        }
+    }
+
     /// Returns an immutable reference to the message cache size.
-    pub fn message_cache_size(&self) -> usize {
+    ///
+    /// Defaults to 100.
+    pub const fn message_cache_size(&self) -> usize {
         self.message_cache_size
     }
 
@@ -42,7 +54,9 @@ impl Config {
         &mut self.message_cache_size
     }
     /// Returns an immutable reference to the resource types enabled.
-    pub fn resource_types(&self) -> ResourceType {
+    ///
+    /// Defaults to all resource types.
+    pub const fn resource_types(&self) -> ResourceType {
         self.resource_types
     }
 
@@ -54,10 +68,7 @@ impl Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Self {
-            resource_types: ResourceType::all(),
-            message_cache_size: 100,
-        }
+        Self::new()
     }
 }
 

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -47,7 +47,13 @@
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
-#![deny(rust_2018_idioms, broken_intra_doc_links, unused, warnings)]
+#![deny(
+    clippy::missing_const_for_fn,
+    broken_intra_doc_links,
+    rust_2018_idioms,
+    unused,
+    warnings
+)]
 
 pub mod model;
 
@@ -229,7 +235,7 @@ impl InMemoryCache {
     }
 
     /// Create a new builder to configure and construct an in-memory cache.
-    pub fn builder() -> InMemoryCacheBuilder {
+    pub const fn builder() -> InMemoryCacheBuilder {
         InMemoryCacheBuilder::new()
     }
 
@@ -979,7 +985,7 @@ impl InMemoryCache {
     }
 }
 
-fn presence_user_id(presence: &Presence) -> UserId {
+const fn presence_user_id(presence: &Presence) -> UserId {
     match presence.user {
         UserOrId::User(ref u) => u.id,
         UserOrId::UserId { id } => id,

--- a/cache/in-memory/src/model/emoji.rs
+++ b/cache/in-memory/src/model/emoji.rs
@@ -33,8 +33,20 @@ impl PartialEq<Emoji> for CachedEmoji {
 #[cfg(test)]
 mod tests {
     use super::CachedEmoji;
+    use static_assertions::{assert_fields, assert_impl_all};
     use std::fmt::Debug;
     use twilight_model::{guild::Emoji, id::EmojiId};
+
+    assert_fields!(
+        CachedEmoji: id,
+        animated,
+        name,
+        managed,
+        require_colons,
+        roles,
+        user
+    );
+    assert_impl_all!(CachedEmoji: Clone, Debug, Eq, PartialEq);
 
     #[test]
     fn test_eq_emoji() {
@@ -60,23 +72,5 @@ mod tests {
         };
 
         assert_eq!(cached, emoji);
-    }
-
-    #[test]
-    fn test_fields() {
-        static_assertions::assert_fields!(
-            CachedEmoji: id,
-            animated,
-            name,
-            managed,
-            require_colons,
-            roles,
-            user
-        );
-    }
-
-    #[test]
-    fn test_impls() {
-        static_assertions::assert_impl_all!(CachedEmoji: Clone, Debug, Eq, PartialEq);
     }
 }

--- a/cache/in-memory/src/model/presence.rs
+++ b/cache/in-memory/src/model/presence.rs
@@ -43,7 +43,7 @@ impl From<&'_ Presence> for CachedPresence {
     }
 }
 
-fn presence_user_id(user: &UserOrId) -> UserId {
+const fn presence_user_id(user: &UserOrId) -> UserId {
     match user {
         UserOrId::User(ref u) => u.id,
         UserOrId::UserId { id } => *id,

--- a/command-parser/src/arguments.rs
+++ b/command-parser/src/arguments.rs
@@ -43,7 +43,7 @@ impl<'a> Arguments<'a> {
     /// }
     /// # else { panic!("Not command match"); }
     /// ```
-    pub fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &str {
         self.buf
     }
 

--- a/command-parser/src/casing.rs
+++ b/command-parser/src/casing.rs
@@ -11,7 +11,7 @@ pub enum CaseSensitivity {
 }
 
 impl CaseSensitivity {
-    pub fn is_sensitive(&self) -> bool {
+    pub const fn is_sensitive(&self) -> bool {
         matches!(self, Self::Sensitive(_))
     }
 }

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -28,8 +28,11 @@ pub struct CommandParserConfig<'a> {
 
 impl<'a> CommandParserConfig<'a> {
     /// Creates a fresh default configuration with no commands or prefixes.
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            commands: Vec::new(),
+            prefixes: Vec::new(),
+        }
     }
 
     /// Returns an iterator of immutable references to the commands.

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -55,6 +55,7 @@
 
 #![deny(
     clippy::all,
+    clippy::missing_const_for_fn,
     clippy::pedantic,
     future_incompatible,
     missing_docs,

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -66,7 +66,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Returns an immutable reference to the configuration.
-    pub fn config(&self) -> &CommandParserConfig<'a> {
+    pub const fn config(&self) -> &CommandParserConfig<'a> {
         &self.config
     }
 

--- a/embed-builder/src/author.rs
+++ b/embed-builder/src/author.rs
@@ -14,11 +14,17 @@ pub struct EmbedAuthorBuilder(EmbedAuthor);
 
 impl EmbedAuthorBuilder {
     /// Create a new default embed author builder.
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self(EmbedAuthor {
+            icon_url: None,
+            name: None,
+            proxy_icon_url: None,
+            url: None,
+        })
     }
 
     /// Build into an embed author.
+    #[allow(clippy::missing_const_for_fn)]
     #[must_use = "should be used as part of an embed builder"]
     pub fn build(self) -> EmbedAuthor {
         self.0
@@ -61,12 +67,7 @@ impl EmbedAuthorBuilder {
 
 impl Default for EmbedAuthorBuilder {
     fn default() -> Self {
-        Self(EmbedAuthor {
-            icon_url: None,
-            name: None,
-            proxy_icon_url: None,
-            url: None,
-        })
+        Self::new()
     }
 }
 

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -22,7 +22,7 @@ pub struct EmbedError {
 impl EmbedError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &EmbedErrorType {
+    pub const fn kind(&self) -> &EmbedErrorType {
         &self.kind
     }
 
@@ -229,8 +229,22 @@ impl EmbedBuilder {
     ///
     /// [crate-level documentation]: crate
     /// [default implementation]: Self::default
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        EmbedBuilder(Embed {
+            author: None,
+            color: None,
+            description: None,
+            fields: Vec::new(),
+            footer: None,
+            image: None,
+            kind: String::new(),
+            provider: None,
+            thumbnail: None,
+            timestamp: None,
+            title: None,
+            url: None,
+            video: None,
+        })
     }
 
     /// Build this into an embed.
@@ -446,6 +460,10 @@ impl EmbedBuilder {
             return Err(EmbedError {
                 kind: EmbedErrorType::TotalContentTooLarge { length: total },
             });
+        }
+
+        if self.0.kind.is_empty() {
+            self.0.kind = "rich".to_string();
         }
 
         Ok(self.0)
@@ -713,21 +731,7 @@ impl Default for EmbedBuilder {
     ///
     /// All embeds have a "rich" type.
     fn default() -> Self {
-        EmbedBuilder(Embed {
-            author: None,
-            color: None,
-            description: None,
-            fields: Vec::new(),
-            footer: None,
-            image: None,
-            kind: String::from("rich"),
-            provider: None,
-            thumbnail: None,
-            timestamp: None,
-            title: None,
-            url: None,
-            video: None,
-        })
+        Self::new()
     }
 }
 

--- a/embed-builder/src/field.rs
+++ b/embed-builder/src/field.rs
@@ -29,7 +29,7 @@ impl EmbedFieldBuilder {
         Self::_new(name.into(), value.into())
     }
 
-    fn _new(name: String, value: String) -> Self {
+    const fn _new(name: String, value: String) -> Self {
         Self(EmbedField {
             inline: false,
             name,
@@ -38,6 +38,7 @@ impl EmbedFieldBuilder {
     }
 
     /// Build into an embed field.
+    #[allow(clippy::missing_const_for_fn)]
     #[must_use = "should be used as part of an embed builder"]
     pub fn build(self) -> EmbedField {
         self.0
@@ -56,7 +57,7 @@ impl EmbedFieldBuilder {
     ///     .inline()
     ///     .build();
     /// ```
-    pub fn inline(mut self) -> Self {
+    pub const fn inline(mut self) -> Self {
         self.0.inline = true;
 
         self

--- a/embed-builder/src/footer.rs
+++ b/embed-builder/src/footer.rs
@@ -23,7 +23,7 @@ impl EmbedFooterBuilder {
         Self::_new(text.into())
     }
 
-    fn _new(text: String) -> Self {
+    const fn _new(text: String) -> Self {
         Self(EmbedFooter {
             icon_url: None,
             proxy_icon_url: None,
@@ -32,6 +32,7 @@ impl EmbedFooterBuilder {
     }
 
     /// Build into an embed footer.
+    #[allow(clippy::missing_const_for_fn)]
     #[must_use = "should be used as part of an embed builder"]
     pub fn build(self) -> EmbedFooter {
         self.0

--- a/embed-builder/src/image_source.rs
+++ b/embed-builder/src/image_source.rs
@@ -15,7 +15,7 @@ pub struct ImageSourceAttachmentError {
 impl ImageSourceAttachmentError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &ImageSourceAttachmentErrorType {
+    pub const fn kind(&self) -> &ImageSourceAttachmentErrorType {
         &self.kind
     }
 
@@ -74,7 +74,7 @@ pub struct ImageSourceUrlError {
 impl ImageSourceUrlError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &ImageSourceUrlErrorType {
+    pub const fn kind(&self) -> &ImageSourceUrlErrorType {
         &self.kind
     }
 

--- a/embed-builder/src/lib.rs
+++ b/embed-builder/src/lib.rs
@@ -48,6 +48,7 @@
 
 #![deny(
     clippy::all,
+    clippy::missing_const_for_fn,
     clippy::pedantic,
     future_incompatible,
     missing_docs,

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -172,6 +172,7 @@ impl ClusterBuilder {
     ///     .await?;
     /// # Ok(()) }
     /// ```
+    #[allow(clippy::missing_const_for_fn)]
     pub fn shard_scheme(mut self, scheme: ShardScheme) -> Self {
         self.0.shard_scheme = scheme;
 
@@ -201,6 +202,7 @@ impl ClusterBuilder {
     /// Note that this does not guarantee all or any of the shards will be able
     /// to resume. If their sessions are invalid they will have to re-identify
     /// to initialize a new session.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn resume_sessions(mut self, resume_sessions: HashMap<u64, ResumeSession>) -> Self {
         self.0.resume_sessions = resume_sessions;
         self

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -23,7 +23,7 @@ impl Config {
     /// Refer to [`ClusterBuilder::http_client`] for the default value.
     ///
     /// [`ClusterBuilder::http_client`]: super::ClusterBuilder::http_client
-    pub fn http_client(&self) -> &Client {
+    pub const fn http_client(&self) -> &Client {
         &self.http_client
     }
 
@@ -33,7 +33,7 @@ impl Config {
     /// Refer to [`ShardBuilder`]'s methods for the default values.
     ///
     /// [`ShardBuilder`]: crate::shard::ShardBuilder#impl
-    pub fn shard_config(&self) -> &ShardConfig {
+    pub const fn shard_config(&self) -> &ShardConfig {
         &self.shard_config
     }
 
@@ -42,7 +42,7 @@ impl Config {
     /// Refer to [`ClusterBuilder::shard_scheme`] for the default value.
     ///
     /// [`ClusterBuilder::shard_scheme`]: super::ClusterBuilder::shard_scheme
-    pub fn shard_scheme(&self) -> &ShardScheme {
+    pub const fn shard_scheme(&self) -> &ShardScheme {
         &self.shard_scheme
     }
 

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -27,7 +27,7 @@ pub struct ClusterCommandError {
 impl ClusterCommandError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &ClusterCommandErrorType {
+    pub const fn kind(&self) -> &ClusterCommandErrorType {
         &self.kind
     }
 
@@ -108,7 +108,7 @@ pub struct ClusterSendError {
 impl ClusterSendError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &ClusterSendErrorType {
+    pub const fn kind(&self) -> &ClusterSendErrorType {
         &self.kind
     }
 
@@ -168,7 +168,7 @@ pub struct ClusterStartError {
 impl ClusterStartError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &ClusterStartErrorType {
+    pub const fn kind(&self) -> &ClusterStartErrorType {
         &self.kind
     }
 

--- a/gateway/src/cluster/scheme.rs
+++ b/gateway/src/cluster/scheme.rs
@@ -17,7 +17,7 @@ pub struct ShardSchemeRangeError {
 impl ShardSchemeRangeError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &ShardSchemeRangeErrorType {
+    pub const fn kind(&self) -> &ShardSchemeRangeErrorType {
         &self.kind
     }
 
@@ -234,7 +234,7 @@ impl ShardScheme {
     /// In the case of the [`Auto`] variant the total is unknown.
     ///
     /// [`Auto`]: Self::Auto
-    pub fn from(&self) -> Option<u64> {
+    pub const fn from(&self) -> Option<u64> {
         match self {
             Self::Auto => None,
             Self::Bucket { bucket_id, .. } => Some(*bucket_id),
@@ -247,7 +247,7 @@ impl ShardScheme {
     /// In the case of the [`Auto`] variant the total is unknown.
     ///
     /// [`Auto`]: Self::Auto
-    pub fn total(&self) -> Option<u64> {
+    pub const fn total(&self) -> Option<u64> {
         match self {
             Self::Auto => None,
             Self::Bucket { total, .. } | Self::Range { total, .. } => Some(*total),

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -111,6 +111,7 @@
 
 #![deny(
     clippy::all,
+    clippy::missing_const_for_fn,
     clippy::pedantic,
     future_incompatible,
     missing_docs,

--- a/gateway/src/listener.rs
+++ b/gateway/src/listener.rs
@@ -14,7 +14,7 @@ pub struct Listener<T> {
 
 impl<T> Listener<T> {
     /// Return whether the listener wants (contains) an event type.
-    pub fn wants(&self, event_type: EventTypeFlags) -> bool {
+    pub const fn wants(&self, event_type: EventTypeFlags) -> bool {
         self.events.contains(event_type)
     }
 }

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -19,7 +19,7 @@ pub struct LargeThresholdError {
 impl LargeThresholdError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &LargeThresholdErrorType {
+    pub const fn kind(&self) -> &LargeThresholdErrorType {
         &self.kind
     }
 
@@ -84,7 +84,7 @@ pub struct ShardIdError {
 impl ShardIdError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &ShardIdErrorType {
+    pub const fn kind(&self) -> &ShardIdErrorType {
         &self.kind
     }
 
@@ -199,6 +199,7 @@ impl ShardBuilder {
     /// information.
     ///
     /// Default is a new, unconfigured instance of an HTTP client.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn http_client(mut self, http_client: HttpClient) -> Self {
         self.0.http_client = http_client;
 
@@ -223,6 +224,7 @@ impl ShardBuilder {
     ///
     /// Returns a [`LargeThresholdErrorType::TooMany`] error type if the
     /// provided value is above 250.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn large_threshold(mut self, large_threshold: u64) -> Result<Self, LargeThresholdError> {
         match large_threshold {
             0..=49 => {
@@ -306,6 +308,7 @@ impl ShardBuilder {
     ///
     /// Returns a [`ShardIdErrorType::IdTooLarge`] error type if the shard ID to
     /// connect as is larger than the total.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn shard(mut self, shard_id: u64, shard_total: u64) -> Result<Self, ShardIdError> {
         if shard_id >= shard_total {
             return Err(ShardIdError {

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -31,18 +31,18 @@ impl Config {
 
     /// Return an immutable reference to the `twilight_http` client to be used
     /// by the shard.
-    pub fn http_client(&self) -> &Client {
+    pub const fn http_client(&self) -> &Client {
         &self.http_client
     }
 
     /// Return a copy of the intents that the gateway is using.
-    pub fn intents(&self) -> Intents {
+    pub const fn intents(&self) -> Intents {
         self.intents
     }
 
     /// Return the maximum threshold at which point the gateway will stop
     /// sending a guild's member list in Guild Create events.
-    pub fn large_threshold(&self) -> u64 {
+    pub const fn large_threshold(&self) -> u64 {
         self.large_threshold
     }
 
@@ -51,18 +51,18 @@ impl Config {
     ///
     /// This will be the bot's presence. For example, setting the online status
     /// to Do Not Disturb will show the status in the bot's presence.
-    pub fn presence(&self) -> Option<&UpdateStatusInfo> {
+    pub const fn presence(&self) -> Option<&UpdateStatusInfo> {
         self.presence.as_ref()
     }
 
     /// The shard's ID and the total number of shards used by the bot.
-    pub fn shard(&self) -> [u64; 2] {
+    pub const fn shard(&self) -> [u64; 2] {
         self.shard
     }
 
     /// Return an immutable reference to the token used to authenticate with
     /// when identifying with the gateway.
-    pub fn token(&self) -> &str {
+    pub const fn token(&self) -> &str {
         &self.token
     }
 }

--- a/gateway/src/shard/event.rs
+++ b/gateway/src/shard/event.rs
@@ -44,12 +44,12 @@ pub struct Events {
 }
 
 impl Events {
-    pub(super) fn new(event_types: EventTypeFlags, rx: UnboundedReceiver<Event>) -> Self {
+    pub(super) const fn new(event_types: EventTypeFlags, rx: UnboundedReceiver<Event>) -> Self {
         Self { event_types, rx }
     }
 
     /// Returns the event types that can be passed to this stream.
-    pub fn event_types(&self) -> EventTypeFlags {
+    pub const fn event_types(&self) -> EventTypeFlags {
         self.event_types
     }
 }

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -33,7 +33,7 @@ pub struct CommandError {
 impl CommandError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &CommandErrorType {
+    pub const fn kind(&self) -> &CommandErrorType {
         &self.kind
     }
 
@@ -124,7 +124,7 @@ pub struct SendError {
 impl SendError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &SendErrorType {
+    pub const fn kind(&self) -> &SendErrorType {
         &self.kind
     }
 
@@ -181,7 +181,7 @@ pub struct ShardStartError {
 impl ShardStartError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &ShardStartErrorType {
+    pub const fn kind(&self) -> &ShardStartErrorType {
         &self.kind
     }
 
@@ -249,7 +249,7 @@ pub struct Information {
 
 impl Information {
     /// Return the ID of the shard.
-    pub fn id(&self) -> u64 {
+    pub const fn id(&self) -> u64 {
         self.id
     }
 
@@ -257,7 +257,7 @@ impl Information {
     ///
     /// This includes the average latency over all time, and the latency
     /// information for the 5 most recent heartbeats.
-    pub fn latency(&self) -> &Latency {
+    pub const fn latency(&self) -> &Latency {
         &self.latency
     }
 
@@ -273,7 +273,7 @@ impl Information {
     /// been connected for a longer time, while a smaller number typically
     /// correlates to meaning that it's been connected for a less amount of
     /// time.
-    pub fn seq(&self) -> u64 {
+    pub const fn seq(&self) -> u64 {
         self.seq
     }
 
@@ -282,7 +282,7 @@ impl Information {
     /// For example, once a shard is fully booted then it will be [`Connected`].
     ///
     /// [`Connected`]: Stage::Connected
-    pub fn stage(&self) -> Stage {
+    pub const fn stage(&self) -> Stage {
         self.stage
     }
 }

--- a/gateway/src/shard/processor/emitter.rs
+++ b/gateway/src/shard/processor/emitter.rs
@@ -64,11 +64,12 @@ pub struct Emitter {
 
 impl Emitter {
     /// Create a new emitter for events and bytes.
-    pub fn new(listeners: Listeners<Event>) -> Self {
+    pub const fn new(listeners: Listeners<Event>) -> Self {
         Self { listeners }
     }
 
     /// Consume the emitter, returning the inner listeners.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn into_listeners(self) -> Listeners<Event> {
         self.listeners
     }

--- a/gateway/src/shard/processor/heartbeat.rs
+++ b/gateway/src/shard/processor/heartbeat.rs
@@ -43,29 +43,29 @@ impl Latency {
     /// # Note
     ///
     /// If this is None, the shard has not received a heartbeat yet.
-    pub fn average(&self) -> Option<Duration> {
+    pub const fn average(&self) -> Option<Duration> {
         self.average
     }
 
     /// The total number of heartbeats that have been sent during this session.
-    pub fn heartbeats(&self) -> u32 {
+    pub const fn heartbeats(&self) -> u32 {
         self.heartbeats
     }
 
     /// The 5 most recent latency times.
     ///
     /// Index 0 is the oldest, 4 is the most recent.
-    pub fn recent(&self) -> &VecDeque<Duration> {
+    pub const fn recent(&self) -> &VecDeque<Duration> {
         &self.recent
     }
 
     /// When the last heartbeat acknowledgement was received.
-    pub fn received(&self) -> Option<Instant> {
+    pub const fn received(&self) -> Option<Instant> {
         self.received
     }
 
     /// When the last heartbeat was sent.
-    pub fn sent(&self) -> Option<Instant> {
+    pub const fn sent(&self) -> Option<Instant> {
         self.sent
     }
 }

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -93,7 +93,7 @@ struct ProcessError {
 }
 
 impl ProcessError {
-    fn fatal(&self) -> bool {
+    const fn fatal(&self) -> bool {
         matches!(
             self.kind,
             ProcessErrorType::SendingClose { .. } | ProcessErrorType::SessionSend { .. }
@@ -159,7 +159,7 @@ struct ReceivingEventError {
 }
 
 impl ReceivingEventError {
-    fn fatal(&self) -> bool {
+    const fn fatal(&self) -> bool {
         matches!(
             self.kind,
             ReceivingEventErrorType::AuthorizationInvalid { .. }
@@ -168,7 +168,7 @@ impl ReceivingEventError {
         )
     }
 
-    fn reconnectable(&self) -> bool {
+    const fn reconnectable(&self) -> bool {
         #[cfg(feature = "compression")]
         {
             matches!(self.kind, ReceivingEventErrorType::Decompressing)
@@ -179,7 +179,7 @@ impl ReceivingEventError {
         }
     }
 
-    fn resumable(&self) -> bool {
+    const fn resumable(&self) -> bool {
         matches!(self.kind, ReceivingEventErrorType::EventStreamEnded)
     }
 }

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -32,7 +32,7 @@ pub struct SessionSendError {
 
 impl SessionSendError {
     /// Immutable reference to the type of error that occurred.
-    pub fn kind(&self) -> &SessionSendErrorType {
+    pub const fn kind(&self) -> &SessionSendErrorType {
         &self.kind
     }
 }

--- a/gateway/src/shard/stage.rs
+++ b/gateway/src/shard/stage.rs
@@ -25,7 +25,7 @@ pub struct StageConversionError {
 impl StageConversionError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &StageConversionErrorType {
+    pub const fn kind(&self) -> &StageConversionErrorType {
         &self.kind
     }
 

--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -210,7 +210,7 @@ pub enum ErrorCode {
 }
 
 impl ErrorCode {
-    pub fn num(&self) -> u64 {
+    pub const fn num(&self) -> u64 {
         match self {
             Self::GeneralError => 0,
             Self::UnknownAccount => 10001,

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -106,7 +106,7 @@ impl ClientBuilder {
     /// Set the timeout for HTTP requests.
     ///
     /// The default is 10 seconds.
-    pub fn timeout(mut self, duration: Duration) -> Self {
+    pub const fn timeout(mut self, duration: Duration) -> Self {
         self.timeout = duration;
 
         self

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -385,7 +385,10 @@ impl Client {
         GetChannelMessages::new(self, channel_id)
     }
 
-    pub const fn delete_channel_permission(&self, channel_id: ChannelId) -> DeleteChannelPermission<'_> {
+    pub const fn delete_channel_permission(
+        &self,
+        channel_id: ChannelId,
+    ) -> DeleteChannelPermission<'_> {
         DeleteChannelPermission::new(self, channel_id)
     }
 

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -385,7 +385,7 @@ impl Client {
         GetChannelMessages::new(self, channel_id)
     }
 
-    pub fn delete_channel_permission(&self, channel_id: ChannelId) -> DeleteChannelPermission<'_> {
+    pub const fn delete_channel_permission(&self, channel_id: ChannelId) -> DeleteChannelPermission<'_> {
         DeleteChannelPermission::new(self, channel_id)
     }
 
@@ -414,7 +414,7 @@ impl Client {
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn update_channel_permission(
+    pub const fn update_channel_permission(
         &self,
         channel_id: ChannelId,
         allow: Permissions,

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -22,7 +22,7 @@ pub struct Error {
 impl Error {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &ErrorType {
+    pub const fn kind(&self) -> &ErrorType {
         &self.kind
     }
 

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -75,6 +75,7 @@
 
 #![deny(
     clippy::all,
+    clippy::missing_const_for_fn,
     clippy::pedantic,
     future_incompatible,
     nonstandard_style,

--- a/http/src/ratelimiting/error.rs
+++ b/http/src/ratelimiting/error.rs
@@ -16,7 +16,7 @@ pub struct RatelimitError {
 impl RatelimitError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &RatelimitErrorType {
+    pub const fn kind(&self) -> &RatelimitErrorType {
         &self.kind
     }
 

--- a/http/src/ratelimiting/headers.rs
+++ b/http/src/ratelimiting/headers.rs
@@ -23,7 +23,7 @@ pub enum RatelimitHeaders {
 }
 
 impl RatelimitHeaders {
-    pub fn global(&self) -> bool {
+    pub const fn global(&self) -> bool {
         match self {
             Self::GlobalLimited { .. } => true,
             Self::None => false,

--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -71,7 +71,7 @@ pub struct AuditLogReasonError {
 impl AuditLogReasonError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &AuditLogReasonErrorType {
+    pub const fn kind(&self) -> &AuditLogReasonErrorType {
         &self.kind
     }
 

--- a/http/src/request/base.rs
+++ b/http/src/request/base.rs
@@ -84,7 +84,7 @@ impl RequestBuilder {
     /// is set.
     ///
     /// This is primarily useful for executing webhooks.
-    pub fn use_authorization_token(mut self, use_authorization_token: bool) -> Self {
+    pub const fn use_authorization_token(mut self, use_authorization_token: bool) -> Self {
         self.0.use_authorization_token = use_authorization_token;
 
         self

--- a/http/src/request/base.rs
+++ b/http/src/request/base.rs
@@ -35,6 +35,7 @@ impl RequestBuilder {
     }
 
     /// Consume the builder, returning the built request.
+    #[allow(clippy::missing_const_for_fn)]
     #[must_use = "request information is not useful on its own and must be acted on"]
     pub fn build(self) -> Request {
         self.0

--- a/http/src/request/channel/delete_channel_permission.rs
+++ b/http/src/request/channel/delete_channel_permission.rs
@@ -11,7 +11,7 @@ pub struct DeleteChannelPermission<'a> {
 }
 
 impl<'a> DeleteChannelPermission<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+    pub(crate) const fn new(http: &'a Client, channel_id: ChannelId) -> Self {
         Self { channel_id, http }
     }
 

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -17,7 +17,7 @@ pub struct CreateInviteError {
 impl CreateInviteError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &CreateInviteErrorType {
+    pub const fn kind(&self) -> &CreateInviteErrorType {
         &self.kind
     }
 

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -56,7 +56,7 @@ impl<'a> GetInvite<'a> {
     }
 
     /// Whether the invite returned should contain its expiration date.
-    pub fn with_expiration(mut self) -> Self {
+    pub const fn with_expiration(mut self) -> Self {
         self.fields.with_expiration = true;
 
         self

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -49,7 +49,7 @@ impl<'a> GetInvite<'a> {
     }
 
     /// Whether the invite returned should contain approximate member counts.
-    pub fn with_counts(mut self) -> Self {
+    pub const fn with_counts(mut self) -> Self {
         self.fields.with_counts = true;
 
         self

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -22,7 +22,7 @@ pub struct CreateMessageError {
 impl CreateMessageError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &CreateMessageErrorType {
+    pub const fn kind(&self) -> &CreateMessageErrorType {
         &self.kind
     }
 

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -18,7 +18,7 @@ pub struct GetChannelMessagesError {
 impl GetChannelMessagesError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &GetChannelMessagesErrorType {
+    pub const fn kind(&self) -> &GetChannelMessagesErrorType {
         &self.kind
     }
 

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -17,7 +17,7 @@ pub struct GetChannelMessagesConfiguredError {
 impl GetChannelMessagesConfiguredError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &GetChannelMessagesConfiguredErrorType {
+    pub const fn kind(&self) -> &GetChannelMessagesConfiguredErrorType {
         &self.kind
     }
 

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -22,7 +22,7 @@ pub struct UpdateMessageError {
 impl UpdateMessageError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &UpdateMessageErrorType {
+    pub const fn kind(&self) -> &UpdateMessageErrorType {
         &self.kind
     }
 

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -17,7 +17,7 @@ pub struct GetReactionsError {
 impl GetReactionsError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &GetReactionsErrorType {
+    pub const fn kind(&self) -> &GetReactionsErrorType {
         &self.kind
     }
 

--- a/http/src/request/channel/stage/create_stage_instance.rs
+++ b/http/src/request/channel/stage/create_stage_instance.rs
@@ -15,7 +15,7 @@ pub struct CreateStageInstanceError {
 impl CreateStageInstanceError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &CreateStageInstanceErrorType {
+    pub const fn kind(&self) -> &CreateStageInstanceErrorType {
         &self.kind
     }
 

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -15,7 +15,7 @@ pub struct UpdateStageInstanceError {
 impl UpdateStageInstanceError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &UpdateStageInstanceErrorType {
+    pub const fn kind(&self) -> &UpdateStageInstanceErrorType {
         &self.kind
     }
 

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -17,7 +17,7 @@ pub struct UpdateChannelError {
 impl UpdateChannelError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &UpdateChannelErrorType {
+    pub const fn kind(&self) -> &UpdateChannelErrorType {
         &self.kind
     }
 

--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -39,7 +39,7 @@ pub struct UpdateChannelPermission<'a> {
 }
 
 impl<'a> UpdateChannelPermission<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         channel_id: ChannelId,
         allow: Permissions,

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -28,7 +28,7 @@ pub struct UpdateWebhookMessageError {
 impl UpdateWebhookMessageError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &UpdateWebhookMessageErrorType {
+    pub const fn kind(&self) -> &UpdateWebhookMessageErrorType {
         &self.kind
     }
 

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -14,7 +14,7 @@ pub struct CreateBanError {
 impl CreateBanError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &CreateBanErrorType {
+    pub const fn kind(&self) -> &CreateBanErrorType {
         &self.kind
     }
 

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -18,7 +18,7 @@ pub struct RoleFieldsError {
 impl RoleFieldsError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &RoleFieldsErrorType {
+    pub const fn kind(&self) -> &RoleFieldsErrorType {
         &self.kind
     }
 
@@ -93,6 +93,7 @@ impl RoleFieldsBuilder {
     }
 
     /// Build the role fields.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn build(self) -> RoleFields {
         self.0
     }
@@ -173,7 +174,7 @@ pub struct TextFieldsError {
 impl TextFieldsError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &TextFieldsErrorType {
+    pub const fn kind(&self) -> &TextFieldsErrorType {
         &self.kind
     }
 
@@ -311,6 +312,7 @@ impl TextFieldsBuilder {
     }
 
     /// Build the text fields.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn build(self) -> TextFields {
         self.0
     }
@@ -379,7 +381,7 @@ pub struct VoiceFieldsError {
 impl VoiceFieldsError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &VoiceFieldsErrorType {
+    pub const fn kind(&self) -> &VoiceFieldsErrorType {
         &self.kind
     }
 
@@ -486,6 +488,7 @@ impl VoiceFieldsBuilder {
     }
 
     /// Build the voice fields.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn build(self) -> VoiceFields {
         self.0
     }
@@ -521,7 +524,7 @@ pub struct CategoryFieldsError {
 impl CategoryFieldsError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &CategoryFieldsErrorType {
+    pub const fn kind(&self) -> &CategoryFieldsErrorType {
         &self.kind
     }
 
@@ -675,11 +678,12 @@ pub struct GuildChannelFieldsBuilder(Vec<GuildChannelFields>);
 
 impl GuildChannelFieldsBuilder {
     /// Create a new channels builder.
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self(Vec::new())
     }
 
     /// Build the list of channels.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn build(self) -> Vec<GuildChannelFields> {
         self.0
     }

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -25,7 +25,7 @@ pub struct CreateGuildError {
 impl CreateGuildError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &CreateGuildErrorType {
+    pub const fn kind(&self) -> &CreateGuildErrorType {
         &self.kind
     }
 
@@ -145,6 +145,7 @@ pub enum GuildChannelFields {
 }
 
 impl GuildChannelFields {
+    #[allow(clippy::missing_const_for_fn)]
     pub fn id(self) -> ChannelId {
         match self {
             Self::Category(c) => c.id,

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -17,7 +17,7 @@ pub struct CreateGuildChannelError {
 impl CreateGuildChannelError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &CreateGuildChannelErrorType {
+    pub const fn kind(&self) -> &CreateGuildChannelErrorType {
         &self.kind
     }
 

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -17,7 +17,7 @@ pub struct CreateGuildPruneError {
 impl CreateGuildPruneError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &CreateGuildPruneErrorType {
+    pub const fn kind(&self) -> &CreateGuildPruneErrorType {
         &self.kind
     }
 

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -17,7 +17,7 @@ pub struct GetAuditLogError {
 impl GetAuditLogError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &GetAuditLogErrorType {
+    pub const fn kind(&self) -> &GetAuditLogErrorType {
         &self.kind
     }
 

--- a/http/src/request/guild/get_guild.rs
+++ b/http/src/request/guild/get_guild.rs
@@ -26,7 +26,7 @@ impl<'a> GetGuild<'a> {
 
     /// Sets if you want to receive `approximate_member_count` and `approximate_presence_count` in
     /// the guild structure.
-    pub fn with_counts(mut self, with: bool) -> Self {
+    pub const fn with_counts(mut self, with: bool) -> Self {
         self.fields.with_counts = with;
 
         self

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -17,7 +17,7 @@ pub struct GetGuildPruneCountError {
 impl GetGuildPruneCountError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &GetGuildPruneCountErrorType {
+    pub const fn kind(&self) -> &GetGuildPruneCountErrorType {
         &self.kind
     }
 

--- a/http/src/request/guild/member/add_guild_member.rs
+++ b/http/src/request/guild/member/add_guild_member.rs
@@ -23,7 +23,7 @@ pub struct AddGuildMemberError {
 impl AddGuildMemberError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &AddGuildMemberErrorType {
+    pub const fn kind(&self) -> &AddGuildMemberErrorType {
         &self.kind
     }
 

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -27,7 +27,7 @@ pub struct GetGuildMembersError {
 impl GetGuildMembersError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &GetGuildMembersErrorType {
+    pub const fn kind(&self) -> &GetGuildMembersErrorType {
         &self.kind
     }
 

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -27,7 +27,7 @@ pub struct UpdateGuildMemberError {
 impl UpdateGuildMemberError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &UpdateGuildMemberErrorType {
+    pub const fn kind(&self) -> &UpdateGuildMemberErrorType {
         &self.kind
     }
 

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -19,7 +19,7 @@ pub struct UpdateGuildError {
 impl UpdateGuildError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &UpdateGuildErrorType {
+    pub const fn kind(&self) -> &UpdateGuildErrorType {
         &self.kind
     }
 

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -118,7 +118,7 @@ pub enum Method {
 }
 
 impl Method {
-    pub(crate) fn into_hyper(self) -> HyperMethod {
+    pub(crate) const fn into_hyper(self) -> HyperMethod {
         match self {
             Self::Delete => HyperMethod::DELETE,
             Self::Get => HyperMethod::GET,

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -14,7 +14,7 @@ pub struct GetCurrentUserGuildsError {
 impl GetCurrentUserGuildsError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &GetCurrentUserGuildsErrorType {
+    pub const fn kind(&self) -> &GetCurrentUserGuildsErrorType {
         &self.kind
     }
 

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -14,7 +14,7 @@ pub struct UpdateCurrentUserError {
 impl UpdateCurrentUserError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &UpdateCurrentUserErrorType {
+    pub const fn kind(&self) -> &UpdateCurrentUserErrorType {
         &self.kind
     }
 

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -427,19 +427,19 @@ mod tests {
     #[test]
     fn test_channel_name() {
         assert!(channel_name("aa"));
-        assert!(channel_name("a".repeat(100)));
+        assert!(channel_name("a".repeat(100).as_ref()));
 
         assert!(!channel_name(""));
         assert!(!channel_name("a"));
-        assert!(!channel_name("a".repeat(101)));
+        assert!(!channel_name("a".repeat(101).as_ref()));
     }
 
     #[test]
     fn test_content_limit() {
         assert!(content_limit(""));
-        assert!(content_limit("a".repeat(2000)));
+        assert!(content_limit("a".repeat(2000).as_ref()));
 
-        assert!(!content_limit("a".repeat(2001)));
+        assert!(!content_limit("a".repeat(2001).as_ref()));
     }
 
     #[test]
@@ -677,11 +677,11 @@ mod tests {
     #[test]
     fn test_guild_name() {
         assert!(guild_name("aa"));
-        assert!(guild_name("a".repeat(100)));
+        assert!(guild_name("a".repeat(100).as_ref()));
 
         assert!(!guild_name(""));
         assert!(!guild_name("a"));
-        assert!(!guild_name("a".repeat(101)));
+        assert!(!guild_name("a".repeat(101).as_ref()));
     }
 
     #[test]
@@ -711,18 +711,18 @@ mod tests {
     #[test]
     fn test_nickname() {
         assert!(nickname("a"));
-        assert!(nickname("a".repeat(32)));
+        assert!(nickname("a".repeat(32).as_ref()));
 
         assert!(!nickname(""));
-        assert!(!nickname("a".repeat(33)));
+        assert!(!nickname("a".repeat(33).as_ref()));
     }
 
     #[test]
     fn test_username() {
         assert!(username("aa"));
-        assert!(username("a".repeat(32)));
+        assert!(username("a".repeat(32).as_ref()));
 
         assert!(!username("a"));
-        assert!(!username("a".repeat(33)));
+        assert!(!username("a".repeat(33).as_ref()));
     }
 }

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -198,14 +198,22 @@ pub const fn ban_delete_message_days(value: u64) -> bool {
     value <= 7
 }
 
-pub fn channel_name(value: &str) -> bool {
+pub fn channel_name(value: impl AsRef<str>) -> bool {
+    _channel_name(value.as_ref())
+}
+
+fn _channel_name(value: &str) -> bool {
     let len = value.chars().count();
 
     // <https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure>
     (2..=100).contains(&len)
 }
 
-pub fn content_limit(value: &str) -> bool {
+pub fn content_limit(value: impl AsRef<str>) -> bool {
+    _content_limit(value.as_ref())
+}
+
+fn _content_limit(value: &str) -> bool {
     // <https://discordapp.com/developers/docs/resources/channel#create-message-params>
     value.chars().count() <= 2000
 }
@@ -331,7 +339,11 @@ pub const fn get_reactions_limit(value: u64) -> bool {
     value >= 1 && value <= 100
 }
 
-pub fn guild_name(value: &str) -> bool {
+pub fn guild_name(value: impl AsRef<str>) -> bool {
+    _guild_name(value.as_ref())
+}
+
+fn _guild_name(value: &str) -> bool {
     let len = value.chars().count();
 
     // <https://discordapp.com/developers/docs/resources/guild#guild-object-guild-structure>
@@ -353,28 +365,45 @@ pub const fn invite_max_uses(value: u64) -> bool {
     value <= 100
 }
 
-pub fn nickname(value: &str) -> bool {
+pub fn nickname(value: impl AsRef<str>) -> bool {
+    _nickname(value.as_ref())
+}
+
+fn _nickname(value: &str) -> bool {
     let len = value.chars().count();
 
     // <https://discordapp.com/developers/docs/resources/user#usernames-and-nicknames>
     (1..=32).contains(&len)
 }
 
-pub fn username(value: &str) -> bool {
+pub fn username(value: impl AsRef<str>) -> bool {
+    // <https://discordapp.com/developers/docs/resources/user#usernames-and-nicknames>
+    _username(value.as_ref())
+}
+
+fn _username(value: &str) -> bool {
     let len = value.chars().count();
 
     // <https://discordapp.com/developers/docs/resources/user#usernames-and-nicknames>
     (2..=32).contains(&len)
 }
 
-pub fn template_name(value: &str) -> bool {
+pub fn template_name(value: impl AsRef<str>) -> bool {
+    _template_name(value.as_ref())
+}
+
+fn _template_name(value: &str) -> bool {
     let len = value.chars().count();
 
     // <https://discord.com/developers/docs/resources/template#create-guild-template-json-params>
     (1..=100).contains(&len)
 }
 
-pub fn template_description(value: &str) -> bool {
+pub fn template_description(value: impl AsRef<str>) -> bool {
+    _template_name(value.as_ref())
+}
+
+fn _template_description(value: &str) -> bool {
     let len = value.chars().count();
 
     // <https://discord.com/developers/docs/resources/template#create-guild-template-json-params>
@@ -427,19 +456,19 @@ mod tests {
     #[test]
     fn test_channel_name() {
         assert!(channel_name("aa"));
-        assert!(channel_name("a".repeat(100).as_ref()));
+        assert!(channel_name("a".repeat(100)));
 
         assert!(!channel_name(""));
         assert!(!channel_name("a"));
-        assert!(!channel_name("a".repeat(101).as_ref()));
+        assert!(!channel_name("a".repeat(101)));
     }
 
     #[test]
     fn test_content_limit() {
         assert!(content_limit(""));
-        assert!(content_limit("a".repeat(2000).as_ref()));
+        assert!(content_limit("a".repeat(2000)));
 
-        assert!(!content_limit("a".repeat(2001).as_ref()));
+        assert!(!content_limit("a".repeat(2001)));
     }
 
     #[test]
@@ -677,11 +706,11 @@ mod tests {
     #[test]
     fn test_guild_name() {
         assert!(guild_name("aa"));
-        assert!(guild_name("a".repeat(100).as_ref()));
+        assert!(guild_name("a".repeat(100)));
 
         assert!(!guild_name(""));
         assert!(!guild_name("a"));
-        assert!(!guild_name("a".repeat(101).as_ref()));
+        assert!(!guild_name("a".repeat(101)));
     }
 
     #[test]
@@ -711,18 +740,18 @@ mod tests {
     #[test]
     fn test_nickname() {
         assert!(nickname("a"));
-        assert!(nickname("a".repeat(32).as_ref()));
+        assert!(nickname("a".repeat(32)));
 
         assert!(!nickname(""));
-        assert!(!nickname("a".repeat(33).as_ref()));
+        assert!(!nickname("a".repeat(33)));
     }
 
     #[test]
     fn test_username() {
         assert!(username("aa"));
-        assert!(username("a".repeat(32).as_ref()));
+        assert!(username("a".repeat(32)));
 
         assert!(!username("a"));
-        assert!(!username("a".repeat(33).as_ref()));
+        assert!(!username("a".repeat(33)));
     }
 }

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -46,7 +46,7 @@ impl EmbedValidationError {
 
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &EmbedValidationErrorType {
+    pub const fn kind(&self) -> &EmbedValidationErrorType {
         &self.kind
     }
 
@@ -193,27 +193,19 @@ pub enum EmbedValidationErrorType {
     },
 }
 
-pub fn ban_delete_message_days(value: u64) -> bool {
+pub const fn ban_delete_message_days(value: u64) -> bool {
     // <https://discordapp.com/developers/docs/resources/guild#create-guild-ban-query-string-params>
     value <= 7
 }
 
-pub fn channel_name(value: impl AsRef<str>) -> bool {
-    _channel_name(value.as_ref())
-}
-
-fn _channel_name(value: &str) -> bool {
+pub fn channel_name(value: &str) -> bool {
     let len = value.chars().count();
 
     // <https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure>
     (2..=100).contains(&len)
 }
 
-pub fn content_limit(value: impl AsRef<str>) -> bool {
-    _content_limit(value.as_ref())
-}
-
-fn _content_limit(value: &str) -> bool {
+pub fn content_limit(value: &str) -> bool {
     // <https://discordapp.com/developers/docs/resources/channel#create-message-params>
     value.chars().count() <= 2000
 }
@@ -310,99 +302,79 @@ pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
     Ok(())
 }
 
-pub fn get_audit_log_limit(value: u64) -> bool {
+pub const fn get_audit_log_limit(value: u64) -> bool {
     // <https://discordapp.com/developers/docs/resources/audit-log#get-guild-audit-log-query-string-parameters>
-    (1..=100).contains(&value)
+    value >= 1 && value <= 100
 }
 
-pub fn get_channel_messages_limit(value: u64) -> bool {
+pub const fn get_channel_messages_limit(value: u64) -> bool {
     // <https://discordapp.com/developers/docs/resources/channel#get-channel-messages-query-string-params>
-    (1..=100).contains(&value)
+    value >= 1 && value <= 100
 }
 
-pub fn get_current_user_guilds_limit(value: u64) -> bool {
+pub const fn get_current_user_guilds_limit(value: u64) -> bool {
     // <https://discordapp.com/developers/docs/resources/user#get-current-user-guilds-query-string-params>
-    (1..=100).contains(&value)
+    value >= 1 && value <= 100
 }
 
-pub fn get_guild_members_limit(value: u64) -> bool {
+pub const fn get_guild_members_limit(value: u64) -> bool {
     // <https://discordapp.com/developers/docs/resources/guild#list-guild-members-query-string-params>
-    (1..=1000).contains(&value)
+    value >= 1 && value <= 1000
 }
 
-pub fn search_guild_members_limit(value: u64) -> bool {
+pub const fn search_guild_members_limit(value: u64) -> bool {
     value > 0 && value <= 1000
 }
 
-pub fn get_reactions_limit(value: u64) -> bool {
+pub const fn get_reactions_limit(value: u64) -> bool {
     // <https://discordapp.com/developers/docs/resources/channel#get-reactions-query-string-params>
-    (1..=100).contains(&value)
+    value >= 1 && value <= 100
 }
 
-pub fn guild_name(value: impl AsRef<str>) -> bool {
-    _guild_name(value.as_ref())
-}
-
-fn _guild_name(value: &str) -> bool {
+pub fn guild_name(value: &str) -> bool {
     let len = value.chars().count();
 
     // <https://discordapp.com/developers/docs/resources/guild#guild-object-guild-structure>
     (2..=100).contains(&len)
 }
 
-pub fn guild_prune_days(value: u64) -> bool {
+pub const fn guild_prune_days(value: u64) -> bool {
     // <https://discordapp.com/developers/docs/resources/guild#get-guild-prune-count-query-string-params>
     value > 0 && value <= 30
 }
 
-pub fn invite_max_age(value: u64) -> bool {
+pub const fn invite_max_age(value: u64) -> bool {
     // <https://discord.com/developers/docs/resources/channel#create-channel-invite-json-params>
     value <= 604_800
 }
 
-pub fn invite_max_uses(value: u64) -> bool {
+pub const fn invite_max_uses(value: u64) -> bool {
     // <https://discord.com/developers/docs/resources/channel#create-channel-invite-json-params>
     value <= 100
 }
 
-pub fn nickname(value: impl AsRef<str>) -> bool {
-    _nickname(value.as_ref())
-}
-
-fn _nickname(value: &str) -> bool {
+pub fn nickname(value: &str) -> bool {
     let len = value.chars().count();
 
     // <https://discordapp.com/developers/docs/resources/user#usernames-and-nicknames>
     (1..=32).contains(&len)
 }
 
-pub fn username(value: impl AsRef<str>) -> bool {
-    // <https://discordapp.com/developers/docs/resources/user#usernames-and-nicknames>
-    _username(value.as_ref())
-}
-
-fn _username(value: &str) -> bool {
+pub fn username(value: &str) -> bool {
     let len = value.chars().count();
 
+    // <https://discordapp.com/developers/docs/resources/user#usernames-and-nicknames>
     (2..=32).contains(&len)
 }
 
-pub fn template_name(value: impl AsRef<str>) -> bool {
-    _template_name(value.as_ref())
-}
-
-fn _template_name(value: &str) -> bool {
+pub fn template_name(value: &str) -> bool {
     let len = value.chars().count();
 
     // <https://discord.com/developers/docs/resources/template#create-guild-template-json-params>
     (1..=100).contains(&len)
 }
 
-pub fn template_description(value: impl AsRef<str>) -> bool {
-    _template_name(value.as_ref())
-}
-
-fn _template_description(value: &str) -> bool {
+pub fn template_description(value: &str) -> bool {
     let len = value.chars().count();
 
     // <https://discord.com/developers/docs/resources/template#create-guild-template-json-params>

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -17,7 +17,7 @@ pub struct PathParseError {
 impl PathParseError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &PathParseErrorType {
+    pub const fn kind(&self) -> &PathParseErrorType {
         &self.kind
     }
 

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -26,7 +26,7 @@ pub struct ClientError {
 
 impl ClientError {
     /// Immutable reference to the type of error that occurred.
-    pub fn kind(&self) -> &ClientErrorType {
+    pub const fn kind(&self) -> &ClientErrorType {
         &self.kind
     }
 

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -112,6 +112,7 @@
 
 #![deny(
     clippy::all,
+    clippy::missing_const_for_fn,
     future_incompatible,
     missing_docs,
     nonstandard_style,

--- a/lavalink/src/model.rs
+++ b/lavalink/src/model.rs
@@ -123,7 +123,7 @@ pub mod outgoing {
 
     impl Destroy {
         /// Create a new destroy event.
-        pub fn new(guild_id: GuildId) -> Self {
+        pub const fn new(guild_id: GuildId) -> Self {
             Self {
                 guild_id,
                 op: Opcode::Destroy,

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -58,7 +58,7 @@ pub struct NodeError {
 impl NodeError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &NodeErrorType {
+    pub const fn kind(&self) -> &NodeErrorType {
         &self.kind
     }
 
@@ -133,7 +133,7 @@ pub struct NodeSenderError {
 
 impl NodeSenderError {
     /// Immutable reference to the type of error that occurred.
-    pub fn kind(&self) -> &NodeSenderErrorType {
+    pub const fn kind(&self) -> &NodeSenderErrorType {
         &self.kind
     }
 
@@ -254,7 +254,7 @@ pub struct Resume {
 impl Resume {
     /// Configure resume capability, providing the number of seconds that the
     /// Lavalink server should queue events for when the connection is resumed.
-    pub fn new(seconds: u64) -> Self {
+    pub const fn new(seconds: u64) -> Self {
         Self { timeout: seconds }
     }
 }
@@ -289,7 +289,7 @@ impl NodeConfig {
         )
     }
 
-    fn _new(
+    const fn _new(
         user_id: UserId,
         shard_count: u64,
         address: SocketAddr,

--- a/mention/src/lib.rs
+++ b/mention/src/lib.rs
@@ -31,6 +31,7 @@
 
 #![deny(
     clippy::all,
+    clippy::missing_const_for_fn,
     clippy::pedantic,
     future_incompatible,
     missing_docs,

--- a/mention/src/parse/error.rs
+++ b/mention/src/parse/error.rs
@@ -13,7 +13,7 @@ pub struct ParseMentionError<'a> {
 impl<'a> ParseMentionError<'a> {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &ParseMentionErrorType<'_> {
+    pub const fn kind(&self) -> &ParseMentionErrorType<'_> {
         &self.kind
     }
 

--- a/mention/src/parse/iter.rs
+++ b/mention/src/parse/iter.rs
@@ -46,7 +46,7 @@ impl<'a, T> MentionIter<'a, T> {
 
     /// Return an immutable reference to the underlying buffer of the iterator.
     #[must_use]
-    pub fn as_str(&self) -> &'a str {
+    pub const fn as_str(&self) -> &'a str {
         self.buf
     }
 }

--- a/model/src/channel/channel_type.rs
+++ b/model/src/channel/channel_type.rs
@@ -16,7 +16,7 @@ pub enum ChannelType {
 }
 
 impl ChannelType {
-    pub fn name(self) -> &'static str {
+    pub const fn name(self) -> &'static str {
         match self {
             Self::Group => "Group",
             Self::GuildCategory => "GuildCategory",

--- a/model/src/channel/message/allowed_mentions/builder.rs
+++ b/model/src/channel/message/allowed_mentions/builder.rs
@@ -8,8 +8,13 @@ pub struct AllowedMentionsBuilder(AllowedMentions);
 
 impl AllowedMentionsBuilder {
     /// Create a new [`AllowedMentionsBuilder`].
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self(AllowedMentions {
+            parse: Vec::new(),
+            users: Vec::new(),
+            roles: Vec::new(),
+            replied_user: false,
+        })
     }
 
     /// Allow parsing of `@everyone`.
@@ -20,7 +25,7 @@ impl AllowedMentionsBuilder {
     }
 
     /// When replying, whether to mention the target user.
-    pub fn replied_user(mut self) -> Self {
+    pub const fn replied_user(mut self) -> Self {
         self.0.replied_user = true;
 
         self

--- a/model/src/channel/message/allowed_mentions/mod.rs
+++ b/model/src/channel/message/allowed_mentions/mod.rs
@@ -32,7 +32,7 @@ pub struct AllowedMentions {
 }
 
 impl AllowedMentions {
-    pub fn builder() -> AllowedMentionsBuilder {
+    pub const fn builder() -> AllowedMentionsBuilder {
         AllowedMentionsBuilder::new()
     }
 }

--- a/model/src/channel/message/sticker/kind.rs
+++ b/model/src/channel/message/sticker/kind.rs
@@ -42,7 +42,7 @@ pub struct StickerFormatTypeConversionError {
 
 impl<'a> StickerFormatTypeConversionError {
     /// Retrieve a copy of the input value that couldn't be parsed.
-    pub fn value(&self) -> u8 {
+    pub const fn value(&self) -> u8 {
         self.value
     }
 }

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -58,7 +58,7 @@ pub enum Channel {
 
 impl Channel {
     /// Return the ID of the inner channel.
-    pub fn id(&self) -> ChannelId {
+    pub const fn id(&self) -> ChannelId {
         match self {
             Self::Group(group) => group.id,
             Self::Guild(guild_channel) => guild_channel.id(),
@@ -91,7 +91,7 @@ pub enum GuildChannel {
 
 impl GuildChannel {
     /// Return the guild ID of the inner guild channel.
-    pub fn guild_id(&self) -> Option<GuildId> {
+    pub const fn guild_id(&self) -> Option<GuildId> {
         match self {
             Self::Category(category) => category.guild_id,
             Self::Text(text) => text.guild_id,
@@ -101,7 +101,7 @@ impl GuildChannel {
     }
 
     /// Return the ID of the inner guild channel.
-    pub fn id(&self) -> ChannelId {
+    pub const fn id(&self) -> ChannelId {
         match self {
             Self::Category(category) => category.id,
             Self::Text(text) => text.id,
@@ -493,7 +493,7 @@ mod tests {
         }
     }
 
-    fn private() -> PrivateChannel {
+    const fn private() -> PrivateChannel {
         PrivateChannel {
             id: ChannelId(234),
             last_message_id: None,

--- a/model/src/channel/video_quality_mode.rs
+++ b/model/src/channel/video_quality_mode.rs
@@ -12,7 +12,7 @@ pub enum VideoQualityMode {
 }
 
 impl VideoQualityMode {
-    pub fn name(self) -> &'static str {
+    pub const fn name(self) -> &'static str {
         match self {
             Self::Auto => "Auto",
             Self::Full => "Full",

--- a/model/src/channel/voice_channel.rs
+++ b/model/src/channel/voice_channel.rs
@@ -100,7 +100,7 @@ mod tests {
             }
         }
 
-        fn tokens(kind: ChannelType) -> [Token; 33] {
+        const fn tokens(kind: ChannelType) -> [Token; 33] {
             [
                 Token::Struct {
                     name: "VoiceChannel",

--- a/model/src/gateway/close_code.rs
+++ b/model/src/gateway/close_code.rs
@@ -48,11 +48,11 @@ pub struct CloseCodeConversionError {
 }
 
 impl CloseCodeConversionError {
-    fn new(code: u16) -> Self {
+    const fn new(code: u16) -> Self {
         Self { code }
     }
 
-    pub fn code(&self) -> u16 {
+    pub const fn code(&self) -> u16 {
         self.code
     }
 }

--- a/model/src/gateway/event/dispatch.rs
+++ b/model/src/gateway/event/dispatch.rs
@@ -58,7 +58,7 @@ pub enum DispatchEvent {
 
 impl DispatchEvent {
     /// Returns the type of event that this event is.
-    pub fn kind(&self) -> EventType {
+    pub const fn kind(&self) -> EventType {
         match self {
             Self::BanAdd(_) => EventType::BanAdd,
             Self::BanRemove(_) => EventType::BanRemove,
@@ -161,7 +161,7 @@ pub struct DispatchEventWithTypeDeserializer<'a>(&'a str);
 
 impl<'a> DispatchEventWithTypeDeserializer<'a> {
     /// Create a new deserializer.
-    pub fn new(event_name: &'a str) -> Self {
+    pub const fn new(event_name: &'a str) -> Self {
         Self(event_name)
     }
 }

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -103,17 +103,18 @@ impl GatewayEventDeserializerOwned {
     }
 
     /// Return the opcode of the payload.
-    pub fn op(&self) -> u8 {
+    pub const fn op(&self) -> u8 {
         self.op
     }
 
     /// Return the sequence of the payload.
-    pub fn sequence(&self) -> Option<u64> {
+    pub const fn sequence(&self) -> Option<u64> {
         self.sequence
     }
 
     /// Consume the deserializer, returning its opcode, sequence, and event type
     /// components.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn into_parts(self) -> (u8, Option<u64>, Option<String>) {
         (self.op, self.sequence, self.event_type)
     }
@@ -139,7 +140,7 @@ impl<'a> GatewayEventDeserializer<'a> {
     ///
     /// This might be useful if you scan the payload for this information and
     /// do some work with the event type prior to deserializing the payload.
-    pub fn new(op: u8, sequence: Option<u64>, event_type: Option<&'a str>) -> Self {
+    pub const fn new(op: u8, sequence: Option<u64>, event_type: Option<&'a str>) -> Self {
         Self {
             event_type,
             op,
@@ -166,23 +167,23 @@ impl<'a> GatewayEventDeserializer<'a> {
     }
 
     /// Return an immutable reference to the event type of the payload.
-    pub fn event_type_ref(&self) -> Option<&str> {
+    pub const fn event_type_ref(&self) -> Option<&str> {
         self.event_type
     }
 
     /// Return the opcode of the payload.
-    pub fn op(&self) -> u8 {
+    pub const fn op(&self) -> u8 {
         self.op
     }
 
     /// Return the sequence of the payload.
-    pub fn sequence(&self) -> Option<u64> {
+    pub const fn sequence(&self) -> Option<u64> {
         self.sequence
     }
 
     /// Consume the deserializer, returning its opcode and event type
     /// components.
-    pub fn into_parts(self) -> (u8, Option<u64>, Option<&'a str>) {
+    pub const fn into_parts(self) -> (u8, Option<u64>, Option<&'a str>) {
         (self.op, self.sequence, self.event_type)
     }
 
@@ -464,7 +465,7 @@ impl<'de> DeserializeSeed<'de> for GatewayEventDeserializerOwned {
 
 impl Serialize for GatewayEvent {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        fn opcode(gateway_event: &GatewayEvent) -> OpCode {
+        const fn opcode(gateway_event: &GatewayEvent) -> OpCode {
             match gateway_event {
                 GatewayEvent::Dispatch(_, _) => OpCode::Event,
                 GatewayEvent::Heartbeat(_) => OpCode::Heartbeat,

--- a/model/src/gateway/event/kind.rs
+++ b/model/src/gateway/event/kind.rs
@@ -72,7 +72,7 @@ pub enum EventType {
 }
 
 impl EventType {
-    pub fn name(self) -> Option<&'static str> {
+    pub const fn name(self) -> Option<&'static str> {
         match self {
             Self::BanAdd => Some("GUILD_BAN_ADD"),
             Self::BanRemove => Some("GUILD_BAN_REMOVE"),

--- a/model/src/gateway/event/mod.rs
+++ b/model/src/gateway/event/mod.rs
@@ -136,7 +136,7 @@ pub enum Event {
 }
 
 impl Event {
-    pub fn kind(&self) -> EventType {
+    pub const fn kind(&self) -> EventType {
         match self {
             Self::BanAdd(_) => EventType::BanAdd,
             Self::BanRemove(_) => EventType::BanRemove,
@@ -266,20 +266,24 @@ impl From<ShardEvent> for Event {
     }
 }
 
-/// An error that describes a failure to convert
-/// from one event type to another.
+/// An error that describes a failure to convert from one event type to another.
 #[derive(Debug)]
 pub struct EventConversionError {
-    /// The original event
     event: Event,
 }
 
 impl EventConversionError {
-    pub fn new(event: Event) -> EventConversionError {
+    pub const fn new(event: Event) -> EventConversionError {
         Self { event }
     }
 
-    /// Get the original event
+    /// Return an immutable reference to the original event.
+    pub const fn event_ref(&self) -> &Event {
+        &self.event
+    }
+
+    /// Consume the error, returning the original event.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn into_event(self) -> Event {
         self.event
     }

--- a/model/src/gateway/payload/heartbeat.rs
+++ b/model/src/gateway/payload/heartbeat.rs
@@ -8,7 +8,7 @@ pub struct Heartbeat {
 }
 
 impl Heartbeat {
-    pub fn new(seq: u64) -> Self {
+    pub const fn new(seq: u64) -> Self {
         Self {
             d: seq,
             op: OpCode::Heartbeat,

--- a/model/src/gateway/payload/identify.rs
+++ b/model/src/gateway/payload/identify.rs
@@ -9,7 +9,7 @@ pub struct Identify {
 }
 
 impl Identify {
-    pub fn new(info: IdentifyInfo) -> Self {
+    pub const fn new(info: IdentifyInfo) -> Self {
         Self {
             d: info,
             op: OpCode::Identify,

--- a/model/src/gateway/payload/request_guild_members.rs
+++ b/model/src/gateway/payload/request_guild_members.rs
@@ -19,7 +19,7 @@ pub struct UserIdsError {
 impl UserIdsError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &UserIdsErrorType {
+    pub const fn kind(&self) -> &UserIdsErrorType {
         &self.kind
     }
 
@@ -78,7 +78,7 @@ impl RequestGuildMembers {
     ///
     /// This is an alias to [`RequestGuildMembersBuilder::new`]. Refer to its
     /// documentation for more information.
-    pub fn builder(guild_id: GuildId) -> RequestGuildMembersBuilder {
+    pub const fn builder(guild_id: GuildId) -> RequestGuildMembersBuilder {
         RequestGuildMembersBuilder::new(guild_id)
     }
 }
@@ -92,7 +92,7 @@ pub struct RequestGuildMembersBuilder {
 impl RequestGuildMembersBuilder {
     /// Create a new builder to configure and construct a
     /// [`RequestGuildMembers`].
-    pub fn new(guild_id: GuildId) -> Self {
+    pub const fn new(guild_id: GuildId) -> Self {
         Self {
             guild_id,
             nonce: None,
@@ -186,6 +186,7 @@ impl RequestGuildMembersBuilder {
     ///
     /// assert_eq!(Some(RequestGuildMemberId::One(UserId(2))), request.d.user_ids);
     /// ```
+    #[allow(clippy::missing_const_for_fn)]
     pub fn user_id(self, user_id: UserId) -> RequestGuildMembers {
         RequestGuildMembers {
             d: RequestGuildMembersInfo {

--- a/model/src/gateway/payload/update_status.rs
+++ b/model/src/gateway/payload/update_status.rs
@@ -42,7 +42,7 @@ impl UpdateStatusInfo {
         Self::_new(activities.into(), afk, since.into(), status.into())
     }
 
-    fn _new(
+    const fn _new(
         activities: Option<Vec<Activity>>,
         afk: bool,
         since: Option<u64>,

--- a/model/src/gateway/payload/update_voice_state.rs
+++ b/model/src/gateway/payload/update_voice_state.rs
@@ -42,7 +42,7 @@ impl UpdateVoiceStateInfo {
         Self::_new(guild_id.into(), channel_id.into(), self_deaf, self_mute)
     }
 
-    fn _new(
+    const fn _new(
         guild_id: GuildId,
         channel_id: Option<ChannelId>,
         self_deaf: bool,

--- a/model/src/gateway/presence/mod.rs
+++ b/model/src/gateway/presence/mod.rs
@@ -87,7 +87,7 @@ pub struct PresenceDeserializer(GuildId);
 impl PresenceDeserializer {
     /// Create a new deserializer for a presence when you know the guild ID but
     /// the payload probably doesn't contain it.
-    pub fn new(guild_id: GuildId) -> Self {
+    pub const fn new(guild_id: GuildId) -> Self {
         Self(guild_id)
     }
 }
@@ -106,7 +106,7 @@ pub struct PresenceListDeserializer(GuildId);
 impl PresenceListDeserializer {
     /// Create a new deserializer for a map of presences when you know the
     /// Guild ID but the payload probably doesn't contain it.
-    pub fn new(guild_id: GuildId) -> Self {
+    pub const fn new(guild_id: GuildId) -> Self {
         Self(guild_id)
     }
 }

--- a/model/src/guild/member.rs
+++ b/model/src/guild/member.rs
@@ -55,7 +55,7 @@ pub struct MemberDeserializer(GuildId);
 impl MemberDeserializer {
     /// Create a new deserializer for a member when you know the ID but the
     /// payload probably doesn't contain it.
-    pub fn new(guild_id: GuildId) -> Self {
+    pub const fn new(guild_id: GuildId) -> Self {
         Self(guild_id)
     }
 }
@@ -102,7 +102,7 @@ pub(crate) struct OptionalMemberDeserializer(GuildId);
 impl OptionalMemberDeserializer {
     /// Create a new deserializer for a member when you know the ID but the
     /// payload probably doesn't contain it.
-    pub fn new(guild_id: GuildId) -> Self {
+    pub const fn new(guild_id: GuildId) -> Self {
         Self(guild_id)
     }
 }
@@ -139,7 +139,7 @@ pub struct MemberListDeserializer(GuildId);
 impl MemberListDeserializer {
     /// Create a new deserializer for a map of members when you know the
     /// Guild ID but the payload probably doesn't contain it.
-    pub fn new(guild_id: GuildId) -> Self {
+    pub const fn new(guild_id: GuildId) -> Self {
         Self(guild_id)
     }
 }

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -37,6 +37,7 @@
 
 #![deny(
     clippy::all,
+    clippy::missing_const_for_fn,
     clippy::pedantic,
     future_incompatible,
     nonstandard_style,

--- a/model/src/voice/close_code.rs
+++ b/model/src/voice/close_code.rs
@@ -44,11 +44,11 @@ pub struct CloseCodeConversionError {
 }
 
 impl CloseCodeConversionError {
-    fn new(code: u16) -> Self {
+    const fn new(code: u16) -> Self {
         Self { code }
     }
 
-    pub fn code(&self) -> u16 {
+    pub const fn code(&self) -> u16 {
         self.code
     }
 }

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -120,7 +120,13 @@
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
 
-#![deny(rust_2018_idioms, broken_intra_doc_links, unused, warnings)]
+#![deny(
+    broken_intra_doc_links,
+    clippy::missing_const_for_fn,
+    rust_2018_idioms,
+    unused,
+    warnings
+)]
 
 mod futures;
 
@@ -790,39 +796,39 @@ impl Standby {
     }
 }
 
-fn event_guild_id(event: &Event) -> Option<GuildId> {
+const fn event_guild_id(event: &Event) -> Option<GuildId> {
     match event {
         Event::BanAdd(e) => Some(e.guild_id),
         Event::BanRemove(e) => Some(e.guild_id),
-        Event::ChannelCreate(e) => channel_guild_id(e),
-        Event::ChannelDelete(e) => channel_guild_id(e),
+        Event::ChannelCreate(e) => channel_guild_id(&e.0),
+        Event::ChannelDelete(e) => channel_guild_id(&e.0),
         Event::ChannelPinsUpdate(_) => None,
-        Event::ChannelUpdate(e) => channel_guild_id(e),
+        Event::ChannelUpdate(e) => channel_guild_id(&e.0),
         Event::GatewayHeartbeatAck => None,
         Event::GatewayHeartbeat(_) => None,
         Event::GatewayHello(_) => None,
         Event::GatewayInvalidateSession(_) => None,
         Event::GatewayReconnect => None,
         Event::GiftCodeUpdate => None,
-        Event::GuildCreate(e) => Some(e.id),
+        Event::GuildCreate(e) => Some(e.0.id),
         Event::GuildDelete(e) => Some(e.id),
         Event::GuildEmojisUpdate(e) => Some(e.guild_id),
         Event::GuildIntegrationsUpdate(e) => Some(e.guild_id),
-        Event::GuildUpdate(e) => Some(e.id),
+        Event::GuildUpdate(e) => Some(e.0.id),
         Event::InviteCreate(e) => Some(e.guild_id),
         Event::InviteDelete(e) => Some(e.guild_id),
-        Event::MemberAdd(e) => Some(e.guild_id),
+        Event::MemberAdd(e) => Some(e.0.guild_id),
         Event::MemberChunk(e) => Some(e.guild_id),
         Event::MemberRemove(e) => Some(e.guild_id),
         Event::MemberUpdate(e) => Some(e.guild_id),
-        Event::MessageCreate(e) => e.guild_id,
+        Event::MessageCreate(e) => e.0.guild_id,
         Event::MessageDelete(_) => None,
         Event::MessageDeleteBulk(_) => None,
         Event::MessageUpdate(_) => None,
         Event::PresenceUpdate(e) => Some(e.guild_id),
         Event::PresencesReplace => None,
-        Event::ReactionAdd(e) => e.guild_id,
-        Event::ReactionRemove(e) => e.guild_id,
+        Event::ReactionAdd(e) => e.0.guild_id,
+        Event::ReactionRemove(e) => e.0.guild_id,
         Event::ReactionRemoveAll(e) => e.guild_id,
         Event::ReactionRemoveEmoji(e) => Some(e.guild_id),
         Event::Ready(_) => None,
@@ -846,7 +852,7 @@ fn event_guild_id(event: &Event) -> Option<GuildId> {
     }
 }
 
-fn channel_guild_id(channel: &Channel) -> Option<GuildId> {
+const fn channel_guild_id(channel: &Channel) -> Option<GuildId> {
     match channel {
         Channel::Guild(c) => c.guild_id(),
         _ => None,

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -24,6 +24,7 @@
 
 #![deny(
     clippy::all,
+    clippy::missing_const_for_fn,
     clippy::pedantic,
     future_incompatible,
     missing_docs,

--- a/util/src/link/webhook.rs
+++ b/util/src/link/webhook.rs
@@ -22,7 +22,7 @@ pub struct WebhookParseError {
 impl WebhookParseError {
     /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
-    pub fn kind(&self) -> &WebhookParseErrorType {
+    pub const fn kind(&self) -> &WebhookParseErrorType {
         &self.kind
     }
 


### PR DESCRIPTION
Make many simple functions constant. Functions that are harder to be constant haven't been included in this work.

Some lints had to be ignored due to false-positives in Clippy relating to Drop implementations.