### PR TITLE
fix(http/update_channel): serialize fields as body

### DIFF
--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -285,7 +285,8 @@ impl<'a> UpdateChannel<'a> {
     fn start(&mut self) -> Result<()> {
         let mut request = Request::builder(Route::UpdateChannel {
             channel_id: self.channel_id.0,
-        });
+        })
+        .json(&self.fields)?;
 
         if let Some(reason) = &self.reason {
             request = request.headers(audit_header(reason)?);


### PR DESCRIPTION
Set the body of `UpdateChannel` to include the serialized fields.

This was accidentally left out during the method rewrite in #814.