### PR TITLE
Use `NullableField` enum for `Option<Option<T>>` representations

### DIFF
--- a/http/src/request/application/update_followup_message.rs
+++ b/http/src/request/application/update_followup_message.rs
@@ -3,7 +3,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Form, Pending, Request},
+    request::{validate, Form, NullableField, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -108,12 +108,10 @@ struct UpdateFollowupMessageFields {
     allowed_mentions: Option<AllowedMentions>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     attachments: Vec<Attachment>,
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<Option<String>>,
-    #[allow(clippy::option_option)]
+    content: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    embeds: Option<Option<Vec<Embed>>>,
+    embeds: Option<NullableField<Vec<Embed>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payload_json: Option<Vec<u8>>,
 }
@@ -241,7 +239,9 @@ impl<'a> UpdateFollowupMessage<'a> {
             }
         }
 
-        self.fields.content.replace(content);
+        self.fields
+            .content
+            .replace(NullableField::from_option(content));
 
         Ok(self)
     }
@@ -322,7 +322,9 @@ impl<'a> UpdateFollowupMessage<'a> {
             }
         }
 
-        self.fields.embeds.replace(embeds);
+        self.fields
+            .embeds
+            .replace(NullableField::from_option(embeds));
 
         Ok(self)
     }

--- a/http/src/request/application/update_original_response.rs
+++ b/http/src/request/application/update_original_response.rs
@@ -3,7 +3,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Form, Pending, Request},
+    request::{validate, Form, NullableField, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -108,12 +108,10 @@ struct UpdateOriginalResponseFields {
     allowed_mentions: Option<AllowedMentions>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     attachments: Vec<Attachment>,
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<Option<String>>,
-    #[allow(clippy::option_option)]
+    content: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    embeds: Option<Option<Vec<Embed>>>,
+    embeds: Option<NullableField<Vec<Embed>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payload_json: Option<Vec<u8>>,
 }
@@ -238,7 +236,9 @@ impl<'a> UpdateOriginalResponse<'a> {
             }
         }
 
-        self.fields.content.replace(content);
+        self.fields
+            .content
+            .replace(NullableField::from_option(content));
 
         Ok(self)
     }
@@ -320,7 +320,9 @@ impl<'a> UpdateOriginalResponse<'a> {
             }
         }
 
-        self.fields.embeds.replace(embeds);
+        self.fields
+            .embeds
+            .replace(NullableField::from_option(embeds));
 
         Ok(self)
     }

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate, NullableField, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -97,12 +97,10 @@ struct UpdateMessageFields {
     // - Some(None): Removing the "content" by giving the Discord API a written
     //   `"content": null` in the JSON;
     // - None: Don't serialize the field at all, not modifying the state.
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<Option<String>>,
-    #[allow(clippy::option_option)]
+    content: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    embed: Option<Option<Embed>>,
+    embed: Option<NullableField<Embed>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
 }
@@ -214,7 +212,9 @@ impl<'a> UpdateMessage<'a> {
             }
         }
 
-        self.fields.content.replace(content);
+        self.fields
+            .content
+            .replace(NullableField::from_option(content));
 
         Ok(self)
     }
@@ -241,7 +241,7 @@ impl<'a> UpdateMessage<'a> {
             }
         }
 
-        self.fields.embed.replace(embed);
+        self.fields.embed.replace(NullableField::from_option(embed));
 
         Ok(self)
     }

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -1,7 +1,9 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    request::{
+        self, validate, AuditLogReason, AuditLogReasonError, NullableField, Pending, Request,
+    },
     routing::Route,
 };
 use serde::Serialize;
