### PR TITLE
Standby: Promote `missing_docs` to `deny`

### DIFF
--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -122,6 +122,7 @@
 #![deny(
     broken_intra_doc_links,
     clippy::missing_const_for_fn,
+    missing_docs,
     rust_2018_idioms,
     unused,
     warnings


### PR DESCRIPTION
This crate was actually already fully documented.

Part of #542.
