### PR TITLE
Remove unnecessary doc test bounds

### DIFF
--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -256,7 +256,7 @@ impl Cluster {
     /// use std::env;
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let types = EventTypeFlags::MESSAGE_CREATE
     ///     | EventTypeFlags::MESSAGE_DELETE
     ///     | EventTypeFlags::MESSAGE_UPDATE;
@@ -395,7 +395,7 @@ impl Cluster {
     /// use std::env;
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let token = env::var("DISCORD_TOKEN")?;
     /// let types = EventTypeFlags::MESSAGE_CREATE
     ///     | EventTypeFlags::MESSAGE_DELETE
@@ -442,7 +442,7 @@ impl Cluster {
     /// };
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let token = env::var("DISCORD_TOKEN")?;
     /// let scheme = ShardScheme::try_from((0..=9, 10))?;
     /// let (cluster, _) = Cluster::builder(token, Intents::GUILD_MESSAGES)
@@ -520,7 +520,7 @@ impl Cluster {
     /// use std::{env, time::Duration};
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let (cluster, _) = Cluster::new(env::var("DISCORD_TOKEN")?, Intents::empty()).await?;
     /// cluster.up().await;
     ///

--- a/gateway/src/cluster/mod.rs
+++ b/gateway/src/cluster/mod.rs
@@ -12,7 +12,7 @@
 //! use std::env;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let token = env::var("DISCORD_TOKEN")?;
 //!     let intents = Intents::GUILD_BANS | Intents::GUILD_EMOJIS | Intents::GUILD_MESSAGES;
 //!     let (cluster, mut events) = Cluster::new(token, intents).await?;

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -379,7 +379,7 @@ impl Shard {
     /// use tokio::time as tokio_time;
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let token = env::var("DISCORD_TOKEN")?;
     ///
     /// let intents = Intents::GUILD_MESSAGES | Intents::GUILD_MESSAGE_TYPING;

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -129,7 +129,7 @@ impl Debug for State {
 /// use twilight_http::Client;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 /// # Ok(()) }
 /// ```
@@ -140,7 +140,7 @@ impl Debug for State {
 /// use std::time::Duration;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::builder()
 ///     .token("my token")
 ///     .timeout(Duration::from_secs(5))
@@ -252,7 +252,7 @@ impl Client {
     /// use twilight_model::id::GuildId;
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let guild_id = GuildId(1);
@@ -284,7 +284,7 @@ impl Client {
     /// use twilight_model::id::{GuildId, UserId};
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let guild_id = GuildId(100);
@@ -310,7 +310,7 @@ impl Client {
     /// use twilight_model::id::{GuildId, UserId};
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let guild_id = GuildId(100);
@@ -334,7 +334,7 @@ impl Client {
     /// # use twilight_model::id::ChannelId;
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let channel_id = ChannelId(100);
@@ -397,7 +397,7 @@ impl Client {
     /// use twilight_model::id::{ChannelId, MessageId};
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new("my token");
     /// let channel_id = ChannelId(123);
     /// let message_id = MessageId(234);
@@ -446,7 +446,7 @@ impl Client {
     /// use twilight_model::id::{ChannelId, RoleId};
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     ///
     /// let channel_id = ChannelId(123);
@@ -526,7 +526,7 @@ impl Client {
     /// use twilight_model::id::GuildId;
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let after = GuildId(300);
@@ -562,7 +562,7 @@ impl Client {
     /// # use twilight_model::id::GuildId;
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let guild_id = GuildId(100);
@@ -585,7 +585,7 @@ impl Client {
     /// # use twilight_model::id::{EmojiId, GuildId};
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let guild_id = GuildId(50);
@@ -635,7 +635,7 @@ impl Client {
     /// # use twilight_http::Client;
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let info = client.gateway().await?;
@@ -649,7 +649,7 @@ impl Client {
     /// # use twilight_http::Client;
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let info = client.gateway().authed().await?;
@@ -801,7 +801,7 @@ impl Client {
     /// use twilight_model::id::{GuildId, UserId};
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let guild_id = GuildId(100);
@@ -833,7 +833,7 @@ impl Client {
     /// use twilight_model::id::GuildId;
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new("my token");
     ///
     /// let guild_id = GuildId(100);
@@ -936,7 +936,7 @@ impl Client {
     /// use twilight_model::id::{GuildId, RoleId, UserId};
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let guild_id = GuildId(1);
@@ -1029,7 +1029,7 @@ impl Client {
     /// # use twilight_http::Client;
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let invite = client
@@ -1056,7 +1056,7 @@ impl Client {
     /// # use twilight_model::id::ChannelId;
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let channel_id = ChannelId(123);
@@ -1097,7 +1097,7 @@ impl Client {
     /// # use twilight_model::id::ChannelId;
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let channel_id = ChannelId(123);
@@ -1168,7 +1168,7 @@ impl Client {
     /// use twilight_model::id::{ChannelId, MessageId};
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new("my token");
     /// client.update_message(ChannelId(1), MessageId(2))
     ///     .content("test update".to_owned())?
@@ -1183,7 +1183,7 @@ impl Client {
     /// # use twilight_model::id::{ChannelId, MessageId};
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// client.update_message(ChannelId(1), MessageId(2))
     ///     .content(None)?
@@ -1249,7 +1249,7 @@ impl Client {
     /// # };
     /// #
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token");
     /// #
     /// let channel_id = ChannelId(123);

--- a/http/src/request/channel/get_channel.rs
+++ b/http/src/request/channel/get_channel.rs
@@ -17,7 +17,7 @@ use twilight_model::{channel::Channel, id::ChannelId};
 /// use twilight_model::id::ChannelId;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let channel_id = ChannelId(100);

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -97,7 +97,7 @@ struct CreateInviteFields {
 /// use twilight_model::id::ChannelId;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let channel_id = ChannelId(123);

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -24,7 +24,7 @@ struct GetInviteFields {
 /// use twilight_http::Client;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let invite = client

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -109,7 +109,7 @@ pub(crate) struct CreateMessageFields {
 /// use twilight_model::id::ChannelId;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let channel_id = ChannelId(123);

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -86,7 +86,7 @@ struct GetChannelMessagesFields {
 /// use twilight_model::id::{ChannelId, MessageId};
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 /// let channel_id = ChannelId(123);
 /// let message_id = MessageId(234);

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -122,7 +122,7 @@ struct UpdateMessageFields {
 /// use twilight_model::id::{ChannelId, MessageId};
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 /// client.update_message(ChannelId(1), MessageId(2))
 ///     .content("test update".to_owned())?
@@ -137,7 +137,7 @@ struct UpdateMessageFields {
 /// # use twilight_model::id::{ChannelId, MessageId};
 /// #
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let client = Client::new("my token");
 /// client.update_message(ChannelId(1), MessageId(2))
 ///     .content(None)?

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -19,7 +19,7 @@ use twilight_model::id::{ChannelId, MessageId};
 /// };
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let channel_id = ChannelId(123);

--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -18,7 +18,7 @@ use twilight_model::{
 /// use twilight_model::id::{ChannelId, RoleId};
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let channel_id = ChannelId(123);

--- a/http/src/request/get_gateway.rs
+++ b/http/src/request/get_gateway.rs
@@ -17,7 +17,7 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 /// use twilight_http::Client;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let info = client.gateway().await?;
@@ -31,7 +31,7 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 /// use twilight_http::Client;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let info = client.gateway().authed().await?;

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -79,7 +79,7 @@ struct CreateBanFields {
 /// use twilight_model::id::{GuildId, UserId};
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let guild_id = GuildId(100);

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -17,7 +17,7 @@ use twilight_model::id::{GuildId, UserId};
 /// use twilight_model::id::{GuildId, UserId};
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let guild_id = GuildId(100);

--- a/http/src/request/guild/ban/get_bans.rs
+++ b/http/src/request/guild/ban/get_bans.rs
@@ -17,7 +17,7 @@ use twilight_model::{guild::Ban, id::GuildId};
 /// use twilight_model::id::GuildId;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let guild_id = GuildId(1);

--- a/http/src/request/guild/emoji/get_emoji.rs
+++ b/http/src/request/guild/emoji/get_emoji.rs
@@ -20,7 +20,7 @@ use twilight_model::{
 /// use twilight_model::id::{EmojiId, GuildId};
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let guild_id = GuildId(50);

--- a/http/src/request/guild/emoji/get_emojis.rs
+++ b/http/src/request/guild/emoji/get_emojis.rs
@@ -17,7 +17,7 @@ use twilight_model::{guild::Emoji, id::GuildId};
 /// use twilight_model::id::GuildId;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let guild_id = GuildId(100);

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -17,7 +17,7 @@ use twilight_model::id::{GuildId, RoleId, UserId};
 /// use twilight_model::id::{GuildId, RoleId, UserId};
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let guild_id = GuildId(1);

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -97,7 +97,7 @@ struct GetGuildMembersFields {
 /// use twilight_model::id::{GuildId, UserId};
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let guild_id = GuildId(100);

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -94,7 +94,7 @@ struct SearchGuildMembersFields {
 /// use twilight_model::id::GuildId;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let guild_id = GuildId(100);

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -83,7 +83,7 @@ struct GetCurrentUserGuildsFields {
 /// use twilight_model::id::GuildId;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
 /// let after = GuildId(300);


### PR DESCRIPTION
Remove unnecessary bounds in doc tests in the gateway and HTTP crates, namely changing doc test function return types from `Result<(), Box<dyn std::error::Error + Send + Sync>>` to `Result<(), Box<dyn std::error::Error>>`.