### PR TITLE
Add 6 new HTTP API error codes

### DIFF
--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -66,6 +66,10 @@ pub enum ErrorCode {
     UnknownGiftCode,
     /// Unknown guild template
     UnknownGuildTemplate,
+    /// Unknown discoverable server category
+    UnknownDiscoverableServerCategory,
+    /// Unknown sticker
+    UnknownSticker,
     /// Unknown interaction
     UnknownInteraction,
     /// Unknown application command
@@ -74,6 +78,10 @@ pub enum ErrorCode {
     UnknownApplicationCommandPermissions,
     /// Unknown Stage Instance
     UnknownStageInstance,
+    /// Unknown Guild Member Verification Form
+    UnknownGuildMemberVerificationForm,
+    /// Unknown Guild Welcome Screen
+    UnknownGuildWelcomeScreen,
     /// Bots cannot use this endpoint
     BotsCannotUseEndpoint,
     /// Only bots can use this endpoint
@@ -118,12 +126,16 @@ pub enum ErrorCode {
     MaximumAnimatedEmojisReached,
     /// Maximum number of server members reached
     MaximumGuildMembersReached,
+    /// Maximum number of server categories has been reached
+    MaximumServerCategoriesReached,
     /// Guild already has a template
     GuildTemplateAlreadyExist,
     /// Maximum number of bans for non-guild members have been exceeded
     MaximumNonGuildBansReached,
     /// Maximum number of bans fetches has been reached
     MaximumGuildBansFetchesReached,
+    /// Maximum number of stickers reached
+    MaximumStickersReached,
     /// Unauthorized. Provide a valid token and try again
     Unauthorized,
     /// You need to verify your account in order to perform this action
@@ -258,10 +270,14 @@ impl ErrorCode {
             Self::UnknownRedistributable => 10036,
             Self::UnknownGiftCode => 10038,
             Self::UnknownGuildTemplate => 10057,
+            Self::UnknownDiscoverableServerCategory => 10059,
+            Self::UnknownSticker => 10060,
             Self::UnknownInteraction => 10062,
             Self::UnknownApplicationCommand => 10063,
             Self::UnknownApplicationCommandPermissions => 10066,
             Self::UnknownStageInstance => 10067,
+            Self::UnknownGuildMemberVerificationForm => 10068,
+            Self::UnknownGuildWelcomeScreen => 10069,
             Self::BotsCannotUseEndpoint => 20001,
             Self::OnlyBotsCanUseEndpoint => 20002,
             Self::ExplicitContentSendingBlocked => 20009,
@@ -284,9 +300,11 @@ impl ErrorCode {
             Self::MaximumInvitesReached => 30016,
             Self::MaximumAnimatedEmojisReached => 30018,
             Self::MaximumGuildMembersReached => 30019,
+            Self::MaximumServerCategoriesReached => 30030,
             Self::GuildTemplateAlreadyExist => 30031,
             Self::MaximumNonGuildBansReached => 30035,
             Self::MaximumGuildBansFetchesReached => 30037,
+            Self::MaximumStickersReached => 30039,
             Self::Unauthorized => 40001,
             Self::AccountNeedsVerification => 40002,
             Self::OpeningDirectMessageRateLimitReached => 40003,
@@ -372,10 +390,14 @@ impl From<u64> for ErrorCode {
             10036 => Self::UnknownRedistributable,
             10038 => Self::UnknownGiftCode,
             10057 => Self::UnknownGuildTemplate,
+            10059 => Self::UnknownDiscoverableServerCategory,
+            10060 => Self::UnknownSticker,
             10062 => Self::UnknownInteraction,
             10063 => Self::UnknownApplicationCommand,
             10066 => Self::UnknownApplicationCommandPermissions,
             10067 => Self::UnknownStageInstance,
+            10068 => Self::UnknownGuildMemberVerificationForm,
+            10069 => Self::UnknownGuildWelcomeScreen,
             20001 => Self::BotsCannotUseEndpoint,
             20002 => Self::OnlyBotsCanUseEndpoint,
             20022 => Self::AnnouncementRateLimitReached,
@@ -398,9 +420,11 @@ impl From<u64> for ErrorCode {
             30016 => Self::MaximumInvitesReached,
             30018 => Self::MaximumAnimatedEmojisReached,
             30019 => Self::MaximumGuildMembersReached,
+            30030 => Self::MaximumServerCategoriesReached,
             30031 => Self::GuildTemplateAlreadyExist,
             30035 => Self::MaximumNonGuildBansReached,
             30037 => Self::MaximumGuildBansFetchesReached,
+            30039 => Self::MaximumStickersReached,
             40001 => Self::Unauthorized,
             40002 => Self::AccountNeedsVerification,
             40003 => Self::OpeningDirectMessageRateLimitReached,
@@ -486,10 +510,14 @@ impl Display for ErrorCode {
             Self::UnknownRedistributable => f.write_str("Unknown redistributable"),
             Self::UnknownGiftCode => f.write_str("Unknown gift code"),
             Self::UnknownGuildTemplate => f.write_str("Unknown guild template"),
+            Self::UnknownDiscoverableServerCategory => f.write_str("Unknown discoverable server category"),
+            Self::UnknownSticker => f.write_str("Unknown sticker"),
             Self::UnknownInteraction => f.write_str("Unknown interaction"),
             Self::UnknownApplicationCommand => f.write_str("Unknown application command"),
             Self::UnknownApplicationCommandPermissions => f.write_str("Unknown application command permissions"),
             Self::UnknownStageInstance => f.write_str("Unknown Stage Instance"),
+            Self::UnknownGuildMemberVerificationForm => f.write_str("Unknown Guild Member Verification Form"),
+            Self::UnknownGuildWelcomeScreen => f.write_str("Unknown Guild Welcome Screen"),
             Self::BotsCannotUseEndpoint => f.write_str("Bots cannot use this endpoint"),
             Self::OnlyBotsCanUseEndpoint => f.write_str("Only bots can use this endpoint"),
             Self::ExplicitContentSendingBlocked => f.write_str("Explicit content cannot be sent to the desired recipient(s)"),
@@ -512,9 +540,11 @@ impl Display for ErrorCode {
             Self::MaximumInvitesReached => f.write_str("Maximum number of invites reached (1000)"),
             Self::MaximumAnimatedEmojisReached => f.write_str("Maximum animated emojis reached"),
             Self::MaximumGuildMembersReached => f.write_str("Maximum number of server members reached"),
+            Self::MaximumServerCategoriesReached => f.write_str("Maximum number of server categories has been reached"),
             Self::GuildTemplateAlreadyExist => f.write_str("Guild already has a template"),
             Self::MaximumNonGuildBansReached => f.write_str("Maximum number of bans for non-guild members have been exceeded"),
             Self::MaximumGuildBansFetchesReached => f.write_str("Maximum number of bans fetches has been reached"),
+            Self::MaximumStickersReached => f.write_str("Maximum number of stickers reached"),
             Self::Unauthorized => f.write_str("Unauthorized. Provide a valid token and try again"),
             Self::AccountNeedsVerification => f.write_str("You need to verify your account in order to perform this action"),
             Self::OpeningDirectMessageRateLimitReached => f.write_str("You are opening direct messages too fast"),
@@ -742,6 +772,27 @@ mod tests {
         RatelimitedApiError,
     };
     use serde_test::Token;
+    use static_assertions::assert_impl_all;
+    use std::{convert::TryFrom, fmt::Debug};
+
+    assert_impl_all!(ErrorCode: Clone, Copy, Debug, Eq, PartialEq, Send, Sync);
+
+    #[derive(Clone, Copy)]
+    struct AssertErrorCode<'a> {
+        code: ErrorCode,
+        display: &'a str,
+        num: u64,
+    }
+
+    /// Test that the provided error code has the correct number and that the
+    /// variant's Display implementation is correct.
+    fn assert_error_code(details: AssertErrorCode<'_>) {
+        let AssertErrorCode { code, display, num } = details;
+
+        assert_eq!(num, code.num());
+        assert_eq!(Ok(code), ErrorCode::try_from(num));
+        assert_eq!(display, code.to_string());
+    }
 
     #[test]
     fn test_api_error_deser() {
@@ -826,5 +877,40 @@ mod tests {
                 Token::StructEnd,
             ],
         );
+    }
+
+    /// Test the values and display formatters of error codes.
+    #[test]
+    fn test_variants() {
+        assert_error_code(AssertErrorCode {
+            code: ErrorCode::UnknownDiscoverableServerCategory,
+            display: "Unknown discoverable server category",
+            num: 10059,
+        });
+        assert_error_code(AssertErrorCode {
+            code: ErrorCode::UnknownSticker,
+            display: "Unknown sticker",
+            num: 10060,
+        });
+        assert_error_code(AssertErrorCode {
+            code: ErrorCode::UnknownGuildMemberVerificationForm,
+            display: "Unknown Guild Member Verification Form",
+            num: 10068,
+        });
+        assert_error_code(AssertErrorCode {
+            code: ErrorCode::UnknownGuildWelcomeScreen,
+            display: "Unknown Guild Welcome Screen",
+            num: 10069,
+        });
+        assert_error_code(AssertErrorCode {
+            code: ErrorCode::MaximumServerCategoriesReached,
+            display: "Maximum number of server categories has been reached",
+            num: 30030,
+        });
+        assert_error_code(AssertErrorCode {
+            code: ErrorCode::MaximumStickersReached,
+            display: "Maximum number of stickers reached",
+            num: 30039,
+        });
     }
 }


### PR DESCRIPTION
Add 6 new HTTP API error codes:

- 10059: Unknown discoverable server category
- 10060: Unknown sticker
- 10068: Unknown Guild Member Verification Form
- 10069: Unknown Guild Welcome Screen
- 30030: Maximum number of server categories has been reached
- 30039: Maximum number of stickers reached

Tests have been added.

Closes #1002.