### PR TITLE
Make `Shard::start` take ref instead of mut

### DIFF
--- a/cache/in-memory/README.md
+++ b/cache/in-memory/README.md
@@ -19,7 +19,7 @@ use twilight_cache_inmemory::InMemoryCache;
 use twilight_gateway::{Intents, Shard};
 
 let token = env::var("DISCORD_TOKEN")?;
-let mut shard = Shard::new(token, Intents::GUILD_MESSAGES);
+let shard = Shard::new(token, Intents::GUILD_MESSAGES);
 shard.start().await?;
 
 // Create a cache, caching up to 10 messages per channel:

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let token = env::var("DISCORD_TOKEN")?;
-//! let mut shard = Shard::new(token, Intents::GUILD_MESSAGES);
+//! let shard = Shard::new(token, Intents::GUILD_MESSAGES);
 //! shard.start().await?;
 //!
 //! // Create a cache, caching up to 10 messages per channel:

--- a/gateway/examples/intents/src/main.rs
+++ b/gateway/examples/intents/src/main.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt::init();
 
     let intents = Intents::GUILD_MESSAGES | Intents::DIRECT_MESSAGES;
-    let mut shard = Shard::new(env::var("DISCORD_TOKEN")?, intents);
+    let shard = Shard::new(env::var("DISCORD_TOKEN")?, intents);
 
     shard.start().await?;
     println!("Created shard");

--- a/gateway/examples/request-members/src/main.rs
+++ b/gateway/examples/request-members/src/main.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
 
     // to interact with the gateway we first need to connect to it (with a shard or cluster)
-    let mut shard = Shard::new(env::var("DISCORD_TOKEN")?, Intents::GUILD_MEMBERS);
+    let shard = Shard::new(env::var("DISCORD_TOKEN")?, Intents::GUILD_MEMBERS);
     shard.start().await?;
     println!("Created shard");
 

--- a/gateway/examples/shard/src/main.rs
+++ b/gateway/examples/shard/src/main.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt::init();
 
     let intents = Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES;