@@ -88,9 +90,8 @@ struct UpdateChannelFields {
     name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     nsfw: Option<bool>,
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    parent_id: Option<Option<ChannelId>>,
+    parent_id: Option<NullableField<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     permission_overwrites: Option<Vec<PermissionOverwrite>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -173,7 +174,11 @@ impl<'a> UpdateChannel<'a> {
     /// If this is specified, and the parent ID is a `ChannelType::CategoryChannel`, move this
     /// channel to a child of the category channel.
     pub fn parent_id(mut self, parent_id: impl Into<Option<ChannelId>>) -> Self {
-        self.fields.parent_id.replace(parent_id.into());
+        let parent_id = parent_id.into();
+
+        self.fields
+            .parent_id
+            .replace(NullableField::from_option(parent_id));
 
         self
     }

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    request::{self, AuditLogReason, AuditLogReasonError, NullableField, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -12,15 +12,12 @@ use twilight_model::{
 
 #[derive(Default, Serialize)]
 struct UpdateWebhookFields {
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<Option<String>>,
-    #[allow(clippy::option_option)]
+    avatar: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     channel_id: Option<ChannelId>,
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<Option<String>>,
+    name: Option<NullableField<String>>,
 }
 
 /// Update a webhook by ID.
@@ -52,7 +49,9 @@ impl<'a> UpdateWebhook<'a> {
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
     pub fn avatar(mut self, avatar: impl Into<Option<String>>) -> Self {
-        self.fields.avatar.replace(avatar.into());
+        self.fields
+            .avatar
+            .replace(NullableField::from_option(avatar.into()));
 
         self
     }
@@ -66,7 +65,9 @@ impl<'a> UpdateWebhook<'a> {
 
     /// Change the name of the webhook.
     pub fn name(mut self, name: impl Into<Option<String>>) -> Self {
-        self.fields.name.replace(name.into());
+        self.fields
+            .name
+            .replace(NullableField::from_option(name.into()));
 
         self
     }

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -3,7 +3,9 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, validate, AuditLogReason, AuditLogReasonError, Form, Pending, Request},
+    request::{
+        self, validate, AuditLogReason, AuditLogReasonError, Form, NullableField, Pending, Request,
+    },
     routing::Route,
 };
 use serde::Serialize;
@@ -108,12 +110,10 @@ struct UpdateWebhookMessageFields {
     allowed_mentions: Option<AllowedMentions>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     attachments: Vec<Attachment>,
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<Option<String>>,
-    #[allow(clippy::option_option)]
+    content: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    embeds: Option<Option<Vec<Embed>>>,
+    embeds: Option<NullableField<Vec<Embed>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payload_json: Option<Vec<u8>>,
 }
@@ -240,7 +240,9 @@ impl<'a> UpdateWebhookMessage<'a> {
             }
         }
 
-        self.fields.content.replace(content);
+        self.fields
+            .content
+            .replace(NullableField::from_option(content));
 
         Ok(self)
     }
@@ -315,7 +317,9 @@ impl<'a> UpdateWebhookMessage<'a> {
             }
         }
 
-        self.fields.embeds.replace(embeds);
+        self.fields
+            .embeds
+            .replace(NullableField::from_option(embeds));
 
         Ok(self)
     }
