### PR TITLE
Use Formatter calls over `write!`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,41 @@ pub enum TwilightErrorType {
 }
 ```
 
+# Formatters
+
+Macros like `format_args!` and `write!` have runtime performance hits. Instead,
+use `core::fmt::Formatter` methods such as `Formatter::write_str` and calling
+`Display::fmt` directly.
+
+An example of what *not* to do:
+
+```rust
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+struct Foo {
+    number: u64,
+}
+
+impl Display for Foo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "the number {} is too high", self.number)
+    }
+}
+```
+
+Instead, write the `Display` implementation like this:
+
+```rust
+impl Display for Foo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str("the number ")?;
+        Display::fmt(&self.number, f)?;
+
+        f.write_str(" is too high")
+    }
+}
+```
+
 # Pull Requests
 
 Pull requests must be named with a short description of the contained changes. Pull requests must be

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,10 @@ impl Display for TwilightError {
         match self.kind {
             TwilightErrorType::AnError => f.write_str("something went wrong"),
             TwilightErrorType::AnotherError { mistake_count } => {
-                f.write_fmt(format_args!("something else went wrong, {} mistakes", mistake_count))
+                f.write_str("something else went wrong, ")?;
+                Display::fmt(mistake_count, f)?;
+
+                f.write_str(" mistakes")
             }
         }
     }

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -46,7 +46,10 @@ impl Display for EmbedError {
             EmbedErrorType::AuthorNameEmpty { .. } => f.write_str("the author name is empty"),
             EmbedErrorType::AuthorNameTooLong { .. } => f.write_str("the author name is too long"),
             EmbedErrorType::ColorNotRgb { color } => {
-                f.write_fmt(format_args!("the color {} is invalid", color))
+                f.write_str("the color ")?;
+                Display::fmt(color, f)?;
+
+                f.write_str(" is invalid")
             }
             EmbedErrorType::ColorZero => {
                 f.write_str("the given color value is 0, which is not acceptable")

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -71,7 +71,10 @@ impl Display for ClusterCommandError {
                 f.write_str("sending the message over the websocket failed")
             }
             ClusterCommandErrorType::ShardNonexistent { id } => {
-                f.write_fmt(format_args!("shard {} does not exist", id,))
+                f.write_str("shard ")?;
+                Display::fmt(id, f)?;
+
+                f.write_str(" does not exist")
             }
         }
     }
@@ -131,7 +134,10 @@ impl Display for ClusterSendError {
         match &self.kind {
             ClusterSendErrorType::Sending => f.write_str("failed to send message over websocket"),
             ClusterSendErrorType::ShardNonexistent { id } => {
-                f.write_fmt(format_args!("shard {} does not exist", id))
+                f.write_str("shard ")?;
+                Display::fmt(id, f)?;
+
+                f.write_str(" does not exist")
             }
         }
     }

--- a/gateway/src/cluster/scheme.rs
+++ b/gateway/src/cluster/scheme.rs
@@ -47,15 +47,23 @@ impl Display for ShardSchemeRangeError {
                 bucket_id,
                 concurrency,
                 ..
-            } => f.write_fmt(format_args!(
-                "bucket ID {} is larger than maximum concurrency ({})",
-                bucket_id, concurrency
-            )),
+            } => {
+                f.write_str("bucket ID ")?;
+                Display::fmt(bucket_id, f)?;
+                f.write_str(" is larger than maximum concurrency (")?;
+                Display::fmt(concurrency, f)?;
+
+                f.write_str(")")
+            }
             ShardSchemeRangeErrorType::IdTooLarge { end, start, total } => {
-                f.write_fmt(format_args!(
-                    "The shard ID range {}-{}/{} is larger than the total",
-                    start, end, total
-                ))
+                f.write_str("The shard ID range ")?;
+                Display::fmt(start, f)?;
+                f.write_str("-")?;
+                Display::fmt(end, f)?;
+                f.write_str("/")?;
+                Display::fmt(total, f)?;
+
+                f.write_str(" is larger than the total")
             }
         }
     }

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -106,10 +106,13 @@ impl ShardIdError {
 impl Display for ShardIdError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            ShardIdErrorType::IdTooLarge { id, total } => f.write_fmt(format_args!(
-                "provided shard ID {} is larger than the total {}",
-                id, total,
-            )),
+            ShardIdErrorType::IdTooLarge { id, total } => {
+                f.write_str("provided shard ID ")?;
+                Display::fmt(id, f)?;
+                f.write_str(" is larger than the total ")?;
+
+                Display::fmt(total, f)
+            }
         }
     }
 }

--- a/gateway/src/shard/emitter.rs
+++ b/gateway/src/shard/emitter.rs
@@ -3,7 +3,7 @@ use crate::{Event, EventTypeFlags};
 use std::{
     convert::TryFrom,
     error::Error,
-    fmt::{Display, Formatter, Result as FmtResult},
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
 };
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use twilight_model::gateway::event::shard::Payload;
@@ -23,10 +23,14 @@ impl EmitJsonError {
 impl Display for EmitJsonError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            EmitJsonErrorType::EventTypeUnknown { event_type, op } => f.write_fmt(format_args!(
-                "provided event type ({:?})/op ({}) pair is unknown",
-                event_type, op,
-            )),
+            EmitJsonErrorType::EventTypeUnknown { event_type, op } => {
+                f.write_str("provided event type (")?;
+                Debug::fmt(event_type, f)?;
+                f.write_str(")/op (")?;
+                Display::fmt(op, f)?;
+
+                f.write_str(") pair is unknown")
+            }
             EmitJsonErrorType::Parsing => f.write_str("parsing a gateway event failed"),
         }
     }

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -203,7 +203,10 @@ impl Display for ShardStartError {
         match &self.kind {
             ShardStartErrorType::Establishing => f.write_str("establishing the connection failed"),
             ShardStartErrorType::ParsingGatewayUrl { url } => {
-                f.write_fmt(format_args!("the gateway url `{}` is invalid", url,))
+                f.write_str("the gateway url `")?;
+                f.write_str(url)?;
+
+                f.write_str("` is invalid")
             }
             ShardStartErrorType::RetrievingGatewayUrl => {
                 f.write_str("retrieving the gateway URL via HTTP failed")

--- a/gateway/src/shard/stage.rs
+++ b/gateway/src/shard/stage.rs
@@ -52,7 +52,10 @@ impl Display for StageConversionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
             StageConversionErrorType::InvalidInteger { value } => {
-                write!(f, "The integer {} is invalid", value)
+                f.write_str("the integer ")?;
+                Display::fmt(value, f)?;
+
+                f.write_str(" is invalid")
             }
         }
     }

