### PR TITLE
Fix HTTP route variant name typo

### DIFF
--- a/http/src/request/channel/reaction/delete_all_reaction.rs
+++ b/http/src/request/channel/reaction/delete_all_reaction.rs
@@ -33,7 +33,7 @@ impl<'a> DeleteAllReaction<'a> {
     }
 
     fn start(&mut self) -> Result<(), Error> {
-        let request = Request::from_route(Route::DeleteMessageSpecficReaction {
+        let request = Request::from_route(Route::DeleteMessageSpecificReaction {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
             emoji: self.emoji.clone(),

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -480,7 +480,7 @@ pub enum Route {
     },
     /// Route information to delete all of the reactions on a message with a
     /// specific emoji.
-    DeleteMessageSpecficReaction {
+    DeleteMessageSpecificReaction {
         /// The ID of the channel.
         channel_id: u64,
         /// The URI encoded custom or unicode emoji.
@@ -1185,7 +1185,7 @@ impl Route {
                 Path::ChannelsIdMessagesIdReactions(channel_id),
                 format!("channels/{}/messages/{}/reactions", channel_id, message_id).into(),
             ),
-            Self::DeleteMessageSpecficReaction {
+            Self::DeleteMessageSpecificReaction {
                 channel_id,
                 message_id,
                 emoji,
@@ -1822,9 +1822,12 @@ impl Route {
 
 #[cfg(test)]
 mod tests {
-    use super::{Path, PathParseErrorType};
+    use super::{Path, PathParseErrorType, Route};
     use crate::request::Method;
+    use static_assertions::assert_fields;
     use std::{convert::TryFrom, error::Error, str::FromStr};
+
+    assert_fields!(Route::DeleteMessageSpecificReaction: channel_id, emoji, message_id);
 
     #[test]
     fn test_path_prefix_unimportant() -> Result<(), Box<dyn Error>> {

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -1827,7 +1827,11 @@ mod tests {
     use static_assertions::assert_fields;
     use std::{convert::TryFrom, error::Error, str::FromStr};
 
-    assert_fields!(Route::DeleteMessageSpecificReaction: channel_id, emoji, message_id);
+    assert_fields!(
+        Route::DeleteMessageSpecificReaction: channel_id,
+        emoji,
+        message_id
+    );
 
     #[test]
     fn test_path_prefix_unimportant() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
The `Route::DeleteMessageSpecficReaction` variant is a typo and should be `Route::DeleteMessageSpecificReaction`. Note the typo "specfic".