### PR TITLE
Activities is required when updating presence

### DIFF
--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -285,12 +285,12 @@ impl ShardBuilder {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let shard = Shard::builder("token", Intents::empty())
     ///     .presence(UpdateStatusInfo::new(
-    ///         Some(vec![MinimalActivity {
+    ///         vec![MinimalActivity {
     ///             kind: ActivityType::Playing,
     ///             name: "Not accepting commands".into(),
     ///             url: None,
     ///         }
-    ///         .into()]),
+    ///         .into()],
     ///         false,
     ///         None,
     ///         Status::Idle,

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -294,7 +294,7 @@ impl ShardBuilder {
     ///         false,
     ///         None,
     ///         Status::Idle,
-    ///     ));
+    ///     )?);
     /// # Ok(()) }
     ///
     /// ```

--- a/gateway/tests/test_shard_command_ratelimit.rs
+++ b/gateway/tests/test_shard_command_ratelimit.rs
@@ -65,7 +65,8 @@ async fn test_shard_command_ratelimit() {
         false,
         Some(1),
         Status::DoNotDisturb,
-    ).unwrap();
+    )
+    .unwrap();
     let now = Instant::now();
     shard.command(&payload).await.unwrap();
     assert!(now.elapsed() < Duration::from_millis(500));

--- a/gateway/tests/test_shard_command_ratelimit.rs
+++ b/gateway/tests/test_shard_command_ratelimit.rs
@@ -65,7 +65,7 @@ async fn test_shard_command_ratelimit() {
         false,
         Some(1),
         Status::DoNotDisturb,
-    );
+    ).unwrap();
     let now = Instant::now();
     shard.command(&payload).await.unwrap();
     assert!(now.elapsed() < Duration::from_millis(500));

--- a/model/src/gateway/payload/update_status.rs
+++ b/model/src/gateway/payload/update_status.rs
@@ -3,6 +3,56 @@ use crate::gateway::{
     presence::{Activity, Status},
 };
 use serde::{Deserialize, Serialize};
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+
+/// Error emitted when the payload can not be created as configured.
+#[derive(Debug)]
+pub struct UpdateStatusError {
+    kind: UpdateStatusErrorType,
+}
+
+impl UpdateStatusError {
+    /// Immutable reference to the type of error that occured.
+    #[must_use = "retrieving the type has no effect if let unused"]
+    pub const fn kind(&self) -> &UpdateStatusErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the source has no effect if let unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (UpdateStatusErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, None)
+    }
+}
+
+impl Display for UpdateStatusError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self.kind {
+            UpdateStatusErrorType::MissingActivity => {
+                f.write_str("at least one activity must be provided")
+            }
+        }
+    }
+}
+
+impl Error for UpdateStatusError {}
+
+/// Type of [`UpdateStatusError`] that occured.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum UpdateStatusErrorType {
+    /// No activities provided.
+    MissingActivity,
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct UpdateStatus {
@@ -12,21 +62,26 @@ pub struct UpdateStatus {
 
 impl UpdateStatus {
     pub fn new(
-        activities: impl Into<Option<Vec<Activity>>>,
+        activities: impl Into<Vec<Activity>>,
         afk: bool,
         since: impl Into<Option<u64>>,
         status: impl Into<Status>,
-    ) -> Self {
-        Self {
-            d: UpdateStatusInfo::new(activities, afk, since, status),
+    ) -> Result<Self, UpdateStatusError> {
+        let d = UpdateStatusInfo::new(activities, afk, since, status)?;
+
+        Ok(Self {
+            d,
             op: OpCode::StatusUpdate,
-        }
+        })
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct UpdateStatusInfo {
-    pub activities: Option<Vec<Activity>>,
+    /// User's activities.
+    ///
+    /// At least one is required.
+    pub activities: Vec<Activity>,
     pub afk: bool,
     pub since: Option<u64>,
     pub status: Status,
@@ -34,25 +89,31 @@ pub struct UpdateStatusInfo {
 
 impl UpdateStatusInfo {
     pub fn new(
-        activities: impl Into<Option<Vec<Activity>>>,
+        activities: impl Into<Vec<Activity>>,
         afk: bool,
         since: impl Into<Option<u64>>,
         status: impl Into<Status>,
-    ) -> Self {
+    ) -> Result<Self, UpdateStatusError> {
         Self::_new(activities.into(), afk, since.into(), status.into())
     }
 
-    const fn _new(
-        activities: Option<Vec<Activity>>,
+    fn _new(
+        activities: Vec<Activity>,
         afk: bool,
         since: Option<u64>,
         status: Status,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, UpdateStatusError> {
+        if activities.is_empty() {
+            return Err(UpdateStatusError {
+                kind: UpdateStatusErrorType::MissingActivity,
+            });
+        }
+
+        Ok(Self {
             activities,
             afk,
             since,
             status,
-        }
+        })
     }
 }

--- a/model/src/gateway/payload/update_status.rs
+++ b/model/src/gateway/payload/update_status.rs
@@ -47,7 +47,7 @@ impl Display for UpdateStatusError {
 
 impl Error for UpdateStatusError {}
 
-/// Type of [`UpdateStatusError`] that occured.
+/// Type of [`UpdateStatusError`] that occurred.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum UpdateStatusErrorType {
@@ -95,12 +95,12 @@ pub struct UpdateStatusInfo {
 }
 
 impl UpdateStatusInfo {
-    /// Create a new, valid [`UpdateStatusInfo`] struct.
+    /// Create a validated stats update info struct.
     ///
     /// # Errors
     ///
-    /// Returns an error of type [`UpdateStatusErrorType::MissingActivity`] if
-    /// an empty set of activites is provided.
+    /// Returns an [`UpdateStatusErrorType::MissingActivity`] error type if an
+    /// empty set of activites is provided.
     pub fn new(
         activities: impl Into<Vec<Activity>>,
         afk: bool,

--- a/model/src/gateway/payload/update_status.rs
+++ b/model/src/gateway/payload/update_status.rs
@@ -22,6 +22,7 @@ impl UpdateStatusError {
     }
 
     /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
     #[must_use = "consuming the error and retrieving the source has no effect if let unused"]
     pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
         None
@@ -61,6 +62,12 @@ pub struct UpdateStatus {
 }
 
 impl UpdateStatus {
+    /// Create a new, valid [`UpdateStatus`] payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`UpdateStatusErrorType::MissingActivity`] if
+    /// an empty set of activites is provided.
     pub fn new(
         activities: impl Into<Vec<Activity>>,
         afk: bool,
@@ -88,6 +95,12 @@ pub struct UpdateStatusInfo {
 }
 
 impl UpdateStatusInfo {
+    /// Create a new, valid [`UpdateStatusInfo`] struct.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`UpdateStatusErrorType::MissingActivity`] if
+    /// an empty set of activites is provided.
     pub fn new(
         activities: impl Into<Vec<Activity>>,
         afk: bool,


### PR DESCRIPTION
This PR removes the `Some` from `UpdateStatusInfo`, as the list is now
required. It also validates that at least one activity is present when
using the `new` method.

Fixes #858.