--- a/gateway/src/shard/stage.rs
+++ b/gateway/src/shard/stage.rs
@@ -52,7 +52,7 @@ impl Display for StageConversionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
             StageConversionErrorType::InvalidInteger { value } => {
-                f.write_str("the integer ")?;
+                f.write_str("The integer ")?;
                 Display::fmt(value, f)?;
 
                 f.write_str(" is invalid")

--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -552,7 +552,11 @@ impl Display for ErrorCode {
             Self::NoSuchUser => f.write_str("No users with DiscordTag exist"),
             Self::ReactionBlocked => f.write_str("Reaction was blocked"),
             Self::ApiResourceOverloaded => f.write_str("API resource is currently overloaded. Try again a little later"),
-            Self::Other(number) => write!(f, "An error code Twilight doesn't have registered: {}", number),
+            Self::Other(number) => {
+                f.write_str("error code not registered by Twilight: ")?;
+
+                Display::fmt(number, f)
+            }
         }
     }
 }
@@ -706,7 +710,10 @@ impl Display for RatelimitedApiError {
             f.write_str("global ")?;
         }
 
-        write!(f, "ratelimited for {}s", self.retry_after)
+        f.write_str("ratelimited for ")?;
+        Display::fmt(&self.retry_after, f)?;
+
+        f.write_str("s")
     }
 }
 

