### PR TITLE
Remove gateway `tokio::select!` macro usage

### DIFF
--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -121,10 +121,6 @@
     warnings
 )]
 #![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
-// Required due to `futures_util::select!`.
-//
-// <https://github.com/rust-lang/futures-rs/issues/1917>
-#![recursion_limit = "256"]
 
 pub mod cluster;
 pub mod shard;


### PR DESCRIPTION
Remove usage of the `tokio::select!` macro in favor of `futures_util::future::select`. This allows us to remove a peer feature dependency on `tokio`'s `macros` feature; users had to manually enable this feature to use the gateway crate if it wasn't enabled elsewhere.

Additionally, this allows us to remove the recursion limit setting.