### PR TITLE
Add missing `Send` bound on `Cluster` methods

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -81,7 +81,7 @@ impl ClusterBuilder {
     ) -> Result<
         (
             Cluster,
-            impl Stream<Item = (u64, Event)> + Unpin + Sync + 'static,
+            impl Stream<Item = (u64, Event)> + Unpin + Send + Sync + 'static,
         ),
         ClusterStartError,
     > {

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -81,7 +81,7 @@ impl ClusterBuilder {
     ) -> Result<
         (
             Cluster,
-            impl Stream<Item = (u64, Event)> + Unpin + Send + Sync + 'static,
+            impl Stream<Item = (u64, Event)> + Send + Sync + Unpin + 'static,
         ),
         ClusterStartError,
     > {

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -291,7 +291,7 @@ impl Cluster {
     ) -> Result<
         (
             Self,
-            impl Stream<Item = (u64, Event)> + Unpin + Send + Sync + 'static,
+            impl Stream<Item = (u64, Event)> + Send + Sync + Unpin + 'static,
         ),
         ClusterStartError,
     > {
@@ -303,7 +303,7 @@ impl Cluster {
     ) -> Result<
         (
             Self,
-            impl Stream<Item = (u64, Event)> + Unpin + Send + Sync + 'static,
+            impl Stream<Item = (u64, Event)> + Send + Sync + Unpin + 'static,
         ),
         ClusterStartError,
     > {

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -291,7 +291,7 @@ impl Cluster {
     ) -> Result<
         (
             Self,
-            impl Stream<Item = (u64, Event)> + Unpin + Sync + 'static,
+            impl Stream<Item = (u64, Event)> + Unpin + Send + Sync + 'static,
         ),
         ClusterStartError,
     > {
@@ -303,7 +303,7 @@ impl Cluster {
     ) -> Result<
         (
             Self,
-            impl Stream<Item = (u64, Event)> + Unpin + Sync + 'static,
+            impl Stream<Item = (u64, Event)> + Unpin + Send + Sync + 'static,
         ),
         ClusterStartError,
     > {


### PR DESCRIPTION
Adds a missing `Send` bound on cluster return types.

This was forgotten in #939.