--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -553,7 +553,7 @@ impl Display for ErrorCode {
             Self::ReactionBlocked => f.write_str("Reaction was blocked"),
             Self::ApiResourceOverloaded => f.write_str("API resource is currently overloaded. Try again a little later"),
             Self::Other(number) => {
-                f.write_str("error code not registered by Twilight: ")?;
+                f.write_str("An error code Twilight doesn't have registered: ")?;
 
                 Display::fmt(number, f)
             }

--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -628,11 +628,11 @@ pub struct GeneralApiError {
 
 impl Display for GeneralApiError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_fmt(format_args!(
-            "Error code {}: {}",
-            self.code.num(),
-            self.message
-        ))
+        f.write_str("Error code ")?;
+        Display::fmt(&self.code.num(), f)?;
+        f.write_str(": ")?;
+
+        f.write_str(&self.message)
     }
 }
 

--- a/http/src/ratelimiting/error.rs
+++ b/http/src/ratelimiting/error.rs
@@ -1,7 +1,7 @@
 use hyper::header::ToStrError;
 use std::{
     error::Error,
-    fmt::{Display, Formatter, Result as FmtResult},
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
     result::Result as StdResult,
 };
 
@@ -52,26 +52,39 @@ impl Display for RatelimitError {
         match &self.kind {
             RatelimitErrorType::NoHeaders => f.write_str("No headers are present"),
             RatelimitErrorType::HeaderMissing { name } => {
-                write!(f, "At least one header, {:?}, is missing", name)
+                f.write_str(r#"At least one header, ""#)?;
+                f.write_str(name)?;
+
+                f.write_str(r#"", is missing"#)
             }
             RatelimitErrorType::HeaderNotUtf8 { name, value, .. } => {
-                write!(f, "The header {:?} has invalid UTF-16: {:?}", name, value)
+                f.write_str(r#"The header ""#)?;
+                f.write_str(name)?;
+                f.write_str(r#"" has invalid UTF-16: "#)?;
+
+                Debug::fmt(value, f)
             }
-            RatelimitErrorType::ParsingBoolText { name, text, .. } => write!(
-                f,
-                "The header {:?} should be a bool but isn't: {:?}",
-                name, text
-            ),
-            RatelimitErrorType::ParsingFloatText { name, text, .. } => write!(
-                f,
-                "The header {:?} should be a float but isn't: {:?}",
-                name, text
-            ),
-            RatelimitErrorType::ParsingIntText { name, text, .. } => write!(
-                f,
-                "The header {:?} should be an integer but isn't: {:?}",
-                name, text
-            ),
+            RatelimitErrorType::ParsingBoolText { name, text, .. } => {
+                f.write_str(r#"The header ""#)?;
+                f.write_str(name)?;
+                f.write_str(r#"" should be a bool but isn't: ""#)?;
+
+                f.write_str(text)
+            }
+            RatelimitErrorType::ParsingFloatText { name, text, .. } => {
+                f.write_str(r#"The header ""#)?;
+                f.write_str(name)?;
+                f.write_str(r#"" should be a float but isn't: ""#)?;
+
+                f.write_str(text)
+            }
+            RatelimitErrorType::ParsingIntText { name, text, .. } => {
+                f.write_str(r#"The header ""#)?;
+                f.write_str(name)?;
+                f.write_str(r#"" should be an integer but isn't: ""#)?;
+
+                f.write_str(text)
+            }
         }
     }
 }

--- a/http/src/request/application/update_followup_message.rs
+++ b/http/src/request/application/update_followup_message.rs
@@ -57,10 +57,11 @@ impl Display for UpdateFollowupMessageError {
             UpdateFollowupMessageErrorType::EmbedTooLarge { .. } => {
                 f.write_str("length of one of the embeds is too large")
             }
-            UpdateFollowupMessageErrorType::TooManyEmbeds { embeds } => f.write_fmt(format_args!(
-                "{} embeds were provided, but only 10 may be provided",
-                embeds.len()
-            )),
+            UpdateFollowupMessageErrorType::TooManyEmbeds { embeds } => {
+                Display::fmt(&embeds.len(), f)?;
+
+                f.write_str(" embeds were provided, but only 10 may be provided")
+            }
         }
     }
 }

--- a/http/src/request/application/update_original_response.rs
+++ b/http/src/request/application/update_original_response.rs
@@ -57,10 +57,11 @@ impl Display for UpdateOriginalResponseError {
             UpdateOriginalResponseErrorType::EmbedTooLarge { .. } => {
                 f.write_str("length of one of the embeds is too large")
             }
-            UpdateOriginalResponseErrorType::TooManyEmbeds { embeds } => f.write_fmt(format_args!(
-                "{} embeds were provided, but only 10 may be provided",
-                embeds.len()
-            )),
+            UpdateOriginalResponseErrorType::TooManyEmbeds { embeds } => {
+                Display::fmt(&embeds.len(), f)?;
+
+                f.write_str(" embeds were provided, but only 10 may be provided")
+            }
         }
     }
 }

--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -116,12 +116,13 @@ impl AuditLogReasonError {
 impl Display for AuditLogReasonError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            AuditLogReasonErrorType::TooLarge { reason } => write!(
-                f,
-                "the audit log reason is {} characters long, but the max is {}",
-                reason.chars().count(),
-                Self::AUDIT_REASON_LENGTH
-            ),
+            AuditLogReasonErrorType::TooLarge { reason } => {
+                f.write_str("the audit log reason is ")?;
+                Display::fmt(&reason.chars().count(), f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::AUDIT_REASON_LENGTH, f)
+            }
         }
     }
 }

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -46,9 +46,7 @@ impl UpdateStageInstanceError {
 impl Display for UpdateStageInstanceError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            UpdateStageInstanceErrorType::InvalidTopic { .. } => {
-                f.write_fmt(format_args!("invalid topic"))
-            }
+            UpdateStageInstanceErrorType::InvalidTopic { .. } => f.write_str("invalid topic"),
         }
     }
 }

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -57,10 +57,11 @@ impl Display for UpdateWebhookMessageError {
             UpdateWebhookMessageErrorType::EmbedTooLarge { .. } => {
                 f.write_str("length of one of the embeds is too large")
             }
-            UpdateWebhookMessageErrorType::TooManyEmbeds { embeds } => f.write_fmt(format_args!(
-                "{} embeds were provided, but only 10 may be provided",
-                embeds.len()
-            )),
+            UpdateWebhookMessageErrorType::TooManyEmbeds { embeds } => {
+                Display::fmt(&embeds.len(), f)?;
+
+                f.write_str(" embeds were provided, but only 10 may be provided")
+            }
         }
     }
 }

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -40,7 +40,10 @@ impl Display for RoleFieldsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
             RoleFieldsErrorType::ColorNotRgb { color } => {
-                f.write_fmt(format_args!("the color {} is invalid", color))
+                f.write_str("the color ")?;
+                Display::fmt(color, f)?;
+
+                f.write_str(" is invalid")
             }
             RoleFieldsErrorType::IdInvalid => {
                 f.write_str("the given id value is 1, which is not acceptable")
@@ -196,16 +199,25 @@ impl Display for TextFieldsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
             TextFieldsErrorType::NameTooShort { name } => {
-                f.write_fmt(format_args!("the name is too short: {}", name.len()))
+                f.write_str("the name is too short: ")?;
+
+                Display::fmt(&name.len(), f)
             }
             TextFieldsErrorType::NameTooLong { name } => {
-                f.write_fmt(format_args!("the name is too long: {}", name.len()))
+                f.write_str("the name is too long: ")?;
+
+                Display::fmt(&name.len(), f)
             }
             TextFieldsErrorType::RateLimitInvalid { limit } => {
-                f.write_fmt(format_args!("the rate limit {} is invalid", limit))
+                f.write_str("the rate limit ")?;
+                Display::fmt(limit, f)?;
+
+                f.write_str(" is invalid")
             }
             TextFieldsErrorType::TopicTooLong { topic } => {
-                f.write_fmt(format_args!("the topic is too long: {}", topic.len()))
+                f.write_str("the topic is too long: ")?;
+
+                Display::fmt(&topic.len(), f)
             }
         }
     }
