### PR TITLE
Rename audit log event variant `GuildCreate` to `GuildUpdate`

### DIFF
--- a/model/src/guild/audit_log/event.rs
+++ b/model/src/guild/audit_log/event.rs
@@ -1,11 +1,13 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
+/// Action to cause an audit log entry.
 #[derive(
     Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
 )]
 #[repr(u8)]
 pub enum AuditLogEvent {
-    GuildCreate = 1,
+    /// Guild was updated.
+    GuildUpdate = 1,
     ChannelCreate = 10,
     ChannelUpdate = 11,
     ChannelDelete = 12,
@@ -43,4 +45,26 @@ pub enum AuditLogEvent {
     StageInstanceCreate = 83,
     StageInstanceUpdate = 84,
     StageInstanceDelete = 85,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AuditLogEvent;
+    use serde::{Deserialize, Serialize};
+    use static_assertions::{assert_impl_all, const_assert_eq};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_impl_all!(
+        AuditLogEvent: Clone,
+        Copy,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        PartialOrd,
+        Ord,
+        Serialize
+    );
+    const_assert_eq!(1, AuditLogEvent::GuildUpdate as u8);
 }


### PR DESCRIPTION
Rename the `AuditLogEntry` variant `GuildCreate` to `GuildUpdate` due to `GuildUpdate` being the correct name.

Docs: <https://github.com/discord/discord-api-docs/blob/101c24dc80460e2e168ffd66551ea22eab72e796/docs/resources/Audit_Log.md#audit-log-events>

Closes #616.