### PR TITLE
Make Standby `tracing` dependency optional

### DIFF
--- a/standby/Cargo.toml
+++ b/standby/Cargo.toml
@@ -17,11 +17,16 @@ version = "0.5.0"
 [dependencies]
 dashmap = { default-features = false, version = "4.0" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
-tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 tokio = { default-features = false, features = ["sync"], version = "1.0" }
 twilight-model = { default-features = false, path = "../model" }
+
+# Optional dependencies.
+tracing = { default-features = false, features = ["std", "attributes"], optional = true, version = "0.1" }
 
 [dev-dependencies]
 static_assertions = { default-features = false, version = "1" }
 twilight-gateway = { path = "../gateway" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
+
+[features]
+default = ["tracing"]

--- a/standby/README.md
+++ b/standby/README.md
@@ -36,6 +36,14 @@ The difference is that if you use the futures variant in a loop then you may
 miss some events while processing a received event. By using a stream, you
 won't miss any events.
 
+## Features
+
+### Tracing
+
+The `tracing` feature enables logging via the [`tracing`] crate.
+
+This is enabled by default.
+
 ## Examples
 
 ### At a glance

--- a/standby/README.md
+++ b/standby/README.md
@@ -119,6 +119,7 @@ async fn react(msg: Message, standby: Standby) -> Result<(), Box<dyn Error + Sen
 
 For more examples, check out each of the methods on [`Standby`].
 
+[`tracing`]: https://crates.io/crates/tracing
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -119,6 +119,7 @@
 //!
 //! For more examples, check out each of the methods on [`Standby`].
 //!
+//! [`tracing`]: https://crates.io/crates/tracing
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github


### PR DESCRIPTION
Make the `tracing` dependency optional. Users can now opt-out of it by disabling `default-features` for the crate in their dependencies section.