### PR TITLE
enhancement!(gateway): rename zlib features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,13 +58,13 @@ jobs:
             rustflags: '-C target-cpu=native'
           - package: gateway
             features: rustls
-            additional: --features stock-zlib
+            additional: --features zlib-stock
           - package: gateway
             features: native
-            additional: --features stock-zlib
+            additional: --features zlib-stock
           - package: gateway
             features: simd-json
-            additional: --features rustls,stock-zlib
+            additional: --features rustls,zlib-stock
             rustflags: '-C target-cpu=native'
           - package: lavalink
             additional: --features http-support

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -50,8 +50,8 @@ native = ["twilight-http/native", "twilight-gateway-queue/native", "tokio-tungst
 rustls = ["rustls-native-roots"]
 rustls-native-roots = ["twilight-http/rustls-native-roots", "twilight-gateway-queue/rustls-native-roots", "tokio-tungstenite/rustls-tls"]
 rustls-webpki-roots = ["twilight-http/rustls-webpki-roots", "twilight-gateway-queue/rustls-webpki-roots", "tokio-tungstenite/rustls-tls"]
-simd-zlib = ["compression", "flate2/zlib-ng-compat"]
+zlib-simd = ["compression", "flate2/zlib-ng-compat"]
 # if the `zlib` feature is enabled anywhere in the dependency tree it will
 # always use stock zlib instead of zlib-ng.
 # https://github.com/rust-lang/libz-sys/blob/main/README.md#zlib-ng
-stock-zlib = ["compression", "flate2/zlib"]
+zlib-stock = ["compression", "flate2/zlib"]

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -78,12 +78,12 @@ zlib is enabled with the feature `compression` and one of the two `zlib` feature
 described below. Enabling any of the two features below will also enable
 `compression`. `compression` is enabled by default.
 
-There are 2 zlib features `stock-zlib` and `simd-zlib` for the library to work
-one of them has to be enabled. If both are enabled it will use `stock-zlib`
+There are 2 zlib features `zlib-stock` and `zlib-simd` for the library to work
+one of them has to be enabled. If both are enabled it will use `zlib-stock`
 
-`stock-zlib` enabled by default.
+`zlib-stock` enabled by default.
 
-Enabling **only** `simd-zlib` will make the library use [`zlib-ng`] which is a modern
+Enabling **only** `zlib-simd` will make the library use [`zlib-ng`] which is a modern
 fork of zlib that is faster and more effective, but it needs `cmake` to compile.
 
 ### Metrics

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -76,12 +76,12 @@
 //! described below. Enabling any of the two features below will also enable
 //! `compression`. `compression` is enabled by default.
 //!
-//! There are 2 zlib features `stock-zlib` and `simd-zlib` for the library to work
-//! one of them has to be enabled. If both are enabled it will use `stock-zlib`
+//! There are 2 zlib features `zlib-stock` and `zlib-simd` for the library to work
+//! one of them has to be enabled. If both are enabled it will use `zlib-stock`
 //!
-//! `stock-zlib` enabled by default.
+//! `zlib-stock` enabled by default.
 //!
-//! Enabling **only** `simd-zlib` will make the library use [`zlib-ng`] which is a modern
+//! Enabling **only** `zlib-simd` will make the library use [`zlib-ng`] which is a modern
 //! fork of zlib that is faster and more effective, but it needs `cmake` to compile.
 //!
 //! ### Metrics


### PR DESCRIPTION
Rename the two zlib features - `stock-zlib` and `simd-zlib` - for consistency with other feature flags. These have been renamed to `zlib-stock` and `zlib-simd` to properly namespace the feature flags.

Closes #717.