@@ -403,10 +415,14 @@ impl Display for VoiceFieldsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
             VoiceFieldsErrorType::NameTooShort { name } => {
-                f.write_fmt(format_args!("the name is too short: {}", name.len()))
+                f.write_str("the name is too short: ")?;
+
+                Display::fmt(&name.len(), f)
             }
             VoiceFieldsErrorType::NameTooLong { name } => {
-                f.write_fmt(format_args!("the name is too long: {}", name.len()))
+                f.write_str("the name is too long: ")?;
+
+                Display::fmt(&name.len(), f)
             }
         }
     }
@@ -551,10 +567,14 @@ impl Display for CategoryFieldsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
             CategoryFieldsErrorType::NameTooShort { name } => {
-                f.write_fmt(format_args!("the name is too short: {}", name.len()))
+                f.write_str("the name is too short: ")?;
+
+                Display::fmt(&name.len(), f)
             }
             CategoryFieldsErrorType::NameTooLong { name } => {
-                f.write_fmt(format_args!("the name is too long: {}", name.len()))
+                f.write_str("the name is too long: ")?;
+
+                Display::fmt(&name.len(), f)
             }
         }
     }

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -72,54 +72,62 @@ impl EmbedValidationError {
 impl Display for EmbedValidationError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            EmbedValidationErrorType::AuthorNameTooLarge { chars } => write!(
-                f,
-                "the author name is {} characters long, but the max is {}",
-                chars,
-                Self::AUTHOR_NAME_LENGTH
-            ),
-            EmbedValidationErrorType::DescriptionTooLarge { chars } => write!(
-                f,
-                "the description is {} characters long, but the max is {}",
-                chars,
-                Self::DESCRIPTION_LENGTH
-            ),
-            EmbedValidationErrorType::EmbedTooLarge { chars } => write!(
-                f,
-                "the combined total length of the embed is {} characters long, but the max is {}",
-                chars,
-                Self::EMBED_TOTAL_LENGTH
-            ),
-            EmbedValidationErrorType::FieldNameTooLarge { chars } => write!(
-                f,
-                "a field name is {} characters long, but the max is {}",
-                chars,
-                Self::FIELD_NAME_LENGTH
-            ),
-            EmbedValidationErrorType::FieldValueTooLarge { chars } => write!(
-                f,
-                "a field value is {} characters long, but the max is {}",
-                chars,
-                Self::FIELD_VALUE_LENGTH
-            ),
-            EmbedValidationErrorType::FooterTextTooLarge { chars } => write!(
-                f,
-                "the footer's text is {} characters long, but the max is {}",
-                chars,
-                Self::FOOTER_TEXT_LENGTH
-            ),
-            EmbedValidationErrorType::TitleTooLarge { chars } => write!(
-                f,
-                "the title's length is {} characters long, but the max is {}",
-                chars,
-                Self::TITLE_LENGTH
-            ),
-            EmbedValidationErrorType::TooManyFields { amount } => write!(
-                f,
-                "there are {} fields, but the maximum amount is {}",
-                amount,
-                Self::FIELD_COUNT
-            ),
+            EmbedValidationErrorType::AuthorNameTooLarge { chars } => {
+                f.write_str("the author name is ")?;
+                Display::fmt(chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::AUTHOR_NAME_LENGTH, f)
+            }
+            EmbedValidationErrorType::DescriptionTooLarge { chars } => {
+                f.write_str("the description is ")?;
+                Display::fmt(chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::DESCRIPTION_LENGTH, f)
+            }
+            EmbedValidationErrorType::EmbedTooLarge { chars } => {
+                f.write_str("the combined total length of the embed is ")?;
+                Display::fmt(chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::EMBED_TOTAL_LENGTH, f)
+            }
+            EmbedValidationErrorType::FieldNameTooLarge { chars } => {
+                f.write_str("a field name is ")?;
+                Display::fmt(chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::FIELD_NAME_LENGTH, f)
+            }
+            EmbedValidationErrorType::FieldValueTooLarge { chars } => {
+                f.write_str("a field value is ")?;
+                Display::fmt(chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::FIELD_VALUE_LENGTH, f)
+            }
+            EmbedValidationErrorType::FooterTextTooLarge { chars } => {
+                f.write_str("the footer's text is ")?;
+                Display::fmt(chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::FOOTER_TEXT_LENGTH, f)
+            }
+            EmbedValidationErrorType::TitleTooLarge { chars } => {
+                f.write_str("the title's length is ")?;
+                Display::fmt(chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::TITLE_LENGTH, f)
+            }
+            EmbedValidationErrorType::TooManyFields { amount } => {
+                f.write_str("there are ")?;
+                Display::fmt(amount, f)?;
+                f.write_str(" fields, but the maximum amount is ")?;
+
+                Display::fmt(&Self::FIELD_COUNT, f)
+            }
         }
     }
 }

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -85,11 +85,12 @@ impl Display for NodeError {
             NodeErrorType::SerializingMessage { .. } => {
                 f.write_str("failed to serialize outgoing message as json")
             }
-            NodeErrorType::Unauthorized { address, .. } => write!(
-                f,
-                "the authorization used to connect to node {} is invalid",
-                address
-            ),
+            NodeErrorType::Unauthorized { address, .. } => {
+                f.write_str("the authorization used to connect to node ")?;
+                Display::fmt(address, f)?;
+
+                f.write_str(" is invalid")
+            }
         }
     }
 }

