### PR TITLE
fix(model): Make CurrentApplicationInfo::flags optional

### DIFF
--- a/model/src/oauth/current_application_info/mod.rs
+++ b/model/src/oauth/current_application_info/mod.rs
@@ -142,7 +142,7 @@ mod tests {
                 Token::NewtypeStruct { name: "GuildId" },
                 Token::Str("1"),
                 Token::Str("flags"),
-                Token::U64(131_072),
+                Token::Some,
                 Token::Str("icon"),
                 Token::Some,
                 Token::Str("icon hash"),

--- a/model/src/oauth/current_application_info/mod.rs
+++ b/model/src/oauth/current_application_info/mod.rs
@@ -143,6 +143,7 @@ mod tests {
                 Token::Str("1"),
                 Token::Str("flags"),
                 Token::Some,
+                Token::U64(131072),
                 Token::Str("icon"),
                 Token::Some,
                 Token::Str("icon hash"),

--- a/model/src/oauth/current_application_info/mod.rs
+++ b/model/src/oauth/current_application_info/mod.rs
@@ -143,7 +143,7 @@ mod tests {
                 Token::Str("1"),
                 Token::Str("flags"),
                 Token::Some,
-                Token::U64(131072),
+                Token::U64(131_072),
                 Token::Str("icon"),
                 Token::Some,
                 Token::Str("icon hash"),

--- a/model/src/oauth/current_application_info/mod.rs
+++ b/model/src/oauth/current_application_info/mod.rs
@@ -17,7 +17,7 @@ pub struct CurrentApplicationInfo {
     pub description: String,
     pub guild_id: Option<GuildId>,
     /// Public flags of the application.
-    pub flags: ApplicationFlags,
+    pub flags: Option<ApplicationFlags>,
     pub icon: Option<String>,
     pub id: ApplicationId,
     pub name: String,
@@ -86,7 +86,7 @@ mod tests {
             cover_image: Some("cover image hash".to_owned()),
             description: "a pretty cool application".to_owned(),
             guild_id: Some(GuildId(1)),
-            flags: ApplicationFlags::EMBEDDED,
+            flags: Some(ApplicationFlags::EMBEDDED),
             icon: Some("icon hash".to_owned()),
             id: ApplicationId(2),
             name: "cool application".to_owned(),


### PR DESCRIPTION
` /oauth2/applications/@me` returns the CurrentApplicationInfo without `flags`, so this must be an `Option`.