### PR TITLE
Emit disconnects on shard self close

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -330,6 +330,8 @@ impl ShardProcessor {
                 Err(source) => {
                     tracing::warn!("{}", source);
 
+                    self.emit_disconnected(None, None).await;
+
                     if source.fatal() {
                         break;
                     }
@@ -356,6 +358,7 @@ impl ShardProcessor {
 
                 if source.fatal() {
                     tracing::debug!("error processing event; reconnecting");
+                    self.emit_disconnected(None, None).await;
 
                     self.reconnect().await;
                 }
@@ -559,6 +562,7 @@ impl ShardProcessor {
 
         if let Err(err) = self.session.heartbeat() {
             tracing::warn!("error sending heartbeat; reconnecting: {}", err);
+            self.emit_disconnected(None, None).await;
 
             self.reconnect().await;
         }
@@ -607,6 +611,8 @@ impl ShardProcessor {
     }
 
     async fn process_invalidate_session(&mut self, resumable: bool) {
+        self.emit_disconnected(None, None).await;
+
         if resumable {
             #[cfg(feature = "metrics")]
             metrics::counter!("GatewayEvent", 1, "GatewayEvent" => "InvalidateSessionTrue");
@@ -632,11 +638,13 @@ impl ShardProcessor {
             reason: Cow::Borrowed("Reconnecting"),
         };
         self.session
-            .close(Some(frame))
+            .close(Some(frame.clone()))
             .map_err(|source| ProcessError {
                 source: Some(Box::new(source)),
                 kind: ProcessErrorType::SendingClose,
             })?;
+        self.emit_disconnected(Some(frame.code.into()), Some(frame.reason.to_string()))
+            .await;
         self.resume().await;
 
         Ok(())
@@ -647,6 +655,8 @@ impl ShardProcessor {
             tracing::warn!("sending message failed: {:?}", source);
 
             if matches!(source.kind(), SessionSendErrorType::Sending { .. }) {
+                self.emit_disconnected(None, None).await;
+
                 self.reconnect().await;
             }
 
@@ -745,13 +755,11 @@ impl ShardProcessor {
     ) -> Result<(), ReceivingEventError> {
         tracing::info!("got close code: {:?}", close_frame);
 
-        self.emitter.event(Event::ShardDisconnected(Disconnected {
-            code: close_frame.as_ref().map(|frame| frame.code.into()),
-            reason: close_frame
-                .as_ref()
-                .map(|frame| frame.reason.clone().into()),
-            shard_id: self.config.shard()[0],
-        }));
+        self.emit_disconnected(
+            close_frame.map(|c| c.code.into()),
+            close_frame.map(|c| c.reason.to_string()),
+        )
+        .await;
 
         if let Some(close_frame) = close_frame {
             match close_frame.code {
@@ -954,5 +962,13 @@ impl ShardProcessor {
 
         self.session.set_stage(stage);
         self.compression.reset();
+    }
+
+    async fn emit_disconnected(&self, code: Option<u16>, reason: Option<String>) {
+        self.emitter.event(Event::ShardDisconnected(Disconnected {
+            code,
+            reason,
+            shard_id: self.config.shard()[0],
+        }));
     }
 }


### PR DESCRIPTION
We emit `Event::ShardDisconnected` events when the remote sends a close message, but we don't emit the event when *we're* the ones to close the connection, such as due to a fatal error or between a session invalidation. This fixes that by having the processor emit an event in those situations.

Closes #761.