### PR TITLE
UpdateStageInstance topic no longer required

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -7,10 +7,7 @@ use crate::{
     error::{Error, ErrorType},
     ratelimiting::{RatelimitHeaders, Ratelimiter},
     request::{
-        channel::stage::{
-            create_stage_instance::CreateStageInstanceError,
-            update_stage_instance::UpdateStageInstanceError,
-        },
+        channel::stage::create_stage_instance::CreateStageInstanceError,
         guild::{
             create_guild::CreateGuildError, create_guild_channel::CreateGuildChannelError,
             update_guild_channel_positions::Position,
@@ -1356,19 +1353,8 @@ impl Client {
     /// Update fields of an existing stage instance.
     ///
     /// Requires the user to be a moderator of the stage channel.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`UpdateStageInstanceError`] of type [`InvalidTopic`] when the
-    ///
-    /// [`InvalidTopic`]: crate::request::channel::stage::update_stage_instance::UpdateStageInstanceErrorType::InvalidTopic
-    /// topic is not between 1 and 120 characters in length.
-    pub fn update_stage_instance(
-        &self,
-        channel_id: ChannelId,
-        topic: impl Into<String>,
-    ) -> Result<UpdateStageInstance<'_>, UpdateStageInstanceError> {
-        UpdateStageInstance::new(self, channel_id, topic)
+    pub fn update_stage_instance(&self, channel_id: ChannelId) -> UpdateStageInstance<'_> {
+        UpdateStageInstance::new(self, channel_id)
     }
 
     /// Delete the stage instance of a stage channel.

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -89,35 +89,13 @@ pub struct UpdateStageInstance<'a> {
 }
 
 impl<'a> UpdateStageInstance<'a> {
-    pub(crate) fn new(
-        http: &'a Client,
-        channel_id: ChannelId,
-        topic: impl Into<String>,
-    ) -> Result<Self, UpdateStageInstanceError> {
-        Self::_new(http, channel_id, topic.into())
-    }
-
-    fn _new(
-        http: &'a Client,
-        channel_id: ChannelId,
-        topic: String,
-    ) -> Result<Self, UpdateStageInstanceError> {
-        if !validate::stage_topic(&topic) {
-            return Err(UpdateStageInstanceError {
-                kind: UpdateStageInstanceErrorType::InvalidTopic { topic },
-                source: None,
-            });
-        }
-
-        Ok(Self {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self {
             channel_id,
-            fields: UpdateStageInstanceFields {
-                topic: Some(topic),
-                ..UpdateStageInstanceFields::default()
-            },
+            fields: UpdateStageInstanceFields::default(),
             fut: None,
             http,
-        })
+        }
     }
 
     /// Set the [`PrivacyLevel`] of the instance.


### PR DESCRIPTION
BREAKING CHANGE: `UpdateStageInstance` requests like this: 
```rust
client.update_stage_instance(ChannelId(1), "topic")?.await?;
```
are now written like this: 
```rust
client.update_stage_instance(ChannelId(1))
    .topic("topic")?
    .await?;
```

Continued from #867.