--- a/mention/benches/fmt.rs
+++ b/mention/benches/fmt.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::fmt::{Display, Write};
-use twilight_mention::fmt::{Mention, MentionFormat};
+use twilight_mention::fmt::Mention;
 use twilight_model::id::{ChannelId, EmojiId, RoleId, UserId};
 
 fn format_id<T: Display>(input: &mut String, formatter: &T) {

--- a/mention/src/parse/error.rs
+++ b/mention/src/parse/error.rs
@@ -45,29 +45,38 @@ impl<'a> ParseMentionError<'a> {
 impl Display for ParseMentionError<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            ParseMentionErrorType::IdNotU64 { found, .. } => f.write_fmt(format_args!(
-                "id portion ('{}') of mention is not a u64",
-                found,
-            )),
+            ParseMentionErrorType::IdNotU64 { found, .. } => {
+                f.write_str("id portion ('")?;
+                Display::fmt(found, f)?;
+
+                f.write_str("') of mention is not a u64")
+            }
             ParseMentionErrorType::LeadingArrow { found } => {
-                f.write_str("expected to find a leading arrow ('<') but instead ")?;
+                f.write_str("expected to find a leading arrow ('<') but instead found ")?;
 
                 if let Some(c) = found {
-                    f.write_fmt(format_args!("found '{}'", c))
+                    f.write_str("'")?;
+                    f.write_str(c.encode_utf8(&mut [0; 4]))?;
+
+                    f.write_str("'")
                 } else {
-                    f.write_str("found nothing")
+                    f.write_str("nothing")
                 }
             }
-            ParseMentionErrorType::PartMissing { expected, found } => f.write_fmt(format_args!(
-                "
-                    expected {} parts but only found {}",
-                expected, found,
-            )),
+            ParseMentionErrorType::PartMissing { expected, found } => {
+                f.write_str("expected ")?;
+                Display::fmt(expected, f)?;
+                f.write_str(" parts but only found ")?;
+
+                Display::fmt(found, f)
+            }
             ParseMentionErrorType::Sigil { expected, found } => {
                 f.write_str("expected to find a mention sigil (")?;
 
                 for (idx, sigil) in expected.iter().enumerate() {
-                    f.write_fmt(format_args!("'{}'", sigil))?;
+                    f.write_str("'")?;
+                    f.write_str(sigil)?;
+                    f.write_str("'")?;
 
                     if idx < expected.len() - 1 {
                         f.write_str(", ")?;
@@ -77,7 +86,10 @@ impl Display for ParseMentionError<'_> {
                 f.write_str(") but instead found ")?;
 
                 if let Some(c) = found {
-                    f.write_fmt(format_args!("'{}'", c))
+                    f.write_str("'")?;
+                    f.write_str(c.encode_utf8(&mut [0; 4]))?;
+
+                    f.write_str("'")
                 } else {
                     f.write_str("nothing")
                 }
@@ -89,12 +101,15 @@ impl Display for ParseMentionError<'_> {
                 f.write_str("' is invalid")
             }
             ParseMentionErrorType::TrailingArrow { found } => {
-                f.write_str("expected to find a trailing arrow ('>') but instead ")?;
+                f.write_str("expected to find a trailing arrow ('>') but instead found ")?;
 
                 if let Some(c) = found {
-                    f.write_fmt(format_args!("found '{}'", c))
+                    f.write_str("'")?;
+                    f.write_str(c.encode_utf8(&mut [0; 4]))?;
+
+                    f.write_str("'")
                 } else {
-                    f.write_str("found nothing")
+                    f.write_str("nothing")
                 }
             }
         }

--- a/model/src/application/interaction/interaction_type.rs
+++ b/model/src/application/interaction/interaction_type.rs
@@ -33,7 +33,9 @@ pub struct UnknownInteractionTypeError {
 
 impl Display for UnknownInteractionTypeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "unknown interaction type: {}", self.value)
+        f.write_str("unknown interaction type: ")?;
+
+        Display::fmt(&self.value, f)
     }
 }
 

--- a/model/src/channel/message/sticker/kind.rs
+++ b/model/src/channel/message/sticker/kind.rs
@@ -49,10 +49,10 @@ impl<'a> StickerFormatTypeConversionError {
 
 impl Display for StickerFormatTypeConversionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_fmt(format_args!(
-            "Value ({}) doesn't match a sticker type",
-            self.value,
-        ))
+        f.write_str("Value (")?;
+        Display::fmt(&self.value, f)?;
+
+        f.write_str(") doesn't match a sticker type")
     }
 }
 

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -31,18 +31,21 @@ use serde::{
     de::{Deserializer, Error as DeError, IgnoredAny, MapAccess, Visitor},
     Deserialize, Serialize,
 };
