### PR TITLE
Make Gateway `tracing` dependency optional

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -21,7 +21,6 @@ twilight-gateway-queue = { default-features = false, path = "./queue" }
 twilight-http = { default-features = false, path = "../http" }
 twilight-model = { default-features = false, path = "../model" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
-tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 once_cell = { default-features = false, features = ["std"], version = "1" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, version = "1" }
@@ -36,6 +35,7 @@ url = { default-features = false, version = "2" }
 flate2 = { default-features = false, optional = true, version = "1.0" }
 metrics = { default-features = false, optional = true, version = "0.14", features = ["std"] }
 simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.4" }
+tracing = { default-features = false, features = ["std", "attributes"], optional = true, version = "0.1" }
 
 [dev-dependencies]
 futures = { default-features = false, version = "0.3" }
@@ -43,7 +43,7 @@ static_assertions = { default-features = false, version = "1" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
 
 [features]
-default = ["compression", "rustls", "flate2/zlib"]
+default = ["compression", "rustls", "tracing", "flate2/zlib"]
 compression = ["flate2"]
 native = ["twilight-http/native", "twilight-gateway-queue/native", "tokio-tungstenite/native-tls"]
 rustls = ["rustls-native-roots"]

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -86,6 +86,12 @@ one of them has to be enabled. If both are enabled it will use `zlib-stock`
 Enabling **only** `zlib-simd` will make the library use [`zlib-ng`] which is a modern
 fork of zlib that is faster and more effective, but it needs `cmake` to compile.
 
+### Tracing
+
+The `tracing` feature enables logging via the [`tracing`] crate.
+
+This is enabled by default.
+
 ### Metrics
 
 The `metrics` feature provides metrics information via the `metrics` crate.
@@ -100,6 +106,7 @@ This is disabled by default.
 [`rustls`]: https://crates.io/crates/rustls
 [`serde_json`]: https://crates.io/crates/serde_json
 [`simd-json`]: https://crates.io/crates/simd-json
+[`tracing`]: https://crates.io/crates/tracing
 [`twilight-http`]: https://twilight-rs.github.io/twilight/twilight_http/index.html
 [`zlib-ng`]: https://github.com/zlib-ng/zlib-ng
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -84,6 +84,12 @@
 //! Enabling **only** `zlib-simd` will make the library use [`zlib-ng`] which is a modern
 //! fork of zlib that is faster and more effective, but it needs `cmake` to compile.
 //!
+//! ### Tracing
+//!
+//! The `tracing` feature enables logging via the [`tracing`] crate.
+//!
+//! This is enabled by default.
+//!
 //! ### Metrics
 //!
 //! The `metrics` feature provides metrics information via the `metrics` crate.
@@ -98,6 +104,7 @@
 //! [`rustls`]: https://crates.io/crates/rustls
 //! [`serde_json`]: https://crates.io/crates/serde_json
 //! [`simd-json`]: https://crates.io/crates/simd-json
+//! [`tracing`]: https://crates.io/crates/tracing
 //! [`twilight-http`]: https://twilight-rs.github.io/twilight/twilight_http/index.html
 //! [`zlib-ng`]: https://github.com/zlib-ng/zlib-ng
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
@@ -121,7 +128,11 @@
     unused,
     warnings
 )]
-#![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::used_underscore_binding
+)]
 
 pub mod cluster;
 pub mod shard;

