### PR TITLE
Make `CreateStageInstance` work

### DIFF
--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -428,12 +428,7 @@ pub enum Route {
         guild_id: u64,
     },
     /// Route information to create a stage instance.
-    CreateStageInstance {
-        /// ID of the channel.
-        channel_id: u64,
-        /// Topic of the stage instance.
-        topic: String,
-    },
+    CreateStageInstance,
     /// Route information to create a guild template.
     CreateTemplate {
         /// The ID of the guild.


### PR DESCRIPTION
Removes paramaters from `Route::CreateStageInstance` that were unused.
Actually sends the request data to Discord.

Fixes #935.