-use std::fmt::{self, Formatter, Result as FmtResult};
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ConversionError {
     MessageType(u8),
 }
 
-impl fmt::Display for ConversionError {
+impl Display for ConversionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             ConversionError::MessageType(num) => {
-                write!(f, "Could not convert {} into a valid MessageType!", num)
+                f.write_str("Could not convert ")?;
+                Display::fmt(num, f)?;
+
+                f.write_str(" into a valid MessageType")
             }
         }
     }

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -45,7 +45,7 @@ impl Display for ConversionError {
                 f.write_str("Could not convert ")?;
                 Display::fmt(num, f)?;
 
-                f.write_str(" into a valid MessageType")
+                f.write_str(" into a valid MessageType!")
             }
         }
     }

--- a/model/src/gateway/close_code.rs
+++ b/model/src/gateway/close_code.rs
@@ -59,7 +59,9 @@ impl CloseCodeConversionError {
 
 impl Display for CloseCodeConversionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_fmt(format_args!("{} isn't a valid close code", self.code))
+        Display::fmt(&self.code, f)?;
+
+        f.write_str(" isn't a valid close code")
     }
 }
 

--- a/model/src/gateway/event/mod.rs
+++ b/model/src/gateway/event/mod.rs
@@ -319,7 +319,7 @@ impl EventConversionError {
 
 impl Display for EventConversionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "event variant failed to convert")
