### PR TITLE
Remove tracing, serde `rc` feature from cache

### DIFF
--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -17,9 +17,8 @@ version = "0.5.0"
 [dependencies]
 bitflags = { default-features = false, version = "1" }
 dashmap = { default-features = false, version = "4.0" }
-serde = { default-features = false, features = ["derive", "rc"], version = "1" }
+serde = { default-features = false, features = ["derive"], version = "1" }
 twilight-model = { default-features = false, path = "../../model" }
-tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 
 [dev-dependencies]
 futures = { default-features = false, version = "0.3" }


### PR DESCRIPTION
Remove `tracing` from the cache as a dependency due to no longer being used. Additionally due to #871 we no longer need to enable `serde`'s `rc` feature.