### PR TITLE
Remove deprecated nsfw field

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -732,7 +732,6 @@ impl InMemoryCache {
             member_count: guild.member_count,
             mfa_level: guild.mfa_level,
             name: guild.name,
-            nsfw: false,
             nsfw_level: guild.nsfw_level,
             owner: guild.owner,
             owner_id: guild.owner_id,
@@ -1218,7 +1217,6 @@ mod tests {
             topic: None,
         })]);
 
-        #[allow(deprecated)]
         let guild = Guild {
             id: GuildId(123),
             afk_channel_id: None,
@@ -1241,7 +1239,6 @@ mod tests {
             members: Vec::new(),
             mfa_level: MfaLevel::Elevated,
             name: "this is a guild".to_owned(),
-            nsfw: false,
             nsfw_level: NSFWLevel::AgeRestricted,
             owner: Some(false),
             owner_id: UserId(456),

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -1217,6 +1217,7 @@ mod tests {
             topic: None,
         })]);
 
+        #[allow(deprecated)]
         let guild = Guild {
             id: GuildId(123),
             afk_channel_id: None,

--- a/cache/in-memory/src/model/guild.rs
+++ b/cache/in-memory/src/model/guild.rs
@@ -27,8 +27,6 @@ pub struct CachedGuild {
     pub member_count: Option<u64>,
     pub mfa_level: MfaLevel,
     pub name: String,
-    #[deprecated(since = "0.4.3", note = "no longer provided by discord, see #839")]
-    pub nsfw: bool,
     pub nsfw_level: NSFWLevel,
     pub owner: Option<bool>,
     pub owner_id: UserId,

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -914,7 +914,6 @@ mod tests {
         cache
     }
 
-    #[allow(deprecated)]
     #[test]
     fn test_guild_update() {
         let cache = InMemoryCache::new();
@@ -944,7 +943,6 @@ mod tests {
             members: Vec::new(),
             mfa_level: MfaLevel::None,
             name: "test".to_owned(),
-            nsfw: false,
             nsfw_level: NSFWLevel::Default,
             owner_id: UserId(1),
             owner: None,
@@ -970,7 +968,6 @@ mod tests {
 
         cache.update(&GuildCreate(guild.clone()));
 
-        #[allow(deprecated)]
         let mutation = PartialGuild {
             id: guild.id,
             afk_channel_id: guild.afk_channel_id,
@@ -989,7 +986,6 @@ mod tests {
             member_count: guild.member_count,
             mfa_level: guild.mfa_level,
             name: "test2222".to_owned(),
-            nsfw: false,
             nsfw_level: guild.nsfw_level,
             owner_id: UserId(2),
             owner: guild.owner,

--- a/cache/in-memory/src/updates.rs
+++ b/cache/in-memory/src/updates.rs
@@ -968,6 +968,7 @@ mod tests {
 
         cache.update(&GuildCreate(guild.clone()));
 
+        #[allow(deprecated)]
         let mutation = PartialGuild {
             id: guild.id,
             afk_channel_id: guild.afk_channel_id,

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -709,6 +709,7 @@ impl<'de> Deserialize<'de> for Guild {
                     voice_state.guild_id.replace(id);
                 }
 
+                #[allow(deprecated)]
                 Ok(Guild {
                     afk_channel_id,
                     afk_timeout,

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -86,9 +86,6 @@ pub struct Guild {
     pub members: Vec<Member>,
     pub mfa_level: MfaLevel,
     pub name: String,
-    #[deprecated(since = "0.4.3", note = "no longer provided by discord, see #839")]
-    #[serde(skip)]
-    pub nsfw: bool,
     pub nsfw_level: NSFWLevel,
     pub owner_id: UserId,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -712,7 +709,6 @@ impl<'de> Deserialize<'de> for Guild {
                     voice_state.guild_id.replace(id);
                 }
 
-                #[allow(deprecated)]
                 Ok(Guild {
                     afk_channel_id,
                     afk_timeout,
@@ -738,7 +734,6 @@ impl<'de> Deserialize<'de> for Guild {
                     members,
                     mfa_level,
                     name,
-                    nsfw: false,
                     nsfw_level,
                     owner_id,
                     owner,
@@ -825,7 +820,6 @@ mod tests {
     use serde_test::Token;
 
     #[allow(clippy::too_many_lines)]
-    #[allow(deprecated)]
     #[test]
     fn test_guild() {
         #[allow(deprecated)]
@@ -854,7 +848,6 @@ mod tests {
             members: Vec::new(),
             mfa_level: MfaLevel::Elevated,
             name: "the name".to_owned(),
-            nsfw: false,
             nsfw_level: NSFWLevel::Default,
             owner_id: UserId(5),
             owner: Some(false),

--- a/model/src/guild/partial_guild.rs
+++ b/model/src/guild/partial_guild.rs
@@ -29,9 +29,6 @@ pub struct PartialGuild {
     pub member_count: Option<u64>,
     pub mfa_level: MfaLevel,
     pub name: String,
-    #[deprecated(since = "0.4.3", note = "no longer provided by discord, see #839")]
-    #[serde(skip)]
-    pub nsfw: bool,
     pub nsfw_level: NSFWLevel,
     pub owner_id: UserId,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -67,7 +64,6 @@ mod tests {
     use serde_test::Token;
 
     #[allow(clippy::too_many_lines)]
-    #[allow(deprecated)]
     #[test]
     fn test_partial_guild() {
         #[allow(deprecated)]
@@ -89,7 +85,6 @@ mod tests {
             member_count: Some(12_000),
             mfa_level: MfaLevel::Elevated,
             name: "the name".to_owned(),
-            nsfw: false,
             nsfw_level: NSFWLevel::Default,
             owner_id: UserId(5),
             owner: Some(false),


### PR DESCRIPTION
BREAKING CHANGE: This PR removes the `nsfw` field on guild models, which
has been replaced by Discord with `NSFWLevel`.

Related to #839 and #848.