### PR TITLE
Move accessor methods back to root `impl` block

### DIFF
--- a/cache/in-memory/src/event/channel.rs
+++ b/cache/in-memory/src/event/channel.rs
@@ -1,5 +1,4 @@
 use crate::{config::ResourceType, InMemoryCache, UpdateCache};
-use std::collections::HashSet;
 use twilight_model::{
     channel::{Channel, Group, GuildChannel, PrivateChannel},
     gateway::payload::{ChannelCreate, ChannelDelete, ChannelPinsUpdate, ChannelUpdate},
@@ -7,44 +6,6 @@ use twilight_model::{
 };
 
 impl InMemoryCache {
-    /// Gets a channel by ID.
-    ///
-    /// This is an O(1) operation. This requires the [`GUILDS`] intent.
-    ///
-    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
-    pub fn guild_channel(&self, channel_id: ChannelId) -> Option<GuildChannel> {
-        self.0
-            .channels_guild
-            .get(&channel_id)
-            .map(|r| r.data.clone())
-    }
-
-    /// Gets the set of channels in a guild.
-    ///
-    /// This is a O(m) operation, where m is the amount of channels in the
-    /// guild. This requires the [`GUILDS`] intent.
-    ///
-    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
-    pub fn guild_channels(&self, guild_id: GuildId) -> Option<HashSet<ChannelId>> {
-        self.0.guild_channels.get(&guild_id).map(|r| r.clone())
-    }
-
-    /// Gets a group by ID.
-    ///
-    /// This is an O(1) operation.
-    pub fn group(&self, channel_id: ChannelId) -> Option<Group> {
-        self.0.groups.get(&channel_id).map(|r| r.clone())
-    }
-
-    /// Gets a private channel by ID.
-    ///
-    /// This is an O(1) operation. This requires the [`DIRECT_MESSAGES`] intent.
-    ///
-    /// [`DIRECT_MESSAGES`]: ::twilight_model::gateway::Intents::DIRECT_MESSAGES
-    pub fn private_channel(&self, channel_id: ChannelId) -> Option<PrivateChannel> {
-        self.0.channels_private.get(&channel_id).map(|r| r.clone())
-    }
-
     pub(crate) fn cache_guild_channels(
         &self,
         guild_id: GuildId,

--- a/cache/in-memory/src/event/emoji.rs
+++ b/cache/in-memory/src/event/emoji.rs
@@ -1,5 +1,5 @@
 use crate::{config::ResourceType, model::CachedEmoji, GuildItem, InMemoryCache, UpdateCache};
-use std::{borrow::Cow, collections::HashSet};
+use std::borrow::Cow;
 use twilight_model::{
     gateway::payload::GuildEmojisUpdate,
     guild::Emoji,
@@ -7,26 +7,6 @@ use twilight_model::{
 };
 
 impl InMemoryCache {
-    /// Gets an emoji by ID.
-    ///
-    /// This is an O(1) operation. This requires the [`GUILD_EMOJIS`] intent.
-    ///
-    /// [`GUILD_EMOJIS`]: ::twilight_model::gateway::Intents::GUILD_EMOJIS
-    pub fn emoji(&self, emoji_id: EmojiId) -> Option<CachedEmoji> {
-        self.0.emojis.get(&emoji_id).map(|r| r.data.clone())
-    }
-
-    /// Gets the set of emojis in a guild.
-    ///
-    /// This is a O(m) operation, where m is the amount of emojis in the guild.
-    /// This requires both the [`GUILDS`] and [`GUILD_EMOJIS`] intents.
-    ///
-    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
-    /// [`GUILD_EMOJIS`]: ::twilight_model::gateway::Intents::GUILD_EMOJIS
-    pub fn guild_emojis(&self, guild_id: GuildId) -> Option<HashSet<EmojiId>> {
-        self.0.guild_emojis.get(&guild_id).map(|r| r.clone())
-    }
-
     pub(crate) fn cache_emojis(&self, guild_id: GuildId, emojis: Vec<Emoji>) {
         if let Some(mut guild_emojis) = self.0.guild_emojis.get_mut(&guild_id) {
             let incoming: Vec<EmojiId> = emojis.iter().map(|e| e.id).collect();

--- a/cache/in-memory/src/event/guild.rs
+++ b/cache/in-memory/src/event/guild.rs
@@ -12,15 +12,6 @@ use twilight_model::{
 };
 
 impl InMemoryCache {
-    /// Gets a guild by ID.
-    ///
-    /// This is an O(1) operation. This requires the [`GUILDS`] intent.
-    ///
-    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
-    pub fn guild(&self, guild_id: GuildId) -> Option<CachedGuild> {
-        self.0.guilds.get(&guild_id).map(|r| r.clone())
-    }
-
     fn cache_guild(&self, guild: Guild) {
         // The map and set creation needs to occur first, so caching states and
         // objects always has a place to put them.

--- a/cache/in-memory/src/event/member.rs
+++ b/cache/in-memory/src/event/member.rs
@@ -1,5 +1,5 @@
 use crate::{config::ResourceType, model::CachedMember, InMemoryCache, UpdateCache};
-use std::{borrow::Cow, collections::HashSet};
+use std::borrow::Cow;
 use twilight_model::{
     application::interaction::application_command::InteractionMember,
     gateway::payload::{MemberAdd, MemberChunk, MemberRemove, MemberUpdate},
@@ -8,27 +8,6 @@ use twilight_model::{
 };
 
 impl InMemoryCache {
-    /// Gets the set of members in a guild.
-    ///
-    /// This list may be incomplete if not all members have been cached.
-    ///
-    /// This is a O(m) operation, where m is the amount of members in the guild.
-    /// This requires the [`GUILD_MEMBERS`] intent.
-    ///
-    /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
-    pub fn guild_members(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
-        self.0.guild_members.get(&guild_id).map(|r| r.clone())
-    }
-
-    /// Gets a member by guild ID and user ID.
-    ///
-    /// This is an O(1) operation. This requires the [`GUILD_MEMBERS`] intent.
-    ///
-    /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
-    pub fn member(&self, guild_id: GuildId, user_id: UserId) -> Option<CachedMember> {
-        self.0.members.get(&(guild_id, user_id)).map(|r| r.clone())
-    }
-
     pub(crate) fn cache_members(
         &self,
         guild_id: GuildId,

--- a/cache/in-memory/src/event/message.rs
+++ b/cache/in-memory/src/event/message.rs
@@ -1,24 +1,8 @@
 use crate::{config::ResourceType, model::CachedMessage, InMemoryCache, UpdateCache};
 use std::borrow::Cow;
-use twilight_model::{
-    gateway::payload::{MessageCreate, MessageDelete, MessageDeleteBulk, MessageUpdate},
-    id::{ChannelId, MessageId},
+use twilight_model::gateway::payload::{
+    MessageCreate, MessageDelete, MessageDeleteBulk, MessageUpdate,
 };
-
-impl InMemoryCache {
-    /// Gets a message by channel ID and message ID.
-    ///
-    /// This is an O(n) operation. This requires one or both of the
-    /// [`GUILD_MESSAGES`] or [`DIRECT_MESSAGES`] intents.
-    ///
-    /// [`GUILD_MESSAGES`]: ::twilight_model::gateway::Intents::GUILD_MESSAGES
-    /// [`DIRECT_MESSAGES`]: ::twilight_model::gateway::Intents::DIRECT_MESSAGES
-    pub fn message(&self, channel_id: ChannelId, message_id: MessageId) -> Option<CachedMessage> {
-        let channel = self.0.messages.get(&channel_id)?;
-
-        channel.iter().find(|msg| msg.id == message_id).cloned()
-    }
-}
 
 impl UpdateCache for MessageCreate {
     fn update(&self, cache: &InMemoryCache) {
@@ -136,7 +120,7 @@ mod tests {
     use twilight_model::{
         channel::message::{Message, MessageFlags, MessageType},
         guild::PartialMember,
-        id::{ChannelId, GuildId, UserId},
+        id::{ChannelId, GuildId, MessageId, UserId},
         user::User,
     };
 

--- a/cache/in-memory/src/event/mod.rs
+++ b/cache/in-memory/src/event/mod.rs
@@ -12,44 +12,14 @@ pub mod stage_instance;
 pub mod voice_state;
 
 use crate::{config::ResourceType, InMemoryCache, UpdateCache};
-use dashmap::mapref::one::Ref;
 use std::{borrow::Cow, collections::BTreeSet};
 use twilight_model::{
     gateway::payload::{Ready, UnavailableGuild, UserUpdate},
-    id::{GuildId, UserId},
+    id::GuildId,
     user::{CurrentUser, User},
 };
 
 impl InMemoryCache {
-    /// Gets the current user.
-    ///
-    /// This is an O(1) operation.
-    pub fn current_user(&self) -> Option<CurrentUser> {
-        self.0
-            .current_user
-            .lock()
-            .expect("current user poisoned")
-            .clone()
-    }
-
-    /// Gets a user by ID.
-    ///
-    /// This is an O(1) operation. This requires the [`GUILD_MEMBERS`] intent.
-    ///
-    /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
-    pub fn user(&self, user_id: UserId) -> Option<User> {
-        self.0.users.get(&user_id).map(|r| r.0.clone())
-    }
-
-    /// Gets a user by ID.
-    ///
-    /// This is an O(1) operation. This requires the [`GUILD_MEMBERS`] intent.
-    ///
-    /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
-    pub fn user_ref(&self, user_id: UserId) -> Option<Ref<'_, UserId, (User, BTreeSet<GuildId>)>> {
-        self.0.users.get(&user_id)
-    }
-
     fn cache_current_user(&self, current_user: CurrentUser) {
         self.0
             .current_user

--- a/cache/in-memory/src/event/presence.rs
+++ b/cache/in-memory/src/event/presence.rs
@@ -1,5 +1,4 @@
 use crate::{config::ResourceType, model::CachedPresence, InMemoryCache, UpdateCache};
-use std::collections::HashSet;
 use twilight_model::{
     gateway::{payload::PresenceUpdate, presence::UserOrId},
     id::{GuildId, UserId},
@@ -13,30 +12,6 @@ const fn presence_user_id(user_or_id: &UserOrId) -> UserId {
 }
 
 impl InMemoryCache {
-    /// Gets the set of presences in a guild.
-    ///
-    /// This list may be incomplete if not all members have been cached.
-    ///
-    /// This is a O(m) operation, where m is the amount of members in the guild.
-    /// This requires the [`GUILD_PRESENCES`] intent.
-    ///
-    /// [`GUILD_PRESENCES`]: ::twilight_model::gateway::Intents::GUILD_PRESENCES
-    pub fn guild_presences(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
-        self.0.guild_presences.get(&guild_id).map(|r| r.clone())
-    }
-
-    /// Gets a presence by, optionally, guild ID, and user ID.
-    ///
-    /// This is an O(1) operation. This requires the [`GUILD_PRESENCES`] intent.
-    ///
-    /// [`GUILD_PRESENCES`]: ::twilight_model::gateway::Intents::GUILD_PRESENCES
-    pub fn presence(&self, guild_id: GuildId, user_id: UserId) -> Option<CachedPresence> {
-        self.0
-            .presences
-            .get(&(guild_id, user_id))
-            .map(|r| r.clone())
-    }
-
     pub(crate) fn cache_presences(
         &self,
         guild_id: GuildId,

--- a/cache/in-memory/src/event/role.rs
+++ b/cache/in-memory/src/event/role.rs
@@ -1,5 +1,4 @@
 use crate::{config::ResourceType, InMemoryCache, UpdateCache};
-use std::collections::HashSet;
 use twilight_model::{
     gateway::payload::{RoleCreate, RoleDelete, RoleUpdate},
     guild::Role,
@@ -7,25 +6,6 @@ use twilight_model::{
 };
 
 impl InMemoryCache {
-    /// Gets the set of roles in a guild.
-    ///
-    /// This is a O(m) operation, where m is the amount of roles in the guild.
-    /// This requires the [`GUILDS`] intent.
-    ///
-    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
-    pub fn guild_roles(&self, guild_id: GuildId) -> Option<HashSet<RoleId>> {
-        self.0.guild_roles.get(&guild_id).map(|r| r.clone())
-    }
-
-    /// Gets a role by ID.
-    ///
-    /// This is an O(1) operation. This requires the [`GUILDS`] intent.
-    ///
-    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
-    pub fn role(&self, role_id: RoleId) -> Option<Role> {
-        self.0.roles.get(&role_id).map(|r| r.data.clone())
-    }
-
     pub(crate) fn cache_roles(&self, guild_id: GuildId, roles: impl IntoIterator<Item = Role>) {
         for role in roles {
             self.cache_role(guild_id, role);

--- a/cache/in-memory/src/event/stage_instance.rs
+++ b/cache/in-memory/src/event/stage_instance.rs
@@ -1,5 +1,4 @@
 use crate::{config::ResourceType, InMemoryCache, UpdateCache};
-use std::collections::HashSet;
 use twilight_model::{
     channel::StageInstance,
     gateway::payload::{StageInstanceCreate, StageInstanceDelete, StageInstanceUpdate},
@@ -7,31 +6,6 @@ use twilight_model::{
 };
 
 impl InMemoryCache {
-    /// Gets the set of stage instances in a guild.
-    ///
-    /// This is a O(m) operation, where m is the amount of stage instances in
-    /// the guild. This requires the [`GUILDS`] intent.
-    ///
-    /// [`GUILDS`]: twilight_model::gateway::Intents::GUILDS
-    pub fn guild_stage_instances(&self, guild_id: GuildId) -> Option<HashSet<StageId>> {
-        self.0
-            .guild_stage_instances
-            .get(&guild_id)
-            .map(|r| r.value().clone())
-    }
-
-    /// Gets a stage instance by ID.
-    ///
-    /// This is an O(1) operation. This requires the [`GUILDS`] intent.
-    ///
-    /// [`GUILDS`]: twilight_model::gateway::Intents::GUILDS
-    pub fn stage_instance(&self, stage_id: StageId) -> Option<StageInstance> {
-        self.0
-            .stage_instances
-            .get(&stage_id)
-            .map(|role| role.data.clone())
-    }
-
     pub(crate) fn cache_stage_instances(
         &self,
         guild_id: GuildId,

--- a/cache/in-memory/src/event/voice_state.rs
+++ b/cache/in-memory/src/event/voice_state.rs
@@ -1,42 +1,7 @@
 use crate::{config::ResourceType, InMemoryCache, UpdateCache};
-use twilight_model::{
-    gateway::payload::VoiceStateUpdate,
-    id::{ChannelId, GuildId, UserId},
-    voice::VoiceState,
-};
+use twilight_model::{gateway::payload::VoiceStateUpdate, voice::VoiceState};
 
 impl InMemoryCache {
-    /// Gets the voice states within a voice channel.
-    ///
-    /// This requires both the [`GUILDS`] and [`GUILD_VOICE_STATES`] intents.
-    ///
-    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
-    /// [`GUILD_VOICE_STATES`]: ::twilight_model::gateway::Intents::GUILD_VOICE_STATES
-    pub fn voice_channel_states(&self, channel_id: ChannelId) -> Option<Vec<VoiceState>> {
-        let user_ids = self.0.voice_state_channels.get(&channel_id)?;
-
-        Some(
-            user_ids
-                .iter()
-                .filter_map(|key| self.0.voice_states.get(&key).map(|r| r.clone()))
-                .collect(),
-        )
-    }
-
-    /// Gets a voice state by user ID and Guild ID.
-    ///
-    /// This is an O(1) operation. This requires both the [`GUILDS`] and
-    /// [`GUILD_VOICE_STATES`] intents.
-    ///
-    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
-    /// [`GUILD_VOICE_STATES`]: ::twilight_model::gateway::Intents::GUILD_VOICE_STATES
-    pub fn voice_state(&self, user_id: UserId, guild_id: GuildId) -> Option<VoiceState> {
-        self.0
-            .voice_states
-            .get(&(guild_id, user_id))
-            .map(|r| r.clone())
-    }
-
     pub(crate) fn cache_voice_states(&self, voice_states: impl IntoIterator<Item = VoiceState>) {
         for voice_state in voice_states {
             self.cache_voice_state(voice_state);
@@ -133,6 +98,7 @@ impl UpdateCache for VoiceStateUpdate {
 mod tests {
     use super::*;
     use crate::test;
+    use twilight_model::id::{ChannelId, GuildId, UserId};
 
     #[test]
     fn test_voice_state_inserts_and_removes() {

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -526,7 +526,6 @@ impl InMemoryCache {
     fn wants(&self, resource_type: ResourceType) -> bool {
         self.0.config.resource_types().contains(resource_type)
     }
-
 }
 
 pub trait UpdateCache {

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -70,7 +70,10 @@ pub use self::{
 };
 
 use self::model::*;
-use dashmap::{mapref::entry::Entry, DashMap, DashSet};
+use dashmap::{
+    mapref::{entry::Entry, one::Ref},
+    DashMap, DashSet,
+};
 use std::{
     collections::{BTreeSet, HashSet, VecDeque},
     hash::Hash,
@@ -81,7 +84,7 @@ use twilight_model::{
     channel::{Group, GuildChannel, PrivateChannel, StageInstance},
     gateway::event::Event,
     guild::{GuildIntegration, Role},
-    id::{ChannelId, EmojiId, GuildId, IntegrationId, RoleId, StageId, UserId},
+    id::{ChannelId, EmojiId, GuildId, IntegrationId, MessageId, RoleId, StageId, UserId},
     user::{CurrentUser, User},
     voice::VoiceState,
 };
@@ -213,13 +216,6 @@ impl InMemoryCache {
         Self::default()
     }
 
-    fn new_with_config(config: Config) -> Self {
-        Self(Arc::new(InMemoryCacheRef {
-            config,
-            ..Default::default()
-        }))
-    }
-
     /// Create a new builder to configure and construct an in-memory cache.
     pub const fn builder() -> InMemoryCacheBuilder {
         InMemoryCacheBuilder::new()
@@ -287,11 +283,250 @@ impl InMemoryCache {
         value.update(self);
     }
 
+    /// Gets the current user.
+    ///
+    /// This is an O(1) operation.
+    pub fn current_user(&self) -> Option<CurrentUser> {
+        self.0
+            .current_user
+            .lock()
+            .expect("current user poisoned")
+            .clone()
+    }
+
+    /// Gets an emoji by ID.
+    ///
+    /// This is an O(1) operation. This requires the [`GUILD_EMOJIS`] intent.
+    ///
+    /// [`GUILD_EMOJIS`]: ::twilight_model::gateway::Intents::GUILD_EMOJIS
+    pub fn emoji(&self, emoji_id: EmojiId) -> Option<CachedEmoji> {
+        self.0.emojis.get(&emoji_id).map(|r| r.data.clone())
+    }
+
+    /// Gets a group by ID.
+    ///
+    /// This is an O(1) operation.
+    pub fn group(&self, channel_id: ChannelId) -> Option<Group> {
+        self.0.groups.get(&channel_id).map(|r| r.clone())
+    }
+
+    /// Gets a guild by ID.
+    ///
+    /// This is an O(1) operation. This requires the [`GUILDS`] intent.
+    ///
+    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
+    pub fn guild(&self, guild_id: GuildId) -> Option<CachedGuild> {
+        self.0.guilds.get(&guild_id).map(|r| r.clone())
+    }
+
+    /// Gets a channel by ID.
+    ///
+    /// This is an O(1) operation. This requires the [`GUILDS`] intent.
+    ///
+    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
+    pub fn guild_channel(&self, channel_id: ChannelId) -> Option<GuildChannel> {
+        self.0
+            .channels_guild
+            .get(&channel_id)
+            .map(|r| r.data.clone())
+    }
+
+    /// Gets the set of channels in a guild.
+    ///
+    /// This is a O(m) operation, where m is the amount of channels in the
+    /// guild. This requires the [`GUILDS`] intent.
+    ///
+    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
+    pub fn guild_channels(&self, guild_id: GuildId) -> Option<HashSet<ChannelId>> {
+        self.0.guild_channels.get(&guild_id).map(|r| r.clone())
+    }
+
+    /// Gets the set of emojis in a guild.
+    ///
+    /// This is a O(m) operation, where m is the amount of emojis in the guild.
+    /// This requires both the [`GUILDS`] and [`GUILD_EMOJIS`] intents.
+    ///
+    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
+    /// [`GUILD_EMOJIS`]: ::twilight_model::gateway::Intents::GUILD_EMOJIS
+    pub fn guild_emojis(&self, guild_id: GuildId) -> Option<HashSet<EmojiId>> {
+        self.0.guild_emojis.get(&guild_id).map(|r| r.clone())
+    }
+
+    /// Gets the set of members in a guild.
+    ///
+    /// This list may be incomplete if not all members have been cached.
+    ///
+    /// This is a O(m) operation, where m is the amount of members in the guild.
+    /// This requires the [`GUILD_MEMBERS`] intent.
+    ///
+    /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
+    pub fn guild_members(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
+        self.0.guild_members.get(&guild_id).map(|r| r.clone())
+    }
+
+    /// Gets the set of presences in a guild.
+    ///
+    /// This list may be incomplete if not all members have been cached.
+    ///
+    /// This is a O(m) operation, where m is the amount of members in the guild.
+    /// This requires the [`GUILD_PRESENCES`] intent.
+    ///
+    /// [`GUILD_PRESENCES`]: ::twilight_model::gateway::Intents::GUILD_PRESENCES
+    pub fn guild_presences(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
+        self.0.guild_presences.get(&guild_id).map(|r| r.clone())
+    }
+
+    /// Gets the set of roles in a guild.
+    ///
+    /// This is a O(m) operation, where m is the amount of roles in the guild.
+    /// This requires the [`GUILDS`] intent.
+    ///
+    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
+    pub fn guild_roles(&self, guild_id: GuildId) -> Option<HashSet<RoleId>> {
+        self.0.guild_roles.get(&guild_id).map(|r| r.clone())
+    }
+
+    /// Gets the set of stage instances in a guild.
+    ///
+    /// This is a O(m) operation, where m is the amount of stage instances in
+    /// the guild. This requires the [`GUILDS`] intent.
+    ///
+    /// [`GUILDS`]: twilight_model::gateway::Intents::GUILDS
+    pub fn guild_stage_instances(&self, guild_id: GuildId) -> Option<HashSet<StageId>> {
+        self.0
+            .guild_stage_instances
+            .get(&guild_id)
+            .map(|r| r.value().clone())
+    }
+
+    /// Gets a member by guild ID and user ID.
+    ///
+    /// This is an O(1) operation. This requires the [`GUILD_MEMBERS`] intent.
+    ///
+    /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
+    pub fn member(&self, guild_id: GuildId, user_id: UserId) -> Option<CachedMember> {
+        self.0.members.get(&(guild_id, user_id)).map(|r| r.clone())
+    }
+
+    /// Gets a message by channel ID and message ID.
+    ///
+    /// This is an O(n) operation. This requires one or both of the
+    /// [`GUILD_MESSAGES`] or [`DIRECT_MESSAGES`] intents.
+    ///
+    /// [`GUILD_MESSAGES`]: ::twilight_model::gateway::Intents::GUILD_MESSAGES
+    /// [`DIRECT_MESSAGES`]: ::twilight_model::gateway::Intents::DIRECT_MESSAGES
+    pub fn message(&self, channel_id: ChannelId, message_id: MessageId) -> Option<CachedMessage> {
+        let channel = self.0.messages.get(&channel_id)?;
+
+        channel.iter().find(|msg| msg.id == message_id).cloned()
+    }
+
+    /// Gets a presence by, optionally, guild ID, and user ID.
+    ///
+    /// This is an O(1) operation. This requires the [`GUILD_PRESENCES`] intent.
+    ///
+    /// [`GUILD_PRESENCES`]: ::twilight_model::gateway::Intents::GUILD_PRESENCES
+    pub fn presence(&self, guild_id: GuildId, user_id: UserId) -> Option<CachedPresence> {
+        self.0
+            .presences
+            .get(&(guild_id, user_id))
+            .map(|r| r.clone())
+    }
+
+    /// Gets a private channel by ID.
+    ///
+    /// This is an O(1) operation. This requires the [`DIRECT_MESSAGES`] intent.
+    ///
+    /// [`DIRECT_MESSAGES`]: ::twilight_model::gateway::Intents::DIRECT_MESSAGES
+    pub fn private_channel(&self, channel_id: ChannelId) -> Option<PrivateChannel> {
+        self.0.channels_private.get(&channel_id).map(|r| r.clone())
+    }
+
+    /// Gets a role by ID.
+    ///
+    /// This is an O(1) operation. This requires the [`GUILDS`] intent.
+    ///
+    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
+    pub fn role(&self, role_id: RoleId) -> Option<Role> {
+        self.0.roles.get(&role_id).map(|r| r.data.clone())
+    }
+
+    /// Gets a stage instance by ID.
+    ///
+    /// This is an O(1) operation. This requires the [`GUILDS`] intent.
+    ///
+    /// [`GUILDS`]: twilight_model::gateway::Intents::GUILDS
+    pub fn stage_instance(&self, stage_id: StageId) -> Option<StageInstance> {
+        self.0
+            .stage_instances
+            .get(&stage_id)
+            .map(|role| role.data.clone())
+    }
+
+    /// Gets a user by ID.
+    ///
+    /// This is an O(1) operation. This requires the [`GUILD_MEMBERS`] intent.
+    ///
+    /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
+    pub fn user(&self, user_id: UserId) -> Option<User> {
+        self.0.users.get(&user_id).map(|r| r.0.clone())
+    }
+
+    /// Gets a user by ID.
+    ///
+    /// This is an O(1) operation. This requires the [`GUILD_MEMBERS`] intent.
+    ///
+    /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
+    #[deprecated(since = "0.5.1", note = "use `user`")]
+    #[doc(hidden)]
+    pub fn user_ref(&self, user_id: UserId) -> Option<Ref<'_, UserId, (User, BTreeSet<GuildId>)>> {
+        self.0.users.get(&user_id)
+    }
+
+    /// Gets the voice states within a voice channel.
+    ///
+    /// This requires both the [`GUILDS`] and [`GUILD_VOICE_STATES`] intents.
+    ///
+    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
+    /// [`GUILD_VOICE_STATES`]: ::twilight_model::gateway::Intents::GUILD_VOICE_STATES
+    pub fn voice_channel_states(&self, channel_id: ChannelId) -> Option<Vec<VoiceState>> {
+        let user_ids = self.0.voice_state_channels.get(&channel_id)?;
+
+        Some(
+            user_ids
+                .iter()
+                .filter_map(|key| self.0.voice_states.get(&key).map(|r| r.clone()))
+                .collect(),
+        )
+    }
+
+    /// Gets a voice state by user ID and Guild ID.
+    ///
+    /// This is an O(1) operation. This requires both the [`GUILDS`] and
+    /// [`GUILD_VOICE_STATES`] intents.
+    ///
+    /// [`GUILDS`]: ::twilight_model::gateway::Intents::GUILDS
+    /// [`GUILD_VOICE_STATES`]: ::twilight_model::gateway::Intents::GUILD_VOICE_STATES
+    pub fn voice_state(&self, user_id: UserId, guild_id: GuildId) -> Option<VoiceState> {
+        self.0
+            .voice_states
+            .get(&(guild_id, user_id))
+            .map(|r| r.clone())
+    }
+
+    fn new_with_config(config: Config) -> Self {
+        Self(Arc::new(InMemoryCacheRef {
+            config,
+            ..Default::default()
+        }))
+    }
+
     /// Determine whether the configured cache wants a specific resource to be
     /// processed.
     fn wants(&self, resource_type: ResourceType) -> bool {
         self.0.config.resource_types().contains(resource_type)
     }
+
 }
 
 pub trait UpdateCache {


### PR DESCRIPTION
Moves the accessor methods back to the root level `impl` block, which
makes rustdoc only show one impl block for consistency.

Also adds `#[doc(hidden)]` and `#[deprecated]` on `user_ref` as this was
included by mistake in a previous PR.

Part of #937.
