### PR TITLE
New fields for `update_guild_channel_positions`

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -11,7 +11,10 @@ use crate::{
             create_stage_instance::CreateStageInstanceError,
             update_stage_instance::UpdateStageInstanceError,
         },
-        guild::{create_guild::CreateGuildError, create_guild_channel::CreateGuildChannelError},
+        guild::{
+            create_guild::CreateGuildError, create_guild_channel::CreateGuildChannelError,
+            update_guild_channel_positions::Position,
+        },
         prelude::*,
         GetUserApplicationInfo, Method, Request,
     },
@@ -696,10 +699,13 @@ impl Client {
     /// Modify the positions of the channels.
     ///
     /// The minimum amount of channels to modify, is a swap between two channels.
+    ///
+    /// This function accepts an `Iterator` of `(ChannelId, u64)`. It also
+    /// accepts an `Iterator` of `Position`, which has extra fields.
     pub fn update_guild_channel_positions(
         &self,
         guild_id: GuildId,
-        channel_positions: impl Iterator<Item = (ChannelId, u64)>,
+        channel_positions: impl Iterator<Item = impl Into<Position>>,
     ) -> UpdateGuildChannelPositions<'_> {
         UpdateGuildChannelPositions::new(self, guild_id, channel_positions)
     }

--- a/http/src/request/guild/mod.rs
+++ b/http/src/request/guild/mod.rs
@@ -9,6 +9,7 @@ pub mod integration;
 pub mod member;
 pub mod role;
 pub mod update_guild;
+pub mod update_guild_channel_positions;
 pub mod user;
 
 mod delete_guild;
@@ -22,7 +23,6 @@ mod get_guild_webhooks;
 mod get_guild_welcome_screen;
 mod get_guild_widget;
 mod update_current_user_nick;
-mod update_guild_channel_positions;
 mod update_guild_welcome_screen;
 mod update_guild_widget;
 

--- a/http/src/request/guild/update_guild_channel_positions.rs
+++ b/http/src/request/guild/update_guild_channel_positions.rs
@@ -8,14 +8,33 @@ use serde::Serialize;
 use twilight_model::id::{ChannelId, GuildId};
 
 #[derive(Serialize)]
-struct Position {
+pub struct Position {
     id: ChannelId,
-    position: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lock_permissions: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_id: Option<ChannelId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    position: Option<u64>,
+}
+
+impl From<(ChannelId, u64)> for Position {
+    fn from((id, position): (ChannelId, u64)) -> Self {
+        Self {
+            id,
+            lock_permissions: None,
+            parent_id: None,
+            position: Some(position),
+        }
+    }
 }
 
 /// Modify the positions of the channels.
 ///
 /// The minimum amount of channels to modify, is a swap between two channels.
+///
+/// This function accepts an `Iterator` of `(ChannelId, u64)`. It also accepts
+/// an `Iterator` of `Position`, which has extra fields.
 pub struct UpdateGuildChannelPositions<'a> {
     fut: Option<Pending<'a, ()>>,
     guild_id: GuildId,
@@ -27,11 +46,9 @@ impl<'a> UpdateGuildChannelPositions<'a> {
     pub(crate) fn new(
         http: &'a Client,
         guild_id: GuildId,
-        channel_positions: impl Iterator<Item = (ChannelId, u64)>,
+        channel_positions: impl Iterator<Item = impl Into<Position>>,
     ) -> Self {
-        let positions = channel_positions
-            .map(|(id, position)| Position { id, position })
-            .collect::<Vec<_>>();
+        let positions = channel_positions.map(Into::into).collect();
 
         Self {
             fut: None,


### PR DESCRIPTION
This PR changes the signature of `Client::update_guild_channel_positions` from `impl Iterator<Item = (ChannelId, u64)>` to `impl Iterator<Item = impl Into<Position>>`. It adds more fields to the `update_guild_channel_positions::Position` struct, and makes it public.  It also adds a `From<(ChannelId, u64)>` implementation for `Position`, allowing the previous signature to function.

Fixes #846.
