### PR TITLE
Slash Commands: validate permission overwrite count

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -2100,13 +2100,7 @@ impl Client {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;
 
-        Ok(UpdateCommandPermissions::new(
-            self,
-            application_id,
-            guild_id,
-            command_id,
-            permissions,
-        ))
+        UpdateCommandPermissions::new(self, application_id, guild_id, command_id, permissions)
     }
 
     /// Update command permissions for all commands in a guild.
@@ -2128,12 +2122,7 @@ impl Client {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;
 
-        Ok(SetCommandPermissions::new(
-            self,
-            application_id,
-            guild_id,
-            permissions,
-        ))
+        SetCommandPermissions::new(self, application_id, guild_id, permissions)
     }
 
     /// Execute a request, returning the response.

--- a/http/src/request/application/mod.rs
+++ b/http/src/request/application/mod.rs
@@ -69,6 +69,8 @@ pub enum InteractionErrorType {
     CommandDescriptionValidationFailed { description: String },
     /// Required command options have to be passed before optional ones.
     CommandOptionsRequiredFirst { option: CommandOption },
+    /// More than 10 permission overwrites were set.
+    TooManyCommandPermissions,
 }
 
 impl InteractionError {
@@ -106,6 +108,9 @@ impl Display for InteractionError {
             }
             InteractionErrorType::CommandOptionsRequiredFirst { .. } => {
                 f.write_str("optional command options must be added after required")
+            }
+            InteractionErrorType::TooManyCommandPermissions { .. } => {
+                f.write_str("more than 10 permission overwrites were set")
             }
         }
     }

