### PR TITLE
Update forgotten error types

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -803,10 +803,11 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns [`SearchGuildMembersError::LimitInvalid`] if the limit is invalid.
+    /// Returns a [`SearchGuildMembersErrorType::LimitInvalid`] error type if
+    /// the limit is invalid.
     ///
     /// [`GUILD_MEMBERS`]: ../../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_MEMBERS
-    /// [`SearchGuildMembersError::LimitInvalid`]: ../request/guild/member/search_guild_members/enum.SearchGuildMembersError.html#variant.LimitInvalid
+    /// [`SearchGuildMembersErrorType::LimitInvalid`]: ../request/guild/member/search_guild_members/enum.SearchGuildMembersError.html#variant.LimitInvalid
     pub fn search_guild_members(
         &self,
         guild_id: GuildId,
@@ -1384,10 +1385,10 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateGuildFromTemplateError::NameInvalid`] when the name is
-    /// invalid.
+    /// Returns a [`CreateGuildFromTemplateErrorType::NameInvalid`] error type
+    /// if the name is invalid.
     ///
-    /// [`CreateGuildFromTemplateError::NameInvalid`]: crate::request::template::create_guild_from_template::CreateGuildFromTemplateError::NameInvalid
+    /// [`CreateGuildFromTemplateErrorType::NameInvalid`]: crate::request::template::create_guild_from_template::CreateGuildFromTemplateErrorType::NameInvalid
     pub fn create_guild_from_template(
         &self,
         template_code: impl Into<String>,
@@ -1403,9 +1404,10 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateTemplateError::NameInvalid`] when the name is invalid.
+    /// Returns a [`CreateTemplateErrorType::NameInvalid`] error type if the
+    /// name is invalid.
     ///
-    /// [`CreateTemplateError::NameInvalid`]: crate::request::template::create_template::CreateTemplateError::NameInvalid
+    /// [`CreateTemplateErrorType::NameInvalid`]: crate::request::template::create_template::CreateTemplateErrorType::NameInvalid
     pub fn create_template(
         &self,
         guild_id: GuildId,

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -65,7 +65,7 @@ impl Display for SearchGuildMembersError {
 
 impl Error for SearchGuildMembersError {}
 
-/// Type of error that occured.
+/// Type of [`SearchGuildMembersError`] that occurred.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum SearchGuildMembersErrorType {

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -24,25 +24,57 @@ use serde_json::Value;
 use simd_json::value::OwnedValue as Value;
 
 /// The error created when the members can not be queried as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct SearchGuildMembersError {
+    kind: SearchGuildMembersErrorType,
+}
+
+impl SearchGuildMembersError {
+    /// Immutable reference to the type of error that occured.
+    #[must_use = "retrieving the type has no effect if left unused"]
+    pub const fn kind(&self) -> &SearchGuildMembersErrorType {
+        &self.kind
+    }
+
+    /// Consumes the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type nad the source error.
+    #[must_use = "consuming the error int its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        SearchGuildMembersErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for SearchGuildMembersError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self.kind {
+            SearchGuildMembersErrorType::LimitInvalid { .. } => f.write_str("the limit is invalid"),
+        }
+    }
+}
+
+impl Error for SearchGuildMembersError {}
+
+/// Type of error that occured.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum SearchGuildMembersError {
+pub enum SearchGuildMembersErrorType {
     /// The limit is either 0 or more than 1000.
     LimitInvalid {
         /// Provided limit.
         limit: u64,
     },
 }
