### PR TITLE
Fix non-idiomatic usage of self in HTTP crate

### DIFF
--- a/http/src/request/guild/update_guild_welcome_screen.rs
+++ b/http/src/request/guild/update_guild_welcome_screen.rs
@@ -44,7 +44,7 @@ impl<'a> UpdateGuildWelcomeScreen<'a> {
 
     /// Set the description of the welcome screen.
     pub fn description(self, description: impl Into<String>) -> Self {
-        Self::_description(self, description.into())
+        self._description(description.into())
     }
 
     fn _description(mut self, description: String) -> Self {

--- a/http/src/request/guild/user/update_current_user_voice_state.rs
+++ b/http/src/request/guild/user/update_current_user_voice_state.rs
@@ -48,7 +48,7 @@ impl<'a> UpdateCurrentUserVoiceState<'a> {
     /// - You are able to set `request_to_speak_timestamp` to any present or
     /// future time.
     pub fn request_to_speak_timestamp(self, request_to_speak_timestamp: impl Into<String>) -> Self {
-        Self::_request_to_speak_timestamp(self, request_to_speak_timestamp.into())
+        self._request_to_speak_timestamp(request_to_speak_timestamp.into())
     }
 
     fn _request_to_speak_timestamp(mut self, request_to_speak_timestamp: String) -> Self {


### PR DESCRIPTION
Fix an instance of a non-idiomatic usage of `self` by replacing usage from `Self::_foo(self, arg)` with `self._foo(arg)`.