--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -94,6 +94,7 @@ poll_req!(SetCommandPermissions<'_>, ());
 mod tests {
     use super::SetCommandPermissions;
     use crate::Client;
+    use std::iter;
     use twilight_model::{
         application::command::permissions::{CommandPermissions, CommandPermissionsType},
         id::{ApplicationId, CommandId, GuildId, RoleId},
@@ -103,92 +104,14 @@ mod tests {
     fn test_validation() {
         let http = Client::new("token");
 
-        let permissions = vec![
-            (
-                CommandId(3),
-                CommandPermissions {
-                    id: CommandPermissionsType::Role(RoleId(4)),
-                    permission: true,
-                },
-            ),
-            (
-                CommandId(3),
-                CommandPermissions {
-                    id: CommandPermissionsType::Role(RoleId(4)),
-                    permission: true,
-                },
-            ),
-            (
-                CommandId(3),
-                CommandPermissions {
-                    id: CommandPermissionsType::Role(RoleId(4)),
-                    permission: true,
-                },
-            ),
-            (
-                CommandId(3),
-                CommandPermissions {
-                    id: CommandPermissionsType::Role(RoleId(4)),
-                    permission: true,
-                },
-            ),
-            (
-                CommandId(3),
-                CommandPermissions {
-                    id: CommandPermissionsType::Role(RoleId(4)),
-                    permission: true,
-                },
-            ),
-            (
-                CommandId(3),
-                CommandPermissions {
-                    id: CommandPermissionsType::Role(RoleId(4)),
-                    permission: true,
-                },
-            ),
-            (
-                CommandId(3),
-                CommandPermissions {
-                    id: CommandPermissionsType::Role(RoleId(4)),
-                    permission: true,
-                },
-            ),
-            (
-                CommandId(3),
-                CommandPermissions {
-                    id: CommandPermissionsType::Role(RoleId(4)),
-                    permission: true,
-                },
-            ),
-            (
-                CommandId(3),
-                CommandPermissions {
-                    id: CommandPermissionsType::Role(RoleId(4)),
-                    permission: true,
-                },
-            ),
-            (
-                CommandId(3),
-                CommandPermissions {
-                    id: CommandPermissionsType::Role(RoleId(4)),
-                    permission: true,
-                },
-            ),
-            (
-                CommandId(3),
-                CommandPermissions {
-                    id: CommandPermissionsType::Role(RoleId(4)),
-                    permission: true,
-                },
-            ),
-            (
-                CommandId(3),
-                CommandPermissions {
-                    id: CommandPermissionsType::Role(RoleId(4)),
-                    permission: true,
-                },
-            ),
-        ];
+        let permissions = iter::repeat((
+            CommandId(3),
+            CommandPermissions {
+                id: CommandPermissionsType::Role(RoleId(4)),
+                permission: true,
+            },
+        ))
+        .take(11);
 
         let request = SetCommandPermissions::new(
             &http,

--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -53,14 +53,12 @@ impl<'a> SetCommandPermissions<'a> {
             .fold(HashMap::new(), |mut acc, permission| {
                 acc.entry(permission.id)
                     .and_modify(|p| *p += 1)
-                    .or_insert(1usize);
+                    .or_insert(1_usize);
 
                 acc
             })
             .iter()
-            .fold(true, |valid, permission| {
-                valid && validate::command_permissions(*permission.1)
-            })
+            .all(|permission| validate::command_permissions(*permission.1))
         {
             return Err(InteractionError {
                 kind: InteractionErrorType::TooManyCommandPermissions,

--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -117,7 +117,7 @@ mod tests {
             &http,
             ApplicationId(1),
             GuildId(2),
-            permissions.into_iter(),
+            permissions,
         );
 
         assert!(request.is_err());

--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -100,18 +100,32 @@ mod tests {
         id::{ApplicationId, CommandId, GuildId, RoleId},
     };
 
-    #[test]
-    fn test_validation() {
-        let http = Client::new("token");
-
-        let permissions = iter::repeat((
+    fn make_iter() -> impl Iterator<Item = (CommandId, CommandPermissions)> {
+        iter::repeat((
             CommandId(3),
             CommandPermissions {
                 id: CommandPermissionsType::Role(RoleId(4)),
                 permission: true,
             },
         ))
-        .take(11);
+    }
+
+    #[test]
+    fn test_correct_validation() {
+        let http = Client::new("token");
+
+        let permissions = make_iter().take(4);
+
+        let request = SetCommandPermissions::new(&http, ApplicationId(1), GuildId(2), permissions);
+
+        assert!(request.is_ok());
+    }
+
+    #[test]
+    fn test_incorrect_validation() {
+        let http = Client::new("token");
+
+        let permissions = make_iter().take(11);
 
         let request = SetCommandPermissions::new(&http, ApplicationId(1), GuildId(2), permissions);
 

--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -113,12 +113,7 @@ mod tests {
         ))
         .take(11);
 
-        let request = SetCommandPermissions::new(
-            &http,
-            ApplicationId(1),
-            GuildId(2),
-            permissions,
-        );
+        let request = SetCommandPermissions::new(&http, ApplicationId(1), GuildId(2), permissions);
 
         assert!(request.is_err());
     }

--- a/http/src/request/application/update_command_permissions.rs
+++ b/http/src/request/application/update_command_permissions.rs
@@ -1,7 +1,10 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{Pending, Request},
+    request::{
+        application::{InteractionError, InteractionErrorType},
+        validate, Pending, Request,
+    },
     routing::Route,
 };
 use serde::Serialize;
@@ -37,15 +40,21 @@ impl<'a> UpdateCommandPermissions<'a> {
         guild_id: GuildId,
         command_id: CommandId,
         permissions: Vec<CommandPermissions>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, InteractionError> {
+        if !validate::command_permissions(permissions.len()) {
+            return Err(InteractionError {
+                kind: InteractionErrorType::TooManyCommandPermissions,
+            });
+        }
+
+        Ok(Self {
             application_id,
             command_id,
             guild_id,
             fields: UpdateCommandPermissionsFields { permissions },
             fut: None,
             http,
-        }
+        })
     }
 
     fn start(&mut self) -> Result<(), Error> {

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -443,6 +443,11 @@ fn _command_description(value: &str) -> bool {
     (1..=100).contains(&len)
 }
 
+pub fn command_permissions(len: usize) -> bool {
+    // https://discord.com/developers/docs/interactions/slash-commands#edit-application-command-permissions
+    (0..=10).contains(&len)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Adds validation for the amount of overwrites a command can have. For
`set_command_permissions`, since multiple commands' permissions can be
set at once, the per-command count is first accumulated and then
validated.

Fixes #856.