-
-impl Display for SearchGuildMembersError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::LimitInvalid { .. } => f.write_str("the limit is invalid"),
-        }
-    }
-}
-
-impl Error for SearchGuildMembersError {}
 
 struct SearchGuildMembersFields {
     query: String,
@@ -72,7 +104,8 @@ struct SearchGuildMembersFields {
 ///
 /// # Errors
 ///
-/// Returns [`SearchGuildMembersError::LimitInvalid`] if the limit is invalid.
+/// Returns a [`SearchGuildMembersErrorType::LimitInvalid`] error type if the
+/// limit is invalid.
 ///
 /// [`GUILD_MEMBERS`]: twilight_model::gateway::Intents#GUILD_MEMBERS
 pub struct SearchGuildMembers<'a> {
@@ -102,13 +135,15 @@ impl<'a> SearchGuildMembers<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`SearchGuildMembersError::LimitInvalid`] if the limit is 0 or
-    /// greater than 1000.
+    /// Returns a [`SearchGuildMembersError::LimitInvalid`] error type if the
+    /// limit is 0 or greater than 1000.
     pub fn limit(mut self, limit: u64) -> Result<Self, SearchGuildMembersError> {
         // Using get_guild_members_limit here as the limits are the same
         // and this endpoint is not officially documented yet.
         if !validate::search_guild_members_limit(limit) {
-            return Err(SearchGuildMembersError::LimitInvalid { limit });
+            return Err(SearchGuildMembersError {
+                kind: SearchGuildMembersErrorType::LimitInvalid { limit },
+            });
         }
 
         self.fields.limit.replace(limit);

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -135,8 +135,8 @@ impl<'a> SearchGuildMembers<'a> {
     ///
     /// # Errors
     ///
-    /// Returns a [`SearchGuildMembersError::LimitInvalid`] error type if the
-    /// limit is 0 or greater than 1000.
+    /// Returns a [`SearchGuildMembersErrorType::LimitInvalid`] error type if
+    /// the limit is 0 or greater than 1000.
     pub fn limit(mut self, limit: u64) -> Result<Self, SearchGuildMembersError> {
         // Using get_guild_members_limit here as the limits are the same
         // and this endpoint is not officially documented yet.

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -30,7 +30,7 @@ pub struct SearchGuildMembersError {
 }
 
 impl SearchGuildMembersError {
-    /// Immutable reference to the type of error that occured.
+    /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
     pub const fn kind(&self) -> &SearchGuildMembersErrorType {
         &self.kind

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -54,6 +54,7 @@ impl Display for CreateGuildFromTemplateError {
 
 impl Error for CreateGuildFromTemplateError {}
 
+/// Type of [`CreateGuildFromTemplateError`] that occurred.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum CreateGuildFromTemplateErrorType {

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -17,7 +17,7 @@ pub struct CreateGuildFromTemplateError {
 }
 
 impl CreateGuildFromTemplateError {
-    /// Immutable reference to the type of error that occured.
+    /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
     pub const fn kind(&self) -> &CreateGuildFromTemplateErrorType {
         &self.kind

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -11,9 +11,52 @@ use std::{
 };
 use twilight_model::guild::Guild;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct CreateGuildFromTemplateError {
+    kind: CreateGuildFromTemplateErrorType,
+}
+
+impl CreateGuildFromTemplateError {
+    /// Immutable reference to the type of error that occured.
+    #[must_use = "retrieving the type has no effect if left unused"]
+    pub const fn kind(&self) -> &CreateGuildFromTemplateErrorType {
+        &self.kind
+    }
+
+    /// Consumes the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type nad the source error.
+    #[must_use = "consuming the error int its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        CreateGuildFromTemplateErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for CreateGuildFromTemplateError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self.kind {
+            CreateGuildFromTemplateErrorType::NameInvalid { .. } => {
+                f.write_str("the guild name is invalid")
+            }
+        }
+    }
+}
+
+impl Error for CreateGuildFromTemplateError {}
+
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum CreateGuildFromTemplateError {
+pub enum CreateGuildFromTemplateErrorType {
     /// Name of the guild is either fewer than 2 UTF-16 characters or more than 100 UTF-16
     /// characters.
     NameInvalid {
@@ -21,16 +64,6 @@ pub enum CreateGuildFromTemplateError {
         name: String,
     },
 }
-
-impl Display for CreateGuildFromTemplateError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NameInvalid { .. } => f.write_str("the guild name is invalid"),
-        }
-    }
-}
-
-impl Error for CreateGuildFromTemplateError {}
 
 #[derive(Serialize)]
 struct CreateGuildFromTemplateFields {
@@ -44,8 +77,8 @@ struct CreateGuildFromTemplateFields {
 ///
 /// # Errors
 ///
-/// Returns [`CreateGuildFromTemplateError::NameInvalid`] when the name is
-/// invalid.
+/// Returns a [`CreateGuildFromTemplateErrorType::NameInvalid`] error type if
+/// the name is invalid.
 pub struct CreateGuildFromTemplate<'a> {
     fields: CreateGuildFromTemplateFields,
     fut: Option<Pending<'a, Guild>>,
@@ -68,7 +101,9 @@ impl<'a> CreateGuildFromTemplate<'a> {
         name: String,
     ) -> Result<Self, CreateGuildFromTemplateError> {
         if !validate::guild_name(&name) {
-            return Err(CreateGuildFromTemplateError::NameInvalid { name });
+            return Err(CreateGuildFromTemplateError {
+                kind: CreateGuildFromTemplateErrorType::NameInvalid { name },
+            });
         }
 
         Ok(Self {

--- a/http/src/request/template/create_template.rs
+++ b/http/src/request/template/create_template.rs
@@ -18,7 +18,7 @@ pub struct CreateTemplateError {
 }
 
 impl CreateTemplateError {
-    /// Immutable reference to the type of error that occured.
+    /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
     pub const fn kind(&self) -> &CreateTemplateErrorType {
         &self.kind

--- a/http/src/request/template/create_template.rs
+++ b/http/src/request/template/create_template.rs
@@ -58,7 +58,7 @@ impl Display for CreateTemplateError {
 
 impl Error for CreateTemplateError {}
 
-/// Type of error.
+/// Type of [`CreateTemplateError`] that occurred.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum CreateTemplateErrorType {

--- a/http/src/request/template/create_template.rs
+++ b/http/src/request/template/create_template.rs
@@ -12,9 +12,56 @@ use std::{
 use twilight_model::{id::GuildId, template::Template};
 
 /// Error returned when the template can not be created as configured.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+pub struct CreateTemplateError {
+    kind: CreateTemplateErrorType,
+}
+
+impl CreateTemplateError {
+    /// Immutable reference to the type of error that occured.
+    #[must_use = "retrieving the type has no effect if left unused"]
+    pub const fn kind(&self) -> &CreateTemplateErrorType {
+        &self.kind
+    }
+
+    /// Consumes the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type nad the source error.
+    #[must_use = "consuming the error int its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        CreateTemplateErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for CreateTemplateError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self.kind {
+            CreateTemplateErrorType::NameInvalid { .. } => {
+                f.write_str("the template name is invalid")
+            }
+            CreateTemplateErrorType::DescriptionTooLarge { .. } => {
+                f.write_str("the template description is too large")
+            }
+        }
+    }
+}
+
+impl Error for CreateTemplateError {}
+
+/// Type of error.
+#[derive(Debug)]
 #[non_exhaustive]
-pub enum CreateTemplateError {
+pub enum CreateTemplateErrorType {
     /// Name of the template is invalid.
     NameInvalid {
         /// Provided name.
@@ -26,19 +73,6 @@ pub enum CreateTemplateError {
         description: String,
     },
 }
-
-impl Display for CreateTemplateError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::NameInvalid { .. } => f.write_str("the template name is invalid"),
-            Self::DescriptionTooLarge { .. } => {
-                f.write_str("the template description is too large")
-            }
-        }
-    }
-}
-
-impl Error for CreateTemplateError {}
 
 #[derive(Serialize)]
 struct CreateTemplateFields {
@@ -53,7 +87,8 @@ struct CreateTemplateFields {
 ///
 /// # Errors
 ///
-/// Returns [`CreateTemplateError::NameInvalid`] when the name is invalid.
+/// Returns a [`CreateTemplateErrorType::NameInvalid`] error type if the name is
+/// invalid.
 pub struct CreateTemplate<'a> {
     fields: CreateTemplateFields,
     fut: Option<Pending<'a, Template>>,
@@ -76,7 +111,9 @@ impl<'a> CreateTemplate<'a> {
         name: String,
     ) -> Result<Self, CreateTemplateError> {
         if !validate::template_name(&name) {
-            return Err(CreateTemplateError::NameInvalid { name });
+            return Err(CreateTemplateError {
+                kind: CreateTemplateErrorType::NameInvalid { name },
+            });
         }
 
         Ok(Self {
@@ -96,15 +133,17 @@ impl<'a> CreateTemplate<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`CreateTemplateError::DescriptionTooLarge`] when the
-    /// description is too large.
+    /// Returns a [`CreateTemplateErrorType::DescriptionTooLarge`] error type if
+    /// the description is too large.
     pub fn description(self, description: impl Into<String>) -> Result<Self, CreateTemplateError> {
         self._description(description.into())
     }
 
     fn _description(mut self, description: String) -> Result<Self, CreateTemplateError> {
         if !validate::template_description(&description) {
-            return Err(CreateTemplateError::DescriptionTooLarge { description });
+            return Err(CreateTemplateError {
+                kind: CreateTemplateErrorType::DescriptionTooLarge { description },
+            });
         }
 
         self.fields.description.replace(description);

--- a/http/src/request/template/update_template.rs
+++ b/http/src/request/template/update_template.rs
@@ -58,6 +58,7 @@ impl Display for UpdateTemplateError {
 
 impl Error for UpdateTemplateError {}
 
+/// Type of [`UpdateTemplateError`] that occurred.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum UpdateTemplateErrorType {

--- a/http/src/request/template/update_template.rs
+++ b/http/src/request/template/update_template.rs
@@ -18,7 +18,7 @@ pub struct UpdateTemplateError {
 }
 
 impl UpdateTemplateError {
-    /// Immutable reference to the type of error that occured.
+    /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if left unused"]
     pub const fn kind(&self) -> &UpdateTemplateErrorType {
         &self.kind


### PR DESCRIPTION
BREAKING CHANGE: Updates four different errors to the new standard that were missed in a
review or rebase.
