### PR TITLE
Remove direct HTTP `bytes` dependency

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -15,7 +15,6 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.4.2"
 
 [dependencies]
-bytes = { default-features = false, version = "1.0" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     API_VERSION,
 };
-use bytes::Bytes;
+use hyper::body::Bytes;
 use hyper::{
     body::{self, Buf},
     client::{Client as HyperClient, HttpConnector},

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -4,7 +4,7 @@ use crate::{
     request::{validate, Pending, Request},
     routing::Route,
 };
-use bytes::Bytes;
+use hyper::body::Bytes;
 use serde::de::DeserializeSeed;
 use std::{
     error::Error,

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -4,7 +4,7 @@ use crate::{
     request::{validate, Pending, Request},
     routing::Route,
 };
-use bytes::Bytes;
+use hyper::body::Bytes;
 use serde::de::DeserializeSeed;
 use std::{
     error::Error,

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -4,7 +4,7 @@ use crate::{
     request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
     routing::Route,
 };
-use bytes::Bytes;
+use hyper::body::Bytes;
 use serde::{de::DeserializeSeed, Serialize};
 use std::{
     error::Error,

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -89,7 +89,7 @@ pub use self::{
 };
 
 use crate::error::{Error, ErrorType};
-use bytes::Bytes;
+use hyper::body::Bytes;
 use hyper::{
     header::{HeaderName, HeaderValue},
     Method as HyperMethod,


### PR DESCRIPTION
Remove a direct dependency on the `bytes` crate by instead using `hyper`'s re-export.