+        f.write_str("event variant failed to convert")
     }
 }
 

--- a/model/src/gateway/payload/request_guild_members.rs
+++ b/model/src/gateway/payload/request_guild_members.rs
@@ -46,10 +46,10 @@ impl UserIdsError {
 impl Display for UserIdsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            UserIdsErrorType::TooMany { ids } => f.write_fmt(format_args!(
-                "{} user IDs were provided when only a maximum of 100 is allowed",
-                ids.len(),
-            )),
+            UserIdsErrorType::TooMany { ids } => {
+                Display::fmt(&ids.len(), f)?;
+                f.write_str(" user IDs were provided when only a maximum of 100 is allowed")
+            }
         }
     }
 }

--- a/model/src/voice/close_code.rs
+++ b/model/src/voice/close_code.rs
@@ -55,7 +55,9 @@ impl CloseCodeConversionError {
 
 impl Display for CloseCodeConversionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_fmt(format_args!("{} isn't a valid close code", self.code))
+        Display::fmt(&self.code, f)?;
+
+        f.write_str(" isn't a valid close code")
     }
 }
 


### PR DESCRIPTION
Instead of using the `write!` and `format_args!` macros use `Display` and `Formatter` method calls. The motivation for doing this is shown in PR #942.

This does not include the work required to replace `write!` calls in `http/src/routing.rs`; this work will be done in a separate PR. Additionally one call is left in `http/src/request/channel/reaction/mod.rs` and will be resolved in another PR extracted from further work on #923.

Relates to #943.