@@ -414,7 +418,7 @@ mod tests {
     use super::{UpdateWebhookMessage, UpdateWebhookMessageFields};
     use crate::{
         client::Client,
-        request::{AuditLogReason, Request},
+        request::{AuditLogReason, NullableField, Request},
         routing::Route,
     };
     use twilight_model::id::{MessageId, WebhookId};
@@ -432,7 +436,7 @@ mod tests {
         let body = UpdateWebhookMessageFields {
             allowed_mentions: None,
             attachments: Vec::new(),
-            content: Some(Some("test".to_owned())),
+            content: Some(NullableField::Value("test".to_owned())),
             embeds: None,
             payload_json: None,
         };

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{Pending, Request},
+    request::{NullableField, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -9,12 +9,10 @@ use twilight_model::{channel::Webhook, id::WebhookId};
 
 #[derive(Default, Serialize)]
 struct UpdateWebhookWithTokenFields {
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<Option<String>>,
-    #[allow(clippy::option_option)]
+    avatar: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<Option<String>>,
+    name: Option<NullableField<String>>,
 }
 
 /// Update a webhook, with a token, by ID.
@@ -45,14 +43,18 @@ impl<'a> UpdateWebhookWithToken<'a> {
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
     pub fn avatar(mut self, avatar: impl Into<Option<String>>) -> Self {
-        self.fields.avatar.replace(avatar.into());
+        self.fields
+            .avatar
+            .replace(NullableField::from_option(avatar.into()));
 
         self
     }
 
     /// Change the name of the webhook.
     pub fn name(mut self, name: impl Into<Option<String>>) -> Self {
-        self.fields.name.replace(name.into());
+        self.fields
+            .name
+            .replace(NullableField::from_option(name.into()));
 
         self
     }

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -1,7 +1,9 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    request::{
+        self, validate, AuditLogReason, AuditLogReasonError, NullableField, Pending, Request,
+    },
     routing::Route,
 };
 use hyper::body::Bytes;
@@ -77,16 +79,14 @@ pub enum UpdateGuildMemberErrorType {
 
 #[derive(Default, Serialize)]
 struct UpdateGuildMemberFields {
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    channel_id: Option<Option<ChannelId>>,
+    channel_id: Option<NullableField<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     deaf: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     mute: Option<bool>,
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    nick: Option<Option<String>>,
+    nick: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     roles: Option<Vec<RoleId>>,
 }
@@ -119,7 +119,10 @@ impl<'a> UpdateGuildMember<'a> {
 
     /// Move the member to a different voice channel.
     pub fn channel_id(mut self, channel_id: impl Into<Option<ChannelId>>) -> Self {
-        self.fields.channel_id.replace(channel_id.into());
+        let channel_id = channel_id.into();
+        self.fields
+            .channel_id
+            .replace(NullableField::from_option(channel_id));
 
         self
     }
@@ -158,7 +161,7 @@ impl<'a> UpdateGuildMember<'a> {
                 });
             }
 
-            self.fields.nick.replace(Some(nick));
+            self.fields.nick.replace(NullableField::Value(nick));
         } else {
             self.fields.nick = None;
         }

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Pending, Request},
+    request::{self, AuditLogReason, AuditLogReasonError, NullableField, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -12,16 +12,14 @@ use twilight_model::{
 
 #[derive(Default, Serialize)]
 struct UpdateRoleFields {
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    color: Option<Option<u32>>,
+    color: Option<NullableField<u32>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     mentionable: Option<bool>,
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<Option<String>>,
+    name: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     permissions: Option<Permissions>,
 }
@@ -50,7 +48,9 @@ impl<'a> UpdateRole<'a> {
 
     /// Set the color of the role.
     pub fn color(mut self, color: impl Into<Option<u32>>) -> Self {
-        self.fields.color.replace(color.into());
+        self.fields
+            .color
+            .replace(NullableField::from_option(color.into()));
 
         self
     }
@@ -71,7 +71,9 @@ impl<'a> UpdateRole<'a> {
 
     /// Set the name of the role.
     pub fn name(mut self, name: impl Into<Option<String>>) -> Self {
-        self.fields.name.replace(name.into());
+        self.fields
+            .name
+            .replace(NullableField::from_option(name.into()));
 
         self
     }

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -1,7 +1,9 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    request::{
+        self, validate, AuditLogReason, AuditLogReasonError, NullableField, Pending, Request,
+    },
     routing::Route,
 };
 use serde::Serialize;
@@ -68,54 +70,40 @@ pub enum UpdateGuildErrorType {
 
 #[derive(Default, Serialize)]
 struct UpdateGuildFields {
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    afk_channel_id: Option<Option<ChannelId>>,
+    afk_channel_id: Option<NullableField<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     afk_timeout: Option<u64>,
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    banner: Option<Option<String>>,
-    #[allow(clippy::option_option)]
+    banner: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_message_notifications: Option<Option<DefaultMessageNotificationLevel>>,
-    #[allow(clippy::option_option)]
+    default_message_notifications: Option<NullableField<DefaultMessageNotificationLevel>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discovery_splash: Option<Option<String>>,
-    #[allow(clippy::option_option)]
+    discovery_splash: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    explicit_content_filter: Option<Option<ExplicitContentFilter>>,
-    #[allow(clippy::option_option)]
+    explicit_content_filter: Option<NullableField<ExplicitContentFilter>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    features: Option<Option<Vec<String>>>,
-    #[allow(clippy::option_option)]
+    features: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<Option<String>>,
+    icon: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     owner_id: Option<UserId>,
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    splash: Option<Option<String>>,
-    #[allow(clippy::option_option)]
+    splash: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    system_channel_id: Option<Option<ChannelId>>,
-    #[allow(clippy::option_option)]
+    system_channel_id: Option<NullableField<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    system_channel_flags: Option<Option<SystemChannelFlags>>,
-    #[allow(clippy::option_option)]
+    system_channel_flags: Option<NullableField<SystemChannelFlags>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    verification_level: Option<Option<VerificationLevel>>,
-    #[allow(clippy::option_option)]
+    verification_level: Option<NullableField<VerificationLevel>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    rules_channel_id: Option<Option<ChannelId>>,
-    #[allow(clippy::option_option)]
+    rules_channel_id: Option<NullableField<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    public_updates_channel_id: Option<Option<ChannelId>>,
-    #[allow(clippy::option_option)]
+    public_updates_channel_id: Option<NullableField<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    preferred_locale: Option<Option<String>>,
+    preferred_locale: Option<NullableField<String>>,
 }
 
 /// Update a guild.
@@ -144,7 +132,9 @@ impl<'a> UpdateGuild<'a> {
 
     /// Set the voice channel where AFK voice users are sent.
     pub fn afk_channel_id(mut self, afk_channel_id: impl Into<Option<ChannelId>>) -> Self {
-        self.fields.afk_channel_id.replace(afk_channel_id.into());
+        self.fields
+            .afk_channel_id
+            .replace(NullableField::from_option(afk_channel_id.into()));
 
         self
     }
@@ -163,7 +153,9 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// The server must have the `BANNER` feature.
     pub fn banner(mut self, banner: impl Into<Option<String>>) -> Self {
-        self.fields.banner.replace(banner.into());
+        self.fields
+            .banner
+            .replace(NullableField::from_option(banner.into()));
 
         self
     }
@@ -178,7 +170,9 @@ impl<'a> UpdateGuild<'a> {
     ) -> Self {
         self.fields
             .default_message_notifications
-            .replace(default_message_notifications.into());
+            .replace(NullableField::from_option(
+                default_message_notifications.into(),
+            ));
 
         self
     }
@@ -189,7 +183,7 @@ impl<'a> UpdateGuild<'a> {
     pub fn discovery_splash(mut self, discovery_splash: impl Into<Option<String>>) -> Self {
         self.fields
             .discovery_splash
-            .replace(discovery_splash.into());
+            .replace(NullableField::from_option(discovery_splash.into()));
 
         self
     }
@@ -201,16 +195,14 @@ impl<'a> UpdateGuild<'a> {
     ) -> Self {
         self.fields
             .explicit_content_filter
-            .replace(explicit_content_filter.into());
+            .replace(NullableField::from_option(explicit_content_filter.into()));
 
         self
     }
 
     /// Set the enabled features of the guild.
     pub fn features(mut self, features: impl IntoIterator<Item = String>) -> Self {
-        self.fields
-            .features
-            .replace(Some(features.into_iter().collect()));
+        self.fields.features.replace(features.into_iter().collect());
 
         self
     }
@@ -223,7 +215,9 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
     pub fn icon(mut self, icon: impl Into<Option<String>>) -> Self {
-        self.fields.icon.replace(icon.into());
+        self.fields
+            .icon
+            .replace(NullableField::from_option(icon.into()));
 
         self
     }
@@ -266,7 +260,9 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// Requires the guild to have the `INVITE_SPLASH` feature enabled.
     pub fn splash(mut self, splash: impl Into<Option<String>>) -> Self {
-        self.fields.splash.replace(splash.into());
+        self.fields
+            .splash
+            .replace(NullableField::from_option(splash.into()));
 
         self
     }
@@ -275,7 +271,7 @@ impl<'a> UpdateGuild<'a> {
     pub fn system_channel(mut self, system_channel_id: impl Into<Option<ChannelId>>) -> Self {
         self.fields
             .system_channel_id
-            .replace(system_channel_id.into());
+            .replace(NullableField::from_option(system_channel_id.into()));
 
         self
     }
@@ -287,7 +283,7 @@ impl<'a> UpdateGuild<'a> {
     ) -> Self {
         self.fields
             .system_channel_flags
-            .replace(system_channel_flags.into());
+            .replace(NullableField::from_option(system_channel_flags.into()));
 
         self
     }
@@ -300,7 +296,7 @@ impl<'a> UpdateGuild<'a> {
     pub fn rules_channel(mut self, rules_channel_id: impl Into<Option<ChannelId>>) -> Self {
         self.fields
             .rules_channel_id
-            .replace(rules_channel_id.into());
+            .replace(NullableField::from_option(rules_channel_id.into()));
 
         self
     }
@@ -314,7 +310,7 @@ impl<'a> UpdateGuild<'a> {
     ) -> Self {
         self.fields
             .public_updates_channel_id
-            .replace(public_updates_channel_id.into());
+            .replace(NullableField::from_option(public_updates_channel_id.into()));
 
         self
     }
@@ -325,7 +321,7 @@ impl<'a> UpdateGuild<'a> {
     pub fn preferred_locale(mut self, preferred_locale: impl Into<Option<String>>) -> Self {
         self.fields
             .preferred_locale
-            .replace(preferred_locale.into());
+            .replace(NullableField::from_option(preferred_locale.into()));
 
         self
     }
@@ -339,7 +335,7 @@ impl<'a> UpdateGuild<'a> {
     ) -> Self {
         self.fields
             .verification_level
-            .replace(verification_level.into());
+            .replace(NullableField::from_option(verification_level.into()));
 
         self
     }

--- a/http/src/request/guild/update_guild_widget.rs
+++ b/http/src/request/guild/update_guild_widget.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{Pending, Request},
+    request::{NullableField, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -12,9 +12,8 @@ use twilight_model::{
 
 #[derive(Default, Serialize)]
 struct UpdateGuildWidgetFields {
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    channel_id: Option<Option<ChannelId>>,
+    channel_id: Option<NullableField<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
 }
@@ -39,7 +38,10 @@ impl<'a> UpdateGuildWidget<'a> {
 
     /// Set which channel to display on the widget.
     pub fn channel_id(mut self, channel_id: impl Into<Option<ChannelId>>) -> Self {
-        self.fields.channel_id.replace(channel_id.into());
+        let channel_id = channel_id.into();
+        self.fields
+            .channel_id
+            .replace(NullableField::from_option(channel_id));
 
         self
     }

--- a/http/src/request/guild/user/update_current_user_voice_state.rs
+++ b/http/src/request/guild/user/update_current_user_voice_state.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{Pending, Request},
+    request::{NullableField, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -12,9 +12,8 @@ struct UpdateCurrentUserVoiceStateFields {
     channel_id: ChannelId,
     #[serde(skip_serializing_if = "Option::is_none")]
     suppress: Option<bool>,
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    request_to_speak_timestamp: Option<Option<String>>,
+    request_to_speak_timestamp: Option<NullableField<String>>,
 }
 
 /// Update the current user's voice state.
@@ -53,11 +52,13 @@ impl<'a> UpdateCurrentUserVoiceState<'a> {
 
     fn _request_to_speak_timestamp(mut self, request_to_speak_timestamp: String) -> Self {
         if request_to_speak_timestamp.is_empty() {
-            self.fields.request_to_speak_timestamp.replace(None);
+            self.fields
+                .request_to_speak_timestamp
+                .replace(NullableField::Null);
         } else {
             self.fields
                 .request_to_speak_timestamp
-                .replace(Some(request_to_speak_timestamp));
+                .replace(NullableField::Value(request_to_speak_timestamp));
         }
 
         self

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -96,6 +96,7 @@ use hyper::{
     Method as HyperMethod,
 };
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use serde::{Serialize, Serializer};
 use std::{future::Future, iter, pin::Pin};
 
 type Pending<'a, T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>>;
@@ -125,6 +126,40 @@ impl Method {
             Self::Patch => HyperMethod::PATCH,
             Self::Post => HyperMethod::POST,
             Self::Put => HyperMethod::PUT,
+        }
+    }
+}
+
+/// Field that either serializes to null or a value.
+///
+/// This is particularly useful when combined with an `Option` by allowing three
+/// states via `Option<NullableField<T>>`: undefined, null, and T.
+///
+/// When undefined a field can skip serialization, while if it's null then it will
+/// serialize as null. This mechanism is primarily used in patch requests.
+enum NullableField<T> {
+    /// Remove a value.
+    Null,
+    /// Set a value.
+    Value(T),
+}
+
+impl<T> NullableField<T> {
+    /// Create a `NullableField` from an option.
+    #[allow(clippy::missing_const_for_fn)]
+    fn from_option(option: Option<T>) -> Self {
+        match option {
+            Some(value) => Self::Value(value),
+            None => Self::Null,
+        }
+    }
+}
+
+impl<T: Serialize> Serialize for NullableField<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Null => serializer.serialize_none(),
+            Self::Value(inner) => serializer.serialize_some(inner),
         }
     }
 }

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate, NullableField, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -69,9 +69,8 @@ pub enum UpdateCurrentUserErrorType {
 
 #[derive(Default, Serialize)]
 struct UpdateCurrentUserFields {
-    #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<Option<String>>,
+    avatar: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     username: Option<String>,
 }
@@ -103,7 +102,9 @@ impl<'a> UpdateCurrentUser<'a> {
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
     pub fn avatar(mut self, avatar: impl Into<Option<String>>) -> Self {
-        self.fields.avatar.replace(avatar.into());
+        self.fields
+            .avatar
+            .replace(NullableField::from_option(avatar.into()));
 
         self
     }


### PR DESCRIPTION
Instead of setting fields in request field structs as `Option<Option<T>>`s - causing us to need to ignore clippy lints - set `Option<NullableField<T>>`s instead. This `NullableField` represents two states: having a value and not having a value. This is very similar to `Option` except that it's explicit that the state of having no value is clearly represented as serializing to `null` while the state of having a value serializes to that value.

Closes #865.