### PR TITLE
Only tick shard ratelimiter on successful sends

### DIFF
--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -585,22 +585,25 @@ impl Shard {
     ///
     /// [`shutdown`]: Self::shutdown
     pub async fn send(&self, message: Message) -> Result<(), SendError> {
-        if let Ok(session) = self.session() {
-            // Tick ratelimiter.
-            session.ratelimit.lock().await.next().await;
+        let session = self.session().map_err(|source| SendError {
+            source: Some(Box::new(source)),
+            kind: SendErrorType::SessionInactive,
+        })?;
 
-            session
-                .tx
-                .send(message.into_tungstenite())
-                .map_err(|source| SendError {
-                    source: Some(Box::new(source)),
-                    kind: SendErrorType::Sending,
-                })
-        } else {
-            Err(SendError {
-                source: Some(Box::new(SessionInactiveError)),
-                kind: SendErrorType::SessionInactive,
-            })
+        // Only tick the ratelimiter if there wasn't an error sending it over
+        // the tx. If tx sending fails then the message couldn't be sent anyway,
+        // which does not affect ratelimiting of external sending.
+        match session.tx.send(message.into_tungstenite()) {
+            Ok(()) => {
+                // Tick ratelimiter.
+                session.ratelimit.lock().await.next().await;
+
+                Ok(())
+            }
+            Err(source) => Err(SendError {
+                source: Some(Box::new(source)),
+                kind: SendErrorType::Sending,
+            }),
         }
     }
 


### PR DESCRIPTION
When a session is inactive the shard's ratelimiter will still be ticked, even though an inactive session can't successfully send a message. Instead, only tick the ratelimiter on a successful send.

Closes #633.