### PR TITLE
Add HTTP reaction display formatter

### DIFF
--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -33,7 +33,7 @@ use twilight_model::id::{ChannelId, MessageId};
 /// ```
 pub struct CreateReaction<'a> {
     channel_id: ChannelId,
-    emoji: String,
+    emoji: RequestReactionType,
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
@@ -48,7 +48,7 @@ impl<'a> CreateReaction<'a> {
     ) -> Self {
         Self {
             channel_id,
-            emoji: super::format_emoji(emoji),
+            emoji,
             fut: None,
             http,
             message_id,
@@ -58,7 +58,7 @@ impl<'a> CreateReaction<'a> {
     fn request(&self) -> Request {
         Request::from_route(Route::CreateReaction {
             channel_id: self.channel_id.0,
-            emoji: self.emoji.clone(),
+            emoji: self.emoji.display().to_string(),
             message_id: self.message_id.0,
         })
     }

--- a/http/src/request/channel/reaction/delete_all_reaction.rs
+++ b/http/src/request/channel/reaction/delete_all_reaction.rs
@@ -10,7 +10,7 @@ use twilight_model::id::{ChannelId, MessageId};
 /// Remove all reactions of a specified emoji from a message.
 pub struct DeleteAllReaction<'a> {
     channel_id: ChannelId,
-    emoji: String,
+    emoji: RequestReactionType,
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
@@ -25,7 +25,7 @@ impl<'a> DeleteAllReaction<'a> {
     ) -> Self {
         Self {
             channel_id,
-            emoji: super::format_emoji(emoji),
+            emoji,
             fut: None,
             http,
             message_id,
@@ -36,7 +36,7 @@ impl<'a> DeleteAllReaction<'a> {
         let request = Request::from_route(Route::DeleteMessageSpecificReaction {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
-            emoji: self.emoji.clone(),
+            emoji: self.emoji.display().to_string(),
         });
 
         self.fut.replace(Box::pin(self.http.verify(request)));

--- a/http/src/request/channel/reaction/delete_reaction.rs
+++ b/http/src/request/channel/reaction/delete_reaction.rs
@@ -10,7 +10,7 @@ use twilight_model::id::{ChannelId, MessageId};
 /// Delete one reaction by a user on a message.
 pub struct DeleteReaction<'a> {
     channel_id: ChannelId,
-    emoji: String,
+    emoji: RequestReactionType,
     fut: Option<Pending<'a, ()>>,
     http: &'a Client,
     message_id: MessageId,
@@ -27,7 +27,7 @@ impl<'a> DeleteReaction<'a> {
     ) -> Self {
         Self {
             channel_id,
-            emoji: super::format_emoji(emoji),
+            emoji,
             fut: None,
             http,
             message_id,
@@ -38,7 +38,7 @@ impl<'a> DeleteReaction<'a> {
     fn start(&mut self) -> Result<(), Error> {
         let request = Request::from_route(Route::DeleteReaction {
             channel_id: self.channel_id.0,
-            emoji: self.emoji.clone(),
+            emoji: self.emoji.display().to_string(),
             message_id: self.message_id.0,
             user: self.target_user.clone(),
         });

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -74,7 +74,7 @@ struct GetReactionsFields {
 /// requests must be chained until all reactions are retireved.
 pub struct GetReactions<'a> {
     channel_id: ChannelId,
-    emoji: String,
+    emoji: RequestReactionType,
     fields: GetReactionsFields,
     fut: Option<Pending<'a, Vec<User>>>,
     http: &'a Client,
@@ -90,7 +90,7 @@ impl<'a> GetReactions<'a> {
     ) -> Self {
         Self {
             channel_id,
-            emoji: super::format_emoji(emoji),
+            emoji,
             fields: GetReactionsFields::default(),
             fut: None,
             http,
@@ -130,7 +130,7 @@ impl<'a> GetReactions<'a> {
         let request = Request::from_route(Route::GetReactionUsers {
             after: self.fields.after.map(|x| x.0),
             channel_id: self.channel_id.0,
-            emoji: self.emoji.clone(),
+            emoji: self.emoji.display().to_string(),
             limit: self.fields.limit,
             message_id: self.message_id.0,
         });

--- a/http/src/request/channel/reaction/mod.rs
+++ b/http/src/request/channel/reaction/mod.rs
@@ -11,13 +11,57 @@ pub use self::{
     get_reactions::GetReactions,
 };
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
-use std::fmt::Write;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 use twilight_model::{channel::ReactionType, id::EmojiId};
 
-#[derive(Eq, PartialEq)]
+/// Handle a reaction of either a custom or unicode emoji.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RequestReactionType {
-    Custom { id: EmojiId, name: Option<String> },
-    Unicode { name: String },
+    /// Reaction of a custom emoji.
+    Custom {
+        /// ID of the custom emoji.
+        id: EmojiId,
+        /// Name of the custom emoji.
+        ///
+        /// This is not strictly required, but may be helpful for Discord to
+        /// work with.
+        name: Option<String>,
+    },
+    /// Reaction of a unicode emoji, such as "🌈".
+    Unicode {
+        /// Unicode emoji.
+        name: String,
+    },
+}
+
+impl RequestReactionType {
+    /// Create a display formatter for a reaction type resulting in a format
+    /// acceptable for use in URLs.
+    ///
+    /// # Examples
+    ///
+    /// Format the transgender flag for use in a URL:
+    ///
+    /// ```
+    /// use twilight_http::request::channel::reaction::RequestReactionType;
+    /// use twilight_model::id::EmojiId;
+    ///
+    /// let reaction = RequestReactionType::Unicode {
+    ///     name: "🏳️‍⚧️".to_owned(),
+    /// };
+    ///
+    /// // Retrieve the display formatter.
+    /// let display = reaction.display();
+    ///
+    /// // And now format it into a percent-encoded string and then check it.
+    /// assert_eq!(
+    ///     "%F0%9F%8F%B3%EF%B8%8F%E2%80%8D%E2%9A%A7%EF%B8%8F",
+    ///     display.to_string(),
+    /// );
+    /// ```
+    pub const fn display(&self) -> RequestReactionTypeDisplay<'_> {
+        RequestReactionTypeDisplay(self)
+    }
 }
 
 impl From<ReactionType> for RequestReactionType {
@@ -29,19 +73,99 @@ impl From<ReactionType> for RequestReactionType {
     }
 }
 
-fn format_emoji(emoji: RequestReactionType) -> String {
-    match emoji {
-        RequestReactionType::Custom { id, name } => {
-            let mut emoji = String::new();
-            match name {
-                Some(name) => emoji.push_str(name.as_ref()),
-                None => emoji.push('e'),
+/// Format a [`RequestReactionType`] into a format acceptable for use in URLs.
+///
+/// # Examples
+///
+/// Format a custom reaction for use in a URL:
+///
+/// ```
+/// use twilight_http::request::channel::reaction::RequestReactionType;
+/// use twilight_model::id::EmojiId;
+///
+/// let reaction = RequestReactionType::Custom {
+///     id: EmojiId(123),
+///     name: Some("rarity".to_owned()),
+/// };
+///
+/// // Retrieve the display formatter.
+/// let display = reaction.display();
+///
+/// // And now format it into an acceptable string and then check it.
+/// assert_eq!("rarity:123", display.to_string());
+/// ```
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RequestReactionTypeDisplay<'a>(&'a RequestReactionType);
+
+impl Display for RequestReactionTypeDisplay<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self.0 {
+            RequestReactionType::Custom { id, name } => {
+                if let Some(name) = name {
+                    f.write_str(name)?;
+                } else {
+                    f.write_str("e")?;
+                }
+
+                f.write_str(":")?;
+
+                Display::fmt(id, f)
             }
-            let _ = write!(emoji, ":{}", id);
-            emoji
+            RequestReactionType::Unicode { name } => {
+                Display::fmt(&utf8_percent_encode(&name, NON_ALPHANUMERIC), f)
+            }
         }
-        RequestReactionType::Unicode { name } => {
-            utf8_percent_encode(&name, NON_ALPHANUMERIC).to_string()
-        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // `clippy::non_ascii_literal` can't be allowed on an item level; it can
+    // only be enabled on a module level.
+    #![allow(clippy::non_ascii_literal)]
+
+    use super::{RequestReactionType, RequestReactionTypeDisplay};
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::fmt::{Debug, Display};
+    use twilight_model::id::EmojiId;
+
+    assert_fields!(RequestReactionType::Custom: id, name);
+    assert_fields!(RequestReactionType::Unicode: name);
+    assert_impl_all!(RequestReactionTypeDisplay<'_>: Clone, Debug, Display, Eq, PartialEq, Send, Sync);
+    assert_impl_all!(RequestReactionType: Clone, Debug, Eq, PartialEq, Send, Sync);
+
+    #[test]
+    fn test_display_custom_with_name() {
+        let reaction = RequestReactionType::Custom {
+            id: EmojiId(123),
+            name: Some("foo".to_owned()),
+        };
+
+        assert_eq!("foo:123", reaction.display().to_string());
+    }
+
+    #[test]
+    fn test_display_custom_without_name() {
+        let reaction = RequestReactionType::Custom {
+            id: EmojiId(123),
+            name: None,
+        };
+
+        assert_eq!("e:123", reaction.display().to_string());
+    }
+
+    /// Test that unicode reactions format with percent encoding.
+    // We can't use the actual flag here
+    #[test]
+    fn test_display_unicode() {
+        let reaction = RequestReactionType::Unicode {
+            // Rainbow flag 🏳️‍🌈
+            name: "🏳️‍🌈".to_owned(),
+        };
+
+        assert_eq!(
+            "%F0%9F%8F%B3%EF%B8%8F%E2%80%8D%F0%9F%8C%88",
+            reaction.display().to_string()
+        );
     }
 }


### PR DESCRIPTION
Add a `Display` formatter for `request::channel::reaction::RequestReactionType`. The new method, `RequestReactionType::display`, returns `RequestReactionTypeDisplay` which in turn implements `std::fmt::Display` to format the reaction into a format acceptable for URLs.

This replaces the private `format_emoji` function which allocates a String. With how the Display formatter is used a string still needs to be allocated, but this will enable an optimization in the future.