### PR TITLE
Add an HTTP `ResponseFuture` struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,10 @@ async fn handle_event(
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     match event {
         Event::MessageCreate(msg) if msg.content == "!ping" => {
-            http.create_message(msg.channel_id).content("Pong!")?.await?;
+            http.create_message(msg.channel_id)
+                .content("Pong!")?
+                .exec()
+                .await?;
         }
         Event::ShardConnected(_) => {
             println!("Connected on shard {}", shard_id);

--- a/gateway/queue/src/day_limiter.rs
+++ b/gateway/queue/src/day_limiter.rs
@@ -59,6 +59,7 @@ impl DayLimiter {
         let info = http
             .gateway()
             .authed()
+            .exec()
             .await
             .map_err(|source| DayLimiterError {
                 kind: DayLimiterErrorType::RetrievingSessionAvailability,
@@ -94,7 +95,7 @@ impl DayLimiter {
         } else {
             let wait = lock.last_check + lock.next_reset;
             time::sleep_until(wait).await;
-            if let Ok(res) = lock.http.gateway().authed().await {
+            if let Ok(res) = lock.http.gateway().authed().exec().await {
                 if let Ok(info) = res.model().await {
                     let last_check = Instant::now();
                     let next_reset = Duration::from_millis(info.session_start_limit.remaining);

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -86,7 +86,7 @@ impl ClusterBuilder {
         ClusterStartError,
     > {
         if (self.1).0.gateway_url.is_none() {
-            let maybe_response = (self.1).0.http_client.gateway().authed().await;
+            let maybe_response = (self.1).0.http_client.gateway().authed().exec().await;
 
             if let Ok(response) = maybe_response {
                 let gateway_url = response.model().await.ok().map(|info| info.url);

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -375,6 +375,7 @@ impl Cluster {
         let gateway = http
             .gateway()
             .authed()
+            .exec()
             .await
             .map_err(|source| ClusterStartError {
                 kind: ClusterStartErrorType::RetrievingGatewayInfo,

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -451,6 +451,7 @@ impl Shard {
                 .http_client()
                 .gateway()
                 .authed()
+                .exec()
                 .await
                 .map_err(|source| ShardStartError {
                     source: Some(Box::new(source)),

--- a/http/examples/allowed-mentions/src/main.rs
+++ b/http/examples/allowed-mentions/src/main.rs
@@ -32,6 +32,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 .user_ids(vec![user_id])
                 .build(),
         )
+        .exec()
         .await?;
 
     Ok(())

--- a/http/examples/get-message/src/main.rs
+++ b/http/examples/get-message/src/main.rs
@@ -16,10 +16,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             .create_message(channel_id)
             .content(format!("Ping #{}", x))
             .expect("content not a valid length")
+            .exec()
     }))
     .await;
 
-    let me = client.current_user().await?.model().await?;
+    let me = client.current_user().exec().await?.model().await?;
     println!("Current user: {}#{}", me.name, me.discriminator);
 
     Ok(())

--- a/http/examples/proxy/src/main.rs
+++ b/http/examples/proxy/src/main.rs
@@ -19,10 +19,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             .create_message(channel_id)
             .content(format!("Ping #{}", x))
             .expect("content not a valid length")
+            .exec()
     }))
     .await;
 
-    let me = client.current_user().await?.model().await?;
+    let me = client.current_user().exec().await?.model().await?;
     println!("Current user: {}#{}", me.name, me.discriminator);
 
     Ok(())

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -51,7 +51,7 @@ impl ClientBuilder {
                 proxy: self.proxy,
                 ratelimiter: self.ratelimiter,
                 timeout: self.timeout,
-                token_invalid: AtomicBool::new(false),
+                token_invalid: Arc::new(AtomicBool::new(false)),
                 token: self.token,
                 application_id: self.application_id,
                 default_allowed_mentions: self.default_allowed_mentions,

--- a/http/src/json.rs
+++ b/http/src/json.rs
@@ -3,7 +3,6 @@ pub use serde_json::{to_vec, Deserializer as JsonDeserializer, Error as JsonErro
 #[cfg(feature = "simd-json")]
 pub use simd_json::{to_vec, Deserializer as JsonDeserializer, Error as JsonError};
 
-use crate::error::{Error, ErrorType};
 use hyper::body::Bytes;
 use serde::de::DeserializeOwned;
 
@@ -23,13 +22,4 @@ pub fn from_bytes<T: DeserializeOwned>(bytes: &Bytes) -> JsonResult<T> {
         // Bytes does not implement DerefMut so we have to allocate
         simd_json::from_slice(&mut bytes.to_vec())
     }
-}
-
-pub fn parse_bytes<T: DeserializeOwned>(bytes: &Bytes) -> Result<T, Error> {
-    from_bytes(bytes).map_err(|source| Error {
-        kind: ErrorType::Parsing {
-            body: bytes.to_vec(),
-        },
-        source: Some(Box::new(source)),
-    })
 }

--- a/http/src/request/application/delete_global_command.rs
+++ b/http/src/request/application/delete_global_command.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::Request,
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::{ApplicationId, CommandId};
@@ -11,12 +10,11 @@ use twilight_model::id::{ApplicationId, CommandId};
 pub struct DeleteGlobalCommand<'a> {
     application_id: ApplicationId,
     command_id: CommandId,
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     http: &'a Client,
 }
 
 impl<'a> DeleteGlobalCommand<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         application_id: ApplicationId,
         command_id: CommandId,
@@ -24,21 +22,19 @@ impl<'a> DeleteGlobalCommand<'a> {
         Self {
             application_id,
             command_id,
-            fut: None,
             http,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let request = Request::from_route(Route::DeleteGlobalCommand {
             application_id: self.application_id.0,
             command_id: self.command_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(DeleteGlobalCommand<'_>, EmptyBody);

--- a/http/src/request/application/delete_guild_command.rs
+++ b/http/src/request/application/delete_guild_command.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::Request,
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::{ApplicationId, CommandId, GuildId};
@@ -11,13 +10,12 @@ use twilight_model::id::{ApplicationId, CommandId, GuildId};
 pub struct DeleteGuildCommand<'a> {
     application_id: ApplicationId,
     command_id: CommandId,
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> DeleteGuildCommand<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         application_id: ApplicationId,
         guild_id: GuildId,
@@ -26,23 +24,18 @@ impl<'a> DeleteGuildCommand<'a> {
         Self {
             application_id,
             command_id,
-            fut: None,
             guild_id,
             http,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    pub fn exe(self) -> ResponseFuture<EmptyBody> {
         let request = Request::from_route(Route::DeleteGuildCommand {
             application_id: self.application_id.0,
             command_id: self.command_id.0,
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(DeleteGuildCommand<'_>, EmptyBody);

--- a/http/src/request/application/delete_guild_command.rs
+++ b/http/src/request/application/delete_guild_command.rs
@@ -29,7 +29,7 @@ impl<'a> DeleteGuildCommand<'a> {
         }
     }
 
-    pub fn exe(self) -> ResponseFuture<EmptyBody> {
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let request = Request::from_route(Route::DeleteGuildCommand {
             application_id: self.application_id.0,
             command_id: self.command_id.0,

--- a/http/src/request/application/delete_original_response.rs
+++ b/http/src/request/application/delete_original_response.rs
@@ -52,7 +52,7 @@ impl<'a> DeleteOriginalResponse<'a> {
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let request = Request::from_route(Route::DeleteInteractionOriginal {
             application_id: self.application_id.0,
-            interaction_token: self.token.clone(),
+            interaction_token: self.token,
         });
 
         self.http.request(request)

--- a/http/src/request/application/get_global_commands.rs
+++ b/http/src/request/application/get_global_commands.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{application::command::Command, id::ApplicationId};
@@ -10,28 +9,25 @@ use twilight_model::{application::command::Command, id::ApplicationId};
 /// Retrieve all global commands for an application.
 pub struct GetGlobalCommands<'a> {
     application_id: ApplicationId,
-    fut: Option<PendingResponse<'a, ListBody<Command>>>,
     http: &'a Client,
 }
 
 impl<'a> GetGlobalCommands<'a> {
-    pub(crate) fn new(http: &'a Client, application_id: ApplicationId) -> Self {
+    pub(crate) const fn new(http: &'a Client, application_id: ApplicationId) -> Self {
         Self {
             application_id,
-            fut: None,
             http,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<Command>> {
         let request = Request::from_route(Route::GetGlobalCommands {
             application_id: self.application_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetGlobalCommands<'_>, ListBody<Command>);

--- a/http/src/request/application/get_guild_command_permissions.rs
+++ b/http/src/request/application/get_guild_command_permissions.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{
@@ -14,33 +13,31 @@ use twilight_model::{
 pub struct GetGuildCommandPermissions<'a> {
     application_id: ApplicationId,
     guild_id: GuildId,
-    fut: Option<PendingResponse<'a, ListBody<GuildCommandPermissions>>>,
     http: &'a Client,
 }
 
 impl<'a> GetGuildCommandPermissions<'a> {
-    pub(crate) fn new(http: &'a Client, application_id: ApplicationId, guild_id: GuildId) -> Self {
+    pub(crate) const fn new(
+        http: &'a Client,
+        application_id: ApplicationId,
+        guild_id: GuildId,
+    ) -> Self {
         Self {
             application_id,
             guild_id,
-            fut: None,
             http,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<GuildCommandPermissions>> {
         let request = Request::from_route(Route::GetGuildCommandPermissions {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(
-    GetGuildCommandPermissions<'_>,
-    ListBody<GuildCommandPermissions>
-);

--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -3,7 +3,7 @@ use crate::{
     error::Error,
     request::{
         application::{InteractionError, InteractionErrorType},
-        validate, Request,
+        validate, Request, RequestBuilder,
     },
     response::ResponseFuture,
     routing::Route,
@@ -74,12 +74,12 @@ impl<'a> SetCommandPermissions<'a> {
     }
 
     fn request(&self) -> Result<Request, Error> {
-        Ok(Request::builder(Route::SetCommandPermissions {
+        Request::builder(Route::SetCommandPermissions {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,
         })
-        .json(&self.fields)?
-        .build())
+        .json(&self.fields)
+        .map(RequestBuilder::build)
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].

--- a/http/src/request/application/set_global_commands.rs
+++ b/http/src/request/application/set_global_commands.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::Request,
+    request::{Request, RequestBuilder},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -31,11 +31,11 @@ impl<'a> SetGlobalCommands<'a> {
     }
 
     fn request(&self) -> Result<Request, Error> {
-        Ok(Request::builder(Route::SetGlobalCommands {
+        Request::builder(Route::SetGlobalCommands {
             application_id: self.application_id.0,
         })
-        .json(&self.commands)?
-        .build())
+        .json(&self.commands)
+        .map(RequestBuilder::build)
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].

--- a/http/src/request/application/set_guild_commands.rs
+++ b/http/src/request/application/set_guild_commands.rs
@@ -1,8 +1,8 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::Request,
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{
@@ -18,7 +18,6 @@ pub struct SetGuildCommands<'a> {
     commands: Vec<Command>,
     application_id: ApplicationId,
     guild_id: GuildId,
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     http: &'a Client,
 }
 
@@ -33,23 +32,26 @@ impl<'a> SetGuildCommands<'a> {
             commands,
             application_id,
             guild_id,
-            fut: None,
             http,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
-        let request = Request::builder(Route::SetGuildCommands {
+    fn request(&self) -> Result<Request, Error> {
+        Ok(Request::builder(Route::SetGuildCommands {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,
         })
-        .json(&self.commands)?;
+        .json(&self.commands)?
+        .build())
+    }
 
-        self.fut
-            .replace(Box::pin(self.http.request(request.build())));
-
-        Ok(())
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        match self.request() {
+            Ok(request) => self.http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
-
-poll_req!(SetGuildCommands<'_>, EmptyBody);

--- a/http/src/request/application/set_guild_commands.rs
+++ b/http/src/request/application/set_guild_commands.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::Request,
+    request::{Request, RequestBuilder},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -37,12 +37,12 @@ impl<'a> SetGuildCommands<'a> {
     }
 
     fn request(&self) -> Result<Request, Error> {
-        Ok(Request::builder(Route::SetGuildCommands {
+        Request::builder(Route::SetGuildCommands {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,
         })
-        .json(&self.commands)?
-        .build())
+        .json(&self.commands)
+        .map(RequestBuilder::build)
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].

--- a/http/src/request/application/update_command_permissions.rs
+++ b/http/src/request/application/update_command_permissions.rs
@@ -3,7 +3,7 @@ use crate::{
     error::Error,
     request::{
         application::{InteractionError, InteractionErrorType},
-        validate, Request,
+        validate, Request, RequestBuilder,
     },
     response::{marker::ListBody, ResponseFuture},
     routing::Route,
@@ -57,13 +57,13 @@ impl<'a> UpdateCommandPermissions<'a> {
     }
 
     fn request(&self) -> Result<Request, Error> {
-        Ok(Request::builder(Route::UpdateCommandPermissions {
+        Request::builder(Route::UpdateCommandPermissions {
             application_id: self.application_id.0,
             command_id: self.command_id.0,
             guild_id: self.guild_id.0,
         })
-        .json(&self.fields)?
-        .build())
+        .json(&self.fields)
+        .map(RequestBuilder::build)
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].

--- a/http/src/request/application/update_followup_message.rs
+++ b/http/src/request/application/update_followup_message.rs
@@ -3,8 +3,8 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Form, NullableField, PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::{validate, Form, NullableField, Request},
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -148,6 +148,7 @@ struct UpdateFollowupMessageFields {
 ///     // mentioned.
 ///     .allowed_mentions(AllowedMentions::default())
 ///     .content(Some("test <@3>".to_owned()))?
+///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -156,7 +157,6 @@ struct UpdateFollowupMessageFields {
 pub struct UpdateFollowupMessage<'a> {
     fields: UpdateFollowupMessageFields,
     files: Vec<(String, Vec<u8>)>,
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     http: &'a Client,
     message_id: MessageId,
     token: String,
@@ -179,7 +179,6 @@ impl<'a> UpdateFollowupMessage<'a> {
                 ..UpdateFollowupMessageFields::default()
             },
             files: Vec::new(),
-            fut: None,
             http,
             message_id,
             token: token.into(),
@@ -283,6 +282,7 @@ impl<'a> UpdateFollowupMessage<'a> {
     ///
     /// client.update_followup_message("token", MessageId(2))?
     ///     .embeds(Some(vec![embed]))?
+    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -396,12 +396,10 @@ impl<'a> UpdateFollowupMessage<'a> {
         Ok(request.build())
     }
 
-    fn start(&mut self) -> Result<(), HttpError> {
-        let request = self.request()?;
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+    pub fn exec(mut self) -> ResponseFuture<EmptyBody> {
+        match self.request() {
+            Ok(request) => self.http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
-
-poll_req!(UpdateFollowupMessage<'_>, EmptyBody);

--- a/http/src/request/application/update_global_command.rs
+++ b/http/src/request/application/update_global_command.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::Request,
+    request::{Request, RequestBuilder},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -73,12 +73,12 @@ impl<'a> UpdateGlobalCommand<'a> {
     }
 
     fn request(&self) -> Result<Request, Error> {
-        Ok(Request::builder(Route::UpdateGlobalCommand {
+        Request::builder(Route::UpdateGlobalCommand {
             application_id: self.application_id.0,
             command_id: self.command_id.0,
         })
-        .json(&self.fields)?
-        .build())
+        .json(&self.fields)
+        .map(RequestBuilder::build)
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].

--- a/http/src/request/application/update_guild_command.rs
+++ b/http/src/request/application/update_guild_command.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::Request,
+    request::{Request, RequestBuilder},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -76,13 +76,13 @@ impl<'a> UpdateGuildCommand<'a> {
     }
 
     fn request(&self) -> Result<Request, Error> {
-        Ok(Request::builder(Route::UpdateGuildCommand {
+        Request::builder(Route::UpdateGuildCommand {
             application_id: self.application_id.0,
             command_id: self.command_id.0,
             guild_id: self.guild_id.0,
         })
-        .json(&self.fields)?
-        .build())
+        .json(&self.fields)
+        .map(RequestBuilder::build)
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].

--- a/http/src/request/application/update_original_response.rs
+++ b/http/src/request/application/update_original_response.rs
@@ -365,10 +365,12 @@ impl<'a> UpdateOriginalResponse<'a> {
         self
     }
 
-    fn request(&mut self) -> Result<Request, HttpError> {
+    // `self` needs to be consumed and the client returned due to parameters
+    // being consumed in request construction.
+    fn request(mut self) -> Result<(Request, &'a Client), HttpError> {
         let mut request = Request::builder(Route::UpdateInteractionOriginal {
             application_id: self.application_id.0,
-            interaction_token: self.token.clone(),
+            interaction_token: self.token,
         });
 
         if !self.files.is_empty() || self.fields.payload_json.is_some() {
@@ -390,12 +392,12 @@ impl<'a> UpdateOriginalResponse<'a> {
             request = request.json(&self.fields)?;
         }
 
-        Ok(request.build())
+        Ok((request.build(), self.http))
     }
 
-    pub fn exec(mut self) -> ResponseFuture<EmptyBody> {
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
         match self.request() {
-            Ok(request) => self.http.request(request),
+            Ok((request, client)) => client.request(request),
             Err(source) => ResponseFuture::error(source),
         }
     }

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::{self, AuditLogReason, AuditLogReasonError, Request},
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::{ChannelId, MessageId};
@@ -10,37 +9,44 @@ use twilight_model::id::{ChannelId, MessageId};
 /// Create a new pin in a channel.
 pub struct CreatePin<'a> {
     channel_id: ChannelId,
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     http: &'a Client,
     message_id: MessageId,
     reason: Option<String>,
 }
 
 impl<'a> CreatePin<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId, message_id: MessageId) -> Self {
+    pub(crate) const fn new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        message_id: MessageId,
+    ) -> Self {
         Self {
             channel_id,
-            fut: None,
             http,
             message_id,
             reason: None,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let mut request = Request::builder(Route::PinMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });
 
         if let Some(reason) = &self.reason {
-            request = request.headers(request::audit_header(reason)?);
+            let header = match request::audit_header(reason) {
+                Ok(header) => header,
+                Err(source) => return ResponseFuture::error(source),
+            };
+
+            request = request.headers(header);
         }
 
-        self.fut
-            .replace(Box::pin(self.http.request(request.build())));
-
-        Ok(())
+        self.http.request(request.build())
     }
 }
 
@@ -52,5 +58,3 @@ impl<'a> AuditLogReason for CreatePin<'a> {
         Ok(self)
     }
 }
-
-poll_req!(CreatePin<'_>, EmptyBody);

--- a/http/src/request/channel/create_typing_trigger.rs
+++ b/http/src/request/channel/create_typing_trigger.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::Request,
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::ChannelId;
@@ -10,28 +9,22 @@ use twilight_model::id::ChannelId;
 /// Fire a Typing Start event in the channel.
 pub struct CreateTypingTrigger<'a> {
     channel_id: ChannelId,
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     http: &'a Client,
 }
 
 impl<'a> CreateTypingTrigger<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
-        Self {
-            channel_id,
-            fut: None,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self { channel_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let request = Request::from_route(Route::CreateTypingTrigger {
             channel_id: self.channel_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(CreateTypingTrigger<'_>, EmptyBody);

--- a/http/src/request/channel/delete_channel_permission.rs
+++ b/http/src/request/channel/delete_channel_permission.rs
@@ -25,7 +25,7 @@ impl<'a> DeleteChannelPermission<'a> {
         self.configure(role_id.into().0)
     }
 
-    fn configure(self, target_id: u64) -> DeleteChannelPermissionConfigured<'a> {
+    const fn configure(self, target_id: u64) -> DeleteChannelPermissionConfigured<'a> {
         DeleteChannelPermissionConfigured::new(self.http, self.channel_id, target_id)
     }
 }

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::{self, AuditLogReason, AuditLogReasonError, Request},
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::{ChannelId, MessageId};
@@ -10,37 +9,44 @@ use twilight_model::id::{ChannelId, MessageId};
 /// Delete a pin in a channel, by ID.
 pub struct DeletePin<'a> {
     channel_id: ChannelId,
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     http: &'a Client,
     message_id: MessageId,
     reason: Option<String>,
 }
 
 impl<'a> DeletePin<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId, message_id: MessageId) -> Self {
+    pub(crate) const fn new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        message_id: MessageId,
+    ) -> Self {
         Self {
             channel_id,
-            fut: None,
             http,
             message_id,
             reason: None,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let mut request = Request::builder(Route::UnpinMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });
 
         if let Some(reason) = &self.reason {
-            request = request.headers(request::audit_header(reason)?);
+            let header = match request::audit_header(reason) {
+                Ok(header) => header,
+                Err(source) => return ResponseFuture::error(source),
+            };
+
+            request = request.headers(header);
         }
 
-        self.fut
-            .replace(Box::pin(self.http.request(request.build())));
-
-        Ok(())
+        self.http.request(request.build())
     }
 }
 
@@ -52,5 +58,3 @@ impl<'a> AuditLogReason for DeletePin<'a> {
         Ok(self)
     }
 }
-
-poll_req!(DeletePin<'_>, EmptyBody);

--- a/http/src/request/channel/get_channel.rs
+++ b/http/src/request/channel/get_channel.rs
@@ -1,9 +1,4 @@
-use crate::{
-    client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    routing::Route,
-};
+use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::{channel::Channel, id::ChannelId};
 
 /// Get a channel by its ID.
@@ -22,33 +17,27 @@ use twilight_model::{channel::Channel, id::ChannelId};
 ///
 /// let channel_id = ChannelId(100);
 ///
-/// let channel = client.channel(channel_id).await?;
+/// let channel = client.channel(channel_id).exec().await?;
 /// # Ok(()) }
 /// ```
 pub struct GetChannel<'a> {
     channel_id: ChannelId,
-    fut: Option<PendingResponse<'a, Channel>>,
     http: &'a Client,
 }
 
 impl<'a> GetChannel<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
-        Self {
-            channel_id,
-            fut: None,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self { channel_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<Channel> {
         let request = Request::from_route(Route::GetChannel {
             channel_id: self.channel_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetChannel<'_>, Channel);

--- a/http/src/request/channel/get_pins.rs
+++ b/http/src/request/channel/get_pins.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{channel::Message, id::ChannelId};
@@ -10,28 +9,22 @@ use twilight_model::{channel::Message, id::ChannelId};
 /// Get the pins of a channel.
 pub struct GetPins<'a> {
     channel_id: ChannelId,
-    fut: Option<PendingResponse<'a, ListBody<Message>>>,
     http: &'a Client,
 }
 
 impl<'a> GetPins<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
-        Self {
-            channel_id,
-            fut: None,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self { channel_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<Message>> {
         let request = Request::from_route(Route::GetPins {
             channel_id: self.channel_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetPins<'_>, ListBody<Message>);

--- a/http/src/request/channel/invite/get_channel_invites.rs
+++ b/http/src/request/channel/invite/get_channel_invites.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{id::ChannelId, invite::Invite};
@@ -16,28 +15,22 @@ use twilight_model::{id::ChannelId, invite::Invite};
 /// [`GuildChannel`]: twilight_model::channel::GuildChannel
 pub struct GetChannelInvites<'a> {
     channel_id: ChannelId,
-    fut: Option<PendingResponse<'a, ListBody<Invite>>>,
     http: &'a Client,
 }
 
 impl<'a> GetChannelInvites<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
-        Self {
-            channel_id,
-            fut: None,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self { channel_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<Invite>> {
         let request = Request::from_route(Route::GetChannelInvites {
             channel_id: self.channel_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetChannelInvites<'_>, ListBody<Invite>);

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::{self, AuditLogReason, AuditLogReasonError, Request},
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::{ChannelId, MessageId};
@@ -10,37 +9,44 @@ use twilight_model::id::{ChannelId, MessageId};
 /// Delete a message by [`ChannelId`] and [`MessageId`].
 pub struct DeleteMessage<'a> {
     channel_id: ChannelId,
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     http: &'a Client,
     message_id: MessageId,
     reason: Option<String>,
 }
 
 impl<'a> DeleteMessage<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId, message_id: MessageId) -> Self {
+    pub(crate) const fn new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        message_id: MessageId,
+    ) -> Self {
         Self {
             channel_id,
-            fut: None,
             http,
             message_id,
             reason: None,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let mut request = Request::builder(Route::DeleteMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });
 
         if let Some(reason) = &self.reason {
-            request = request.headers(request::audit_header(reason)?);
+            let header = match request::audit_header(reason) {
+                Ok(header) => header,
+                Err(source) => return ResponseFuture::error(source),
+            };
+
+            request = request.headers(header);
         }
 
-        self.fut
-            .replace(Box::pin(self.http.request(request.build())));
-
-        Ok(())
+        self.http.request(request.build())
     }
 }
 
@@ -52,5 +58,3 @@ impl<'a> AuditLogReason for DeleteMessage<'a> {
         Ok(self)
     }
 }
-
-poll_req!(DeleteMessage<'_>, EmptyBody);

--- a/http/src/request/channel/message/get_message.rs
+++ b/http/src/request/channel/message/get_message.rs
@@ -1,9 +1,4 @@
-use crate::{
-    client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    routing::Route,
-};
+use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::{
     channel::Message,
     id::{ChannelId, MessageId},
@@ -12,31 +7,32 @@ use twilight_model::{
 /// Get a message by [`ChannelId`] and [`MessageId`].
 pub struct GetMessage<'a> {
     channel_id: ChannelId,
-    fut: Option<PendingResponse<'a, Message>>,
     http: &'a Client,
     message_id: MessageId,
 }
 
 impl<'a> GetMessage<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId, message_id: MessageId) -> Self {
+    pub(crate) const fn new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        message_id: MessageId,
+    ) -> Self {
         Self {
             channel_id,
-            fut: None,
             http,
             message_id,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<Message> {
         let request = Request::from_route(Route::GetMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetMessage<'_>, Message);

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -54,24 +54,19 @@ impl<'a> CreateReaction<'a> {
         }
     }
 
-    fn request(self) -> (Request, &'a Client) {
-        (
-            Request::from_route(Route::CreateReaction {
-                channel_id: self.channel_id.0,
-                emoji: self.emoji.display().to_string(),
-                message_id: self.message_id.0,
-            }),
-            self.http,
-        )
+    fn request(&self) -> Request {
+        Request::from_route(Route::CreateReaction {
+            channel_id: self.channel_id.0,
+            emoji: self.emoji.display().to_string(),
+            message_id: self.message_id.0,
+        })
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let (request, client) = self.request();
-
-        client.request(request)
+        self.http.request(self.request())
     }
 }
 
@@ -95,7 +90,7 @@ mod tests {
         };
 
         let builder = CreateReaction::new(&client, ChannelId(123), MessageId(456), emoji);
-        let (actual, _) = builder.request();
+        let actual = builder.request();
 
         let expected = Request::from_route(Route::CreateReaction {
             channel_id: 123,

--- a/http/src/request/channel/reaction/delete_all_reactions.rs
+++ b/http/src/request/channel/reaction/delete_all_reactions.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::Request,
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::{ChannelId, MessageId};
@@ -10,31 +9,32 @@ use twilight_model::id::{ChannelId, MessageId};
 /// Delete all reactions by all users on a message.
 pub struct DeleteAllReactions<'a> {
     channel_id: ChannelId,
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     http: &'a Client,
     message_id: MessageId,
 }
 
 impl<'a> DeleteAllReactions<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId, message_id: MessageId) -> Self {
+    pub(crate) const fn new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        message_id: MessageId,
+    ) -> Self {
         Self {
             channel_id,
-            fut: None,
             http,
             message_id,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let request = Request::from_route(Route::DeleteMessageReactions {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(DeleteAllReactions<'_>, EmptyBody);

--- a/http/src/request/channel/stage/delete_stage_instance.rs
+++ b/http/src/request/channel/stage/delete_stage_instance.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::Request,
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::ChannelId;
@@ -12,28 +11,22 @@ use twilight_model::id::ChannelId;
 /// Requires the user to be a moderator of the stage channel.
 pub struct DeleteStageInstance<'a> {
     channel_id: ChannelId,
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     http: &'a Client,
 }
 
 impl<'a> DeleteStageInstance<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
-        Self {
-            channel_id,
-            fut: None,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self { channel_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let request = Request::from_route(Route::DeleteStageInstance {
             channel_id: self.channel_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(DeleteStageInstance<'_>, EmptyBody);

--- a/http/src/request/channel/stage/get_stage_instance.rs
+++ b/http/src/request/channel/stage/get_stage_instance.rs
@@ -1,36 +1,25 @@
-use crate::{
-    client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    routing::Route,
-};
+use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::{channel::StageInstance, id::ChannelId};
 
 /// Gets the stage instance associated with a stage channel, if it exists.
 pub struct GetStageInstance<'a> {
     channel_id: ChannelId,
-    fut: Option<PendingResponse<'a, StageInstance>>,
     http: &'a Client,
 }
 
 impl<'a> GetStageInstance<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
-        Self {
-            channel_id,
-            fut: None,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self { channel_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<StageInstance> {
         let request = Request::from_route(Route::GetStageInstance {
             channel_id: self.channel_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetStageInstance<'_>, StageInstance);

--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -28,6 +28,7 @@ use twilight_model::{
 ///
 /// client.update_channel_permission(channel_id, allow, deny)
 ///     .role(role_id)
+///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -63,7 +64,10 @@ impl<'a> UpdateChannelPermission<'a> {
         self.configure(&PermissionOverwriteType::Role(role_id.into()))
     }
 
-    fn configure(self, target: &PermissionOverwriteType) -> UpdateChannelPermissionConfigured<'a> {
+    const fn configure(
+        self,
+        target: &PermissionOverwriteType,
+    ) -> UpdateChannelPermissionConfigured<'a> {
         UpdateChannelPermissionConfigured::new(
             self.http,
             self.channel_id,

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -77,12 +77,10 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = match self.request() {
-            Ok(request) => request,
-            Err(source) => return ResponseFuture::error(source),
-        };
-
-        self.http.request(request)
+        match self.request() {
+            Ok(request) => self.http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/http/src/request/channel/webhook/delete_webhook_message.rs
+++ b/http/src/request/channel/webhook/delete_webhook_message.rs
@@ -1,8 +1,8 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::{self, AuditLogReason, AuditLogReasonError, Request},
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::{MessageId, WebhookId};
@@ -22,11 +22,11 @@ use twilight_model::id::{MessageId, WebhookId};
 /// client
 ///     .delete_webhook_message(WebhookId(1), "token here", MessageId(2))
 ///     .reason("reason here")?
+///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
 pub struct DeleteWebhookMessage<'a> {
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     http: &'a Client,
     message_id: MessageId,
     reason: Option<String>,
@@ -42,7 +42,6 @@ impl<'a> DeleteWebhookMessage<'a> {
         message_id: MessageId,
     ) -> Self {
         Self {
-            fut: None,
             http,
             message_id,
             reason: None,
@@ -51,10 +50,10 @@ impl<'a> DeleteWebhookMessage<'a> {
         }
     }
 
-    fn request(&self) -> Result<Request, Error> {
+    fn request(self) -> Result<(Request, &'a Client), Error> {
         let mut request = Request::builder(Route::DeleteWebhookMessage {
             message_id: self.message_id.0,
-            token: self.token.clone(),
+            token: self.token,
             webhook_id: self.webhook_id.0,
         })
         .use_authorization_token(false);
@@ -63,14 +62,17 @@ impl<'a> DeleteWebhookMessage<'a> {
             request = request.headers(request::audit_header(reason)?);
         }
 
-        Ok(request.build())
+        Ok((request.build(), self.http))
     }
 
-    fn start(&mut self) -> Result<(), Error> {
-        let request = self.request()?;
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        match self.request() {
+            Ok((request, client)) => client.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 
@@ -83,8 +85,6 @@ impl<'a> AuditLogReason for DeleteWebhookMessage<'a> {
     }
 }
 
-poll_req!(DeleteWebhookMessage<'_>, EmptyBody);
-
 #[cfg(test)]
 mod tests {
     use super::DeleteWebhookMessage;
@@ -95,7 +95,7 @@ mod tests {
     fn test_request() {
         let client = Client::new("token");
         let builder = DeleteWebhookMessage::new(&client, WebhookId(1), "token", MessageId(2));
-        let actual = builder.request().expect("failed to create request");
+        let (actual, _) = builder.request().expect("failed to create request");
 
         let expected = Request::from_route(Route::DeleteWebhookMessage {
             message_id: 2,

--- a/http/src/request/channel/webhook/delete_webhook_message.rs
+++ b/http/src/request/channel/webhook/delete_webhook_message.rs
@@ -50,6 +50,8 @@ impl<'a> DeleteWebhookMessage<'a> {
         }
     }
 
+    // `self` needs to be consumed and the client returned due to parameters
+    // being consumed in request construction.
     fn request(self) -> Result<(Request, &'a Client), Error> {
         let mut request = Request::builder(Route::DeleteWebhookMessage {
             message_id: self.message_id.0,

--- a/http/src/request/channel/webhook/execute_webhook_and_wait.rs
+++ b/http/src/request/channel/webhook/execute_webhook_and_wait.rs
@@ -1,5 +1,5 @@
 use super::execute_webhook::ExecuteWebhook;
-use crate::{error::Error, request::PendingResponse};
+use crate::response::ResponseFuture;
 use twilight_model::channel::Message;
 
 /// Execute a webhook, sending a message to its channel, and then wait for the
@@ -20,6 +20,7 @@ use twilight_model::channel::Message;
 ///     .execute_webhook(id, "webhook token")
 ///     .content("Pinkie...")
 ///     .wait()
+///     .exec()
 ///     .await?
 ///     .model()
 ///     .await?;
@@ -32,21 +33,23 @@ use twilight_model::channel::Message;
 /// [`embeds`]: Self::embeds
 /// [`file`]: Self::file
 pub struct ExecuteWebhookAndWait<'a> {
-    fut: Option<PendingResponse<'a, Message>>,
     inner: ExecuteWebhook<'a>,
 }
 
 impl<'a> ExecuteWebhookAndWait<'a> {
-    pub(crate) fn new(inner: ExecuteWebhook<'a>) -> Self {
-        Self { fut: None, inner }
+    pub(crate) const fn new(inner: ExecuteWebhook<'a>) -> Self {
+        Self { inner }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
-        let request = self.inner.request(true)?;
-        self.fut.replace(Box::pin(self.inner.http.request(request)));
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<Message> {
+        let (request, client) = match self.inner.request(false) {
+            Ok((request, client)) => (request, client),
+            Err(source) => return ResponseFuture::error(source),
+        };
 
-        Ok(())
+        client.request(request)
     }
 }
-
-poll_req!(ExecuteWebhookAndWait<'_>, Message);

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -360,6 +360,8 @@ impl<'a> UpdateWebhookMessage<'a> {
         self
     }
 
+    // `self` needs to be consumed and the client returned due to parameters
+    // being consumed in request construction.
     fn request(self) -> Result<(Request, &'a Client), HttpError> {
         let mut request = Request::builder(Route::UpdateWebhookMessage {
             message_id: self.message_id.0,

--- a/http/src/request/get_gateway.rs
+++ b/http/src/request/get_gateway.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{GetGatewayAuthed, PendingResponse, Request},
+    request::{GetGatewayAuthed, Request},
+    response::ResponseFuture,
     routing::Route,
 };
 use twilight_model::gateway::connection_info::ConnectionInfo;
@@ -20,7 +20,7 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
-/// let info = client.gateway().await?.model().await?;
+/// let info = client.gateway().exec().await?.model().await?;
 /// # Ok(()) }
 /// ```
 ///
@@ -34,37 +34,35 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token");
 ///
-/// let info = client.gateway().authed().await?.model().await?;
+/// let info = client.gateway().authed().exec().await?.model().await?;
 ///
 /// println!("URL: {}", info.url);
 /// println!("Recommended shards to use: {}", info.shards);
 /// # Ok(()) }
 /// ```
 pub struct GetGateway<'a> {
-    fut: Option<PendingResponse<'a, ConnectionInfo>>,
     http: &'a Client,
 }
 
 impl<'a> GetGateway<'a> {
-    pub(crate) fn new(http: &'a Client) -> Self {
-        Self { fut: None, http }
+    pub(crate) const fn new(http: &'a Client) -> Self {
+        Self { http }
     }
 
     /// Call to authenticate this request.
     ///
     /// Returns additional information: the recommended number of shards to use, and information on
     /// the current session start limit.
-    pub fn authed(self) -> GetGatewayAuthed<'a> {
+    pub const fn authed(self) -> GetGatewayAuthed<'a> {
         GetGatewayAuthed::new(self.http)
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ConnectionInfo> {
         let request = Request::from_route(Route::GetGateway);
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetGateway<'_>, ConnectionInfo);

--- a/http/src/request/get_gateway_authed.rs
+++ b/http/src/request/get_gateway_authed.rs
@@ -1,9 +1,4 @@
-use crate::{
-    client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    routing::Route,
-};
+use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::gateway::connection_info::BotConnectionInfo;
 
 /// Get information about the gateway, authenticated as a bot user.
@@ -11,22 +6,20 @@ use twilight_model::gateway::connection_info::BotConnectionInfo;
 /// Returns additional information: the recommended number of shards to use, and information on
 /// the current session start limit.
 pub struct GetGatewayAuthed<'a> {
-    fut: Option<PendingResponse<'a, BotConnectionInfo>>,
     http: &'a Client,
 }
 
 impl<'a> GetGatewayAuthed<'a> {
-    pub(crate) fn new(http: &'a Client) -> Self {
-        Self { fut: None, http }
+    pub(crate) const fn new(http: &'a Client) -> Self {
+        Self { http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<BotConnectionInfo> {
         let request = Request::from_route(Route::GetGatewayBot);
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetGatewayAuthed<'_>, BotConnectionInfo);

--- a/http/src/request/get_user_application.rs
+++ b/http/src/request/get_user_application.rs
@@ -1,28 +1,21 @@
-use crate::{
-    client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    routing::Route,
-};
+use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::oauth::CurrentApplicationInfo;
 
 pub struct GetUserApplicationInfo<'a> {
-    fut: Option<PendingResponse<'a, CurrentApplicationInfo>>,
     http: &'a Client,
 }
 
 impl<'a> GetUserApplicationInfo<'a> {
-    pub(crate) fn new(http: &'a Client) -> Self {
-        Self { fut: None, http }
+    pub(crate) const fn new(http: &'a Client) -> Self {
+        Self { http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<CurrentApplicationInfo> {
         let request = Request::from_route(Route::GetCurrentUserApplicationInfo);
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetUserApplicationInfo<'_>, CurrentApplicationInfo);

--- a/http/src/request/get_voice_regions.rs
+++ b/http/src/request/get_voice_regions.rs
@@ -1,30 +1,27 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::voice::VoiceRegion;
 
 /// Get a list of voice regions that can be used when creating a guild.
 pub struct GetVoiceRegions<'a> {
-    fut: Option<PendingResponse<'a, ListBody<VoiceRegion>>>,
     http: &'a Client,
 }
 
 impl<'a> GetVoiceRegions<'a> {
-    pub(crate) fn new(http: &'a Client) -> Self {
-        Self { fut: None, http }
+    pub(crate) const fn new(http: &'a Client) -> Self {
+        Self { http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<VoiceRegion>> {
         let request = Request::from_route(Route::GetVoiceRegions);
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetVoiceRegions<'_>, ListBody<VoiceRegion>);

--- a/http/src/request/guild/ban/get_ban.rs
+++ b/http/src/request/guild/ban/get_ban.rs
@@ -1,9 +1,4 @@
-use crate::{
-    client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    routing::Route,
-};
+use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::{
     guild::Ban,
     id::{GuildId, UserId},
@@ -13,32 +8,29 @@ use twilight_model::{
 ///
 /// Includes the user banned and the reason.
 pub struct GetBan<'a> {
-    fut: Option<PendingResponse<'a, Ban>>,
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
 }
 
 impl<'a> GetBan<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId, user_id: UserId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId, user_id: UserId) -> Self {
         Self {
-            fut: None,
             guild_id,
             http,
             user_id,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<Ban> {
         let request = Request::from_route(Route::GetBan {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetBan<'_>, Ban);

--- a/http/src/request/guild/ban/get_bans.rs
+++ b/http/src/request/guild/ban/get_bans.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{guild::Ban, id::GuildId};
@@ -23,33 +22,27 @@ use twilight_model::{guild::Ban, id::GuildId};
 ///
 /// let guild_id = GuildId(1);
 ///
-/// let bans = client.bans(guild_id).await?;
+/// let bans = client.bans(guild_id).exec().await?;
 /// # Ok(()) }
 /// ```
 pub struct GetBans<'a> {
-    fut: Option<PendingResponse<'a, ListBody<Ban>>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetBans<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<Ban>> {
         let request = Request::from_route(Route::GetBans {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetBans<'_>, ListBody<Ban>);

--- a/http/src/request/guild/delete_guild.rs
+++ b/http/src/request/guild/delete_guild.rs
@@ -1,37 +1,30 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::Request,
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::GuildId;
 
 /// Delete a guild permanently. The user must be the owner.
 pub struct DeleteGuild<'a> {
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> DeleteGuild<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let request = Request::from_route(Route::DeleteGuild {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(DeleteGuild<'_>, EmptyBody);

--- a/http/src/request/guild/emoji/get_emoji.rs
+++ b/http/src/request/guild/emoji/get_emoji.rs
@@ -1,9 +1,4 @@
-use crate::{
-    client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    routing::Route,
-};
+use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::{
     guild::Emoji,
     id::{EmojiId, GuildId},
@@ -26,36 +21,33 @@ use twilight_model::{
 /// let guild_id = GuildId(50);
 /// let emoji_id = EmojiId(100);
 ///
-/// client.emoji(guild_id, emoji_id).await?;
+/// client.emoji(guild_id, emoji_id).exec().await?;
 /// # Ok(()) }
 /// ```
 pub struct GetEmoji<'a> {
     emoji_id: EmojiId,
-    fut: Option<PendingResponse<'a, Emoji>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetEmoji<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId, emoji_id: EmojiId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId, emoji_id: EmojiId) -> Self {
         Self {
             emoji_id,
-            fut: None,
             guild_id,
             http,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<Emoji> {
         let request = Request::from_route(Route::GetEmoji {
             emoji_id: self.emoji_id.0,
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetEmoji<'_>, Emoji);

--- a/http/src/request/guild/emoji/get_emojis.rs
+++ b/http/src/request/guild/emoji/get_emojis.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{guild::Emoji, id::GuildId};
@@ -23,33 +22,27 @@ use twilight_model::{guild::Emoji, id::GuildId};
 ///
 /// let guild_id = GuildId(100);
 ///
-/// client.emojis(guild_id).await?;
+/// client.emojis(guild_id).exec().await?;
 /// # Ok(()) }
 /// ```
 pub struct GetEmojis<'a> {
-    fut: Option<PendingResponse<'a, ListBody<Emoji>>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetEmojis<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<Emoji>> {
         let request = Request::from_route(Route::GetEmojis {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetEmojis<'_>, ListBody<Emoji>);

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
-    error::Error as HttpError,
-    request::{validate, PendingResponse, Request},
+    request::{validate, Request},
+    response::ResponseFuture,
     routing::Route,
 };
 use std::{
@@ -85,12 +85,12 @@ struct GetAuditLogFields {
 /// let audit_log = client
 /// // not done
 ///     .audit_log(guild_id)
+///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
 pub struct GetAuditLog<'a> {
     fields: GetAuditLogFields,
-    fut: Option<PendingResponse<'a, AuditLog>>,
     guild_id: GuildId,
     http: &'a Client,
 }
@@ -99,7 +99,6 @@ impl<'a> GetAuditLog<'a> {
     pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
         Self {
             fields: GetAuditLogFields::default(),
-            fut: None,
             guild_id,
             http,
         }
@@ -148,7 +147,10 @@ impl<'a> GetAuditLog<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<(), HttpError> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<AuditLog> {
         let request = Request::from_route(Route::GetAuditLogs {
             action_type: self.fields.action_type.map(|x| x as u64),
             before: self.fields.before,
@@ -157,10 +159,6 @@ impl<'a> GetAuditLog<'a> {
             user_id: self.fields.user_id.map(|x| x.0),
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetAuditLog<'_>, AuditLog);

--- a/http/src/request/guild/get_guild_channels.rs
+++ b/http/src/request/guild/get_guild_channels.rs
@@ -1,37 +1,30 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{channel::GuildChannel, id::GuildId};
 
 /// Get the channels in a guild.
 pub struct GetGuildChannels<'a> {
-    fut: Option<PendingResponse<'a, ListBody<GuildChannel>>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetGuildChannels<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<GuildChannel>> {
         let request = Request::from_route(Route::GetChannels {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetGuildChannels<'_>, ListBody<GuildChannel>);

--- a/http/src/request/guild/get_guild_invites.rs
+++ b/http/src/request/guild/get_guild_invites.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{id::GuildId, invite::Invite};
@@ -13,29 +12,23 @@ use twilight_model::{id::GuildId, invite::Invite};
 ///
 /// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
 pub struct GetGuildInvites<'a> {
-    fut: Option<PendingResponse<'a, ListBody<Invite>>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetGuildInvites<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<Invite>> {
         let request = Request::from_route(Route::GetGuildInvites {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetGuildInvites<'_>, ListBody<Invite>);

--- a/http/src/request/guild/get_guild_preview.rs
+++ b/http/src/request/guild/get_guild_preview.rs
@@ -1,38 +1,27 @@
-use crate::{
-    client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    routing::Route,
-};
+use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::{guild::GuildPreview, id::GuildId};
 
 /// For public guilds, get the guild preview.
 ///
 /// This works even if the user is not in the guild.
 pub struct GetGuildPreview<'a> {
-    fut: Option<PendingResponse<'a, GuildPreview>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetGuildPreview<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<GuildPreview> {
         let request = Request::from_route(Route::GetGuildPreview {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetGuildPreview<'_>, GuildPreview);

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -1,36 +1,25 @@
-use crate::{
-    client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    routing::Route,
-};
+use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::{guild::VanityUrl, id::GuildId};
 
 /// Get a guild's vanity url, if there is one.
 pub struct GetGuildVanityUrl<'a> {
-    fut: Option<PendingResponse<'a, VanityUrl>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetGuildVanityUrl<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<VanityUrl> {
         let request = Request::from_route(Route::GetGuildVanityUrl {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetGuildVanityUrl<'_>, VanityUrl);

--- a/http/src/request/guild/get_guild_webhooks.rs
+++ b/http/src/request/guild/get_guild_webhooks.rs
@@ -1,37 +1,30 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{channel::Webhook, id::GuildId};
 
 /// Get the webhooks of a guild.
 pub struct GetGuildWebhooks<'a> {
-    fut: Option<PendingResponse<'a, ListBody<Webhook>>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetGuildWebhooks<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<Webhook>> {
         let request = Request::from_route(Route::GetGuildWebhooks {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetGuildWebhooks<'_>, ListBody<Webhook>);

--- a/http/src/request/guild/get_guild_welcome_screen.rs
+++ b/http/src/request/guild/get_guild_welcome_screen.rs
@@ -1,36 +1,25 @@
-use crate::{
-    client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    routing::Route,
-};
+use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::{id::GuildId, invite::WelcomeScreen};
 
 /// Get the guild's welcome screen.
 pub struct GetGuildWelcomeScreen<'a> {
-    fut: Option<PendingResponse<'a, WelcomeScreen>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetGuildWelcomeScreen<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<WelcomeScreen> {
         let request = Request::from_route(Route::GetGuildWelcomeScreen {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetGuildWelcomeScreen<'_>, WelcomeScreen);

--- a/http/src/request/guild/get_guild_widget.rs
+++ b/http/src/request/guild/get_guild_widget.rs
@@ -1,9 +1,4 @@
-use crate::{
-    client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    routing::Route,
-};
+use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::{guild::GuildWidget, id::GuildId};
 
 /// Get the guild widget.
@@ -12,29 +7,23 @@ use twilight_model::{guild::GuildWidget, id::GuildId};
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#get-guild-widget
 pub struct GetGuildWidget<'a> {
-    fut: Option<PendingResponse<'a, GuildWidget>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetGuildWidget<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<GuildWidget> {
         let request = Request::from_route(Route::GetGuildWidget {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetGuildWidget<'_>, GuildWidget);

--- a/http/src/request/guild/integration/get_guild_integrations.rs
+++ b/http/src/request/guild/integration/get_guild_integrations.rs
@@ -1,37 +1,30 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{guild::GuildIntegration, id::GuildId};
 
 /// Get the guild's integrations.
 pub struct GetGuildIntegrations<'a> {
-    fut: Option<PendingResponse<'a, ListBody<GuildIntegration>>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetGuildIntegrations<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<GuildIntegration>> {
         let request = Request::from_route(Route::GetGuildIntegrations {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetGuildIntegrations<'_>, ListBody<GuildIntegration>);

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -1,63 +1,39 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::{marker::MemberBody, Response},
+    request::Request,
+    response::{marker::MemberBody, ResponseFuture},
     routing::Route,
-};
-use std::{
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
 };
 use twilight_model::id::{GuildId, UserId};
 
 /// Get a member of a guild, by id.
 pub struct GetMember<'a> {
-    fut: Option<PendingResponse<'a, MemberBody>>,
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
 }
 
 impl<'a> GetMember<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId, user_id: UserId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId, user_id: UserId) -> Self {
         Self {
-            fut: None,
             guild_id,
             http,
             user_id,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<MemberBody> {
         let request = Request::from_route(Route::GetMember {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        let mut future = self.http.request(request);
+        future.set_guild_id(self.guild_id);
 
-        Ok(())
-    }
-}
-
-impl Future for GetMember<'_> {
-    type Output = Result<Response<MemberBody>, Error>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        loop {
-            if let Some(fut) = self.as_mut().fut.as_mut() {
-                return fut.as_mut().poll(cx).map_ok(|mut res| {
-                    res.set_guild_id(self.guild_id);
-
-                    res
-                });
-            }
-
-            if let Err(why) = self.as_mut().start() {
-                return Poll::Ready(Err(why));
-            }
-        }
+        future
     }
 }

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -85,7 +85,10 @@ struct SearchGuildMembersFields {
 /// let client = Client::new("my token");
 ///
 /// let guild_id = GuildId(100);
-/// let members = client.search_guild_members(guild_id, String::from("Wumpus")).limit(10)?.exec().await?;
+/// let members = client.search_guild_members(guild_id, String::from("Wumpus"))
+///     .limit(10)?
+///     .exec()
+///     .await?;
 /// # Ok(()) }
 /// ```
 ///

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -179,15 +179,15 @@ impl<'a> UpdateGuildMember<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<MemberBody> {
-        let request = match self.request() {
-            Ok(request) => request,
-            Err(source) => return ResponseFuture::error(source),
-        };
+        match self.request() {
+            Ok(request) => {
+                let mut future = self.http.request(request);
+                future.set_guild_id(self.guild_id);
 
-        let mut future = self.http.request(request);
-        future.set_guild_id(self.guild_id);
-
-        future
+                future
+            }
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/http/src/request/guild/role/get_guild_roles.rs
+++ b/http/src/request/guild/role/get_guild_roles.rs
@@ -1,37 +1,30 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{guild::Role, id::GuildId};
 
 /// Get the roles of a guild.
 pub struct GetGuildRoles<'a> {
-    fut: Option<PendingResponse<'a, ListBody<Role>>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetGuildRoles<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<Role>> {
         let request = Request::from_route(Route::GetGuildRoles {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetGuildRoles<'_>, ListBody<Role>);

--- a/http/src/request/guild/role/update_role_positions.rs
+++ b/http/src/request/guild/role/update_role_positions.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{
@@ -14,7 +13,6 @@ use twilight_model::{
 ///
 /// The minimum amount of roles to modify, is a swap between two roles.
 pub struct UpdateRolePositions<'a> {
-    fut: Option<PendingResponse<'a, ListBody<Role>>>,
     guild_id: GuildId,
     http: &'a Client,
     roles: Vec<(RoleId, u64)>,
@@ -27,24 +25,25 @@ impl<'a> UpdateRolePositions<'a> {
         roles: impl Iterator<Item = (RoleId, u64)>,
     ) -> Self {
         Self {
-            fut: None,
             guild_id,
             http,
             roles: roles.collect(),
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
-        let request = Request::builder(Route::UpdateRolePositions {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<Role>> {
+        let mut request = Request::builder(Route::UpdateRolePositions {
             guild_id: self.guild_id.0,
-        })
-        .json(&self.roles)?
-        .build();
+        });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        request = match request.json(&self.roles) {
+            Ok(request) => request,
+            Err(source) => return ResponseFuture::error(source),
+        };
 
-        Ok(())
+        self.http.request(request.build())
     }
 }
-
-poll_req!(UpdateRolePositions<'_>, ListBody<Role>);

--- a/http/src/request/guild/user/update_user_voice_state.rs
+++ b/http/src/request/guild/user/update_user_voice_state.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::Request,
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -18,14 +17,13 @@ struct UpdateUserVoiceStateFields {
 /// Update another user's voice state.
 pub struct UpdateUserVoiceState<'a> {
     fields: UpdateUserVoiceStateFields,
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
 }
 
 impl<'a> UpdateUserVoiceState<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         guild_id: GuildId,
         user_id: UserId,
@@ -36,7 +34,6 @@ impl<'a> UpdateUserVoiceState<'a> {
                 channel_id,
                 suppress: None,
             },
-            fut: None,
             guild_id,
             http,
             user_id,
@@ -61,18 +58,20 @@ impl<'a> UpdateUserVoiceState<'a> {
         self
     }
 
-    fn start(&mut self) -> Result<(), Error> {
-        let request = Request::builder(Route::UpdateUserVoiceState {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        let mut request = Request::builder(Route::UpdateUserVoiceState {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
-        })
-        .json(&self.fields)?
-        .build();
+        });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
+        request = match request.json(&self.fields) {
+            Ok(request) => request,
+            Err(source) => return ResponseFuture::error(source),
+        };
 
-        Ok(())
+        self.http.request(request.build())
     }
 }
-
-poll_req!(UpdateUserVoiceState<'_>, EmptyBody);

--- a/http/src/request/template/delete_template.rs
+++ b/http/src/request/template/delete_template.rs
@@ -1,15 +1,13 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::Request,
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::GuildId;
 
 /// Delete a template by ID and code.
 pub struct DeleteTemplate<'a> {
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     guild_id: GuildId,
     http: &'a Client,
     template_code: String,
@@ -24,25 +22,23 @@ impl<'a> DeleteTemplate<'a> {
         Self::_new(http, guild_id, template_code.into())
     }
 
-    fn _new(http: &'a Client, guild_id: GuildId, template_code: String) -> Self {
+    const fn _new(http: &'a Client, guild_id: GuildId, template_code: String) -> Self {
         Self {
-            fut: None,
             guild_id,
             http,
             template_code,
         }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let request = Request::from_route(Route::DeleteTemplate {
             guild_id: self.guild_id.0,
-            template_code: self.template_code.clone(),
+            template_code: self.template_code,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(DeleteTemplate<'_>, EmptyBody);

--- a/http/src/request/template/get_templates.rs
+++ b/http/src/request/template/get_templates.rs
@@ -1,37 +1,30 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{id::GuildId, template::Template};
 
 /// Get a list of templates in a guild, by ID.
 pub struct GetTemplates<'a> {
-    fut: Option<PendingResponse<'a, ListBody<Template>>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> GetTemplates<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<Template>> {
         let request = Request::from_route(Route::GetTemplates {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetTemplates<'_>, ListBody<Template>);

--- a/http/src/request/user/get_current_user.rs
+++ b/http/src/request/user/get_current_user.rs
@@ -1,31 +1,24 @@
-use crate::{
-    client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    routing::Route,
-};
+use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::user::CurrentUser;
 
 /// Get information about the current user.
 pub struct GetCurrentUser<'a> {
-    fut: Option<PendingResponse<'a, CurrentUser>>,
     http: &'a Client,
 }
 
 impl<'a> GetCurrentUser<'a> {
-    pub(crate) fn new(http: &'a Client) -> Self {
-        Self { fut: None, http }
+    pub(crate) const fn new(http: &'a Client) -> Self {
+        Self { http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<CurrentUser> {
         let request = Request::from_route(Route::GetUser {
             target_user: "@me".to_owned(),
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetCurrentUser<'_>, CurrentUser);

--- a/http/src/request/user/get_current_user_connections.rs
+++ b/http/src/request/user/get_current_user_connections.rs
@@ -1,8 +1,7 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::ListBody,
+    request::Request,
+    response::{marker::ListBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::user::Connection;
@@ -11,22 +10,20 @@ use twilight_model::user::Connection;
 ///
 /// Requires the `connections` `OAuth2` scope.
 pub struct GetCurrentUserConnections<'a> {
-    fut: Option<PendingResponse<'a, ListBody<Connection>>>,
     http: &'a Client,
 }
 
 impl<'a> GetCurrentUserConnections<'a> {
-    pub(crate) fn new(http: &'a Client) -> Self {
-        Self { fut: None, http }
+    pub(crate) const fn new(http: &'a Client) -> Self {
+        Self { http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<ListBody<Connection>> {
         let request = Request::from_route(Route::GetUserConnections);
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(GetCurrentUserConnections<'_>, ListBody<Connection>);

--- a/http/src/request/user/leave_guild.rs
+++ b/http/src/request/user/leave_guild.rs
@@ -1,37 +1,30 @@
 use crate::{
     client::Client,
-    error::Error,
-    request::{PendingResponse, Request},
-    response::marker::EmptyBody,
+    request::Request,
+    response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::GuildId;
 
 /// Leave a guild by id.
 pub struct LeaveGuild<'a> {
-    fut: Option<PendingResponse<'a, EmptyBody>>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> LeaveGuild<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
-        Self {
-            fut: None,
-            guild_id,
-            http,
-        }
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
+        Self { guild_id, http }
     }
 
-    fn start(&mut self) -> Result<(), Error> {
+    /// Execute the request, returning a future resolving to a [`Response`].
+    ///
+    /// [`Response`]: crate::response::Response
+    pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let request = Request::from_route(Route::LeaveGuild {
             guild_id: self.guild_id.0,
         });
 
-        self.fut.replace(Box::pin(self.http.request(request)));
-
-        Ok(())
+        self.http.request(request)
     }
 }
-
-poll_req!(LeaveGuild<'_>, EmptyBody);

--- a/http/src/response/future.rs
+++ b/http/src/response/future.rs
@@ -1,0 +1,371 @@
+use super::{Response, StatusCode};
+use crate::{
+    api_error::ApiError,
+    error::{Error, ErrorType},
+    ratelimiting::RatelimitHeaders,
+};
+use hyper::{
+    body::Bytes, client::ResponseFuture as HyperResponseFuture, StatusCode as HyperStatusCode,
+};
+use std::{
+    convert::TryFrom,
+    future::Future,
+    marker::PhantomData,
+    mem,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+    time::Duration,
+};
+use tokio::{
+    sync::oneshot::{Receiver, Sender},
+    time::{self, Timeout},
+};
+use twilight_model::id::GuildId;
+
+type Output<T> = Result<Response<T>, Error>;
+
+enum InnerPoll<T> {
+    Advance(ResponseFutureStage),
+    Pending(ResponseFutureStage),
+    Ready(Output<T>),
+}
+
+struct Chunking {
+    future: Pin<Box<dyn Future<Output = Result<Bytes, Error>> + Send + Sync + 'static>>,
+    status: HyperStatusCode,
+}
+
+impl Chunking {
+    fn poll<T>(mut self, cx: &mut Context<'_>) -> InnerPoll<T> {
+        let bytes = match Pin::new(&mut self.future).poll(cx) {
+            Poll::Ready(Ok(bytes)) => bytes,
+            Poll::Ready(Err(source)) => return InnerPoll::Ready(Err(source)),
+            Poll::Pending => {
+                return InnerPoll::Pending(ResponseFutureStage::Chunking(Self {
+                    future: self.future,
+                    status: self.status,
+                }))
+            }
+        };
+
+        let error = match crate::json::from_bytes::<ApiError>(&bytes) {
+            Ok(error) => error,
+            Err(source) => {
+                return InnerPoll::Ready(Err(Error {
+                    kind: ErrorType::Parsing {
+                        body: bytes.to_vec(),
+                    },
+                    source: Some(Box::new(source)),
+                }));
+            }
+        };
+
+        #[cfg(feature = "tracing")]
+        if let ApiError::General(ref general) = error {
+            use crate::api_error::ErrorCode;
+
+            if let ErrorCode::Other(num) = general.code {
+                tracing::debug!("got unknown API error code variant: {}; {:?}", num, error);
+            }
+        }
+
+        InnerPoll::Ready(Err(Error {
+            kind: ErrorType::Response {
+                body: bytes.to_vec(),
+                error,
+                status: StatusCode::new(self.status.as_u16()),
+            },
+            source: None,
+        }))
+    }
+}
+
+struct Failed {
+    source: Error,
+}
+
+impl Failed {
+    fn poll<T>(self, _: &mut Context<'_>) -> InnerPoll<T> {
+        InnerPoll::Ready(Err(self.source))
+    }
+}
+
+struct InFlight {
+    future: Pin<Box<Timeout<HyperResponseFuture>>>,
+    guild_id: Option<GuildId>,
+    token_invalid: Arc<AtomicBool>,
+    tx: Option<Sender<Option<RatelimitHeaders>>>,
+}
+
+impl InFlight {
+    fn poll<T>(mut self, cx: &mut Context<'_>) -> InnerPoll<T> {
+        let resp = match Pin::new(&mut self.future).poll(cx) {
+            Poll::Ready(Ok(Ok(resp))) => resp,
+            Poll::Ready(Ok(Err(source))) => {
+                return InnerPoll::Ready(Err(Error {
+                    kind: ErrorType::RequestTimedOut,
+                    source: Some(Box::new(source)),
+                }))
+            }
+            Poll::Ready(Err(source)) => {
+                return InnerPoll::Ready(Err(Error {
+                    kind: ErrorType::RequestError,
+                    source: Some(Box::new(source)),
+                }))
+            }
+            Poll::Pending => {
+                return InnerPoll::Pending(ResponseFutureStage::InFlight(Self {
+                    future: self.future,
+                    guild_id: self.guild_id,
+                    token_invalid: self.token_invalid,
+                    tx: self.tx,
+                }))
+            }
+        };
+
+        // If the API sent back an Unauthorized response, then the client's
+        // configured token is permanently invalid and future requests must be
+        // ignored to avoid API bans.
+        if resp.status() == HyperStatusCode::UNAUTHORIZED {
+            self.token_invalid.store(true, Ordering::Relaxed);
+        }
+
+        if let Some(tx) = self.tx {
+            match RatelimitHeaders::try_from(resp.headers()) {
+                Ok(v) => {
+                    let _res = tx.send(Some(v));
+                }
+                #[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
+                Err(source) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!("header parsing failed: {:?}; {:?}", source, resp);
+
+                    let _res = tx.send(None);
+                }
+            }
+        }
+
+        let status = resp.status();
+
+        if status.is_success() {
+            let mut response = Response::new(resp);
+
+            if let Some(guild_id) = self.guild_id {
+                response.set_guild_id(guild_id);
+            }
+
+            return InnerPoll::Ready(Ok(response));
+        }
+
+        match status {
+            HyperStatusCode::TOO_MANY_REQUESTS => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!("429 response: {:?}", resp)
+            }
+            HyperStatusCode::SERVICE_UNAVAILABLE => {
+                return InnerPoll::Ready(Err(Error {
+                    kind: ErrorType::ServiceUnavailable { response: resp },
+                    source: None,
+                }));
+            }
+            _ => {}
+        }
+
+        let fut = Box::pin(async {
+            hyper::body::to_bytes(resp.into_body())
+                .await
+                .map_err(|source| Error {
+                    kind: ErrorType::ChunkingResponse,
+                    source: Some(Box::new(source)),
+                })
+        });
+
+        InnerPoll::Advance(ResponseFutureStage::Chunking(Chunking {
+            future: fut,
+            status,
+        }))
+    }
+}
+
+struct RatelimitQueue {
+    guild_id: Option<GuildId>,
+    request_timeout: Duration,
+    response_future: HyperResponseFuture,
+    token_invalid: Arc<AtomicBool>,
+    wait_for_sender: Receiver<Sender<Option<RatelimitHeaders>>>,
+}
+
+impl RatelimitQueue {
+    fn poll<T>(mut self, cx: &mut Context<'_>) -> InnerPoll<T> {
+        let tx = match Pin::new(&mut self.wait_for_sender).poll(cx) {
+            Poll::Ready(Ok(tx)) => tx,
+            Poll::Ready(Err(source)) => {
+                return InnerPoll::Ready(Err(Error {
+                    kind: ErrorType::RequestCanceled {},
+                    source: Some(Box::new(source)),
+                }))
+            }
+            Poll::Pending => {
+                return InnerPoll::Pending(ResponseFutureStage::RatelimitQueue(Self {
+                    guild_id: self.guild_id,
+                    request_timeout: self.request_timeout,
+                    response_future: self.response_future,
+                    token_invalid: self.token_invalid,
+                    wait_for_sender: self.wait_for_sender,
+                }))
+            }
+        };
+
+        InnerPoll::Advance(ResponseFutureStage::InFlight(InFlight {
+            future: Box::pin(time::timeout(self.request_timeout, self.response_future)),
+            guild_id: self.guild_id,
+            token_invalid: self.token_invalid,
+            tx: Some(tx),
+        }))
+    }
+}
+
+enum ResponseFutureStage {
+    Chunking(Chunking),
+    Completed,
+    Failed(Failed),
+    InFlight(InFlight),
+    RatelimitQueue(RatelimitQueue),
+}
+
+/// Future that will resolve to a [`Response`].
+///
+/// # Errors
+///
+///
+/// Returns an [`ErrorType::Json`] error type if serializing the response body
+/// of the request failed.
+///
+/// Returns an [`ErrorType::Parsing`] error type if the request failed and the
+/// error in the response body could not be deserialized.
+///
+/// Returns an [`ErrorType::RequestCanceled`] error type if the request was
+/// canceled by the user.
+///
+/// Returns an [`ErrorType::RequestError`] error type if creating the request
+/// failed.
+///
+/// Returns an [`ErrorType::RequestTimedOut`] error type if the request timed
+/// out. The timeout value is configured via [`ClientBuilder::timeout`].
+///
+/// Returns an [`ErrorType::Response`] error type if the request failed.
+///
+/// Returns an [`ErrorType::ServiceUnavailable`] error type if the Discord API
+/// is unavailable.
+///
+/// [`ClientBuilder::timeout`]: crate::client::ClientBuilder::timeout
+/// [`ErrorType::Json`]: crate::error::ErrorType::Json
+/// [`ErrorType::Parsing`]: crate::error::ErrorType::Parsing
+/// [`ErrorType::RequestCanceled`]: crate::error::ErrorType::RequestCanceled
+/// [`ErrorType::RequestError`]: crate::error::ErrorType::RequestError
+/// [`ErrorType::RequestTimedOut`]: crate::error::ErrorType::RequestTimedOut
+/// [`ErrorType::Response`]: crate::error::ErrorType::Response
+/// [`ErrorType::ServiceUnavailable`]: crate::error::ErrorType::ServiceUnavailable
+/// [`Response`]: super::Response
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct ResponseFuture<T> {
+    phantom: PhantomData<T>,
+    stage: ResponseFutureStage,
+}
+
+impl<T> ResponseFuture<T> {
+    pub(crate) fn new(
+        token_invalid: Arc<AtomicBool>,
+        future: Timeout<HyperResponseFuture>,
+        ratelimit_tx: Option<Sender<Option<RatelimitHeaders>>>,
+    ) -> Self {
+        Self {
+            phantom: PhantomData,
+            stage: ResponseFutureStage::InFlight(InFlight {
+                future: Box::pin(future),
+                guild_id: None,
+                token_invalid,
+                tx: ratelimit_tx,
+            }),
+        }
+    }
+
+    pub(crate) const fn error(source: Error) -> Self {
+        Self {
+            phantom: PhantomData,
+            stage: ResponseFutureStage::Failed(Failed { source }),
+        }
+    }
+
+    pub(crate) fn ratelimit(
+        guild_id: Option<GuildId>,
+        token_invalid: Arc<AtomicBool>,
+        rx: Receiver<Sender<Option<RatelimitHeaders>>>,
+        request_timeout: Duration,
+        response_future: HyperResponseFuture,
+    ) -> Self {
+        Self {
+            phantom: PhantomData,
+            stage: ResponseFutureStage::RatelimitQueue(RatelimitQueue {
+                guild_id,
+                response_future,
+                wait_for_sender: rx,
+                request_timeout,
+                token_invalid,
+            }),
+        }
+    }
+
+    /// Set the ID of the relevant guild.
+    ///
+    /// Necessary for [`MemberBody`] and [`MemberListBody`] deserialization.
+    pub(crate) fn set_guild_id(&mut self, guild_id: GuildId) {
+        match &mut self.stage {
+            ResponseFutureStage::InFlight(ref mut stage) => {
+                stage.guild_id.replace(guild_id);
+            }
+            ResponseFutureStage::RatelimitQueue(ref mut stage) => {
+                stage.guild_id.replace(guild_id);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<T: Unpin> Future for ResponseFuture<T> {
+    type Output = Output<T>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {
+            let stage = mem::replace(&mut self.stage, ResponseFutureStage::Completed);
+
+            let result = match stage {
+                ResponseFutureStage::Chunking(chunking) => chunking.poll(cx),
+                ResponseFutureStage::Completed => panic!("future already completed"),
+                ResponseFutureStage::Failed(failed) => failed.poll(cx),
+                ResponseFutureStage::InFlight(in_flight) => in_flight.poll(cx),
+                ResponseFutureStage::RatelimitQueue(queue) => queue.poll(cx),
+            };
+
+            match result {
+                InnerPoll::Advance(stage) => {
+                    self.stage = stage;
+                }
+                InnerPoll::Pending(stage) => {
+                    self.stage = stage;
+
+                    return Poll::Pending;
+                }
+                InnerPoll::Ready(output) => {
+                    self.stage = ResponseFutureStage::Completed;
+
+                    return Poll::Ready(output);
+                }
+            }
+        }
+    }
+}

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let shard_count = 1u64;
 
     let http = HttpClient::new(&token);
-    let user_id = http.current_user().await?.model().await?.id;
+    let user_id = http.current_user().exec().await?.model().await?.id;
 
     let lavalink = Lavalink::new(user_id, shard_count);
     lavalink.add(lavalink_host, lavalink_auth).await?;

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let shard_count = 1u64;
 
         let http = HttpClient::new(&token);
-        let user_id = http.current_user().await?.model().await?.id;
+        let user_id = http.current_user().exec().await?.model().await?.id;
 
         let lavalink = Lavalink::new(user_id, shard_count);
         lavalink.add(lavalink_host, lavalink_auth).await?;
@@ -96,6 +96,7 @@ async fn join(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
         .http
         .create_message(msg.channel_id)
         .content("What's the channel ID you want me to join?")?
+        .exec()
         .await?;
 
     let author_id = msg.author.id;
@@ -124,6 +125,7 @@ async fn join(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
         .http
         .create_message(msg.channel_id)
         .content(format!("Joined <#{}>!", channel_id))?
+        .exec()
         .await?;
 
     Ok(())
@@ -156,6 +158,7 @@ async fn leave(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + 
         .http
         .create_message(msg.channel_id)
         .content("Left the channel")?
+        .exec()
         .await?;
 
     Ok(())
@@ -171,6 +174,7 @@ async fn play(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
         .http
         .create_message(msg.channel_id)
         .content("What's the URL of the audio to play?")?
+        .exec()
         .await?;
 
     let author_id = msg.author.id;
@@ -206,12 +210,14 @@ async fn play(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
             .http
             .create_message(msg.channel_id)
             .content(content)?
+            .exec()
             .await?;
     } else {
         state
             .http
             .create_message(msg.channel_id)
             .content("Didn't find any results")?
+            .exec()
             .await?;
     }
 
@@ -236,6 +242,7 @@ async fn pause(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + 
         .http
         .create_message(msg.channel_id)
         .content(format!("{} the track", action))?
+        .exec()
         .await?;
 
     Ok(())
@@ -251,6 +258,7 @@ async fn seek(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
         .http
         .create_message(msg.channel_id)
         .content("Where in the track do you want to seek to (in seconds)?")?
+        .exec()
         .await?;
 
     let author_id = msg.author.id;
@@ -270,6 +278,7 @@ async fn seek(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
         .http
         .create_message(msg.channel_id)
         .content(format!("Seeked to {}s", position))?
+        .exec()
         .await?;
 
     Ok(())
@@ -290,6 +299,7 @@ async fn stop(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
         .http
         .create_message(msg.channel_id)
         .content("Stopped the track")?
+        .exec()
         .await?;
 
     Ok(())
@@ -305,6 +315,7 @@ async fn volume(msg: Message, state: State) -> Result<(), Box<dyn Error + Send +
         .http
         .create_message(msg.channel_id)
         .content("What's the volume you want to set (0-1000, 100 being the default)?")?
+        .exec()
         .await?;
 
     let author_id = msg.author.id;
@@ -322,6 +333,7 @@ async fn volume(msg: Message, state: State) -> Result<(), Box<dyn Error + Send +
             .http
             .create_message(msg.channel_id)
             .content("That's more than 1000")?
+            .exec()
             .await?;
 
         return Ok(());
@@ -334,6 +346,7 @@ async fn volume(msg: Message, state: State) -> Result<(), Box<dyn Error + Send +
         .http
         .create_message(msg.channel_id)
         .content(format!("Set the volume to {}", volume))?
+        .exec()
         .await?;
 
     Ok(())

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -76,7 +76,7 @@
 //!     let shard_count = 1u64;
 //!
 //!     let http = HttpClient::new(&token);
-//!     let user_id = http.current_user().await?.model().await?.id;
+//!     let user_id = http.current_user().exec().await?.model().await?.id;
 //!
 //!     let lavalink = Lavalink::new(user_id, shard_count);
 //!     lavalink.add(lavalink_host, lavalink_auth).await?;

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -180,7 +180,10 @@
 //! ) -> Result<(), Box<dyn Error + Send + Sync>> {
 //!     match event {
 //!         Event::MessageCreate(msg) if msg.content == "!ping" => {
-//!             http.create_message(msg.channel_id).content("Pong!")?.await?;
+//!             http.create_message(msg.channel_id)
+//!                 .content("Pong!")?
+//!                 .exec()
+//!                 .await?;
 //!         }
 //!         Event::ShardConnected(_) => {
 //!             println!("Connected on shard {}", shard_id);


### PR DESCRIPTION
We currently take owned types, such as Vecs and Strings. This is due to the lifetimes around requests, their inner polled futures, and the caller are difficult to work around.

The way requests currently work is that they implement `std::future::Future` and "start" a future when initially polled for the first time. They then store this future internally in a field like so:

```rust
pub struct SomeRequest {
    fut: Option<Pending<'a, Message>>,
    // more fields...
}
```

This requires a lot of boilerplate on our part: we have a macro implementing `Future` on every request with more or less unique implementations and need fields for the inner future.

For users, this design comes at a cost of performance and clarity. Users need to give us owned arguments. It is also impossible for users to determine whether a request is in flight using the type system due to that information being hidden. We need to clone arguments if we want to avoid panics from users accidentally double polling a request after completion, when it may not be clear that a request has been used due to the request not being consumed.

Instead, we can turn the inner request functions that "start" a future into ones that consume and execute the request and then return a future resolving to a response directly to the user. The new `response::ResponseFuture` implements `Poll` and will begin the execution of a request - if a failure did not occur during construction - while polling it to completion, providing the resulting `response::Response`.

Internally the implementation of the `CreateMessage::exec` function looks like this:

```rust
pub fn exec(self) -> ResponseFuture<Message> {
    let request = Request::from_route(Route::GetMessage {
        channel_id: self.channel_id.0,
        message_id: self.message_id.0,
    });

    self.http.request(request)
}
```

The usage of executing the request and printing the message contents looks like this:

```rust
let msg = client.message(channel_id, message_id).exec().await?;
let message = response.model().await?;

println!("content: {}", message.content);
```

This work does not include the optimization work that turns all of our owned parameters to borrowed ones and will be done by a separate PR.

~~Blocks on #923.~~ Merged.