### PR TITLE
feat(http): Don't allocate without simd feature

### DIFF
--- a/http/src/json.rs
+++ b/http/src/json.rs
@@ -1,17 +1,36 @@
+use crate::error::{Error, ErrorType};
+
 #[cfg(not(feature = "simd-json"))]
 pub use serde_json::to_vec;
 #[cfg(feature = "simd-json")]
 pub use simd_json::to_vec;
 
+use hyper::body::Bytes;
 use serde::Deserialize;
 
 #[cfg(not(feature = "simd-json"))]
-use serde_json::{from_slice as inner_from_slice, Result as JsonResult};
+use serde_json::Result as JsonResult;
 #[cfg(feature = "simd-json")]
-use simd_json::{from_slice as inner_from_slice, Result as JsonResult};
+use simd_json::Result as JsonResult;
 
-// Function will automatically cast mutable references to immutable for
-// `serde_json`.
-pub fn from_slice<'a, T: Deserialize<'a>>(s: &'a mut [u8]) -> JsonResult<T> {
-    inner_from_slice(s)
+pub fn from_bytes<'a, T: Deserialize<'a>>(bytes: &'a Bytes) -> JsonResult<T> {
+    #[cfg(not(feature = "simd-json"))]
+    {
+        serde_json::from_slice(&bytes)
+    }
+
+    #[cfg(feature = "simd-json")]
+    {
+        // Bytes does not implement DerefMut so we have to allocate
+        simd_json::from_slice(&mut bytes.to_vec())
+    }
+}
+
+pub fn parse_bytes<'a, T: Deserialize<'a>>(bytes: &'a Bytes) -> Result<T, Error> {
+    from_bytes(bytes).map_err(|source| Error {
+        kind: ErrorType::Parsing {
+            body: bytes.to_vec(),
+        },
+        source: Some(Box::new(source)),
+    })
 }

--- a/http/src/json.rs
+++ b/http/src/json.rs
@@ -6,17 +6,17 @@ pub use serde_json::to_vec;
 pub use simd_json::to_vec;
 
 use hyper::body::Bytes;
-use serde::Deserialize;
+use serde::de::DeserializeOwned;
 
 #[cfg(not(feature = "simd-json"))]
 use serde_json::Result as JsonResult;
 #[cfg(feature = "simd-json")]
 use simd_json::Result as JsonResult;
 
-pub fn from_bytes<'a, T: Deserialize<'a>>(bytes: &'a Bytes) -> JsonResult<T> {
+pub fn from_bytes<T: DeserializeOwned>(bytes: &Bytes) -> JsonResult<T> {
     #[cfg(not(feature = "simd-json"))]
     {
-        serde_json::from_slice(&bytes)
+        serde_json::from_slice::<T>(&bytes)
     }
 
     #[cfg(feature = "simd-json")]
@@ -26,7 +26,7 @@ pub fn from_bytes<'a, T: Deserialize<'a>>(bytes: &'a Bytes) -> JsonResult<T> {
     }
 }
 
-pub fn parse_bytes<'a, T: Deserialize<'a>>(bytes: &'a Bytes) -> Result<T, Error> {
+pub fn parse_bytes<T: DeserializeOwned>(bytes: &Bytes) -> Result<T, Error> {
     from_bytes(bytes).map_err(|source| Error {
         kind: ErrorType::Parsing {
             body: bytes.to_vec(),

--- a/http/src/json.rs
+++ b/http/src/json.rs
@@ -1,10 +1,9 @@
-use crate::error::{Error, ErrorType};
-
 #[cfg(not(feature = "simd-json"))]
 pub use serde_json::to_vec;
 #[cfg(feature = "simd-json")]
 pub use simd_json::to_vec;
 
+use crate::error::{Error, ErrorType};
 use hyper::body::Bytes;
 use serde::de::DeserializeOwned;
 

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -272,14 +272,7 @@ impl Future for ExecuteWebhook<'_> {
                     return Poll::Ready(Ok(None));
                 }
 
-                let mut bytes = bytes.as_ref().to_vec();
-                let message =
-                    crate::json::from_slice::<Message>(&mut bytes).map_err(|source| Error {
-                        kind: ErrorType::Parsing {
-                            body: bytes.clone(),
-                        },
-                        source: Some(Box::new(source)),
-                    })?;
+                let message = crate::json::parse_bytes::<Message>(&bytes)?;
 
                 return Poll::Ready(Ok(Some(message)));
             }

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -63,14 +63,7 @@ impl Future for GetGuildVanityUrl<'_> {
                     Poll::Pending => return Poll::Pending,
                 };
 
-                let mut bytes = bytes.as_ref().to_vec();
-                let vanity_url =
-                    crate::json::from_slice::<VanityUrl>(&mut bytes).map_err(|source| Error {
-                        kind: ErrorType::Parsing {
-                            body: bytes.clone(),
-                        },
-                        source: Some(Box::new(source)),
-                    })?;
+                let vanity_url: VanityUrl = crate::json::parse_bytes(&bytes)?;
 
                 return Poll::Ready(Ok(Some(vanity_url.code)));
             }

--- a/http/src/request/guild/member/add_guild_member.rs
+++ b/http/src/request/guild/member/add_guild_member.rs
@@ -1,6 +1,6 @@
 use crate::{
     client::Client,
-    error::{Error as HttpError, ErrorType},
+    error::Error as HttpError,
     request::{validate, PendingOption, Request},
     routing::Route,
 };
@@ -195,18 +195,11 @@ impl Future for AddGuildMember<'_> {
                     Poll::Pending => return Poll::Pending,
                 };
 
-                let mut bytes = bytes.as_ref().to_vec();
-
                 if bytes.is_empty() {
                     return Poll::Ready(Ok(None));
                 }
 
-                return Poll::Ready(crate::json::from_slice(&mut bytes).map(Some).map_err(
-                    |source| HttpError {
-                        kind: ErrorType::Parsing { body: bytes },
-                        source: Some(Box::new(source)),
-                    },
-                ));
+                return Poll::Ready(crate::json::parse_bytes(&bytes));
             }
 
             if let Err(why) = self.as_mut().start() {

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -185,9 +185,8 @@ impl Future for GetGuildMembers<'_> {
                 let bytes = res?;
                 let mut members = Vec::new();
 
-                let mut bytes = bytes.as_ref().to_vec();
                 let values =
-                    crate::json::from_slice::<Vec<Value>>(&mut bytes).map_err(HttpError::json)?;
+                    crate::json::from_bytes::<Vec<Value>>(&bytes).map_err(HttpError::json)?;
 
                 for value in values {
                     let member_deserializer = MemberDeserializer::new(self.guild_id);

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -69,8 +69,7 @@ impl Future for GetMember<'_> {
                     Poll::Pending => return Poll::Pending,
                 };
 
-                let mut bytes = bytes.as_ref().to_vec();
-                let value = crate::json::from_slice::<Value>(&mut bytes).map_err(Error::json)?;
+                let value = crate::json::from_bytes::<Value>(&bytes).map_err(Error::json)?;
 
                 let member_deserializer = MemberDeserializer::new(self.guild_id);
                 let member = member_deserializer

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -179,9 +179,8 @@ impl Future for SearchGuildMembers<'_> {
                 let bytes = res?;
                 let mut members = Vec::new();
 
-                let mut bytes = bytes.as_ref().to_vec();
                 let values =
-                    crate::json::from_slice::<Vec<Value>>(&mut bytes).map_err(HttpError::json)?;
+                    crate::json::from_bytes::<Vec<Value>>(&bytes).map_err(HttpError::json)?;
 
                 for value in values {
                     let member_deserializer = MemberDeserializer::new(self.guild_id);

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -216,9 +216,7 @@ impl Future for UpdateGuildMember<'_> {
                     Poll::Pending => return Poll::Pending,
                 };
 
-                let mut bytes = bytes.as_ref().to_vec();
-                let value =
-                    crate::json::from_slice::<Value>(&mut bytes).map_err(HttpError::json)?;
+                let value = crate::json::from_bytes::<Value>(&bytes).map_err(HttpError::json)?;
 
                 let member_deserializer = MemberDeserializer::new(self.guild_id);
                 let member = member_deserializer

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -43,15 +43,7 @@ macro_rules! poll_req {
                             Poll::Pending => return Poll::Pending,
                         };
 
-                        let mut bytes = bytes.as_ref().to_vec();
-                        return Poll::Ready(crate::json::from_slice(&mut bytes).map(Some).map_err(
-                            |source| crate::Error {
-                                kind: crate::error::ErrorType::Parsing {
-                                    body: bytes.to_vec(),
-                                },
-                                source: Some(Box::new(source)),
-                            },
-                        ));
+                        return Poll::Ready(crate::json::parse_bytes(&bytes));
                     }
 
                     if let Err(why) = self.as_mut().start() {


### PR DESCRIPTION
Since `simd_json::from_slice` requires a mutable reference, deserializing always required to copy the response bytes into a `Vec` and then deserialize through a mutable reference to that `Vec`, even if the `simd_json` feature wasn't enabled.

If the feature is not enabled, this PR deserializes through an immutable reference instead of allocating beforehand.
This should clear up a lot of unecessary allocations.

Minor side effect: If the deserialization previously failed, the twilight error would include the bytes. However, since the bytes were potentially mutated while deserializing with simd, the bytes in the error might not have been the actual response bytes. In this PR, it is guaranteed that the error contains the actual response bytes.

I've tested the non-simd version, even if somewhat superficially, and couldn't find any issues. The simd version on the other hand just doesn't want to compile for me so that should still be checked. Something about missing simd flags for my CPU although it definitely supports simd 🙄