### PR TITLE
Rename `UpdateStatus` to `UpdatePresence`

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -11,7 +11,7 @@ use futures_util::stream::Stream;
 use std::{collections::HashMap, sync::Arc};
 use twilight_gateway_queue::{LocalQueue, Queue};
 use twilight_http::Client;
-use twilight_model::gateway::{payload::update_presence::UpdatePresenceData, Intents};
+use twilight_model::gateway::{payload::update_presence::UpdatePresencePayload, Intents};
 
 /// Builder to configure and construct a [`Cluster`].
 ///
@@ -156,7 +156,7 @@ impl ClusterBuilder {
     /// Set the presence to use when identifying with the gateway.
     ///
     /// Refer to the shard's [`ShardBuilder::presence`] for more information.
-    pub fn presence(mut self, presence: UpdatePresenceData) -> Self {
+    pub fn presence(mut self, presence: UpdatePresencePayload) -> Self {
         self.1 = self.1.presence(presence);
 
         self

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -11,7 +11,7 @@ use futures_util::stream::Stream;
 use std::{collections::HashMap, sync::Arc};
 use twilight_gateway_queue::{LocalQueue, Queue};
 use twilight_http::Client;
-use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents};
+use twilight_model::gateway::{payload::update_presence::UpdatePresenceData, Intents};
 
 /// Builder to configure and construct a [`Cluster`].
 ///
@@ -156,7 +156,7 @@ impl ClusterBuilder {
     /// Set the presence to use when identifying with the gateway.
     ///
     /// Refer to the shard's [`ShardBuilder::presence`] for more information.
-    pub fn presence(mut self, presence: UpdateStatusInfo) -> Self {
+    pub fn presence(mut self, presence: UpdatePresenceData) -> Self {
         self.1 = self.1.presence(presence);
 
         self

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -7,7 +7,7 @@ use std::{
 };
 use twilight_gateway_queue::{LocalQueue, Queue};
 use twilight_http::Client as HttpClient;
-use twilight_model::gateway::{payload::update_presence::UpdatePresenceData, Intents};
+use twilight_model::gateway::{payload::update_presence::UpdatePresencePayload, Intents};
 
 /// Large threshold configuration is invalid.
 ///
@@ -278,13 +278,13 @@ impl ShardBuilder {
     /// ```no_run
     /// use twilight_gateway::{Intents, Shard};
     /// use twilight_model::gateway::{
-    ///     payload::update_presence::UpdatePresenceData,
+    ///     payload::update_presence::UpdatePresencePayload,
     ///     presence::{ActivityType, MinimalActivity, Status},
     /// };
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let shard = Shard::builder("token", Intents::empty())
-    ///     .presence(UpdatePresenceData::new(
+    ///     .presence(UpdatePresencePayload::new(
     ///         vec![MinimalActivity {
     ///             kind: ActivityType::Playing,
     ///             name: "Not accepting commands".into(),
@@ -298,7 +298,7 @@ impl ShardBuilder {
     /// # Ok(()) }
     ///
     /// ```
-    pub fn presence(mut self, presence: UpdatePresenceData) -> Self {
+    pub fn presence(mut self, presence: UpdatePresencePayload) -> Self {
         self.0.presence.replace(presence);
 
         self

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -7,7 +7,7 @@ use std::{
 };
 use twilight_gateway_queue::{LocalQueue, Queue};
 use twilight_http::Client as HttpClient;
-use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents};
+use twilight_model::gateway::{payload::update_presence::UpdatePresenceData, Intents};
 
 /// Large threshold configuration is invalid.
 ///
@@ -278,13 +278,13 @@ impl ShardBuilder {
     /// ```no_run
     /// use twilight_gateway::{Intents, Shard};
     /// use twilight_model::gateway::{
-    ///     payload::update_status::UpdateStatusInfo,
+    ///     payload::update_presence::UpdatePresenceData,
     ///     presence::{ActivityType, MinimalActivity, Status},
     /// };
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let shard = Shard::builder("token", Intents::empty())
-    ///     .presence(UpdateStatusInfo::new(
+    ///     .presence(UpdatePresenceData::new(
     ///         vec![MinimalActivity {
     ///             kind: ActivityType::Playing,
     ///             name: "Not accepting commands".into(),
@@ -298,7 +298,7 @@ impl ShardBuilder {
     /// # Ok(()) }
     ///
     /// ```
-    pub fn presence(mut self, presence: UpdateStatusInfo) -> Self {
+    pub fn presence(mut self, presence: UpdatePresenceData) -> Self {
         self.0.presence.replace(presence);
 
         self

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -2,7 +2,7 @@ use crate::EventTypeFlags;
 use std::sync::Arc;
 use twilight_gateway_queue::Queue;
 use twilight_http::Client;
-use twilight_model::gateway::{payload::update_presence::UpdatePresenceData, Intents};
+use twilight_model::gateway::{payload::update_presence::UpdatePresencePayload, Intents};
 
 /// The configuration used by the shard to identify with the gateway and
 /// operate.
@@ -17,7 +17,7 @@ pub struct Config {
     pub(crate) http_client: Client,
     pub(super) intents: Intents,
     pub(super) large_threshold: u64,
-    pub(super) presence: Option<UpdatePresenceData>,
+    pub(super) presence: Option<UpdatePresencePayload>,
     pub(super) queue: Arc<Box<dyn Queue>>,
     pub(crate) shard: [u64; 2],
     pub(super) token: Box<str>,
@@ -58,7 +58,7 @@ impl Config {
     ///
     /// This will be the bot's presence. For example, setting the online status
     /// to Do Not Disturb will show the status in the bot's presence.
-    pub const fn presence(&self) -> Option<&UpdatePresenceData> {
+    pub const fn presence(&self) -> Option<&UpdatePresencePayload> {
         self.presence.as_ref()
     }
 

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -2,7 +2,7 @@ use crate::EventTypeFlags;
 use std::sync::Arc;
 use twilight_gateway_queue::Queue;
 use twilight_http::Client;
-use twilight_model::gateway::{payload::update_status::UpdateStatusInfo, Intents};
+use twilight_model::gateway::{payload::update_presence::UpdatePresenceData, Intents};
 
 /// The configuration used by the shard to identify with the gateway and
 /// operate.
@@ -17,7 +17,7 @@ pub struct Config {
     pub(crate) http_client: Client,
     pub(super) intents: Intents,
     pub(super) large_threshold: u64,
-    pub(super) presence: Option<UpdateStatusInfo>,
+    pub(super) presence: Option<UpdatePresenceData>,
     pub(super) queue: Arc<Box<dyn Queue>>,
     pub(crate) shard: [u64; 2],
     pub(super) token: Box<str>,
@@ -58,7 +58,7 @@ impl Config {
     ///
     /// This will be the bot's presence. For example, setting the online status
     /// to Do Not Disturb will show the status in the bot's presence.
-    pub const fn presence(&self) -> Option<&UpdateStatusInfo> {
+    pub const fn presence(&self) -> Option<&UpdatePresenceData> {
         self.presence.as_ref()
     }
 

--- a/gateway/tests/test_shard_command_ratelimit.rs
+++ b/gateway/tests/test_shard_command_ratelimit.rs
@@ -8,7 +8,7 @@ use twilight_gateway::{
     Event, Intents,
 };
 use twilight_model::gateway::{
-    payload::UpdateStatus,
+    payload::UpdatePresence,
     presence::{Activity, ActivityType, Status},
 };
 
@@ -43,7 +43,7 @@ async fn test_shard_command_ratelimit() {
     assert!(matches!(events.next().await.unwrap(), Event::Ready(_)));
 
     // now that we're connected we can test sending
-    let payload = UpdateStatus::new(
+    let payload = UpdatePresence::new(
         vec![Activity {
             application_id: None,
             assets: None,

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -422,8 +422,8 @@ impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
                 ))
             }
             OpCode::Resume => return Err(DeError::unknown_variant("Resume", VALID_OPCODES)),
-            OpCode::StatusUpdate => {
-                return Err(DeError::unknown_variant("StatusUpdate", VALID_OPCODES))
+            OpCode::PresenceUpdate => {
+                return Err(DeError::unknown_variant("PresenceUpdate", VALID_OPCODES))
             }
             OpCode::VoiceServerPing => {
                 return Err(DeError::unknown_variant("VoiceServerPing", VALID_OPCODES))

--- a/model/src/gateway/opcode.rs
+++ b/model/src/gateway/opcode.rs
@@ -13,7 +13,7 @@ pub enum OpCode {
     /// Start a new session.
     Identify = 2,
     /// Update the client's presence information.
-    StatusUpdate = 3,
+    PresenceUpdate = 3,
     /// Join, leave or move between voice channels.
     VoiceStateUpdate = 4,
     /// Voice ping checking. This opcode is deprecated.
@@ -42,7 +42,7 @@ mod tests {
         serde_test::assert_tokens(&OpCode::Event, &[Token::U8(0)]);
         serde_test::assert_tokens(&OpCode::Heartbeat, &[Token::U8(1)]);
         serde_test::assert_tokens(&OpCode::Identify, &[Token::U8(2)]);
-        serde_test::assert_tokens(&OpCode::StatusUpdate, &[Token::U8(3)]);
+        serde_test::assert_tokens(&OpCode::PresenceUpdate, &[Token::U8(3)]);
         serde_test::assert_tokens(&OpCode::VoiceStateUpdate, &[Token::U8(4)]);
         serde_test::assert_tokens(&OpCode::VoiceServerPing, &[Token::U8(5)]);
         serde_test::assert_tokens(&OpCode::Resume, &[Token::U8(6)]);

--- a/model/src/gateway/payload/identify.rs
+++ b/model/src/gateway/payload/identify.rs
@@ -1,4 +1,4 @@
-use super::update_presence::UpdatePresenceData;
+use super::update_presence::UpdatePresencePayload;
 use crate::gateway::{intents::Intents, opcode::OpCode};
 use serde::{Deserialize, Serialize};
 
@@ -22,7 +22,7 @@ pub struct IdentifyInfo {
     pub compress: bool,
     pub intents: Intents,
     pub large_threshold: u64,
-    pub presence: Option<UpdatePresenceData>,
+    pub presence: Option<UpdatePresencePayload>,
     pub properties: IdentifyProperties,
     pub shard: Option<[u64; 2]>,
     pub token: String,

--- a/model/src/gateway/payload/identify.rs
+++ b/model/src/gateway/payload/identify.rs
@@ -1,4 +1,4 @@
-use super::update_status::UpdateStatusInfo;
+use super::update_presence::UpdatePresenceData;
 use crate::gateway::{intents::Intents, opcode::OpCode};
 use serde::{Deserialize, Serialize};
 
@@ -22,7 +22,7 @@ pub struct IdentifyInfo {
     pub compress: bool,
     pub intents: Intents,
     pub large_threshold: u64,
-    pub presence: Option<UpdateStatusInfo>,
+    pub presence: Option<UpdatePresenceData>,
     pub properties: IdentifyProperties,
     pub shard: Option<[u64; 2]>,
     pub token: String,

--- a/model/src/gateway/payload/mod.rs
+++ b/model/src/gateway/payload/mod.rs
@@ -2,7 +2,7 @@ pub mod identify;
 pub mod reaction_remove_emoji;
 pub mod request_guild_members;
 pub mod resume;
-pub mod update_status;
+pub mod update_presence;
 
 mod ban_add;
 mod ban_remove;
@@ -60,8 +60,8 @@ pub use self::{
     request_guild_members::RequestGuildMembers, role_create::RoleCreate, role_delete::RoleDelete,
     role_update::RoleUpdate, stage_instance_create::StageInstanceCreate,
     stage_instance_delete::StageInstanceDelete, stage_instance_update::StageInstanceUpdate,
-    typing_start::TypingStart, unavailable_guild::UnavailableGuild, update_status::UpdateStatus,
-    update_voice_state::UpdateVoiceState, user_update::UserUpdate,
+    typing_start::TypingStart, unavailable_guild::UnavailableGuild,
+    update_presence::UpdatePresence, update_voice_state::UpdateVoiceState, user_update::UserUpdate,
     voice_server_update::VoiceServerUpdate, voice_state_update::VoiceStateUpdate,
     webhooks_update::WebhooksUpdate,
 };

--- a/model/src/gateway/payload/update_presence.rs
+++ b/model/src/gateway/payload/update_presence.rs
@@ -10,14 +10,14 @@ use std::{
 
 /// Error emitted when the payload can not be created as configured.
 #[derive(Debug)]
-pub struct UpdateStatusError {
-    kind: UpdateStatusErrorType,
+pub struct UpdatePresenceError {
+    kind: UpdatePresenceErrorType,
 }
 
-impl UpdateStatusError {
+impl UpdatePresenceError {
     /// Immutable reference to the type of error that occured.
     #[must_use = "retrieving the type has no effect if let unused"]
-    pub const fn kind(&self) -> &UpdateStatusErrorType {
+    pub const fn kind(&self) -> &UpdatePresenceErrorType {
         &self.kind
     }
 
@@ -30,61 +30,66 @@ impl UpdateStatusError {
 
     /// Consume the error, returning the owned error type and the source error.
     #[must_use = "consuming the error into its parts has no effect if left unused"]
-    pub fn into_parts(self) -> (UpdateStatusErrorType, Option<Box<dyn Error + Send + Sync>>) {
+    pub fn into_parts(
+        self,
+    ) -> (
+        UpdatePresenceErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
         (self.kind, None)
     }
 }
 
-impl Display for UpdateStatusError {
+impl Display for UpdatePresenceError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self.kind {
-            UpdateStatusErrorType::MissingActivity => {
+            UpdatePresenceErrorType::MissingActivity => {
                 f.write_str("at least one activity must be provided")
             }
         }
     }
 }
 
-impl Error for UpdateStatusError {}
+impl Error for UpdatePresenceError {}
 
-/// Type of [`UpdateStatusError`] that occurred.
+/// Type of [`UpdatePresenceError`] that occurred.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum UpdateStatusErrorType {
+pub enum UpdatePresenceErrorType {
     /// No activities provided.
     MissingActivity,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct UpdateStatus {
-    pub d: UpdateStatusInfo,
+pub struct UpdatePresence {
+    pub d: UpdatePresenceData,
     pub op: OpCode,
 }
 
-impl UpdateStatus {
-    /// Create a new, valid [`UpdateStatus`] payload.
+impl UpdatePresence {
+    /// Create a new, valid [`UpdatePresence`] payload.
     ///
     /// # Errors
     ///
-    /// Returns an error of type [`UpdateStatusErrorType::MissingActivity`] if
+    /// Returns an error of type [`UpdatePresenceErrorType::MissingActivity`] if
     /// an empty set of activites is provided.
     pub fn new(
         activities: impl Into<Vec<Activity>>,
         afk: bool,
         since: impl Into<Option<u64>>,
         status: impl Into<Status>,
-    ) -> Result<Self, UpdateStatusError> {
-        let d = UpdateStatusInfo::new(activities, afk, since, status)?;
+    ) -> Result<Self, UpdatePresenceError> {
+        let d = UpdatePresenceData::new(activities, afk, since, status)?;
 
         Ok(Self {
             d,
-            op: OpCode::StatusUpdate,
+            op: OpCode::PresenceUpdate,
         })
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct UpdateStatusInfo {
+pub struct UpdatePresenceData {
     /// User's activities.
     ///
     /// At least one is required.
@@ -94,19 +99,19 @@ pub struct UpdateStatusInfo {
     pub status: Status,
 }
 
-impl UpdateStatusInfo {
+impl UpdatePresenceData {
     /// Create a validated stats update info struct.
     ///
     /// # Errors
     ///
-    /// Returns an [`UpdateStatusErrorType::MissingActivity`] error type if an
+    /// Returns an [`UpdatePresenceErrorType::MissingActivity`] error type if an
     /// empty set of activites is provided.
     pub fn new(
         activities: impl Into<Vec<Activity>>,
         afk: bool,
         since: impl Into<Option<u64>>,
         status: impl Into<Status>,
-    ) -> Result<Self, UpdateStatusError> {
+    ) -> Result<Self, UpdatePresenceError> {
         Self::_new(activities.into(), afk, since.into(), status.into())
     }
 
@@ -115,10 +120,10 @@ impl UpdateStatusInfo {
         afk: bool,
         since: Option<u64>,
         status: Status,
-    ) -> Result<Self, UpdateStatusError> {
+    ) -> Result<Self, UpdatePresenceError> {
         if activities.is_empty() {
-            return Err(UpdateStatusError {
-                kind: UpdateStatusErrorType::MissingActivity,
+            return Err(UpdatePresenceError {
+                kind: UpdatePresenceErrorType::MissingActivity,
             });
         }
 

--- a/model/src/gateway/payload/update_presence.rs
+++ b/model/src/gateway/payload/update_presence.rs
@@ -62,7 +62,7 @@ pub enum UpdatePresenceErrorType {
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct UpdatePresence {
-    pub d: UpdatePresenceData,
+    pub d: UpdatePresencePayload,
     pub op: OpCode,
 }
 
@@ -79,7 +79,7 @@ impl UpdatePresence {
         since: impl Into<Option<u64>>,
         status: impl Into<Status>,
     ) -> Result<Self, UpdatePresenceError> {
-        let d = UpdatePresenceData::new(activities, afk, since, status)?;
+        let d = UpdatePresencePayload::new(activities, afk, since, status)?;
 
         Ok(Self {
             d,
@@ -89,7 +89,7 @@ impl UpdatePresence {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct UpdatePresenceData {
+pub struct UpdatePresencePayload {
     /// User's activities.
     ///
     /// At least one is required.
@@ -99,7 +99,7 @@ pub struct UpdatePresenceData {
     pub status: Status,
 }
 
-impl UpdatePresenceData {
+impl UpdatePresencePayload {
     /// Create a validated stats update info struct.
     ///
     /// # Errors


### PR DESCRIPTION
Renames `UpdateStatus` to `UpdatePresence`, and all similar names, with
the exception of `UpdateStatusInfo` -> `UpdatePresenceData`.

Fixes #859.
