### PR TITLE
Remove Arcs from cache models

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -582,9 +582,11 @@ impl InMemoryCache {
             Some(_) | None => {}
         }
 
-        let user = emoji
-            .user
-            .map(|u| self.cache_user(Cow::Owned(u), Some(guild_id)));
+        let user_id = emoji.user.as_ref().map(|user| user.id);
+
+        if let Some(user) = emoji.user {
+            self.cache_user(Cow::Owned(user), Some(guild_id));
+        }
 
         let cached = Arc::new(CachedEmoji {
             id: emoji.id,
@@ -593,7 +595,7 @@ impl InMemoryCache {
             managed: emoji.managed,
             require_colons: emoji.require_colons,
             roles: emoji.roles,
-            user,
+            user_id,
             available: emoji.available,
         });
 
@@ -725,7 +727,9 @@ impl InMemoryCache {
             Some(_) | None => {}
         }
 
-        let user = self.cache_user(Cow::Owned(member.user), Some(guild_id));
+        let user_id = member.user.id;
+
+        self.cache_user(Cow::Owned(member.user), Some(guild_id));
         let cached = Arc::new(CachedMember {
             deaf: member.deaf,
             guild_id,
@@ -735,7 +739,7 @@ impl InMemoryCache {
             pending: member.pending,
             premium_since: member.premium_since,
             roles: member.roles,
-            user,
+            user_id,
         });
         self.0.members.insert(id, Arc::clone(&cached));
         self.0
@@ -750,9 +754,9 @@ impl InMemoryCache {
         &self,
         guild_id: GuildId,
         member: &PartialMember,
-        user: Arc<User>,
+        user_id: UserId,
     ) -> Arc<CachedMember> {
-        let id = (guild_id, user.id);
+        let id = (guild_id, user_id);
         match self.0.members.get(&id) {
             Some(m) if **m == member => return Arc::clone(&m),
             Some(_) | None => {}
@@ -762,7 +766,7 @@ impl InMemoryCache {
             .guild_members
             .entry(guild_id)
             .or_default()
-            .insert(user.id);
+            .insert(user_id);
 
         let cached = Arc::new(CachedMember {
             deaf: member.deaf,
@@ -773,7 +777,7 @@ impl InMemoryCache {
             pending: false,
             premium_since: None,
             roles: member.roles.to_owned(),
-            user,
+            user_id,
         });
         self.0.members.insert(id, Arc::clone(&cached));
 
@@ -838,27 +842,25 @@ impl InMemoryCache {
         upsert_guild_item(&self.0.roles, guild_id, role.id, role)
     }
 
-    fn cache_user(&self, user: Cow<'_, User>, guild_id: Option<GuildId>) -> Arc<User> {
+    fn cache_user(&self, user: Cow<'_, User>, guild_id: Option<GuildId>) {
         match self.0.users.get_mut(&user.id) {
             Some(mut u) if *u.0 == *user => {
                 if let Some(guild_id) = guild_id {
                     u.1.insert(guild_id);
                 }
 
-                return Arc::clone(&u.value().0);
+                return;
             }
             Some(_) | None => {}
         }
-        let user = Arc::new(user.into_owned());
+
         if let Some(guild_id) = guild_id {
             let mut guild_id_set = BTreeSet::new();
             guild_id_set.insert(guild_id);
             self.0
                 .users
-                .insert(user.id, (Arc::clone(&user), guild_id_set));
+                .insert(user.id, (Arc::new(user.into_owned()), guild_id_set));
         }
-
-        user
     }
 
     fn cache_voice_states(&self, voice_states: impl IntoIterator<Item = VoiceState>) {

--- a/cache/in-memory/src/model/emoji.rs
+++ b/cache/in-memory/src/model/emoji.rs
@@ -1,9 +1,7 @@
 use serde::Serialize;
-use std::sync::Arc;
 use twilight_model::{
     guild::Emoji,
-    id::{EmojiId, RoleId},
-    user::User,
+    id::{EmojiId, RoleId, UserId},
 };
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -14,7 +12,8 @@ pub struct CachedEmoji {
     pub managed: bool,
     pub require_colons: bool,
     pub roles: Vec<RoleId>,
-    pub user: Option<Arc<User>>,
+    /// ID of the user who created the emoji.
+    pub user_id: Option<UserId>,
     pub available: bool,
 }
 
@@ -26,6 +25,7 @@ impl PartialEq<Emoji> for CachedEmoji {
             && self.name == other.name
             && self.require_colons == other.require_colons
             && self.roles == other.roles
+            && self.user_id == other.user.as_ref().map(|user| user.id)
             && self.available == other.available
     }
 }
@@ -44,7 +44,7 @@ mod tests {
         managed,
         require_colons,
         roles,
-        user
+        user_id
     );
     assert_impl_all!(CachedEmoji: Clone, Debug, Eq, PartialEq);
 
@@ -67,7 +67,7 @@ mod tests {
             managed: false,
             require_colons: true,
             roles: vec![],
-            user: None,
+            user_id: None,
             available: true,
         };
 

--- a/cache/in-memory/src/model/member.rs
+++ b/cache/in-memory/src/model/member.rs
@@ -1,9 +1,7 @@
 use serde::Serialize;
-use std::sync::Arc;
 use twilight_model::{
     guild::{Member, PartialMember},
-    id::{GuildId, RoleId},
-    user::User,
+    id::{GuildId, RoleId, UserId},
 };
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -16,7 +14,8 @@ pub struct CachedMember {
     pub pending: bool,
     pub premium_since: Option<String>,
     pub roles: Vec<RoleId>,
-    pub user: Arc<User>,
+    /// ID of the user relating to the member.
+    pub user_id: UserId,
 }
 
 impl PartialEq<Member> for CachedMember {
@@ -29,6 +28,7 @@ impl PartialEq<Member> for CachedMember {
             self.pending,
             self.premium_since.as_ref(),
             &self.roles,
+            self.user_id,
         ) == (
             other.deaf,
             other.joined_at.as_ref(),
@@ -37,6 +37,7 @@ impl PartialEq<Member> for CachedMember {
             other.pending,
             other.premium_since.as_ref(),
             &other.roles,
+            self.user_id,
         )
     }
 }
@@ -64,12 +65,24 @@ impl PartialEq<&PartialMember> for CachedMember {
 #[cfg(test)]
 mod tests {
     use super::CachedMember;
-    use std::sync::Arc;
+    use static_assertions::assert_fields;
     use twilight_model::{
         guild::{Member, PartialMember},
         id::{GuildId, RoleId, UserId},
         user::User,
     };
+
+    assert_fields!(
+        CachedMember: deaf,
+        guild_id,
+        joined_at,
+        mute,
+        nick,
+        pending,
+        premium_since,
+        roles,
+        user_id
+    );
 
     fn cached_member() -> CachedMember {
         CachedMember {
@@ -81,7 +94,7 @@ mod tests {
             pending: false,
             premium_since: None,
             roles: Vec::new(),
-            user: Arc::new(user()),
+            user_id: user().id,
         }
     }
 

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -387,10 +387,10 @@ impl UpdateCache for MessageCreate {
 
         channel.push_front(Arc::new(From::from(self.0.clone())));
 
-        let user = cache.cache_user(Cow::Borrowed(&self.author), self.guild_id);
+        cache.cache_user(Cow::Borrowed(&self.author), self.guild_id);
 
         if let (Some(member), Some(guild_id)) = (&self.member, self.guild_id) {
-            cache.cache_borrowed_partial_member(guild_id, member, user);
+            cache.cache_borrowed_partial_member(guild_id, member, self.author.id);
         }
     }
 }
@@ -1087,8 +1087,8 @@ mod tests {
             assert_eq!(entry.value().1.len(), 1);
         }
         assert_eq!(
-            cache.member(GuildId(2), UserId(3)).unwrap().user.name,
-            "test"
+            cache.member(GuildId(2), UserId(3)).unwrap().user_id,
+            UserId(3),
         );
     }
 
@@ -1154,8 +1154,8 @@ mod tests {
             assert_eq!(entry.value().1.len(), 1);
         }
         assert_eq!(
-            cache.member(GuildId(1), UserId(3)).unwrap().user.name,
-            "test"
+            cache.member(GuildId(1), UserId(3)).unwrap().user_id,
+            UserId(3),
         );
         {
             let entry = cache.0.messages.get(&ChannelId(2)).unwrap();


### PR DESCRIPTION
Remove `Arc`s from the cached versions of models. This results in:

- `CachedEmoji::user` being:
  - renamed to `user_id`; and
  - being changed from an `Option<Arc<User>>` to an `Option<UserId>`.
- `CachedMember::user` being:
  - renamed to `user_id`; and
  - changed from an `Arc<User>` to being a `UserId`.

Closes #868.

Signed-off-by: Vivian Hellyer <vivian@hellyer.dev>