### PR TITLE
refactor!(model): reorganize threads into own module

### DIFF
--- a/cache/in-memory/src/event/guild.rs
+++ b/cache/in-memory/src/event/guild.rs
@@ -207,8 +207,8 @@ mod tests {
     use super::*;
     use twilight_model::{
         channel::{
-            AutoArchiveDuration, ChannelType, GuildChannel, PublicThread, TextChannel,
-            ThreadMember, ThreadMetadata,
+            thread::{AutoArchiveDuration, PublicThread, ThreadMember, ThreadMetadata},
+            ChannelType, GuildChannel, TextChannel,
         },
         guild::{
             DefaultMessageNotificationLevel, ExplicitContentFilter, MfaLevel, NSFWLevel,

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -2,52 +2,44 @@ pub mod embed;
 pub mod message;
 pub mod permission_overwrite;
 pub mod stage_instance;
+pub mod thread;
 pub mod webhook;
 
 mod attachment;
-mod auto_archive_duration;
 mod category_channel;
 mod channel_mention;
 mod channel_type;
 mod followed_channel;
 mod group;
-mod news_thread;
 mod private_channel;
-mod private_thread;
-mod public_thread;
 mod reaction;
 mod reaction_type;
 mod text_channel;
-mod thread_member;
-mod thread_metadata;
 mod video_quality_mode;
 mod voice_channel;
 
 pub use self::{
     attachment::Attachment,
-    auto_archive_duration::AutoArchiveDuration,
     category_channel::CategoryChannel,
     channel_mention::ChannelMention,
     channel_type::ChannelType,
     followed_channel::FollowedChannel,
     group::Group,
     message::Message,
-    news_thread::NewsThread,
     private_channel::PrivateChannel,
-    private_thread::PrivateThread,
-    public_thread::PublicThread,
     reaction::Reaction,
     reaction_type::ReactionType,
     stage_instance::StageInstance,
     text_channel::TextChannel,
-    thread_member::ThreadMember,
-    thread_metadata::ThreadMetadata,
     video_quality_mode::VideoQualityMode,
     voice_channel::VoiceChannel,
     webhook::{Webhook, WebhookType},
 };
 
-use crate::id::{ChannelId, GuildId, MessageId};
+use crate::{
+    channel::thread::{NewsThread, PrivateThread, PublicThread},
+    id::{ChannelId, GuildId, MessageId},
+};
 use serde::{
     de::{Deserializer, Error as DeError, IgnoredAny, MapAccess, Visitor},
     Deserialize, Serialize,

--- a/model/src/channel/thread/auto_archive_duration.rs
+++ b/model/src/channel/thread/auto_archive_duration.rs
@@ -20,7 +20,7 @@ impl AutoArchiveDuration {
     /// # Examples
     ///
     /// ```
-    /// use twilight_model::channel::AutoArchiveDuration;
+    /// use twilight_model::channel::thread::AutoArchiveDuration;
     ///
     /// assert_eq!(60, AutoArchiveDuration::Hour.number());
     /// ```

--- a/model/src/channel/thread/auto_archive_duration.rs
+++ b/model/src/channel/thread/auto_archive_duration.rs
@@ -15,7 +15,7 @@ pub enum AutoArchiveDuration {
 }
 
 impl AutoArchiveDuration {
-    /// Retrieve the length of the duration in seconds, uesd by the API
+    /// Retrieve the length of the duration in seconds, used by the API
     ///
     /// # Examples
     ///

--- a/model/src/channel/thread/member.rs
+++ b/model/src/channel/thread/member.rs
@@ -14,8 +14,7 @@ pub struct ThreadMember {
 
 #[cfg(test)]
 mod tests {
-    use super::ThreadMember;
-    use crate::id::{ChannelId, UserId};
+    use super::{ChannelId, ThreadMember, UserId};
     use serde_test::Token;
 
     #[test]

--- a/model/src/channel/thread/metadata.rs
+++ b/model/src/channel/thread/metadata.rs
@@ -1,6 +1,5 @@
+use crate::{channel::thread::AutoArchiveDuration, id::UserId};
 use serde::{Deserialize, Serialize};
-
-use crate::{channel::AutoArchiveDuration, id::UserId};
 
 /// The thread metadata object contains a number of thread-specific channel fields
 /// that are not needed by other channel types.
@@ -17,8 +16,7 @@ pub struct ThreadMetadata {
 
 #[cfg(test)]
 mod tests {
-    use super::ThreadMetadata;
-    use crate::{channel::AutoArchiveDuration, id::UserId};
+    use super::{AutoArchiveDuration, ThreadMetadata, UserId};
     use serde_test::Token;
 
     #[test]

--- a/model/src/channel/thread/mod.rs
+++ b/model/src/channel/thread/mod.rs
@@ -1,0 +1,11 @@
+mod auto_archive_duration;
+mod member;
+mod metadata;
+mod news;
+mod private;
+mod public;
+
+pub use self::{
+    auto_archive_duration::AutoArchiveDuration, member::ThreadMember, metadata::ThreadMetadata,
+    news::NewsThread, private::PrivateThread, public::PublicThread,
+};

--- a/model/src/channel/thread/news.rs
+++ b/model/src/channel/thread/news.rs
@@ -1,9 +1,12 @@
-use crate::channel::{ChannelType, ThreadMember, ThreadMetadata};
+use crate::channel::{
+    thread::{ThreadMember, ThreadMetadata},
+    ChannelType,
+};
 use crate::id::{ChannelId, GuildId, MessageId, UserId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct PublicThread {
+pub struct NewsThread {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<GuildId>,
     pub id: ChannelId,
@@ -28,21 +31,19 @@ pub struct PublicThread {
 
 #[cfg(test)]
 mod tests {
-    use super::PublicThread;
-    use crate::{
-        channel::{AutoArchiveDuration, ChannelType, ThreadMember, ThreadMetadata},
-        id::{ChannelId, GuildId, MessageId, UserId},
-    };
+    use super::{ChannelId, ChannelType, GuildId, MessageId, ThreadMember, ThreadMetadata, UserId};
+    use crate::channel::thread::{AutoArchiveDuration, NewsThread};
     use serde_test::Token;
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_public_thread() {
-        let value = PublicThread {
+    fn test_news_thread() {
+        let value = NewsThread {
             guild_id: Some(GuildId(2)),
             id: ChannelId(1),
-            kind: ChannelType::GuildPublicThread,
+            kind: ChannelType::GuildNewsThread,
             last_message_id: Some(MessageId(5)),
+            name: "test".to_owned(),
             member_count: 7,
             member: ThreadMember {
                 id: Some(ChannelId(10)),
@@ -51,7 +52,6 @@ mod tests {
                 flags: 12,
             },
             message_count: 6,
-            name: "test".to_owned(),
             owner_id: Some(UserId(3)),
             parent_id: Some(ChannelId(4)),
             rate_limit_per_user: Some(8),
@@ -68,7 +68,7 @@ mod tests {
             &value,
             &[
                 Token::Struct {
-                    name: "PublicThread",
+                    name: "NewsThread",
                     len: 12,
                 },
                 Token::Str("guild_id"),
@@ -79,7 +79,7 @@ mod tests {
                 Token::NewtypeStruct { name: "ChannelId" },
                 Token::Str("1"),
                 Token::Str("type"),
-                Token::U8(11),
+                Token::U8(10),
                 Token::Str("last_message_id"),
                 Token::Some,
                 Token::NewtypeStruct { name: "MessageId" },

--- a/model/src/channel/thread/private.rs
+++ b/model/src/channel/thread/private.rs
@@ -1,9 +1,13 @@
-use crate::channel::{ChannelType, ThreadMember, ThreadMetadata};
+use crate::channel::{
+    permission_overwrite::PermissionOverwrite,
+    thread::{ThreadMember, ThreadMetadata},
+    ChannelType,
+};
 use crate::id::{ChannelId, GuildId, MessageId, UserId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct NewsThread {
+pub struct PrivateThread {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<GuildId>,
     pub id: ChannelId,
@@ -23,27 +27,24 @@ pub struct NewsThread {
     pub parent_id: Option<ChannelId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rate_limit_per_user: Option<u64>,
+    pub permission_overwrites: Vec<PermissionOverwrite>,
     pub thread_metadata: ThreadMetadata,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::NewsThread;
-    use crate::{
-        channel::{AutoArchiveDuration, ChannelType, ThreadMember, ThreadMetadata},
-        id::{ChannelId, GuildId, MessageId, UserId},
-    };
+    use super::{ChannelId, ChannelType, GuildId, MessageId, ThreadMember, ThreadMetadata, UserId};
+    use crate::channel::thread::{AutoArchiveDuration, PrivateThread};
     use serde_test::Token;
 
-    #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_news_thread() {
-        let value = NewsThread {
+    #[allow(clippy::too_many_lines)]
+    fn test_private_thread() {
+        let value = PrivateThread {
             guild_id: Some(GuildId(2)),
             id: ChannelId(1),
-            kind: ChannelType::GuildNewsThread,
+            kind: ChannelType::GuildPrivateThread,
             last_message_id: Some(MessageId(5)),
-            name: "test".to_owned(),
             member_count: 7,
             member: ThreadMember {
                 id: Some(ChannelId(10)),
@@ -52,9 +53,11 @@ mod tests {
                 flags: 12,
             },
             message_count: 6,
+            name: "test".to_owned(),
             owner_id: Some(UserId(3)),
             parent_id: Some(ChannelId(4)),
             rate_limit_per_user: Some(8),
+            permission_overwrites: Vec::new(),
             thread_metadata: ThreadMetadata {
                 archived: true,
                 archiver_id: Some(UserId(9)),
@@ -68,8 +71,8 @@ mod tests {
             &value,
             &[
                 Token::Struct {
-                    name: "NewsThread",
-                    len: 12,
+                    name: "PrivateThread",
+                    len: 13,
                 },
                 Token::Str("guild_id"),
                 Token::Some,
@@ -79,7 +82,7 @@ mod tests {
                 Token::NewtypeStruct { name: "ChannelId" },
                 Token::Str("1"),
                 Token::Str("type"),
-                Token::U8(10),
+                Token::U8(12),
                 Token::Str("last_message_id"),
                 Token::Some,
                 Token::NewtypeStruct { name: "MessageId" },
@@ -119,6 +122,9 @@ mod tests {
                 Token::Str("rate_limit_per_user"),
                 Token::Some,
                 Token::U64(8),
+                Token::Str("permission_overwrites"),
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
                 Token::Str("thread_metadata"),
                 Token::Struct {
                     name: "ThreadMetadata",

--- a/model/src/channel/thread/public.rs
+++ b/model/src/channel/thread/public.rs
@@ -1,11 +1,12 @@
 use crate::channel::{
-    permission_overwrite::PermissionOverwrite, ChannelType, ThreadMember, ThreadMetadata,
+    thread::{ThreadMember, ThreadMetadata},
+    ChannelType,
 };
 use crate::id::{ChannelId, GuildId, MessageId, UserId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct PrivateThread {
+pub struct PublicThread {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<GuildId>,
     pub id: ChannelId,
@@ -25,26 +26,22 @@ pub struct PrivateThread {
     pub parent_id: Option<ChannelId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rate_limit_per_user: Option<u64>,
-    pub permission_overwrites: Vec<PermissionOverwrite>,
     pub thread_metadata: ThreadMetadata,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::PrivateThread;
-    use crate::{
-        channel::{AutoArchiveDuration, ChannelType, ThreadMember, ThreadMetadata},
-        id::{ChannelId, GuildId, MessageId, UserId},
-    };
+    use super::{ChannelId, ChannelType, GuildId, MessageId, ThreadMember, ThreadMetadata, UserId};
+    use crate::channel::thread::{AutoArchiveDuration, PublicThread};
     use serde_test::Token;
 
-    #[test]
     #[allow(clippy::too_many_lines)]
-    fn test_private_thread() {
-        let value = PrivateThread {
+    #[test]
+    fn test_public_thread() {
+        let value = PublicThread {
             guild_id: Some(GuildId(2)),
             id: ChannelId(1),
-            kind: ChannelType::GuildPrivateThread,
+            kind: ChannelType::GuildPublicThread,
             last_message_id: Some(MessageId(5)),
             member_count: 7,
             member: ThreadMember {
@@ -58,7 +55,6 @@ mod tests {
             owner_id: Some(UserId(3)),
             parent_id: Some(ChannelId(4)),
             rate_limit_per_user: Some(8),
-            permission_overwrites: Vec::new(),
             thread_metadata: ThreadMetadata {
                 archived: true,
                 archiver_id: Some(UserId(9)),
@@ -72,8 +68,8 @@ mod tests {
             &value,
             &[
                 Token::Struct {
-                    name: "PrivateThread",
-                    len: 13,
+                    name: "PublicThread",
+                    len: 12,
                 },
                 Token::Str("guild_id"),
                 Token::Some,
@@ -83,7 +79,7 @@ mod tests {
                 Token::NewtypeStruct { name: "ChannelId" },
                 Token::Str("1"),
                 Token::Str("type"),
-                Token::U8(12),
+                Token::U8(11),
                 Token::Str("last_message_id"),
                 Token::Some,
                 Token::NewtypeStruct { name: "MessageId" },
@@ -123,9 +119,6 @@ mod tests {
                 Token::Str("rate_limit_per_user"),
                 Token::Some,
                 Token::U64(8),
-                Token::Str("permission_overwrites"),
-                Token::Seq { len: Some(0) },
-                Token::SeqEnd,
                 Token::Str("thread_metadata"),
                 Token::Struct {
                     name: "ThreadMetadata",

--- a/model/src/gateway/payload/thread_list_sync.rs
+++ b/model/src/gateway/payload/thread_list_sync.rs
@@ -1,5 +1,5 @@
 use crate::{
-    channel::{Channel, ThreadMember},
+    channel::{thread::ThreadMember, Channel},
     id::GuildId,
 };
 use serde::{Deserialize, Serialize};

--- a/model/src/gateway/payload/thread_member_update.rs
+++ b/model/src/gateway/payload/thread_member_update.rs
@@ -1,4 +1,4 @@
-use crate::channel::ThreadMember;
+use crate::channel::thread::ThreadMember;
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 

--- a/model/src/gateway/payload/thread_members_update.rs
+++ b/model/src/gateway/payload/thread_members_update.rs
@@ -1,5 +1,5 @@
 use crate::{
-    channel::ThreadMember,
+    channel::thread::ThreadMember,
     id::{ChannelId, GuildId, UserId},
 };
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
I felt that threads were causing too much noise in the channel module, so I moved them to a module below channel. I also reorganized the imports in each file.
