### PR TITLE
Remove HTTP `futures-util` dependency

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -17,7 +17,6 @@ version = "0.4.2"
 [dependencies]
 bytes = { default-features = false, version = "1.0" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
-futures-util = { default-features = false, features = ["std"], version = "0.3" }
 hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
 hyper-rustls = { default-features = false, optional = true, version = "0.22" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }


### PR DESCRIPTION
Remove the `futures-util` dependency from the HTTP crate by replacing its use in the `ExecuteWebhook` request with a custom Future implementation.

This has been tested.