### PR TITLE
feat(model): add webhook type: application

### DIFF
--- a/model/src/channel/webhook_type.rs
+++ b/model/src/channel/webhook_type.rs
@@ -31,5 +31,6 @@ mod tests {
     fn test_variants() {
         serde_test::assert_tokens(&WebhookType::Incoming, &[Token::U8(1)]);
         serde_test::assert_tokens(&WebhookType::ChannelFollower, &[Token::U8(2)]);
+        serde_test::assert_tokens(&WebhookType::Application, &[Token::U8(3)]);
     }
 }

--- a/model/src/channel/webhook_type.rs
+++ b/model/src/channel/webhook_type.rs
@@ -7,6 +7,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 pub enum WebhookType {
     Incoming = 1,
     ChannelFollower = 2,
+    /// Webhooks used with interactions.
+    Application = 3,
 }
 
 impl Default for WebhookType {


### PR DESCRIPTION
The first of many small model fixes that I'll spot eventually.

Docs: https://discord.com/developers/docs/resources/webhook#webhook-object-webhook-types