### PR TITLE
Make HTTP `tracing` dependency optional

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -24,7 +24,6 @@ hyper-tls = { default-features = false, optional = true, version = "0.5" }
 native-tls = { default-features = false, features = ["alpn"], optional = true, version = "0.2.7" }
 percent-encoding = { default-features = false, version = "2" }
 tokio = { default-features = false, features = ["time"], version = "1.0" }
-tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-model = { default-features = false, path = "../model" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["alloc"], version = "1" }
@@ -32,6 +31,7 @@ serde_repr = { default-features = false, version = "0.1" }
 
 # optional
 simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.4" }
+tracing = { default-features = false, features = ["std", "attributes"], optional = true, version = "0.1" }
 
 [features]
 default = ["rustls"]

--- a/http/README.md
+++ b/http/README.md
@@ -62,11 +62,18 @@ The `rustls` feature enables [`hyper`]'s `rustls` feature, which uses
 
 This is enabled by default.
 
+### Tracing
+
+The `tracing` feature enables logging via the [`tracing`] crate.
+
+This is enabled by default.
+
 [`native-tls`]: https://crates.io/crates/native-tls
 [`hyper`]: https://crates.io/crates/hyper
 [`rustls`]: https://crates.io/crates/rustls
 [`serde_json`]: https://crates.io/crates/serde_json
 [`simd-json`]: https://crates.io/crates/simd-json
+[`tracing`]: https://crates.io/crates/tracing
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -3,7 +3,7 @@ mod builder;
 pub use self::builder::ClientBuilder;
 
 use crate::{
-    api_error::{ApiError, ErrorCode},
+    api_error::ApiError,
     error::{Error, ErrorType},
     ratelimiting::{RatelimitHeaders, Ratelimiter},
     request::{
@@ -1651,6 +1651,7 @@ impl Client {
         let host = self.state.proxy.as_deref().unwrap_or("discord.com");
 
         let url = format!("{}://{}/api/v{}/{}", protocol, host, API_VERSION, path);
+        #[cfg(feature = "tracing")]
         tracing::debug!("URL: {:?}", url);
 
         let mut builder = hyper::Request::builder()
@@ -1792,7 +1793,9 @@ impl Client {
             Ok(v) => {
                 let _res = tx.send(Some(v));
             }
+            #[allow(unused_variables)]
             Err(why) => {
+                #[cfg(feature = "tracing")]
                 tracing::warn!("header parsing failed: {:?}; {:?}", why, resp);
 
                 let _res = tx.send(None);
@@ -1865,11 +1868,17 @@ impl Client {
         }
 
         match status {
-            StatusCode::IM_A_TEAPOT => tracing::warn!(
-                "discord's api now runs off of teapots -- proceed to panic: {:?}",
-                resp,
-            ),
-            StatusCode::TOO_MANY_REQUESTS => tracing::warn!("429 response: {:?}", resp),
+            StatusCode::IM_A_TEAPOT => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    "discord's api now runs off of teapots -- proceed to panic: {:?}",
+                    resp,
+                );
+            }
+            StatusCode::TOO_MANY_REQUESTS => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!("429 response: {:?}", resp);
+            }
             StatusCode::SERVICE_UNAVAILABLE => {
                 return Err(Error {
                     kind: ErrorType::ServiceUnavailable { response: resp },
@@ -1896,7 +1905,10 @@ impl Client {
             source: Some(Box::new(source)),
         })?;
 
+        #[cfg(feature = "tracing")]
         if let ApiError::General(ref general) = error {
+            use crate::api_error::ErrorCode;
+
             if let ErrorCode::Other(num) = general.code {
                 tracing::debug!("got unknown API error code variant: {}; {:?}", num, error);
             }

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -60,11 +60,18 @@
 //!
 //! This is enabled by default.
 //!
+//! ### Tracing
+//!
+//! The `tracing` feature enables logging via the [`tracing`] crate.
+//!
+//! This is enabled by default.
+//!
 //! [`native-tls`]: https://crates.io/crates/native-tls
 //! [`hyper`]: https://crates.io/crates/hyper
 //! [`rustls`]: https://crates.io/crates/rustls
 //! [`serde_json`]: https://crates.io/crates/serde_json
 //! [`simd-json`]: https://crates.io/crates/simd-json
+//! [`tracing`]: https://crates.io/crates/tracing
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github


### PR DESCRIPTION
Make the `tracing` dependency optional. Users can now opt-out of it by disabling `default-features` for the crate in their dependencies section.