### PR TITLE
feat(model): add `MinimalActivity`

### DIFF
--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -253,6 +253,35 @@ impl ShardBuilder {
     ///
     /// Default is no presence, which defaults to strictly being "online"
     /// with no special qualities.
+    ///
+    /// # Examples
+    ///
+    /// Set the bot user's presence to idle with the status "Not accepting
+    /// commands":
+    ///
+    /// ```no_run
+    /// use twilight_gateway::{Intents, Shard};
+    /// use twilight_model::gateway::{
+    ///     payload::update_status::UpdateStatusInfo,
+    ///     presence::{ActivityType, MinimalActivity, Status},
+    /// };
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let shard = Shard::builder("token", Intents::empty())
+    ///     .presence(UpdateStatusInfo::new(
+    ///         Some(vec![MinimalActivity {
+    ///             kind: ActivityType::Playing,
+    ///             name: "Not accepting commands".into(),
+    ///             url: None,
+    ///         }
+    ///         .into()]),
+    ///         false,
+    ///         None,
+    ///         Status::Idle,
+    ///     ));
+    /// # Ok(()) }
+    ///
+    /// ```
     pub fn presence(mut self, presence: UpdateStatusInfo) -> Self {
         self.0.presence.replace(presence);
 

--- a/model/src/gateway/presence/minimal_activity.rs
+++ b/model/src/gateway/presence/minimal_activity.rs
@@ -1,0 +1,31 @@
+use super::{Activity, ActivityType};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct MinimalActivity {
+    pub kind: ActivityType,
+    pub name: String,
+    pub url: Option<String>,
+}
+
+impl From<MinimalActivity> for Activity {
+    fn from(minimal_activity: MinimalActivity) -> Self {
+        Self {
+            application_id: None,
+            assets: None,
+            buttons: Vec::new(),
+            created_at: None,
+            details: None,
+            emoji: None,
+            flags: None,
+            id: None,
+            instance: None,
+            kind: minimal_activity.kind,
+            name: minimal_activity.name,
+            party: None,
+            secrets: None,
+            state: None,
+            timestamps: None,
+            url: minimal_activity.url,
+        }
+    }
+}

--- a/model/src/gateway/presence/mod.rs
+++ b/model/src/gateway/presence/mod.rs
@@ -9,13 +9,15 @@ mod activity_secrets;
 mod activity_timestamps;
 mod activity_type;
 mod client_status;
+mod minimal_activity;
 mod status;
 
 pub use self::{
     activity::Activity, activity_assets::ActivityAssets, activity_button::ActivityButton,
     activity_emoji::ActivityEmoji, activity_flags::ActivityFlags, activity_party::ActivityParty,
     activity_secrets::ActivitySecrets, activity_timestamps::ActivityTimestamps,
-    activity_type::ActivityType, client_status::ClientStatus, status::Status,
+    activity_type::ActivityType, client_status::ClientStatus, minimal_activity::MinimalActivity,
+    status::Status,
 };
 
 use crate::{


### PR DESCRIPTION
The purpose of this struct is to make it a little easier to construct
the requisite Activity struct in `ClusterBuilder` and `ShardBuilder`'s
`presence` functions.

Still, another approach could be taken, which would be to make a builder
for `UpdateStatusInfo`. This approach, however, is opinionated; to avoid
writing too many extranenous methods, the bulder would only support one
`Activity`, which is usually enough for a bot user. If this method is
preferred, I'll repurpose this PR for it.

Fixes #756.
