### PR TITLE
enhancement(http): skip auth token on webhooks

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1550,6 +1550,7 @@ impl Client {
             method,
             path: bucket,
             path_str: path,
+            use_authorization_token,
         } = request;
 
         let protocol = if self.state.use_http { "http" } else { "https" };
@@ -1562,19 +1563,21 @@ impl Client {
             .method(method.into_hyper())
             .uri(&url);
 
-        if let Some(ref token) = self.state.token {
-            let value = HeaderValue::from_str(&token).map_err(|source| {
-                #[allow(clippy::borrow_interior_mutable_const)]
-                let name = AUTHORIZATION.to_string();
+        if use_authorization_token {
+            if let Some(ref token) = self.state.token {
+                let value = HeaderValue::from_str(&token).map_err(|source| {
+                    #[allow(clippy::borrow_interior_mutable_const)]
+                    let name = AUTHORIZATION.to_string();
 
-                Error {
-                    kind: ErrorType::CreatingHeader { name },
-                    source: Some(Box::new(source)),
+                    Error {
+                        kind: ErrorType::CreatingHeader { name },
+                        source: Some(Box::new(source)),
+                    }
+                })?;
+
+                if let Some(headers) = builder.headers_mut() {
+                    headers.insert(AUTHORIZATION, value);
                 }
-            })?;
-
-            if let Some(headers) = builder.headers_mut() {
-                headers.insert(AUTHORIZATION, value);
             }
         }
 

--- a/http/src/request/base.rs
+++ b/http/src/request/base.rs
@@ -78,6 +78,16 @@ impl RequestBuilder {
 
         Ok(self.body(bytes))
     }
+
+    /// Whether to use the client's authorization token in the request, if one
+    /// is set.
+    ///
+    /// This is primarily useful for executing webhooks.
+    pub fn use_authorization_token(mut self, use_authorization_token: bool) -> Self {
+        self.0.use_authorization_token = use_authorization_token;
+
+        self
+    }
 }
 
 #[derive(Debug)]
@@ -94,6 +104,8 @@ pub struct Request {
     pub path: Path,
     /// The URI path to request.
     pub path_str: Cow<'static, str>,
+    /// Whether to use the client's authorization token in the request.
+    pub(crate) use_authorization_token: bool,
 }
 
 impl Request {
@@ -116,6 +128,7 @@ impl Request {
             method,
             path,
             path_str,
+            use_authorization_token: true,
         }
     }
 
@@ -171,7 +184,13 @@ impl Request {
             method,
             path,
             path_str,
+            use_authorization_token: true,
         }
+    }
+
+    /// Whether to use the client's authorization token in the request.
+    pub const fn use_authorization_token(&self) -> bool {
+        self.use_authorization_token
     }
 }
 
@@ -186,6 +205,7 @@ impl From<Route> for Request {
             method,
             path,
             path_str,
+            use_authorization_token: true,
         }
     }
 }
@@ -201,6 +221,7 @@ impl From<(Vec<u8>, Route)> for Request {
             method,
             path,
             path_str,
+            use_authorization_token: true,
         }
     }
 }
@@ -216,6 +237,7 @@ impl From<(Form, Route)> for Request {
             method,
             path,
             path_str,
+            use_authorization_token: true,
         }
     }
 }
@@ -231,6 +253,7 @@ impl From<(Vec<u8>, Form, Route)> for Request {
             method,
             path,
             path_str,
+            use_authorization_token: true,
         }
     }
 }
@@ -246,6 +269,7 @@ impl From<(HeaderMap<HeaderValue>, Route)> for Request {
             method,
             path,
             path_str,
+            use_authorization_token: true,
         }
     }
 }
@@ -261,6 +285,7 @@ impl From<(Vec<u8>, HeaderMap<HeaderValue>, Route)> for Request {
             method,
             path,
             path_str,
+            use_authorization_token: true,
         }
     }
 }
@@ -276,6 +301,7 @@ impl From<(Form, HeaderMap<HeaderValue>, Route)> for Request {
             method,
             path,
             path_str,
+            use_authorization_token: true,
         }
     }
 }

--- a/http/src/request/channel/webhook/delete_webhook_message.rs
+++ b/http/src/request/channel/webhook/delete_webhook_message.rs
@@ -55,7 +55,8 @@ impl<'a> DeleteWebhookMessage<'a> {
             message_id: self.message_id.0,
             token: self.token.clone(),
             webhook_id: self.webhook_id.0,
-        });
+        })
+        .use_authorization_token(false);
 
         if let Some(reason) = self.reason.as_ref() {
             request = request.headers(request::audit_header(reason)?);

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -209,6 +209,10 @@ impl<'a> ExecuteWebhook<'a> {
             webhook_id: self.webhook_id.0,
         });
 
+        // Webhook executions don't need the authorization token, only the
+        // webhook token.
+        request = request.use_authorization_token(false);
+
         if !self.files.is_empty() || self.fields.payload_json.is_some() {
             let mut form = Form::new();
 

--- a/http/src/request/channel/webhook/get_webhook.rs
+++ b/http/src/request/channel/webhook/get_webhook.rs
@@ -24,7 +24,8 @@ impl<'a> GetWebhook<'a> {
         }
     }
 
-    /// Specify the token for auth, if not already authenticated with a Bot token.
+    /// Specify the token for auth, if not already authenticated with a Bot
+    /// token.
     pub fn token(mut self, token: impl Into<String>) -> Self {
         self.fields.token.replace(token.into());
 
@@ -32,12 +33,19 @@ impl<'a> GetWebhook<'a> {
     }
 
     fn start(&mut self) -> Result<()> {
-        let request = Request::from_route(Route::GetWebhook {
+        let mut request = Request::builder(Route::GetWebhook {
             token: self.fields.token.clone(),
             webhook_id: self.id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request_bytes(request)));
+        // If a webhook token has been configured, then we don't need to use
+        // the client's authorization token.
+        if self.fields.token.is_some() {
+            request = request.use_authorization_token(false);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.request_bytes(request.build())));
 
         Ok(())
     }

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -363,7 +363,8 @@ impl<'a> UpdateWebhookMessage<'a> {
             message_id: self.message_id.0,
             token: self.token.clone(),
             webhook_id: self.webhook_id.0,
-        });
+        })
+        .use_authorization_token(false);
 
         if self.files.is_empty() {
             request = request.json(&self.fields)?;

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -57,6 +57,7 @@ impl<'a> UpdateWebhookWithToken<'a> {
             webhook_id: self.webhook_id.0,
         })
         .json(&self.fields)?
+        .use_authorization_token(false)
         .build();
 
         self.fut.replace(Box::pin(self.http.request(request)));


### PR DESCRIPTION
When using a request related to webhooks don't send the client's authorization token if a webhook token is provided. This will ensure that these requests don't count against the authorization token's ratelimits.

This has been manually tested and the resultant headers for a webhook execution are:

```json
Some({
    "content-length": "18",
    "content-type": "application/json",
    "user-agent": "DiscordBot (https://twilight.rs/chapter_1_crates/section_2_http.html, 0.4.1) Twilight-rs"
})
```

Closes #752.