### PR TITLE
Make `ReactionRemoveEmoji::emoji` a `ReactionType`

### DIFF
--- a/cache/in-memory/src/event/reaction.rs
+++ b/cache/in-memory/src/event/reaction.rs
@@ -1,6 +1,6 @@
 use crate::{config::ResourceType, InMemoryCache, UpdateCache};
 use twilight_model::{
-    channel::{message::MessageReaction, ReactionType},
+    channel::message::MessageReaction,
     gateway::payload::{ReactionAdd, ReactionRemove, ReactionRemoveAll, ReactionRemoveEmoji},
 };
 
@@ -111,13 +111,7 @@ impl UpdateCache for ReactionRemoveEmoji {
             None => return,
         };
 
-        let maybe_index = message.reactions.iter().position(|r| {
-            matches!(&r.emoji,
-                ReactionType::Unicode { name, .. }
-                    | ReactionType::Custom { name: Some(name), .. }
-                    if *name == self.emoji.name
-            )
-        });
+        let maybe_index = message.reactions.iter().position(|r| r.emoji == self.emoji);
 
         if let Some(index) = maybe_index {
             message.reactions.remove(index);
@@ -130,8 +124,7 @@ mod tests {
     use super::*;
     use crate::test;
     use twilight_model::{
-        channel::Reaction,
-        gateway::payload::reaction_remove_emoji::PartialEmoji,
+        channel::{Reaction, ReactionType},
         id::{ChannelId, GuildId, MessageId, UserId},
     };
 
@@ -209,8 +202,7 @@ mod tests {
         let cache = test::cache_with_message_and_reactions();
         cache.update(&ReactionRemoveEmoji {
             channel_id: ChannelId(2),
-            emoji: PartialEmoji {
-                id: None,
+            emoji: ReactionType::Unicode {
                 name: "😀".to_owned(),
             },
             guild_id: GuildId(1),

--- a/model/src/gateway/payload/reaction_remove_emoji.rs
+++ b/model/src/gateway/payload/reaction_remove_emoji.rs
@@ -1,16 +1,13 @@
-use crate::id::{ChannelId, EmojiId, GuildId, MessageId};
+use crate::{
+    channel::ReactionType,
+    id::{ChannelId, GuildId, MessageId},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ReactionRemoveEmoji {
     pub channel_id: ChannelId,
-    pub emoji: PartialEmoji,
+    pub emoji: ReactionType,
     pub guild_id: GuildId,
     pub message_id: MessageId,
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct PartialEmoji {
-    pub id: Option<EmojiId>,
-    pub name: String,
 }


### PR DESCRIPTION
Turns out, we store a `ReactionType` in the cache, so this change actually
simplifies the cache code.

This has been tested with both `Unicode` and `Custom` `ReactionType`s.

Fixes #850.