--- a/gateway/src/shard/emitter.rs
+++ b/gateway/src/shard/emitter.rs
@@ -86,7 +86,7 @@ impl Emitter {
     /// be cloned. This means that for most users, this will be a cheap check.
     ///
     /// [`EventTypeFlags::SHARD_PAYLOAD`]: crate::EventTypeFlags::SHARD_PAYLOAD
-    #[tracing::instrument(level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace"))]
     pub fn bytes(&self, bytes: &[u8]) {
         if self.wants(EventTypeFlags::SHARD_PAYLOAD) {
             self.send(Event::ShardPayload(Payload {
@@ -96,7 +96,7 @@ impl Emitter {
     }
 
     /// Send an event to the listener if it has subscribed to its event type.
-    #[tracing::instrument(level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace"))]
     pub fn event(&self, event: Event) {
         let event_type = EventTypeFlags::from(event.kind());
 

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -480,6 +480,7 @@ impl Shard {
         let handle = tokio::spawn(async move {
             processor.run().await;
 
+            #[cfg(feature = "tracing")]
             tracing::debug!("shard processor future ended");
         });
 

--- a/gateway/src/shard/json.rs
+++ b/gateway/src/shard/json.rs
@@ -77,6 +77,7 @@ pub fn parse_gateway_event(
     gateway_deserializer
         .deserialize(&mut json_deserializer)
         .map_err(|source| {
+            #[cfg(feature = "tracing")]
             tracing::debug!("invalid JSON: {}", json);
 
             GatewayEventParsingError {
@@ -125,6 +126,7 @@ pub fn parse_gateway_event(
     gateway_deserializer
         .deserialize(&mut json_deserializer)
         .map_err(|source| {
+            #[cfg(feature = "tracing")]
             tracing::debug!("invalid JSON: {}", json);
 
             GatewayEventParsingError {

--- a/gateway/src/shard/processor/compression/inflater.rs
+++ b/gateway/src/shard/processor/compression/inflater.rs
@@ -27,11 +27,6 @@ impl Inflater {
         }
     }
 
-    /// Return an immutable reference to the buffer.
-    pub fn buffer_ref(&self) -> &[u8] {
-        self.buffer.as_slice()
-    }
-
     /// Return a mutable reference to the buffer.
     pub fn buffer_mut(&mut self) -> &mut [u8] {
         self.buffer.as_mut_slice()
@@ -51,7 +46,7 @@ impl Inflater {
     /// This returns `flate2`'s `DecompressError` as its method's type signature
     /// indicates it can return an error, however in reality in versions up to
     /// 1.0.17 it won't.
-    #[tracing::instrument(level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace"))]
     pub fn msg(&mut self) -> Result<Option<&mut [u8]>, DecompressError> {
         let length = self.compressed.len();
 
@@ -85,6 +80,7 @@ impl Inflater {
             }
         }
 
+        #[cfg(feature = "tracing")]
         tracing::trace!(
             bytes_in = self.compressed.len(),
             bytes_out = self.buffer.len(),
@@ -92,30 +88,35 @@ impl Inflater {
             shard_total = self.shard[1],
             "payload lengths",
         );
+
         self.compressed.clear();
 
-        // It doesn't matter if we lose precision for logging.
-        #[allow(clippy::cast_precision_loss)]
-        let saved_percentage =
-            self.decompress.total_in() as f64 / self.decompress.total_out() as f64;
-        let saved_percentage_readable = saved_percentage * 100.0;
+        #[cfg(feature = "tracing")]
+        {
+            // It doesn't matter if we lose precision for logging.
+            #[allow(clippy::cast_precision_loss)]
+            let saved_percentage =
+                self.decompress.total_in() as f64 / self.decompress.total_out() as f64;
+            let saved_percentage_readable = saved_percentage * 100.0;
+            let saved_kib = (self.decompress.total_out() - self.decompress.total_in()) / 1_024;
 
-        let saved_kib = (self.decompress.total_out() - self.decompress.total_in()) / 1_024;
-
-        tracing::trace!(
-            saved_kib = saved_kib,
-            saved_percentage = %saved_percentage_readable,
-            shard_id = self.shard[0],
-            shard_total = self.shard[1],
-            total_in = self.decompress.total_in(),
-            total_out = self.decompress.total_out(),
-            "data saved",
-        );
+            tracing::trace!(
+                saved_kib = saved_kib,
+                saved_percentage = %saved_percentage_readable,
+                shard_id = self.shard[0],
+                shard_total = self.shard[1],
+                total_in = self.decompress.total_in(),
+                total_out = self.decompress.total_out(),
+                "data saved",
+            );
+        }
 
         #[cfg(feature = "metrics")]
         self.inflater_metrics();
 
+        #[cfg(feature = "tracing")]
         tracing::trace!("capacity: {}", self.buffer.capacity());
+
         Ok(Some(&mut self.buffer))
     }
 
@@ -123,7 +124,7 @@ impl Inflater {
     ///
     /// If the capacity is 4 times larger than the buffer length then the
     /// capacity will be shrunk to the length.
-    #[tracing::instrument(level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace"))]
     pub fn clear(&mut self) {
         self.shrink();
 
@@ -165,12 +166,14 @@ impl Inflater {
         self.compressed.shrink_to_fit();
         self.buffer.shrink_to_fit();
 
+        #[cfg(feature = "tracing")]
         tracing::trace!(
             capacity = self.compressed.capacity(),
             shard_id = self.shard[0],
             shard_total = self.shard[1],
             "compressed capacity",
         );
+        #[cfg(feature = "tracing")]
         tracing::trace!(
             capacity = self.buffer.capacity(),
             shard_id = self.shard[0],

--- a/gateway/src/shard/processor/compression/mod.rs
+++ b/gateway/src/shard/processor/compression/mod.rs
@@ -51,23 +51,6 @@ impl Compression {
         self.inner.as_mut_slice()
     }
 
-    /// Immutable reference to the internal buffer slice.
-    ///
-    /// When compression is enabled this will immutably reference the inflater's
-    /// buffer.
-    ///
-    /// When compression is disabled this will immutably reference the standard
-    /// buffer.
-    pub fn buffer_slice_ref(&self) -> &[u8] {
-        #[cfg(feature = "compression")]
-        {
-            self.inner.buffer_ref()
-        }
-
-        #[cfg(not(feature = "compression"))]
-        self.inner.as_slice()
-    }
-
     /// Mutable reference to the internal buffer slice as a mutable string slice.
     ///
     /// # Safety


### PR DESCRIPTION
Make the `tracing` dependency optional. Users can now opt-out of it by disabling `default-features` for the crate in their dependencies section.