### PR TITLE
chore(gateway,http): fix `disjoint_capture_migration` lint

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -814,11 +814,15 @@ impl ShardProcessor {
     }
 
     async fn connect(url: &str) -> Result<ShardStream, ConnectingError> {
-        let url = Url::parse(url).map_err(|source| ConnectingError {
-            kind: ConnectingErrorType::ParsingUrl {
-                url: url.to_owned(),
-            },
-            source: Some(Box::new(source)),
+        let url = Url::parse(url).map_err(|source| {
+            let _ = &url;
+
+            ConnectingError {
+                kind: ConnectingErrorType::ParsingUrl {
+                    url: url.to_owned(),
+                },
+                source: Some(Box::new(source)),
+            }
         })?;
 
         // `max_frame_size` and `max_message_queue` limits are disabled because

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -814,15 +814,12 @@ impl ShardProcessor {
     }
 
     async fn connect(url: &str) -> Result<ShardStream, ConnectingError> {
-        let url = Url::parse(url).map_err(|source| {
-            let _ = &url;
-
-            ConnectingError {
-                kind: ConnectingErrorType::ParsingUrl {
-                    url: url.to_owned(),
-                },
-                source: Some(Box::new(source)),
-            }
+        #[allow(disjoint_capture_migration)]
+        let url = Url::parse(url).map_err(|source| ConnectingError {
+            kind: ConnectingErrorType::ParsingUrl {
+                url: url.to_owned(),
+            },
+            source: Some(Box::new(source)),
         })?;
 
         // `max_frame_size` and `max_message_queue` limits are disabled because

--- a/http/src/ratelimiting/headers.rs
+++ b/http/src/ratelimiting/headers.rs
@@ -119,15 +119,15 @@ fn header_bool(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitRes
         .get(name)
         .ok_or_else(|| RatelimitError::header_missing(name))?;
 
-    let text = value.to_str().map_err(|source| {
-        RatelimitError::header_not_utf8(name, value.as_bytes().to_owned(), source)
-    })?;
+    let text = value
+        .to_str()
+        .map_err(|source| {
+            RatelimitError::header_not_utf8(name, value.as_bytes().to_owned(), source)
+        })?
+        .to_owned();
 
     let end = text.parse().map_err(|source| RatelimitError {
-        kind: RatelimitErrorType::ParsingBoolText {
-            name,
-            text: text.to_owned(),
-        },
+        kind: RatelimitErrorType::ParsingBoolText { name, text },
         source: Some(Box::new(source)),
     })?;
 
@@ -139,15 +139,15 @@ fn header_float(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitRe
         .get(name)
         .ok_or_else(|| RatelimitError::header_missing(name))?;
 
-    let text = value.to_str().map_err(|source| {
-        RatelimitError::header_not_utf8(name, value.as_bytes().to_owned(), source)
-    })?;
+    let text = value
+        .to_str()
+        .map_err(|source| {
+            RatelimitError::header_not_utf8(name, value.as_bytes().to_owned(), source)
+        })?
+        .to_owned();
 
     let end = text.parse().map_err(|source| RatelimitError {
-        kind: RatelimitErrorType::ParsingFloatText {
-            name,
-            text: text.to_owned(),
-        },
+        kind: RatelimitErrorType::ParsingFloatText { name, text },
         source: Some(Box::new(source)),
     })?;
 
@@ -159,15 +159,15 @@ fn header_int(map: &HeaderMap<HeaderValue>, name: &'static str) -> RatelimitResu
         .get(name)
         .ok_or_else(|| RatelimitError::header_missing(name))?;
 
-    let text = value.to_str().map_err(|source| {
-        RatelimitError::header_not_utf8(name, value.as_bytes().to_owned(), source)
-    })?;
+    let text = value
+        .to_str()
+        .map_err(|source| {
+            RatelimitError::header_not_utf8(name, value.as_bytes().to_owned(), source)
+        })?
+        .to_owned();
 
     let end = text.parse().map_err(|source| RatelimitError {
-        kind: RatelimitErrorType::ParsingIntText {
-            name,
-            text: text.to_owned(),
-        },
+        kind: RatelimitErrorType::ParsingIntText { name, text },
         source: Some(Box::new(source)),
     })?;
 


### PR DESCRIPTION
Fixes a lint appearing in our docs CI.