-    let mut shard = Shard::new(env::var("DISCORD_TOKEN")?, intents);
+    let shard = Shard::new(env::var("DISCORD_TOKEN")?, intents);
     let mut events = shard.events();
 
     shard.start().await?;

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -610,7 +610,7 @@ impl Cluster {
     /// time the future is polled the cluster may have already dropped, bringing
     /// down the queue and shards with it.
     async fn start(cluster: Arc<ClusterRef>, shard_id: u64) -> Option<Shard> {
-        let mut shard = cluster
+        let shard = cluster
             .shards
             .lock()
             .expect("shards poisoned")

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -333,7 +333,7 @@ struct ShardRef {
 /// // Use the value of the "DISCORD_TOKEN" environment variable as the bot's
 /// // token. Of course, you may pass this into your program however you want.
 /// let token = env::var("DISCORD_TOKEN")?;
-/// let mut shard = Shard::new(token, Intents::GUILD_MESSAGES);
+/// let shard = Shard::new(token, Intents::GUILD_MESSAGES);
 ///
 /// // Start the shard.
 /// shard.start().await?;
@@ -382,7 +382,7 @@ impl Shard {
     /// let token = env::var("DISCORD_TOKEN")?;
     ///
     /// let intents = Intents::GUILD_MESSAGES | Intents::GUILD_MESSAGE_TYPING;
-    /// let mut shard = Shard::new(token, intents);
+    /// let shard = Shard::new(token, intents);
     /// shard.start().await?;
     ///
     /// tokio_time::sleep(Duration::from_secs(1)).await;
@@ -433,7 +433,7 @@ impl Shard {
     ///
     /// Returns a [`ShardStartErrorType::RetrievingGatewayUrl`] error type if
     /// the gateway URL couldn't be retrieved from the HTTP API.
-    pub async fn start(&mut self) -> Result<(), ShardStartError> {
+    pub async fn start(&self) -> Result<(), ShardStartError> {
         let url = if let Some(u) = self.0.config.gateway_url.clone() {
             u.into_string()
         } else {
@@ -526,7 +526,7 @@ impl Shard {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    /// let mut shard = Shard::new(env::var("DISCORD_TOKEN")?, Intents::empty());
+    /// let shard = Shard::new(env::var("DISCORD_TOKEN")?, Intents::empty());
     /// shard.start().await?;
     ///
     /// let event_types = EventTypeFlags::SHARD_CONNECTED | EventTypeFlags::SHARD_DISCONNECTED;
@@ -604,7 +604,7 @@ impl Shard {
     /// use twilight_gateway::{shard::{raw_message::Message, Shard}, Intents};
     ///
     /// let token = env::var("DISCORD_TOKEN")?;
-    /// let mut shard = Shard::new(token, Intents::GUILDS);
+    /// let shard = Shard::new(token, Intents::GUILDS);
     /// shard.start().await?;
     ///
     /// shard.send(Message::Ping(Vec::new())).await?;
@@ -625,7 +625,7 @@ impl Shard {
     /// };
     ///
     /// let token = env::var("DISCORD_TOKEN")?;
-    /// let mut shard = Shard::new(token, Intents::GUILDS);
+    /// let shard = Shard::new(token, Intents::GUILDS);
     /// shard.start().await?;
     ///
     /// let close = CloseFrame::from((1000, ""));

--- a/gateway/tests/test_shard_command_ratelimit.rs
+++ b/gateway/tests/test_shard_command_ratelimit.rs
@@ -18,7 +18,7 @@ fn shard() -> Shard {
 #[ignore]
 #[tokio::test]
 async fn test_shard_command_ratelimit() {
-    let mut shard = shard();
+    let shard = shard();
     let mut events = shard.events();
     shard.start().await.unwrap();
 

--- a/gateway/tests/test_shard_state_events.rs
+++ b/gateway/tests/test_shard_state_events.rs
@@ -11,7 +11,7 @@ fn shard() -> Result<Shard, Box<dyn Error>> {
 #[ignore]
 #[tokio::test]
 async fn test_shard_event_emits() -> Result<(), Box<dyn Error>> {
-    let mut shard = shard()?;
+    let shard = shard()?;
     let mut events = shard.events();
     shard.start().await?;
 

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -84,7 +84,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     lavalink.add(lavalink_host, lavalink_auth).await?;
 
     let intents = Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES;
-    let mut shard = Shard::new(token, intents);
+    let shard = Shard::new(token, intents);
     shard.start().await?;
 
     let mut events = shard.events();

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         lavalink.add(lavalink_host, lavalink_auth).await?;
 
         let intents = Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES;
-        let mut shard = Shard::new(token, intents);
+        let shard = Shard::new(token, intents);
         shard.start().await?;
 
         State {

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -82,7 +82,7 @@
 //!     lavalink.add(lavalink_host, lavalink_auth).await?;
 //!
 //!     let intents = Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES;
-//!     let mut shard = Shard::new(token, intents);
+//!     let shard = Shard::new(token, intents);
 //!     shard.start().await?;
 //!
 //!     let mut events = shard.events();

--- a/standby/README.md
+++ b/standby/README.md
@@ -73,7 +73,7 @@ use twilight_standby::Standby;
 async fn main() -> Result<(), Box<dyn Error>> {
     // Start a shard connected to the gateway to receive events.
     let intents = Intents::GUILD_MESSAGES | Intents::GUILD_MESSAGE_REACTIONS;
-    let mut shard = Shard::new(env::var("DISCORD_TOKEN")?, intents);
+    let shard = Shard::new(env::var("DISCORD_TOKEN")?, intents);
     let mut events = shard.events();
     shard.start().await?;
 

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -73,7 +73,7 @@
 //! async fn main() -> Result<(), Box<dyn Error>> {
 //!     // Start a shard connected to the gateway to receive events.
 //!     let intents = Intents::GUILD_MESSAGES | Intents::GUILD_MESSAGE_REACTIONS;
-//!     let mut shard = Shard::new(env::var("DISCORD_TOKEN")?, intents);
+//!     let shard = Shard::new(env::var("DISCORD_TOKEN")?, intents);
 //!     let mut events = shard.events();
 //!     shard.start().await?;
 //!


### PR DESCRIPTION
Instead of taking `&mut self` in `Shard::start`, take `&self`. Mutability is not required here.