### PR TITLE
Take references in request parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let scheme = ShardScheme::Auto;
 
     // Use intents to only receive guild message events.
-    let (cluster, mut events) = Cluster::builder(&token, Intents::GUILD_MESSAGES)
+    let (cluster, mut events) = Cluster::builder(token.to_owned(), Intents::GUILD_MESSAGES)
         .shard_scheme(scheme)
         .build()
         .await?;
@@ -156,7 +156,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     });
 
     // HTTP is separate from the gateway, so create a new client.
-    let http = HttpClient::new(&token);
+    let http = HttpClient::new(token);
 
     // Since we only care about new messages, make the cache only
     // cache new messages.

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -51,7 +51,7 @@ impl ClusterBuilder {
 
         let token = token.into_boxed_str();
 
-        let http_client = Client::new(token.clone());
+        let http_client = Client::new(token.to_string());
 
         let shard_config =
             ShardBuilder::new(token.clone(), intents).http_client(http_client.clone());

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -37,7 +37,13 @@ rustls-native-roots = ["hyper-rustls/native-tokio"]
 rustls-webpki-roots = ["hyper-rustls/webpki-tokio"]
 
 [dev-dependencies]
+criterion = { default-features = false, version = "0.3" }
 serde_test = { default-features = false, version = "1" }
 static_assertions = { default-features = false, version = "1.1.0" }
 twilight-embed-builder = { default-features = false, path = "../embed-builder" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
+
+[[bench]]
+name = "application_command_permissions"
+harness = false
+path = "benches/application_command_permissions.rs"

--- a/http/benches/application_command_permissions.rs
+++ b/http/benches/application_command_permissions.rs
@@ -1,0 +1,48 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use twilight_http::{client::Client, request::application::SetCommandPermissions};
+use twilight_model::{
+    application::command::permissions::{CommandPermissions, CommandPermissionsType},
+    id::{ApplicationId, CommandId, GuildId, RoleId},
+};
+
+fn commands(commands: usize, permissions: usize) -> Vec<(CommandId, CommandPermissions)> {
+    (0..commands)
+        .map(|id| {
+            (0..permissions).map(move |_| {
+                (
+                    CommandId(id as u64),
+                    CommandPermissions {
+                        id: CommandPermissionsType::Role(RoleId(4)),
+                        permission: true,
+                    },
+                )
+            })
+        })
+        .flatten()
+        .collect()
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let client = Client::new(String::new());
+    client.set_application_id(ApplicationId(1));
+
+    let command_counts = [5usize, 10, 50, 100];
+    let permission_counts = [2usize, 5, 10];
+
+    for command in command_counts {
+        for permission in permission_counts {
+            let name = format!("{} commands, {} permissions", command, permission);
+
+            c.bench_function(&name, |b| {
+                let list = commands(command, permission);
+
+                b.iter(|| {
+                    assert!(client.set_command_permissions(GuildId(2), &list).is_ok());
+                });
+            });
+        }
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/http/examples/allowed-mentions/src/main.rs
+++ b/http/examples/allowed-mentions/src/main.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     //but since we did not allow @everyone pings it will not ping everyone
     client
         .create_message(channel_id)
-        .content(format!(
+        .content(&format!(
             "<@{}> you are not allowed to ping @everyone!",
             user_id.0
         ))?

--- a/http/examples/get-message/src/main.rs
+++ b/http/examples/get-message/src/main.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     future::join_all((1u8..=10).map(|x| {
         client
             .create_message(channel_id)
-            .content(format!("Ping #{}", x))
+            .content(&format!("Ping #{}", x))
             .expect("content not a valid length")
             .exec()
     }))

--- a/http/examples/proxy/src/main.rs
+++ b/http/examples/proxy/src/main.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt::init();
 
     let client = Client::builder()
-        .proxy("localhost:3000", true)
+        .proxy("localhost:3000".to_owned(), true)
         .ratelimiter(None)
         .build();
     let channel_id = ChannelId(620_980_184_606_048_278);
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     future::join_all((1u8..=10).map(|x| {
         client
             .create_message(channel_id)
-            .content(format!("Ping #{}", x))
+            .content(&format!("Ping #{}", x))
             .expect("content not a valid length")
             .exec()
     }))

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -90,14 +90,14 @@ impl ClientBuilder {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::builder()
-    ///     .proxy("twilight_http_proxy.internal", true)
+    ///     .proxy("twilight_http_proxy.internal".to_owned(), true)
     ///     .build();
     /// # Ok(()) }
     /// ```
     ///
     /// [twilight's HTTP proxy server]: https://github.com/twilight-rs/http-proxy
-    pub fn proxy(mut self, proxy_url: impl Into<String>, use_http: bool) -> Self {
-        self.proxy.replace(proxy_url.into().into_boxed_str());
+    pub fn proxy(mut self, proxy_url: String, use_http: bool) -> Self {
+        self.proxy.replace(proxy_url.into_boxed_str());
         self.use_http = use_http;
 
         self
@@ -110,8 +110,9 @@ impl ClientBuilder {
     ///
     /// If this method is not called at all then a default ratelimiter will be
     /// created by [`ClientBuilder::build`].
-    pub fn ratelimiter(mut self, ratelimiter: impl Into<Option<Ratelimiter>>) -> Self {
-        self.ratelimiter = ratelimiter.into();
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn ratelimiter(mut self, ratelimiter: Option<Ratelimiter>) -> Self {
+        self.ratelimiter = ratelimiter;
 
         self
     }
@@ -133,9 +134,7 @@ impl ClientBuilder {
     }
 
     /// Set the token to use for HTTP requests.
-    pub fn token(mut self, token: impl Into<String>) -> Self {
-        let mut token = token.into();
-
+    pub fn token(mut self, mut token: String) -> Self {
         let is_bot = token.starts_with("Bot ");
         let is_bearer = token.starts_with("Bearer ");
 

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -14,7 +14,10 @@ use crate::{
             SetGuildCommands, UpdateCommandPermissions, UpdateFollowupMessage, UpdateGlobalCommand,
             UpdateGuildCommand, UpdateOriginalResponse,
         },
-        channel::stage::create_stage_instance::CreateStageInstanceError,
+        channel::{
+            reaction::delete_reaction::TargetUser,
+            stage::create_stage_instance::CreateStageInstanceError,
+        },
         guild::{
             create_guild::CreateGuildError, create_guild_channel::CreateGuildChannelError,
             update_guild_channel_positions::Position,
@@ -127,11 +130,12 @@ impl Debug for State {
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 /// # Ok(()) }
 /// ```
 ///
-/// Use [`ClientBuilder`] to create a client called `client`, with a shorter timeout:
+/// Use [`ClientBuilder`] to create a client called `client`, with a shorter
+/// timeout:
 /// ```rust,no_run
 /// use twilight_http::Client;
 /// use std::time::Duration;
@@ -139,7 +143,7 @@ impl Debug for State {
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::builder()
-///     .token("my token")
+///     .token("my token".to_owned())
 ///     .timeout(Duration::from_secs(5))
 ///     .build();
 /// # Ok(()) }
@@ -157,7 +161,7 @@ pub struct Client {
 impl Client {
     /// Create a new `hyper-rustls` or `hyper-tls` backed client with a token.
     #[cfg_attr(docsrs, doc(cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))))]
-    pub fn new(token: impl Into<String>) -> Self {
+    pub fn new(token: String) -> Self {
         ClientBuilder::default().token(token).build()
     }
 
@@ -226,7 +230,7 @@ impl Client {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("token");
+    /// # let client = Client::new("token".to_owned());
     /// let guild_id = GuildId(101);
     /// let audit_log = client
     /// // not done
@@ -251,7 +255,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let guild_id = GuildId(1);
     ///
@@ -283,7 +287,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let guild_id = GuildId(100);
     /// let user_id = UserId(200);
@@ -310,7 +314,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let guild_id = GuildId(100);
     /// let user_id = UserId(200);
@@ -334,7 +338,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let channel_id = ChannelId(100);
     /// #
@@ -397,7 +401,7 @@ impl Client {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("my token");
+    /// let client = Client::new("my token".to_owned());
     /// let channel_id = ChannelId(123);
     /// let message_id = MessageId(234);
     /// let limit: u64 = 6;
@@ -447,7 +451,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     ///
     /// let channel_id = ChannelId(123);
     /// let allow = Permissions::VIEW_CHANNEL;
@@ -528,7 +532,7 @@ impl Client {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let after = GuildId(300);
     /// let before = GuildId(400);
@@ -545,11 +549,11 @@ impl Client {
     }
 
     /// Changes the user's nickname in a guild.
-    pub fn update_current_user_nick(
-        &self,
+    pub const fn update_current_user_nick<'a>(
+        &'a self,
         guild_id: GuildId,
-        nick: impl Into<String>,
-    ) -> UpdateCurrentUserNick<'_> {
+        nick: &'a str,
+    ) -> UpdateCurrentUserNick<'a> {
         UpdateCurrentUserNick::new(self, guild_id, nick)
     }
 
@@ -565,7 +569,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let guild_id = GuildId(100);
     ///
@@ -588,7 +592,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let guild_id = GuildId(50);
     /// let emoji_id = EmojiId(100);
@@ -607,12 +611,12 @@ impl Client {
     /// discord docs] for more information about image data.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn create_emoji(
-        &self,
+    pub const fn create_emoji<'a>(
+        &'a self,
         guild_id: GuildId,
-        name: impl Into<String>,
-        image: impl Into<String>,
-    ) -> CreateEmoji<'_> {
+        name: &'a str,
+        image: &'a str,
+    ) -> CreateEmoji<'a> {
         CreateEmoji::new(self, guild_id, name, image)
     }
 
@@ -638,7 +642,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let info = client.gateway().exec().await?;
     /// # Ok(()) }
@@ -652,7 +656,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let info = client.gateway().authed().exec().await?.model().await?;
     ///
@@ -680,10 +684,7 @@ impl Client {
     /// length is too short or too long.
     ///
     /// [`CreateGuildErrorType::NameInvalid`]: crate::request::guild::create_guild::CreateGuildErrorType::NameInvalid
-    pub fn create_guild(
-        &self,
-        name: impl Into<String>,
-    ) -> Result<CreateGuild<'_>, CreateGuildError> {
+    pub fn create_guild(&self, name: String) -> Result<CreateGuild<'_>, CreateGuildError> {
         CreateGuild::new(self, name)
     }
 
@@ -730,11 +731,11 @@ impl Client {
     /// [`CreateGuildChannelErrorType::NameInvalid`]: crate::request::guild::create_guild_channel::CreateGuildChannelErrorType::NameInvalid
     /// [`CreateGuildChannelErrorType::RateLimitPerUserInvalid`]: crate::request::guild::create_guild_channel::CreateGuildChannelErrorType::RateLimitPerUserInvalid
     /// [`CreateGuildChannelErrorType::TopicInvalid`]: crate::request::guild::create_guild_channel::CreateGuildChannelErrorType::TopicInvalid
-    pub fn create_guild_channel(
-        &self,
+    pub fn create_guild_channel<'a>(
+        &'a self,
         guild_id: GuildId,
-        name: impl Into<String>,
-    ) -> Result<CreateGuildChannel<'_>, CreateGuildChannelError> {
+        name: &'a str,
+    ) -> Result<CreateGuildChannel<'a>, CreateGuildChannelError> {
         CreateGuildChannel::new(self, guild_id, name)
     }
 
@@ -744,11 +745,11 @@ impl Client {
     ///
     /// This function accepts an `Iterator` of `(ChannelId, u64)`. It also
     /// accepts an `Iterator` of `Position`, which has extra fields.
-    pub fn update_guild_channel_positions(
-        &self,
+    pub const fn update_guild_channel_positions<'a>(
+        &'a self,
         guild_id: GuildId,
-        channel_positions: impl Iterator<Item = impl Into<Position>>,
-    ) -> UpdateGuildChannelPositions<'_> {
+        channel_positions: &'a [Position],
+    ) -> UpdateGuildChannelPositions<'a> {
         UpdateGuildChannelPositions::new(self, guild_id, channel_positions)
     }
 
@@ -804,7 +805,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let guild_id = GuildId(100);
     /// let user_id = UserId(3000);
@@ -836,10 +837,10 @@ impl Client {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("my token");
+    /// let client = Client::new("my token".to_owned());
     ///
     /// let guild_id = GuildId(100);
-    /// let members = client.search_guild_members(guild_id, String::from("Wumpus"))
+    /// let members = client.search_guild_members(guild_id, "Wumpus")
     ///     .limit(10)?
     ///     .exec()
     ///     .await?;
@@ -852,12 +853,12 @@ impl Client {
     /// the limit is invalid.
     ///
     /// [`GUILD_MEMBERS`]: ../../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_MEMBERS
-    /// [`SearchGuildMembersErrorType::LimitInvalid`]: ../request/guild/member/search_guild_members/enum.SearchGuildMembersError.html#variant.LimitInvalid
-    pub fn search_guild_members(
-        &self,
+    /// [`SearchGuildMembersErrorType::LimitInvalid`]: ../request/guild/member/search_guild_members/enum.SearchGuildMembersErrorType.html#variant.LimitInvalid
+    pub const fn search_guild_members<'a>(
+        &'a self,
         guild_id: GuildId,
-        query: impl Into<String>,
-    ) -> SearchGuildMembers<'_> {
+        query: &'a str,
+    ) -> SearchGuildMembers<'a> {
         SearchGuildMembers::new(self, guild_id, query)
     }
 
@@ -880,12 +881,12 @@ impl Client {
     /// [`AddGuildMemberErrorType::NickNameInvalid`]: crate::request::guild::member::add_guild_member::AddGuildMemberErrorType::NicknameInvalid
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#add-guild-member
-    pub fn add_guild_member(
-        &self,
+    pub const fn add_guild_member<'a>(
+        &'a self,
         guild_id: GuildId,
         user_id: UserId,
-        access_token: impl Into<String>,
-    ) -> AddGuildMember<'_> {
+        access_token: &'a str,
+    ) -> AddGuildMember<'a> {
         AddGuildMember::new(self, guild_id, user_id, access_token)
     }
 
@@ -915,7 +916,7 @@ impl Client {
     /// let client = Client::new(env::var("DISCORD_TOKEN")?);
     /// let member = client.update_guild_member(GuildId(1), UserId(2))
     ///     .mute(true)
-    ///     .nick(Some("pinkie pie".to_owned()))?
+    ///     .nick(Some("pinkie pie"))?
     ///     .exec()
     ///     .await?
     ///     .model()
@@ -949,7 +950,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let guild_id = GuildId(1);
     /// let role_id = RoleId(2);
@@ -961,7 +962,7 @@ impl Client {
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn add_guild_member_role(
+    pub const fn add_guild_member_role(
         &self,
         guild_id: GuildId,
         user_id: UserId,
@@ -971,7 +972,7 @@ impl Client {
     }
 
     /// Remove a role from a member in a guild, by id.
-    pub fn remove_guild_member_role(
+    pub const fn remove_guild_member_role(
         &self,
         guild_id: GuildId,
         user_id: UserId,
@@ -1045,7 +1046,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let invite = client
     ///     .invite("code")
@@ -1057,7 +1058,7 @@ impl Client {
     ///
     /// [`with_counts`]: crate::request::channel::invite::GetInvite::with_counts
     /// [`with_expiration`]: crate::request::channel::invite::GetInvite::with_expiration
-    pub fn invite(&self, code: impl Into<String>) -> GetInvite<'_> {
+    pub fn invite<'a>(&'a self, code: &'a str) -> GetInvite<'a> {
         GetInvite::new(self, code)
     }
 
@@ -1073,7 +1074,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let channel_id = ChannelId(123);
     /// let invite = client
@@ -1096,7 +1097,7 @@ impl Client {
     ///
     /// [`MANAGE_CHANNELS`]: twilight_model::guild::Permissions::MANAGE_CHANNELS
     /// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
-    pub fn delete_invite(&self, code: impl Into<String>) -> DeleteInvite<'_> {
+    pub const fn delete_invite<'a>(&'a self, code: &'a str) -> DeleteInvite<'a> {
         DeleteInvite::new(self, code)
     }
 
@@ -1115,7 +1116,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let channel_id = ChannelId(123);
     /// let message = client
@@ -1133,12 +1134,12 @@ impl Client {
     /// [`CreateMessageErrorType::ContentInvalid`] if the content is over 2000
     /// UTF-16 characters.
     ///
-    /// The method [`embed`] returns
+    /// The method [`embeds`] returns
     /// [`CreateMessageErrorType::EmbedTooLarge`] if the length of the embed
     /// is over 6000 characters.
     ///
     /// [`content`]: crate::request::channel::message::create_message::CreateMessage::content
-    /// [`embed`]: crate::request::channel::message::create_message::CreateMessage::embed
+    /// [`embeds`]: crate::request::channel::message::create_message::CreateMessage::embeds
     /// [`CreateMessageErrorType::ContentInvalid`]:
     /// crate::request::channel::message::create_message::CreateMessageErrorType::ContentInvalid
     /// [`CreateMessageErrorType::EmbedTooLarge`]:
@@ -1163,11 +1164,11 @@ impl Client {
     /// than two weeks. Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#bulk-delete-messages
-    pub fn delete_messages(
-        &self,
+    pub const fn delete_messages<'a>(
+        &'a self,
         channel_id: ChannelId,
-        message_ids: impl Into<Vec<MessageId>>,
-    ) -> DeleteMessages<'_> {
+        message_ids: &'a [MessageId],
+    ) -> DeleteMessages<'a> {
         DeleteMessages::new(self, channel_id, message_ids)
     }
 
@@ -1187,9 +1188,9 @@ impl Client {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("my token");
+    /// let client = Client::new("my token".to_owned());
     /// client.update_message(ChannelId(1), MessageId(2))
-    ///     .content("test update".to_owned())?
+    ///     .content(Some("test update"))?
     ///     .exec()
     ///     .await?;
     /// # Ok(()) }
@@ -1203,7 +1204,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// client.update_message(ChannelId(1), MessageId(2))
     ///     .content(None)?
     ///     .exec()
@@ -1248,12 +1249,12 @@ impl Client {
     ///
     /// This endpoint is limited to 100 users maximum, so if a message has more than 100 reactions,
     /// requests must be chained until all reactions are retireved.
-    pub fn reactions(
-        &self,
+    pub fn reactions<'a>(
+        &'a self,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: RequestReactionType,
-    ) -> GetReactions<'_> {
+        emoji: &'a RequestReactionType<'a>,
+    ) -> GetReactions<'a> {
         GetReactions::new(self, channel_id, message_id, emoji)
     }
 
@@ -1270,55 +1271,55 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// #
     /// let channel_id = ChannelId(123);
     /// let message_id = MessageId(456);
-    /// let emoji = RequestReactionType::Unicode { name: String::from("🌃") };
+    /// let emoji = RequestReactionType::Unicode { name: "🌃" };
     ///
     /// let reaction = client
-    ///     .create_reaction(channel_id, message_id, emoji)
+    ///     .create_reaction(channel_id, message_id, &emoji)
     ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub const fn create_reaction(
-        &self,
+    pub const fn create_reaction<'a>(
+        &'a self,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: RequestReactionType,
-    ) -> CreateReaction<'_> {
+        emoji: &'a RequestReactionType<'a>,
+    ) -> CreateReaction<'a> {
         CreateReaction::new(self, channel_id, message_id, emoji)
     }
 
     /// Delete the current user's (`@me`) reaction on a message.
-    pub fn delete_current_user_reaction(
-        &self,
+    pub const fn delete_current_user_reaction<'a>(
+        &'a self,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: RequestReactionType,
-    ) -> DeleteReaction<'_> {
-        DeleteReaction::new(self, channel_id, message_id, emoji, "@me")
+        emoji: &'a RequestReactionType<'a>,
+    ) -> DeleteReaction<'a> {
+        DeleteReaction::new(self, channel_id, message_id, emoji, TargetUser::Current)
     }
 
     /// Delete a reaction by a user on a message.
-    pub fn delete_reaction(
-        &self,
+    pub const fn delete_reaction<'a>(
+        &'a self,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: RequestReactionType,
+        emoji: &'a RequestReactionType<'a>,
         user_id: UserId,
-    ) -> DeleteReaction<'_> {
-        DeleteReaction::new(self, channel_id, message_id, emoji, user_id.to_string())
+    ) -> DeleteReaction<'a> {
+        DeleteReaction::new(self, channel_id, message_id, emoji, TargetUser::Id(user_id))
     }
 
     /// Remove all reactions on a message of an emoji.
-    pub const fn delete_all_reaction(
-        &self,
+    pub const fn delete_all_reaction<'a>(
+        &'a self,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: RequestReactionType,
-    ) -> DeleteAllReaction<'_> {
+        emoji: &'a RequestReactionType<'a>,
+    ) -> DeleteAllReaction<'a> {
         DeleteAllReaction::new(self, channel_id, message_id, emoji)
     }
 
@@ -1358,7 +1359,7 @@ impl Client {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// let guild_id = GuildId(234);
     ///
     /// client.create_role(guild_id)
@@ -1385,11 +1386,11 @@ impl Client {
     /// Modify the position of the roles.
     ///
     /// The minimum amount of roles to modify, is a swap between two roles.
-    pub fn update_role_positions(
-        &self,
+    pub const fn update_role_positions<'a>(
+        &'a self,
         guild_id: GuildId,
-        roles: impl Iterator<Item = (RoleId, u64)>,
-    ) -> UpdateRolePositions<'_> {
+        roles: &'a [(RoleId, u64)],
+    ) -> UpdateRolePositions<'a> {
         UpdateRolePositions::new(self, guild_id, roles)
     }
 
@@ -1403,11 +1404,11 @@ impl Client {
     /// topic is not between 1 and 120 characters in length.
     ///
     /// [`InvalidTopic`]: crate::request::channel::stage::create_stage_instance::CreateStageInstanceErrorType::InvalidTopic
-    pub fn create_stage_instance(
-        &self,
+    pub fn create_stage_instance<'a>(
+        &'a self,
         channel_id: ChannelId,
-        topic: impl Into<String>,
-    ) -> Result<CreateStageInstance<'_>, CreateStageInstanceError> {
+        topic: &'a str,
+    ) -> Result<CreateStageInstance<'a>, CreateStageInstanceError> {
         CreateStageInstance::new(self, channel_id, topic)
     }
 
@@ -1440,11 +1441,11 @@ impl Client {
     /// if the name is invalid.
     ///
     /// [`CreateGuildFromTemplateErrorType::NameInvalid`]: crate::request::template::create_guild_from_template::CreateGuildFromTemplateErrorType::NameInvalid
-    pub fn create_guild_from_template(
-        &self,
-        template_code: impl Into<String>,
-        name: impl Into<String>,
-    ) -> Result<CreateGuildFromTemplate<'_>, CreateGuildFromTemplateError> {
+    pub fn create_guild_from_template<'a>(
+        &'a self,
+        template_code: &'a str,
+        name: &'a str,
+    ) -> Result<CreateGuildFromTemplate<'a>, CreateGuildFromTemplateError> {
         CreateGuildFromTemplate::new(self, template_code, name)
     }
 
@@ -1459,25 +1460,25 @@ impl Client {
     /// name is invalid.
     ///
     /// [`CreateTemplateErrorType::NameInvalid`]: crate::request::template::create_template::CreateTemplateErrorType::NameInvalid
-    pub fn create_template(
-        &self,
+    pub fn create_template<'a>(
+        &'a self,
         guild_id: GuildId,
-        name: impl Into<String>,
-    ) -> Result<CreateTemplate<'_>, CreateTemplateError> {
+        name: &'a str,
+    ) -> Result<CreateTemplate<'a>, CreateTemplateError> {
         CreateTemplate::new(self, guild_id, name)
     }
 
     /// Delete a template by ID and code.
-    pub fn delete_template(
-        &self,
+    pub const fn delete_template<'a>(
+        &'a self,
         guild_id: GuildId,
-        template_code: impl Into<String>,
-    ) -> DeleteTemplate<'_> {
+        template_code: &'a str,
+    ) -> DeleteTemplate<'a> {
         DeleteTemplate::new(self, guild_id, template_code)
     }
 
     /// Get a template by its code.
-    pub fn get_template(&self, template_code: impl Into<String>) -> GetTemplate<'_> {
+    pub const fn get_template<'a>(&'a self, template_code: &'a str) -> GetTemplate<'a> {
         GetTemplate::new(self, template_code)
     }
 
@@ -1487,26 +1488,26 @@ impl Client {
     }
 
     /// Sync a template to the current state of the guild, by ID and code.
-    pub fn sync_template(
-        &self,
+    pub const fn sync_template<'a>(
+        &'a self,
         guild_id: GuildId,
-        template_code: impl Into<String>,
-    ) -> SyncTemplate<'_> {
+        template_code: &'a str,
+    ) -> SyncTemplate<'a> {
         SyncTemplate::new(self, guild_id, template_code)
     }
 
     /// Update the template's metadata, by ID and code.
-    pub fn update_template(
-        &self,
+    pub const fn update_template<'a>(
+        &'a self,
         guild_id: GuildId,
-        template_code: impl Into<String>,
-    ) -> UpdateTemplate<'_> {
+        template_code: &'a str,
+    ) -> UpdateTemplate<'a> {
         UpdateTemplate::new(self, guild_id, template_code)
     }
 
     /// Get a user's information by id.
-    pub fn user(&self, user_id: UserId) -> GetUser<'_> {
-        GetUser::new(self, user_id.to_string())
+    pub const fn user(&self, user_id: UserId) -> GetUser<'_> {
+        GetUser::new(self, user_id)
     }
 
     /// Update another user's voice state.
@@ -1544,7 +1545,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// let channel_id = ChannelId(123);
     ///
     /// let webhook = client
@@ -1553,11 +1554,11 @@ impl Client {
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn create_webhook(
-        &self,
+    pub const fn create_webhook<'a>(
+        &'a self,
         channel_id: ChannelId,
-        name: impl Into<String>,
-    ) -> CreateWebhook<'_> {
+        name: &'a str,
+    ) -> CreateWebhook<'a> {
         CreateWebhook::new(self, channel_id, name)
     }
 
@@ -1572,17 +1573,17 @@ impl Client {
     }
 
     /// Update a webhook, with a token, by ID.
-    pub fn update_webhook_with_token(
-        &self,
+    pub fn update_webhook_with_token<'a>(
+        &'a self,
         webhook_id: WebhookId,
-        token: impl Into<String>,
-    ) -> UpdateWebhookWithToken<'_> {
+        token: &'a str,
+    ) -> UpdateWebhookWithToken<'a> {
         UpdateWebhookWithToken::new(self, webhook_id, token)
     }
 
     /// Executes a webhook, sending a message to its channel.
     ///
-    /// You can only specify one of [`content`], [`embeds`], or [`file`].
+    /// You can only specify one of [`content`], [`embeds`], or [`files`].
     ///
     /// # Examples
     ///
@@ -1592,7 +1593,7 @@ impl Client {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("my token");
+    /// # let client = Client::new("my token".to_owned());
     /// let id = WebhookId(432);
     /// #
     /// let webhook = client
@@ -1605,12 +1606,12 @@ impl Client {
     ///
     /// [`content`]: crate::request::channel::webhook::ExecuteWebhook::content
     /// [`embeds`]: crate::request::channel::webhook::ExecuteWebhook::embeds
-    /// [`file`]: crate::request::channel::webhook::ExecuteWebhook::file
-    pub fn execute_webhook(
-        &self,
+    /// [`files`]: crate::request::channel::webhook::ExecuteWebhook::files
+    pub fn execute_webhook<'a>(
+        &'a self,
         webhook_id: WebhookId,
-        token: impl Into<String>,
-    ) -> ExecuteWebhook<'_> {
+        token: &'a str,
+    ) -> ExecuteWebhook<'a> {
         ExecuteWebhook::new(self, webhook_id, token)
     }
 
@@ -1618,12 +1619,12 @@ impl Client {
     ///
     /// [`WebhookId`]: twilight_model::id::WebhookId
     /// [`MessageId`]: twilight_model::id::MessageId
-    pub fn webhook_message(
-        &self,
+    pub const fn webhook_message<'a>(
+        &'a self,
         webhook_id: WebhookId,
-        token: impl Into<String>,
+        token: &'a str,
         message_id: MessageId,
-    ) -> GetWebhookMessage<'_> {
+    ) -> GetWebhookMessage<'a> {
         GetWebhookMessage::new(self, webhook_id, token, message_id)
     }
 
@@ -1637,19 +1638,19 @@ impl Client {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("token");
+    /// # let client = Client::new("token".to_owned());
     /// client.update_webhook_message(WebhookId(1), "token here", MessageId(2))
-    ///     .content(Some("new message content".to_owned()))?
+    ///     .content(Some("new message content"))?
     ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn update_webhook_message(
-        &self,
+    pub fn update_webhook_message<'a>(
+        &'a self,
         webhook_id: WebhookId,
-        token: impl Into<String>,
+        token: &'a str,
         message_id: MessageId,
-    ) -> UpdateWebhookMessage<'_> {
+    ) -> UpdateWebhookMessage<'a> {
         UpdateWebhookMessage::new(self, webhook_id, token, message_id)
     }
 
@@ -1663,29 +1664,29 @@ impl Client {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = Client::new("token");
+    /// # let client = Client::new("token".to_owned());
     /// client
     ///     .delete_webhook_message(WebhookId(1), "token here", MessageId(2))
     ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn delete_webhook_message(
-        &self,
+    pub const fn delete_webhook_message<'a>(
+        &'a self,
         webhook_id: WebhookId,
-        token: impl Into<String>,
+        token: &'a str,
         message_id: MessageId,
-    ) -> DeleteWebhookMessage<'_> {
+    ) -> DeleteWebhookMessage<'a> {
         DeleteWebhookMessage::new(self, webhook_id, token, message_id)
     }
 
     /// Respond to an interaction, by ID and token.
-    pub fn interaction_callback(
-        &self,
+    pub const fn interaction_callback<'a>(
+        &'a self,
         interaction_id: InteractionId,
-        interaction_token: impl Into<String>,
+        interaction_token: &'a str,
         response: InteractionResponse,
-    ) -> InteractionCallback<'_> {
+    ) -> InteractionCallback<'a> {
         InteractionCallback::new(self, interaction_id, interaction_token, response)
     }
 
@@ -1696,10 +1697,10 @@ impl Client {
     /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
     /// error type if an application ID has not been configured via
     /// [`Client::set_application_id`].
-    pub fn update_interaction_original(
-        &self,
-        interaction_token: impl Into<String>,
-    ) -> Result<UpdateOriginalResponse<'_>, InteractionError> {
+    pub fn update_interaction_original<'a>(
+        &'a self,
+        interaction_token: &'a str,
+    ) -> Result<UpdateOriginalResponse<'a>, InteractionError> {
         let application_id = self.application_id().ok_or(InteractionError {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;
@@ -1718,10 +1719,10 @@ impl Client {
     /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
     /// error type if an application ID has not been configured via
     /// [`Client::set_application_id`].
-    pub fn delete_interaction_original(
-        &self,
-        interaction_token: impl Into<String>,
-    ) -> Result<DeleteOriginalResponse<'_>, InteractionError> {
+    pub fn delete_interaction_original<'a>(
+        &'a self,
+        interaction_token: &'a str,
+    ) -> Result<DeleteOriginalResponse<'a>, InteractionError> {
         let application_id = self.application_id().ok_or(InteractionError {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;
@@ -1740,10 +1741,10 @@ impl Client {
     /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
     /// error type if an application ID has not been configured via
     /// [`Client::set_application_id`].
-    pub fn create_followup_message(
-        &self,
-        interaction_token: impl Into<String>,
-    ) -> Result<CreateFollowupMessage<'_>, InteractionError> {
+    pub fn create_followup_message<'a>(
+        &'a self,
+        interaction_token: &'a str,
+    ) -> Result<CreateFollowupMessage<'a>, InteractionError> {
         let application_id = self.application_id().ok_or(InteractionError {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;
@@ -1762,11 +1763,11 @@ impl Client {
     /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
     /// error type if an application ID has not been configured via
     /// [`Client::set_application_id`].
-    pub fn update_followup_message(
-        &self,
-        interaction_token: impl Into<String>,
+    pub fn update_followup_message<'a>(
+        &'a self,
+        interaction_token: &'a str,
         message_id: MessageId,
-    ) -> Result<UpdateFollowupMessage<'_>, InteractionError> {
+    ) -> Result<UpdateFollowupMessage<'a>, InteractionError> {
         let application_id = self.application_id().ok_or(InteractionError {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;
@@ -1786,11 +1787,11 @@ impl Client {
     /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
     /// error type if an application ID has not been configured via
     /// [`Client::set_application_id`].
-    pub fn delete_followup_message(
-        &self,
-        interaction_token: impl Into<String>,
+    pub fn delete_followup_message<'a>(
+        &'a self,
+        interaction_token: &'a str,
         message_id: MessageId,
-    ) -> Result<DeleteFollowupMessage<'_>, InteractionError> {
+    ) -> Result<DeleteFollowupMessage<'a>, InteractionError> {
         let application_id = self.application_id().ok_or(InteractionError {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;
@@ -1828,8 +1829,8 @@ impl Client {
     pub fn create_guild_command(
         &self,
         guild_id: GuildId,
-        name: impl Into<String>,
-        description: impl Into<String>,
+        name: String,
+        description: String,
     ) -> Result<CreateGuildCommand<'_>, InteractionError> {
         let application_id = self.application_id().ok_or(InteractionError {
             kind: InteractionErrorType::ApplicationIdNotPresent,
@@ -1919,11 +1920,11 @@ impl Client {
     /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
     /// error type if an application ID has not been configured via
     /// [`Client::set_application_id`].
-    pub fn set_guild_commands(
-        &self,
+    pub fn set_guild_commands<'a>(
+        &'a self,
         guild_id: GuildId,
-        commands: Vec<Command>,
-    ) -> Result<SetGuildCommands<'_>, InteractionError> {
+        commands: &'a [Command],
+    ) -> Result<SetGuildCommands<'a>, InteractionError> {
         let application_id = self.application_id().ok_or(InteractionError {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;
@@ -2035,10 +2036,10 @@ impl Client {
     /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
     /// error type if an application ID has not been configured via
     /// [`Client::set_application_id`].
-    pub fn set_global_commands(
-        &self,
-        commands: Vec<Command>,
-    ) -> Result<SetGlobalCommands<'_>, InteractionError> {
+    pub fn set_global_commands<'a>(
+        &'a self,
+        commands: &'a [Command],
+    ) -> Result<SetGlobalCommands<'a>, InteractionError> {
         let application_id = self.application_id().ok_or(InteractionError {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;
@@ -2147,7 +2148,7 @@ impl Client {
     /// token has become invalid due to expiration, revokation, etc.
     ///
     /// [`Response`]: super::response::Response
-    pub fn request<T>(&self, request: Request) -> ResponseFuture<T> {
+    pub fn request<T>(&self, request: Request<'_>) -> ResponseFuture<T> {
         match self.try_request::<T>(request) {
             Ok(future) => future,
             Err(source) => ResponseFuture::error(source),
@@ -2155,7 +2156,7 @@ impl Client {
     }
 
     #[allow(clippy::too_many_lines)]
-    fn try_request<T>(&self, request: Request) -> Result<ResponseFuture<T>, Error> {
+    fn try_request<T>(&self, request: Request<'_>) -> Result<ResponseFuture<T>, Error> {
         if self.state.token_invalid.load(Ordering::Relaxed) {
             return Err(Error {
                 kind: ErrorType::Unauthorized,
@@ -2167,21 +2168,25 @@ impl Client {
             body,
             form,
             headers: req_headers,
-            method,
-            path: bucket,
-            path_str: path,
+            route,
             use_authorization_token,
         } = request;
 
         let protocol = if self.state.use_http { "http" } else { "https" };
         let host = self.state.proxy.as_deref().unwrap_or("discord.com");
 
-        let url = format!("{}://{}/api/v{}/{}", protocol, host, API_VERSION, path);
+        let url = format!(
+            "{}://{}/api/v{}/{}",
+            protocol,
+            host,
+            API_VERSION,
+            route.display()
+        );
         #[cfg(feature = "tracing")]
         tracing::debug!("URL: {:?}", url);
 
         let mut builder = hyper::Request::builder()
-            .method(method.into_hyper())
+            .method(route.method().into_hyper())
             .uri(&url);
 
         if use_authorization_token {
@@ -2217,7 +2222,7 @@ impl Client {
                 }
             } else if let Some(bytes) = &body {
                 let len = bytes.len();
-                headers.insert(CONTENT_LENGTH, len.into());
+                headers.insert(CONTENT_LENGTH, HeaderValue::from(len));
 
                 let content_type = HeaderValue::from_static("application/json");
                 headers.insert(CONTENT_TYPE, content_type);
@@ -2240,10 +2245,12 @@ impl Client {
             }
         }
 
+        let method = route.method();
+
         let req = if let Some(form) = form {
             let form_bytes = form.build();
             if let Some(headers) = builder.headers_mut() {
-                headers.insert(CONTENT_LENGTH, form_bytes.len().into());
+                headers.insert(CONTENT_LENGTH, HeaderValue::from(form_bytes.len()));
             };
             builder
                 .body(Body::from(form_bytes))
@@ -2258,7 +2265,7 @@ impl Client {
             })?
         } else if method == Method::Put || method == Method::Post || method == Method::Patch {
             if let Some(headers) = builder.headers_mut() {
-                headers.insert(CONTENT_LENGTH, 0.into());
+                headers.insert(CONTENT_LENGTH, HeaderValue::from(0));
             }
 
             builder.body(Body::empty()).map_err(|source| Error {
@@ -2279,7 +2286,7 @@ impl Client {
         // due to move semantics in both cases.
         #[allow(clippy::option_if_let_else)]
         if let Some(ratelimiter) = self.state.ratelimiter.as_ref() {
-            let rx = ratelimiter.ticket(bucket);
+            let rx = ratelimiter.ticket(route.path());
 
             Ok(ResponseFuture::ratelimit(
                 None,

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -852,8 +852,8 @@ impl Client {
     /// Returns a [`SearchGuildMembersErrorType::LimitInvalid`] error type if
     /// the limit is invalid.
     ///
-    /// [`GUILD_MEMBERS`]: ../../twilight_model/gateway/struct.Intents.html#associatedconstant.GUILD_MEMBERS
-    /// [`SearchGuildMembersErrorType::LimitInvalid`]: ../request/guild/member/search_guild_members/enum.SearchGuildMembersErrorType.html#variant.LimitInvalid
+    /// [`GUILD_MEMBERS`]: twilight_model::gateway::Intents::GUILD_MEMBERS
+    /// [`SearchGuildMembersErrorType::LimitInvalid`]: crate::request::guild::member::search_guild_members::SearchGuildMembersErrorType::LimitInvalid
     pub const fn search_guild_members<'a>(
         &'a self,
         guild_id: GuildId,
@@ -1685,7 +1685,7 @@ impl Client {
         &'a self,
         interaction_id: InteractionId,
         interaction_token: &'a str,
-        response: InteractionResponse,
+        response: &'a InteractionResponse,
     ) -> InteractionCallback<'a> {
         InteractionCallback::new(self, interaction_id, interaction_token, response)
     }
@@ -1826,12 +1826,12 @@ impl Client {
     /// 100 characters.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command
-    pub fn create_guild_command(
-        &self,
+    pub fn create_guild_command<'a>(
+        &'a self,
         guild_id: GuildId,
-        name: String,
-        description: String,
-    ) -> Result<CreateGuildCommand<'_>, InteractionError> {
+        name: &'a str,
+        description: &'a str,
+    ) -> Result<CreateGuildCommand<'a>, InteractionError> {
         let application_id = self.application_id().ok_or(InteractionError {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;
@@ -1958,11 +1958,11 @@ impl Client {
     /// 100 characters.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
-    pub fn create_global_command(
-        &self,
-        name: impl Into<String>,
-        description: impl Into<String>,
-    ) -> Result<CreateGlobalCommand<'_>, InteractionError> {
+    pub fn create_global_command<'a>(
+        &'a self,
+        name: &'a str,
+        description: &'a str,
+    ) -> Result<CreateGlobalCommand<'a>, InteractionError> {
         let application_id = self.application_id().ok_or(InteractionError {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;
@@ -2105,12 +2105,12 @@ impl Client {
     /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
     /// error type if an application ID has not been configured via
     /// [`Client::set_application_id`].
-    pub fn update_command_permissions(
-        &self,
+    pub fn update_command_permissions<'a>(
+        &'a self,
         guild_id: GuildId,
         command_id: CommandId,
-        permissions: Vec<CommandPermissions>,
-    ) -> Result<UpdateCommandPermissions<'_>, InteractionError> {
+        permissions: &'a [CommandPermissions],
+    ) -> Result<UpdateCommandPermissions<'a>, InteractionError> {
         let application_id = self.application_id().ok_or(InteractionError {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;
@@ -2128,11 +2128,15 @@ impl Client {
     /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
     /// error type if an application ID has not been configured via
     /// [`Client::set_application_id`].
-    pub fn set_command_permissions(
-        &self,
+    ///
+    /// Returns an [`InteractionErrorType::TooManyCommands`] error type if too
+    /// many commands have been provided. The maximum amount is defined by
+    /// [`InteractionError::GUILD_COMMAND_LIMIT`].
+    pub fn set_command_permissions<'a>(
+        &'a self,
         guild_id: GuildId,
-        permissions: impl Iterator<Item = (CommandId, CommandPermissions)>,
-    ) -> Result<SetCommandPermissions<'_>, InteractionError> {
+        permissions: &'a [(CommandId, CommandPermissions)],
+    ) -> Result<SetCommandPermissions<'a>, InteractionError> {
         let application_id = self.application_id().ok_or(InteractionError {
             kind: InteractionErrorType::ApplicationIdNotPresent,
         })?;

--- a/http/src/request/application/create_followup_message.rs
+++ b/http/src/request/application/create_followup_message.rs
@@ -16,22 +16,22 @@ use twilight_model::{
 };
 
 #[derive(Default, Serialize)]
-pub(crate) struct CreateFollowupMessageFields {
+pub(crate) struct CreateFollowupMessageFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar_url: Option<String>,
+    avatar_url: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<String>,
+    content: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    embeds: Option<Vec<Embed>>,
+    embeds: Option<&'a [Embed]>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payload_json: Option<Vec<u8>>,
+    payload_json: Option<&'a [u8]>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tts: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    username: Option<String>,
+    username: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
-    allowed_mentions: Option<AllowedMentions>,
+    allowed_mentions: Option<&'a AllowedMentions>,
 }
 
 /// Create a followup message to an interaction.
@@ -59,40 +59,36 @@ pub(crate) struct CreateFollowupMessageFields {
 ///
 /// [`content`]: Self::content
 /// [`embeds`]: Self::embeds
-/// [`file`]: Self::file
+/// [`files`]: Self::files
 pub struct CreateFollowupMessage<'a> {
-    pub(crate) fields: CreateFollowupMessageFields,
-    files: Vec<(String, Vec<u8>)>,
+    pub(crate) fields: CreateFollowupMessageFields<'a>,
+    files: &'a [(&'a str, &'a [u8])],
     http: &'a Client,
-    token: String,
+    token: &'a str,
     application_id: ApplicationId,
 }
 
 impl<'a> CreateFollowupMessage<'a> {
-    pub(crate) fn new(
-        http: &'a Client,
-        application_id: ApplicationId,
-        token: impl Into<String>,
-    ) -> Self {
+    pub(crate) fn new(http: &'a Client, application_id: ApplicationId, token: &'a str) -> Self {
         Self {
             fields: CreateFollowupMessageFields::default(),
-            files: Vec::new(),
+            files: &[],
             http,
-            token: token.into(),
+            token,
             application_id,
         }
     }
 
     /// Specify the [`AllowedMentions`] for the webhook message.
-    pub fn allowed_mentions(mut self, allowed_mentions: AllowedMentions) -> Self {
+    pub fn allowed_mentions(mut self, allowed_mentions: &'a AllowedMentions) -> Self {
         self.fields.allowed_mentions.replace(allowed_mentions);
 
         self
     }
 
     /// The URL of the avatar of the webhook.
-    pub fn avatar_url(mut self, avatar_url: impl Into<String>) -> Self {
-        self.fields.avatar_url.replace(avatar_url.into());
+    pub fn avatar_url(mut self, avatar_url: &'a str) -> Self {
+        self.fields.avatar_url.replace(avatar_url);
 
         self
     }
@@ -100,14 +96,14 @@ impl<'a> CreateFollowupMessage<'a> {
     /// The content of the webook's message.
     ///
     /// Up to 2000 UTF-16 codepoints.
-    pub fn content(mut self, content: impl Into<String>) -> Self {
-        self.fields.content.replace(content.into());
+    pub fn content(mut self, content: &'a str) -> Self {
+        self.fields.content.replace(content);
 
         self
     }
 
     /// Set the list of embeds of the webhook's message.
-    pub fn embeds(mut self, embeds: Vec<Embed>) -> Self {
+    pub fn embeds(mut self, embeds: &'a [Embed]) -> Self {
         self.fields.embeds.replace(embeds);
 
         self
@@ -124,23 +120,9 @@ impl<'a> CreateFollowupMessage<'a> {
         self
     }
 
-    /// Attach a file to the webhook.
-    ///
-    /// This method is repeatable.
-    pub fn file(mut self, name: impl Into<String>, file: impl Into<Vec<u8>>) -> Self {
-        self.files.push((name.into(), file.into()));
-
-        self
-    }
-
     /// Attach multiple files to the webhook.
-    pub fn files<N: Into<String>, F: Into<Vec<u8>>>(
-        mut self,
-        attachments: impl IntoIterator<Item = (N, F)>,
-    ) -> Self {
-        for (name, file) in attachments {
-            self = self.file(name, file);
-        }
+    pub const fn files(mut self, files: &'a [(&'a str, &'a [u8])]) -> Self {
+        self.files = files;
 
         self
     }
@@ -167,7 +149,7 @@ impl<'a> CreateFollowupMessage<'a> {
     ///
     /// let message = client.create_followup_message("token here")?
     ///     .content("some content")
-    ///     .embeds(vec![EmbedBuilder::new().title("title").build()?])
+    ///     .embeds(&[EmbedBuilder::new().title("title").build()?])
     ///     .exec()
     ///     .await?
     ///     .model()
@@ -191,7 +173,7 @@ impl<'a> CreateFollowupMessage<'a> {
     ///
     /// let message = client.create_followup_message("token here")?
     ///     .content("some content")
-    ///     .payload_json(r#"{ "content": "other content", "embeds": [ { "title": "title" } ] }"#)
+    ///     .payload_json(br#"{ "content": "other content", "embeds": [ { "title": "title" } ] }"#)
     ///     .exec()
     ///     .await?
     ///     .model()
@@ -203,8 +185,8 @@ impl<'a> CreateFollowupMessage<'a> {
     ///
     /// [`payload_json`]: Self::payload_json
     /// [Discord Docs/Create Message]: https://discord.com/developers/docs/resources/channel#create-message-params
-    pub fn payload_json(mut self, payload_json: impl Into<Vec<u8>>) -> Self {
-        self.fields.payload_json.replace(payload_json.into());
+    pub fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
+        self.fields.payload_json.replace(payload_json);
 
         self
     }
@@ -217,15 +199,15 @@ impl<'a> CreateFollowupMessage<'a> {
     }
 
     /// Specify the username of the webhook's message.
-    pub fn username(mut self, username: impl Into<String>) -> Self {
-        self.fields.username.replace(username.into());
+    pub fn username(mut self, username: &'a str) -> Self {
+        self.fields.username.replace(username);
 
         self
     }
 
     // `self` needs to be consumed and the client returned due to parameters
     // being consumed in request construction.
-    fn request(mut self) -> Result<(Request, &'a Client), Error> {
+    fn request(&self) -> Result<Request<'a>, Error> {
         let mut request = Request::builder(Route::ExecuteWebhook {
             token: self.token,
             wait: None,
@@ -235,8 +217,8 @@ impl<'a> CreateFollowupMessage<'a> {
         if !self.files.is_empty() || self.fields.payload_json.is_some() {
             let mut form = Form::new();
 
-            for (index, (name, file)) in self.files.drain(..).enumerate() {
-                form.file(format!("{}", index).as_bytes(), name.as_bytes(), &file);
+            for (index, (name, file)) in self.files.iter().enumerate() {
+                form.file(index.to_be_bytes().as_ref(), name.as_bytes(), file);
             }
 
             if let Some(payload_json) = &self.fields.payload_json {
@@ -251,7 +233,7 @@ impl<'a> CreateFollowupMessage<'a> {
             request = request.json(&self.fields)?;
         }
 
-        Ok((request.build(), self.http))
+        Ok(request.build())
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
@@ -259,7 +241,7 @@ impl<'a> CreateFollowupMessage<'a> {
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Message> {
         match self.request() {
-            Ok((request, client)) => client.request(request),
+            Ok(request) => self.http.request(request),
             Err(source) => ResponseFuture::error(source),
         }
     }

--- a/http/src/request/application/create_followup_message.rs
+++ b/http/src/request/application/create_followup_message.rs
@@ -36,7 +36,7 @@ pub(crate) struct CreateFollowupMessageFields<'a> {
 
 /// Create a followup message to an interaction.
 ///
-/// You must specify at least one of [`content`], [`embeds`], or [`file`].
+/// You must specify at least one of [`content`], [`embeds`], or [`files`].
 ///
 /// # Examples
 ///

--- a/http/src/request/application/create_global_command.rs
+++ b/http/src/request/application/create_global_command.rs
@@ -96,7 +96,7 @@ impl<'a> CreateGlobalCommand<'a> {
         self
     }
 
-    fn request(&self) -> Result<Request, HttpError> {
+    fn request(&self) -> Result<Request<'a>, HttpError> {
         Request::builder(Route::CreateGlobalCommand {
             application_id: self.application_id.0,
         })

--- a/http/src/request/application/create_guild_command.rs
+++ b/http/src/request/application/create_guild_command.rs
@@ -34,12 +34,9 @@ impl<'a> CreateGuildCommand<'a> {
         http: &'a Client,
         application_id: ApplicationId,
         guild_id: GuildId,
-        name: impl Into<String>,
-        description: impl Into<String>,
+        name: String,
+        description: String,
     ) -> Result<Self, InteractionError> {
-        let name = name.into();
-        let description = description.into();
-
         if !validate::command_name(&name) {
             return Err(InteractionError {
                 kind: InteractionErrorType::CommandNameValidationFailed { name },
@@ -60,7 +57,7 @@ impl<'a> CreateGuildCommand<'a> {
                 default_permission: None,
                 description,
                 id: None,
-                options: vec![],
+                options: Vec::new(),
             },
             application_id,
             guild_id,
@@ -101,7 +98,7 @@ impl<'a> CreateGuildCommand<'a> {
         Ok(self)
     }
 
-    fn request(&self) -> Result<Request, HttpError> {
+    fn request(&self) -> Result<Request<'a>, HttpError> {
         Request::builder(Route::CreateGuildCommand {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,

--- a/http/src/request/application/create_guild_command.rs
+++ b/http/src/request/application/create_guild_command.rs
@@ -1,15 +1,13 @@
+use super::{CommandBorrowed, InteractionError, InteractionErrorType};
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{
-        application::{InteractionError, InteractionErrorType},
-        validate, Request, RequestBuilder,
-    },
+    request::{validate, Request, RequestBuilder},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::{
-    application::command::{Command, CommandOption},
+    application::command::CommandOption,
     id::{ApplicationId, GuildId},
 };
 
@@ -23,10 +21,12 @@ use twilight_model::{
 /// [the discord docs]: https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command
 pub struct CreateGuildCommand<'a> {
     application_id: ApplicationId,
-    command: Command,
+    default_permission: Option<bool>,
+    description: &'a str,
     guild_id: GuildId,
     http: &'a Client,
-    optional_option_added: bool,
+    name: &'a str,
+    options: Option<&'a [CommandOption]>,
 }
 
 impl<'a> CreateGuildCommand<'a> {
@@ -34,66 +34,68 @@ impl<'a> CreateGuildCommand<'a> {
         http: &'a Client,
         application_id: ApplicationId,
         guild_id: GuildId,
-        name: String,
-        description: String,
+        name: &'a str,
+        description: &'a str,
     ) -> Result<Self, InteractionError> {
-        if !validate::command_name(&name) {
+        if !validate::command_name(name) {
             return Err(InteractionError {
-                kind: InteractionErrorType::CommandNameValidationFailed { name },
+                kind: InteractionErrorType::CommandNameValidationFailed,
             });
         }
 
-        if !validate::command_description(&description) {
+        if !validate::command_description(description) {
             return Err(InteractionError {
-                kind: InteractionErrorType::CommandDescriptionValidationFailed { description },
+                kind: InteractionErrorType::CommandDescriptionValidationFailed,
             });
         }
 
         Ok(Self {
-            command: Command {
-                application_id: Some(application_id),
-                guild_id: None,
-                name,
-                default_permission: None,
-                description,
-                id: None,
-                options: Vec::new(),
-            },
             application_id,
+            default_permission: None,
+            description,
             guild_id,
             http,
-            optional_option_added: false,
+            name,
+            options: None,
         })
     }
 
     /// Whether the command is enabled by default when the app is added to
     /// a guild.
     pub fn default_permission(mut self, default: bool) -> Self {
-        self.command.default_permission.replace(default);
+        self.default_permission.replace(default);
 
         self
     }
 
-    /// Add a command option.
+    /// Add a list of command options.
     ///
     /// Required command options must be added before optional options.
     ///
     /// Errors
     ///
     /// Retuns an [`InteractionErrorType::CommandOptionsRequiredFirst`]
-    /// if a required option was added after an optional option.
-    pub fn add_command_option(mut self, option: CommandOption) -> Result<Self, InteractionError> {
-        if !self.optional_option_added && !option.is_required() {
-            self.optional_option_added = true
+    /// if a required option was added after an optional option. The problem
+    /// option's index is provided.
+    pub fn command_options(
+        mut self,
+        options: &'a [CommandOption],
+    ) -> Result<Self, InteractionError> {
+        let mut optional_option_added = false;
+
+        for (idx, option) in options.iter().enumerate() {
+            if !optional_option_added && !option.is_required() {
+                optional_option_added = true;
+            }
+
+            if option.is_required() && optional_option_added {
+                return Err(InteractionError {
+                    kind: InteractionErrorType::CommandOptionsRequiredFirst { index: idx },
+                });
+            }
         }
 
-        if option.is_required() && self.optional_option_added {
-            return Err(InteractionError {
-                kind: InteractionErrorType::CommandOptionsRequiredFirst { option },
-            });
-        }
-
-        self.command.options.push(option);
+        self.options = Some(options);
 
         Ok(self)
     }
@@ -103,7 +105,13 @@ impl<'a> CreateGuildCommand<'a> {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,
         })
-        .json(&self.command)
+        .json(&CommandBorrowed {
+            application_id: Some(self.application_id),
+            default_permission: self.default_permission,
+            description: self.description,
+            name: self.name,
+            options: self.options,
+        })
         .map(RequestBuilder::build)
     }
 

--- a/http/src/request/application/delete_followup_message.rs
+++ b/http/src/request/application/delete_followup_message.rs
@@ -26,26 +26,26 @@ use twilight_model::id::{ApplicationId, MessageId};
 pub struct DeleteFollowupMessage<'a> {
     http: &'a Client,
     message_id: MessageId,
-    token: String,
+    token: &'a str,
     application_id: ApplicationId,
 }
 
 impl<'a> DeleteFollowupMessage<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         application_id: ApplicationId,
-        token: impl Into<String>,
+        token: &'a str,
         message_id: MessageId,
     ) -> Self {
         Self {
             http,
             message_id,
-            token: token.into(),
+            token,
             application_id,
         }
     }
 
-    fn request(self) -> Request {
+    const fn request(self) -> Request<'a> {
         Request::from_route(Route::DeleteWebhookMessage {
             message_id: self.message_id.0,
             token: self.token,
@@ -69,18 +69,17 @@ mod tests {
 
     #[test]
     fn test_request() {
-        let client = Client::new("token");
+        let client = Client::new("token".to_owned());
 
         let builder = DeleteFollowupMessage::new(&client, ApplicationId(1), "token", MessageId(2));
         let actual = builder.request();
 
         let expected = Request::from_route(Route::DeleteWebhookMessage {
             message_id: 2,
-            token: "token".to_owned(),
+            token: "token",
             webhook_id: 1,
         });
 
-        assert_eq!(expected.body, actual.body);
-        assert_eq!(expected.path, actual.path);
+        assert_eq!(expected.route, actual.route);
     }
 }

--- a/http/src/request/application/delete_original_response.rs
+++ b/http/src/request/application/delete_original_response.rs
@@ -30,19 +30,19 @@ use twilight_model::id::ApplicationId;
 pub struct DeleteOriginalResponse<'a> {
     application_id: ApplicationId,
     http: &'a Client,
-    token: String,
+    token: &'a str,
 }
 
 impl<'a> DeleteOriginalResponse<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         application_id: ApplicationId,
-        token: impl Into<String>,
+        token: &'a str,
     ) -> Self {
         Self {
             application_id,
             http,
-            token: token.into(),
+            token,
         }
     }
 

--- a/http/src/request/application/interaction_callback.rs
+++ b/http/src/request/application/interaction_callback.rs
@@ -11,7 +11,7 @@ use twilight_model::{application::callback::InteractionResponse, id::Interaction
 pub struct InteractionCallback<'a> {
     interaction_id: InteractionId,
     interaction_token: &'a str,
-    response: InteractionResponse,
+    response: &'a InteractionResponse,
     http: &'a Client,
 }
 
@@ -20,7 +20,7 @@ impl<'a> InteractionCallback<'a> {
         http: &'a Client,
         interaction_id: InteractionId,
         interaction_token: &'a str,
-        response: InteractionResponse,
+        response: &'a InteractionResponse,
     ) -> Self {
         Self {
             interaction_id,
@@ -37,7 +37,7 @@ impl<'a> InteractionCallback<'a> {
             interaction_id: self.interaction_id.0,
             interaction_token: self.interaction_token,
         })
-        .json(&self.response)?
+        .json(self.response)?
         .build();
 
         Ok(request)

--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -73,7 +73,7 @@ impl<'a> SetCommandPermissions<'a> {
         })
     }
 
-    fn request(&self) -> Result<Request, Error> {
+    fn request(&self) -> Result<Request<'a>, Error> {
         Request::builder(Route::SetCommandPermissions {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,
@@ -115,7 +115,7 @@ mod tests {
 
     #[test]
     fn test_correct_validation() {
-        let http = Client::new("token");
+        let http = Client::new("token".to_owned());
 
         let permissions = make_iter().take(4);
 
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn test_incorrect_validation() {
-        let http = Client::new("token");
+        let http = Client::new("token".to_owned());
 
         let permissions = make_iter().take(11);
 

--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -8,28 +8,42 @@ use crate::{
     response::ResponseFuture,
     routing::Route,
 };
-use serde::Serialize;
-use std::collections::HashMap;
+use serde::{Serialize, Serializer};
 use twilight_model::{
     application::command::permissions::CommandPermissions,
     id::{ApplicationId, CommandId, GuildId},
 };
 
 #[derive(Serialize)]
-struct PartialGuildCommandPermissions {
-    id: CommandId,
-    permissions: CommandPermissions,
+struct GuildCommandPermission<'a> {
+    id: &'a CommandId,
+    permissions: &'a CommandPermissions,
+}
+
+struct PermissionListSerializer<'a> {
+    inner: &'a [(CommandId, CommandPermissions)],
+}
+
+impl Serialize for PermissionListSerializer<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_seq(
+            self.inner
+                .iter()
+                .map(|(id, permissions)| GuildCommandPermission { id, permissions }),
+        )
+    }
 }
 
 /// Update command permissions for all commands in a guild.
 ///
 /// This overwrites the command permissions so the full set of permissions
 /// have to be sent every time.
+#[derive(Debug)]
 pub struct SetCommandPermissions<'a> {
     application_id: ApplicationId,
     guild_id: GuildId,
-    fields: Vec<PartialGuildCommandPermissions>,
     http: &'a Client,
+    permissions: &'a [(CommandId, CommandPermissions)],
 }
 
 impl<'a> SetCommandPermissions<'a> {
@@ -37,39 +51,43 @@ impl<'a> SetCommandPermissions<'a> {
         http: &'a Client,
         application_id: ApplicationId,
         guild_id: GuildId,
-        permissions: impl Iterator<Item = (CommandId, CommandPermissions)>,
+        permissions: &'a [(CommandId, CommandPermissions)],
     ) -> Result<Self, InteractionError> {
-        let fields = permissions
-            .map(
-                |(command_id, command_permissions)| PartialGuildCommandPermissions {
-                    id: command_id,
-                    permissions: command_permissions,
-                },
-            )
-            .collect::<Vec<PartialGuildCommandPermissions>>();
+        let mut sorted_permissions =
+            [(CommandId(u64::MAX), 0); InteractionError::GUILD_COMMAND_LIMIT];
 
-        if !fields
-            .iter()
-            .fold(HashMap::new(), |mut acc, permission| {
-                acc.entry(permission.id)
-                    .and_modify(|p| *p += 1)
-                    .or_insert(1_usize);
+        'outer: for (permission_id, _) in permissions {
+            for (ref mut sorted_id, ref mut count) in &mut sorted_permissions {
+                if *sorted_id == *permission_id {
+                    *count += 1;
 
-                acc
-            })
-            .iter()
-            .all(|permission| validate::command_permissions(*permission.1))
-        {
+                    if !validate::guild_command_permissions(*count) {
+                        return Err(InteractionError {
+                            kind: InteractionErrorType::TooManyCommandPermissions,
+                        });
+                    }
+
+                    continue 'outer;
+                } else if sorted_id.0 == u64::MAX {
+                    *count += 1;
+                    *sorted_id = *permission_id;
+
+                    continue 'outer;
+                }
+            }
+
+            // We've run out of space in the sorted permissions, which means the
+            // user provided too many commands.
             return Err(InteractionError {
-                kind: InteractionErrorType::TooManyCommandPermissions,
+                kind: InteractionErrorType::TooManyCommands,
             });
         }
 
         Ok(Self {
             application_id,
             guild_id,
-            fields,
             http,
+            permissions,
         })
     }
 
@@ -78,7 +96,9 @@ impl<'a> SetCommandPermissions<'a> {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,
         })
-        .json(&self.fields)
+        .json(&PermissionListSerializer {
+            inner: self.permissions,
+        })
         .map(RequestBuilder::build)
     }
 
@@ -95,7 +115,10 @@ impl<'a> SetCommandPermissions<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::SetCommandPermissions;
+    use super::{
+        super::{InteractionError, InteractionErrorType},
+        SetCommandPermissions,
+    };
     use crate::Client;
     use std::iter;
     use twilight_model::{
@@ -103,9 +126,12 @@ mod tests {
         id::{ApplicationId, CommandId, GuildId, RoleId},
     };
 
-    fn make_iter() -> impl Iterator<Item = (CommandId, CommandPermissions)> {
+    const APPLICATION_ID: ApplicationId = ApplicationId(1);
+    const GUILD_ID: GuildId = GuildId(2);
+
+    fn command_permissions(id: CommandId) -> impl Iterator<Item = (CommandId, CommandPermissions)> {
         iter::repeat((
-            CommandId(3),
+            id,
             CommandPermissions {
                 id: CommandPermissionsType::Role(RoleId(4)),
                 permission: true,
@@ -116,10 +142,12 @@ mod tests {
     #[test]
     fn test_correct_validation() {
         let http = Client::new("token".to_owned());
+        let command_permissions = command_permissions(CommandId(1))
+            .take(4)
+            .collect::<Vec<_>>();
 
-        let permissions = make_iter().take(4);
-
-        let request = SetCommandPermissions::new(&http, ApplicationId(1), GuildId(2), permissions);
+        let request =
+            SetCommandPermissions::new(&http, APPLICATION_ID, GUILD_ID, &command_permissions);
 
         assert!(request.is_ok());
     }
@@ -127,11 +155,57 @@ mod tests {
     #[test]
     fn test_incorrect_validation() {
         let http = Client::new("token".to_owned());
+        let command_permissions = command_permissions(CommandId(2))
+            .take(InteractionError::GUILD_COMMAND_PERMISSION_LIMIT + 1)
+            .collect::<Vec<_>>();
 
-        let permissions = make_iter().take(11);
+        let request =
+            SetCommandPermissions::new(&http, APPLICATION_ID, GUILD_ID, &command_permissions);
+        assert!(matches!(
+            request.unwrap_err().kind(),
+            InteractionErrorType::TooManyCommandPermissions
+        ));
+    }
 
-        let request = SetCommandPermissions::new(&http, ApplicationId(1), GuildId(2), permissions);
+    #[test]
+    fn test_limits() {
+        const SIZE: usize = InteractionError::GUILD_COMMAND_LIMIT;
 
-        assert!(request.is_err());
+        let http = Client::new("token".to_owned());
+        let command_permissions = (1..=SIZE)
+            .flat_map(|id| {
+                command_permissions(CommandId(id as u64))
+                    .take(InteractionError::GUILD_COMMAND_PERMISSION_LIMIT)
+            })
+            .collect::<Vec<_>>();
+
+        assert!(
+            SetCommandPermissions::new(&http, APPLICATION_ID, GUILD_ID, &command_permissions)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_command_count_over_limit() {
+        const SIZE: usize = 101;
+
+        let http = Client::new("token".to_owned());
+        let command_permissions = (1..=SIZE)
+            .flat_map(|id| command_permissions(CommandId(id as u64)).take(3))
+            .collect::<Vec<_>>();
+
+        let request =
+            SetCommandPermissions::new(&http, APPLICATION_ID, GUILD_ID, &command_permissions);
+        assert!(matches!(
+            request.unwrap_err().kind(),
+            InteractionErrorType::TooManyCommands
+        ));
+    }
+
+    #[test]
+    fn test_no_permissions() {
+        let http = Client::new("token".to_owned());
+
+        assert!(SetCommandPermissions::new(&http, APPLICATION_ID, GUILD_ID, &[]).is_ok());
     }
 }

--- a/http/src/request/application/set_global_commands.rs
+++ b/http/src/request/application/set_global_commands.rs
@@ -12,16 +12,16 @@ use twilight_model::{application::command::Command, id::ApplicationId};
 /// This method is idempotent: it can be used on every start, without being
 /// ratelimited if there aren't changes to the commands.
 pub struct SetGlobalCommands<'a> {
-    commands: Vec<Command>,
+    commands: &'a [Command],
     application_id: ApplicationId,
     http: &'a Client,
 }
 
 impl<'a> SetGlobalCommands<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         application_id: ApplicationId,
-        commands: Vec<Command>,
+        commands: &'a [Command],
     ) -> Self {
         Self {
             commands,
@@ -30,7 +30,7 @@ impl<'a> SetGlobalCommands<'a> {
         }
     }
 
-    fn request(&self) -> Result<Request, Error> {
+    fn request(&self) -> Result<Request<'a>, Error> {
         Request::builder(Route::SetGlobalCommands {
             application_id: self.application_id.0,
         })

--- a/http/src/request/application/set_guild_commands.rs
+++ b/http/src/request/application/set_guild_commands.rs
@@ -15,18 +15,18 @@ use twilight_model::{
 /// This method is idempotent: it can be used on every start, without being
 /// ratelimited if there aren't changes to the commands.
 pub struct SetGuildCommands<'a> {
-    commands: Vec<Command>,
+    commands: &'a [Command],
     application_id: ApplicationId,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> SetGuildCommands<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         application_id: ApplicationId,
         guild_id: GuildId,
-        commands: Vec<Command>,
+        commands: &'a [Command],
     ) -> Self {
         Self {
             commands,
@@ -36,7 +36,7 @@ impl<'a> SetGuildCommands<'a> {
         }
     }
 
-    fn request(&self) -> Result<Request, Error> {
+    fn request(&self) -> Result<Request<'a>, Error> {
         Request::builder(Route::SetGuildCommands {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,

--- a/http/src/request/application/update_command_permissions.rs
+++ b/http/src/request/application/update_command_permissions.rs
@@ -56,7 +56,7 @@ impl<'a> UpdateCommandPermissions<'a> {
         })
     }
 
-    fn request(&self) -> Result<Request, Error> {
+    fn request(&self) -> Result<Request<'a>, Error> {
         Request::builder(Route::UpdateCommandPermissions {
             application_id: self.application_id.0,
             command_id: self.command_id.0,

--- a/http/src/request/application/update_command_permissions.rs
+++ b/http/src/request/application/update_command_permissions.rs
@@ -15,8 +15,8 @@ use twilight_model::{
 };
 
 #[derive(Serialize)]
-struct UpdateCommandPermissionsFields {
-    pub permissions: Vec<CommandPermissions>,
+struct UpdateCommandPermissionsFields<'a> {
+    pub permissions: &'a [CommandPermissions],
 }
 
 /// Update command permissions for a single command in a guild.
@@ -29,7 +29,7 @@ pub struct UpdateCommandPermissions<'a> {
     application_id: ApplicationId,
     command_id: CommandId,
     guild_id: GuildId,
-    fields: UpdateCommandPermissionsFields,
+    fields: UpdateCommandPermissionsFields<'a>,
     http: &'a Client,
 }
 
@@ -39,7 +39,7 @@ impl<'a> UpdateCommandPermissions<'a> {
         application_id: ApplicationId,
         guild_id: GuildId,
         command_id: CommandId,
-        permissions: Vec<CommandPermissions>,
+        permissions: &'a [CommandPermissions],
     ) -> Result<Self, InteractionError> {
         if !validate::command_permissions(permissions.len()) {
             return Err(InteractionError {

--- a/http/src/request/application/update_followup_message.rs
+++ b/http/src/request/application/update_followup_message.rs
@@ -85,8 +85,6 @@ pub enum UpdateFollowupMessageErrorType {
         ///
         /// This can be used to index into the provided embeds to retrieve the
         /// invalid embed.
-        ///
-        /// [`embeds`]: Self::EmbedTooLarge.embeds
         index: usize,
     },
     /// Too many embeds were provided.

--- a/http/src/request/application/update_global_command.rs
+++ b/http/src/request/application/update_global_command.rs
@@ -11,11 +11,11 @@ use twilight_model::{
 };
 
 #[derive(Debug, Default, serde::Serialize)]
-struct UpdateGlobalCommandFields {
+struct UpdateGlobalCommandFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
+    description: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
+    name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     options: Option<Vec<CommandOption>>,
 }
@@ -27,7 +27,7 @@ struct UpdateGlobalCommandFields {
 ///
 /// [the discord docs]: https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command
 pub struct UpdateGlobalCommand<'a> {
-    fields: UpdateGlobalCommandFields,
+    fields: UpdateGlobalCommandFields<'a>,
     command_id: CommandId,
     application_id: ApplicationId,
     http: &'a Client,
@@ -48,15 +48,15 @@ impl<'a> UpdateGlobalCommand<'a> {
     }
 
     /// Edit the name of the command.
-    pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.fields.name = Some(name.into());
+    pub const fn name(mut self, name: &'a str) -> Self {
+        self.fields.name = Some(name);
 
         self
     }
 
     /// Edit the description of the command.
-    pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.fields.description = Some(description.into());
+    pub const fn description(mut self, description: &'a str) -> Self {
+        self.fields.description = Some(description);
 
         self
     }
@@ -66,13 +66,13 @@ impl<'a> UpdateGlobalCommand<'a> {
         if let Some(ref mut arr) = self.fields.options {
             arr.push(option);
         } else {
-            self.fields.options = Some(vec![option]);
+            self.fields.options = Some(Vec::from([option]));
         }
 
         self
     }
 
-    fn request(&self) -> Result<Request, Error> {
+    fn request(&self) -> Result<Request<'a>, Error> {
         Request::builder(Route::UpdateGlobalCommand {
             application_id: self.application_id.0,
             command_id: self.command_id.0,

--- a/http/src/request/application/update_global_command.rs
+++ b/http/src/request/application/update_global_command.rs
@@ -17,7 +17,7 @@ struct UpdateGlobalCommandFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    options: Option<Vec<CommandOption>>,
+    options: Option<&'a [CommandOption]>,
 }
 
 /// Edit a global command, by ID.
@@ -62,12 +62,8 @@ impl<'a> UpdateGlobalCommand<'a> {
     }
 
     /// Edit the command options of the command.
-    pub fn push_command_option(mut self, option: CommandOption) -> Self {
-        if let Some(ref mut arr) = self.fields.options {
-            arr.push(option);
-        } else {
-            self.fields.options = Some(Vec::from([option]));
-        }
+    pub const fn command_options(mut self, options: &'a [CommandOption]) -> Self {
+        self.fields.options = Some(options);
 
         self
     }

--- a/http/src/request/application/update_guild_command.rs
+++ b/http/src/request/application/update_guild_command.rs
@@ -11,11 +11,11 @@ use twilight_model::{
 };
 
 #[derive(Debug, Default, serde::Serialize)]
-struct UpdateGuildCommandFields {
+struct UpdateGuildCommandFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
+    description: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
+    name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     options: Option<Vec<CommandOption>>,
 }
@@ -27,7 +27,7 @@ struct UpdateGuildCommandFields {
 ///
 /// [the discord docs]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
 pub struct UpdateGuildCommand<'a> {
-    fields: UpdateGuildCommandFields,
+    fields: UpdateGuildCommandFields<'a>,
     application_id: ApplicationId,
     command_id: CommandId,
     guild_id: GuildId,
@@ -51,15 +51,15 @@ impl<'a> UpdateGuildCommand<'a> {
     }
 
     /// Edit the name of the command.
-    pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.fields.name = Some(name.into());
+    pub const fn name(mut self, name: &'a str) -> Self {
+        self.fields.name = Some(name);
 
         self
     }
 
     /// Edit the description of the command.
-    pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.fields.description = Some(description.into());
+    pub const fn description(mut self, description: &'a str) -> Self {
+        self.fields.description = Some(description);
 
         self
     }
@@ -75,7 +75,7 @@ impl<'a> UpdateGuildCommand<'a> {
         self
     }
 
-    fn request(&self) -> Result<Request, Error> {
+    fn request(&self) -> Result<Request<'a>, Error> {
         Request::builder(Route::UpdateGuildCommand {
             application_id: self.application_id.0,
             command_id: self.command_id.0,

--- a/http/src/request/application/update_guild_command.rs
+++ b/http/src/request/application/update_guild_command.rs
@@ -17,7 +17,7 @@ struct UpdateGuildCommandFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    options: Option<Vec<CommandOption>>,
+    options: Option<&'a [CommandOption]>,
 }
 
 /// Edit a command in a guild, by ID.
@@ -65,12 +65,8 @@ impl<'a> UpdateGuildCommand<'a> {
     }
 
     /// Edit the command options of the command.
-    pub fn push_command_option(mut self, option: CommandOption) -> Self {
-        if let Some(ref mut arr) = self.fields.options {
-            arr.push(option);
-        } else {
-            self.fields.options = Some(vec![option]);
-        }
+    pub const fn command_options(mut self, options: &'a [CommandOption]) -> Self {
+        self.fields.options = Some(options);
 
         self
     }

--- a/http/src/request/application/update_original_response.rs
+++ b/http/src/request/application/update_original_response.rs
@@ -3,7 +3,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Form, NullableField, Request},
+    request::{self, validate, Form, NullableField, Request},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -52,16 +52,14 @@ impl UpdateOriginalResponseError {
 impl Display for UpdateOriginalResponseError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            UpdateOriginalResponseErrorType::ContentInvalid { .. } => {
+            UpdateOriginalResponseErrorType::ContentInvalid => {
                 f.write_str("message content is invalid")
             }
             UpdateOriginalResponseErrorType::EmbedTooLarge { .. } => {
                 f.write_str("length of one of the embeds is too large")
             }
-            UpdateOriginalResponseErrorType::TooManyEmbeds { embeds } => {
-                Display::fmt(&embeds.len(), f)?;
-
-                f.write_str(" embeds were provided, but only 10 may be provided")
+            UpdateOriginalResponseErrorType::TooManyEmbeds => {
+                f.write_str("more than 10 embeds were provided")
             }
         }
     }
@@ -80,17 +78,13 @@ impl Error for UpdateOriginalResponseError {
 #[non_exhaustive]
 pub enum UpdateOriginalResponseErrorType {
     /// Content is over 2000 UTF-16 characters.
-    ContentInvalid {
-        /// Provided content.
-        content: String,
-    },
+    ContentInvalid,
     /// Length of one of the embeds is over 6000 characters.
     EmbedTooLarge {
-        /// Provided embeds.
-        embeds: Vec<Embed>,
         /// Index of the embed that was too large.
         ///
-        /// This can be used to index into [`embeds`] to retrieve the bad embed.
+        /// This can be used to index into the provided embeds to retrieve the
+        /// invalid embed.
         ///
         /// [`embeds`]: Self::EmbedTooLarge.embeds
         index: usize,
@@ -98,24 +92,21 @@ pub enum UpdateOriginalResponseErrorType {
     /// Too many embeds were provided.
     ///
     /// A original response can have up to 10 embeds.
-    TooManyEmbeds {
-        /// Provided embeds.
-        embeds: Vec<Embed>,
-    },
+    TooManyEmbeds,
 }
 
 #[derive(Default, Serialize)]
-struct UpdateOriginalResponseFields {
+struct UpdateOriginalResponseFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     allowed_mentions: Option<AllowedMentions>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    attachments: Vec<Attachment>,
+    #[serde(skip_serializing_if = "request::slice_is_empty")]
+    attachments: &'a [Attachment],
     #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<NullableField<String>>,
+    content: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    embeds: Option<NullableField<Vec<Embed>>>,
+    embeds: Option<NullableField<&'a [Embed]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payload_json: Option<Vec<u8>>,
+    payload_json: Option<&'a [u8]>,
 }
 
 /// Update the original response created by a interaction.
@@ -147,7 +138,7 @@ struct UpdateOriginalResponseFields {
 ///     // By creating a default set of allowed mentions, no entity can be
 ///     // mentioned.
 ///     .allowed_mentions(AllowedMentions::default())
-///     .content(Some("test <@3>".to_owned()))?
+///     .content(Some("test <@3>"))?
 ///     .exec()
 ///     .await?;
 /// # Ok(()) }
@@ -156,10 +147,10 @@ struct UpdateOriginalResponseFields {
 /// [`DeleteOriginalResponse`]: super::DeleteOriginalResponse
 pub struct UpdateOriginalResponse<'a> {
     application_id: ApplicationId,
-    fields: UpdateOriginalResponseFields,
-    files: Vec<(String, Vec<u8>)>,
+    fields: UpdateOriginalResponseFields<'a>,
+    files: &'a [(&'a str, &'a [u8])],
     http: &'a Client,
-    token: String,
+    token: &'a str,
 }
 
 impl<'a> UpdateOriginalResponse<'a> {
@@ -169,7 +160,7 @@ impl<'a> UpdateOriginalResponse<'a> {
     pub(crate) fn new(
         http: &'a Client,
         application_id: ApplicationId,
-        interaction_token: impl Into<String>,
+        interaction_token: &'a str,
     ) -> Self {
         Self {
             application_id,
@@ -177,9 +168,9 @@ impl<'a> UpdateOriginalResponse<'a> {
                 allowed_mentions: http.default_allowed_mentions(),
                 ..UpdateOriginalResponseFields::default()
             },
-            files: Vec::new(),
+            files: &[],
             http,
-            token: interaction_token.into(),
+            token: interaction_token,
         }
     }
 
@@ -190,24 +181,12 @@ impl<'a> UpdateOriginalResponse<'a> {
         self
     }
 
-    /// Specify an attachment already present in the target message to keep.
-    ///
-    /// If called, all unspecified attachments will be removed from the message.
-    /// If not called, all attachments will be kept.
-    pub fn attachment(mut self, attachment: Attachment) -> Self {
-        self.fields.attachments.push(attachment);
-
-        self
-    }
-
     /// Specify multiple attachments already present in the target message to keep.
     ///
     /// If called, all unspecified attachments will be removed from the message.
     /// If not called, all attachments will be kept.
-    pub fn attachments(mut self, attachments: impl IntoIterator<Item = Attachment>) -> Self {
-        self.fields
-            .attachments
-            .extend(attachments.into_iter().collect::<Vec<Attachment>>());
+    pub const fn attachments(mut self, attachments: &'a [Attachment]) -> Self {
+        self.fields.attachments = attachments;
 
         self
     }
@@ -225,13 +204,14 @@ impl<'a> UpdateOriginalResponse<'a> {
     ///
     /// Returns an [`UpdateOriginalResponseErrorType::ContentInvalid`] error type if
     /// the content length is too long.
-    pub fn content(mut self, content: Option<String>) -> Result<Self, UpdateOriginalResponseError> {
-        if let Some(content_ref) = content.as_ref() {
+    pub fn content(
+        mut self,
+        content: Option<&'a str>,
+    ) -> Result<Self, UpdateOriginalResponseError> {
+        if let Some(content_ref) = content {
             if !validate::content_limit(content_ref) {
                 return Err(UpdateOriginalResponseError {
-                    kind: UpdateOriginalResponseErrorType::ContentInvalid {
-                        content: content.expect("content is known to be some"),
-                    },
+                    kind: UpdateOriginalResponseErrorType::ContentInvalid,
                     source: None,
                 });
             }
@@ -279,7 +259,7 @@ impl<'a> UpdateOriginalResponse<'a> {
     ///     .build()?;
     ///
     /// client.update_interaction_original("token")?
-    ///     .embeds(Some(vec![embed]))?
+    ///     .embeds(Some(&[embed]))?
     ///     .exec()
     ///     .await?;
     /// # Ok(()) }
@@ -297,14 +277,12 @@ impl<'a> UpdateOriginalResponse<'a> {
     /// [`EMBED_COUNT_LIMIT`]: Self::EMBED_COUNT_LIMIT
     pub fn embeds(
         mut self,
-        embeds: Option<Vec<Embed>>,
+        embeds: Option<&'a [Embed]>,
     ) -> Result<Self, UpdateOriginalResponseError> {
-        if let Some(embeds_present) = embeds.as_deref() {
+        if let Some(embeds_present) = embeds {
             if embeds_present.len() > Self::EMBED_COUNT_LIMIT {
                 return Err(UpdateOriginalResponseError {
-                    kind: UpdateOriginalResponseErrorType::TooManyEmbeds {
-                        embeds: embeds.expect("embeds are known to be present"),
-                    },
+                    kind: UpdateOriginalResponseErrorType::TooManyEmbeds,
                     source: None,
                 });
             }
@@ -312,10 +290,7 @@ impl<'a> UpdateOriginalResponse<'a> {
             for (idx, embed) in embeds_present.iter().enumerate() {
                 if let Err(source) = validate::embed(&embed) {
                     return Err(UpdateOriginalResponseError {
-                        kind: UpdateOriginalResponseErrorType::EmbedTooLarge {
-                            embeds: embeds.expect("embeds are known to be present"),
-                            index: idx,
-                        },
+                        kind: UpdateOriginalResponseErrorType::EmbedTooLarge { index: idx },
                         source: Some(Box::new(source)),
                     });
                 }
@@ -329,23 +304,9 @@ impl<'a> UpdateOriginalResponse<'a> {
         Ok(self)
     }
 
-    /// Attach a file to the original response.
-    ///
-    /// This method is repeatable.
-    pub fn file(mut self, name: impl Into<String>, file: impl Into<Vec<u8>>) -> Self {
-        self.files.push((name.into(), file.into()));
-
-        self
-    }
-
     /// Attach multiple files to the original response.
-    pub fn files<N: Into<String>, F: Into<Vec<u8>>>(
-        mut self,
-        attachments: impl IntoIterator<Item = (N, F)>,
-    ) -> Self {
-        for (name, file) in attachments {
-            self = self.file(name, file);
-        }
+    pub const fn files(mut self, files: &'a [(&'a str, &'a [u8])]) -> Self {
+        self.files = files;
 
         self
     }
@@ -353,21 +314,21 @@ impl<'a> UpdateOriginalResponse<'a> {
     /// JSON encoded body of any additional request fields.
     ///
     /// If this method is called, all other fields are ignored, except for
-    /// [`file`]. See [Discord Docs/Create Message] and
+    /// [`files`]. See [Discord Docs/Create Message] and
     /// [`CreateFollowupMessage::payload_json`].
     ///
-    /// [`file`]: Self::file
+    /// [`files`]: Self::files
     /// [`CreateFollowupMessage::payload_json`]: super::CreateFollowupMessage::payload_json
     /// [Discord Docs/Create Message]: https://discord.com/developers/docs/resources/channel#create-message-params
-    pub fn payload_json(mut self, payload_json: impl Into<Vec<u8>>) -> Self {
-        self.fields.payload_json.replace(payload_json.into());
+    pub fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
+        self.fields.payload_json.replace(payload_json);
 
         self
     }
 
     // `self` needs to be consumed and the client returned due to parameters
     // being consumed in request construction.
-    fn request(mut self) -> Result<(Request, &'a Client), HttpError> {
+    fn request(&self) -> Result<Request<'a>, HttpError> {
         let mut request = Request::builder(Route::UpdateInteractionOriginal {
             application_id: self.application_id.0,
             interaction_token: self.token,
@@ -376,8 +337,8 @@ impl<'a> UpdateOriginalResponse<'a> {
         if !self.files.is_empty() || self.fields.payload_json.is_some() {
             let mut form = Form::new();
 
-            for (index, (name, file)) in self.files.drain(..).enumerate() {
-                form.file(format!("{}", index).as_bytes(), name.as_bytes(), &file);
+            for (index, (name, file)) in self.files.iter().enumerate() {
+                form.file(index.to_be_bytes().as_ref(), name.as_bytes(), file);
             }
 
             if let Some(payload_json) = &self.fields.payload_json {
@@ -392,12 +353,12 @@ impl<'a> UpdateOriginalResponse<'a> {
             request = request.json(&self.fields)?;
         }
 
-        Ok((request.build(), self.http))
+        Ok(request.build())
     }
 
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
         match self.request() {
-            Ok((request, client)) => client.request(request),
+            Ok(request) => self.http.request(request),
             Err(source) => ResponseFuture::error(source),
         }
     }

--- a/http/src/request/application/update_original_response.rs
+++ b/http/src/request/application/update_original_response.rs
@@ -85,8 +85,6 @@ pub enum UpdateOriginalResponseErrorType {
         ///
         /// This can be used to index into the provided embeds to retrieve the
         /// invalid embed.
-        ///
-        /// [`embeds`]: Self::EmbedTooLarge.embeds
         index: usize,
     },
     /// Too many embeds were provided.

--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -3,8 +3,8 @@ use std::{
     fmt::{Display, Formatter, Result as FmtResult},
 };
 
-pub trait AuditLogReason: private::Sealed {
-    fn reason(self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError>
+pub trait AuditLogReason<'a>: private::Sealed {
+    fn reason(self, reason: &'a str) -> Result<Self, AuditLogReasonError>
     where
         Self: Sized;
 }
@@ -70,12 +70,12 @@ impl AuditLogReasonError {
     /// The maximum audit log reason length in UTF-16 codepoints.
     pub const AUDIT_REASON_LENGTH: usize = 512;
 
-    pub(crate) fn validate(reason: String) -> Result<String, AuditLogReasonError> {
+    pub(crate) fn validate(reason: &str) -> Result<&str, AuditLogReasonError> {
         if reason.chars().count() <= Self::AUDIT_REASON_LENGTH {
             Ok(reason)
         } else {
             Err(AuditLogReasonError {
-                kind: AuditLogReasonErrorType::TooLarge { reason },
+                kind: AuditLogReasonErrorType::TooLarge,
             })
         }
     }
@@ -116,12 +116,11 @@ impl AuditLogReasonError {
 impl Display for AuditLogReasonError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            AuditLogReasonErrorType::TooLarge { reason } => {
-                f.write_str("the audit log reason is ")?;
-                Display::fmt(&reason.chars().count(), f)?;
-                f.write_str(" characters long, but the max is ")?;
+            AuditLogReasonErrorType::TooLarge => {
+                f.write_str("audit log reason is longer than ")?;
+                Display::fmt(&Self::AUDIT_REASON_LENGTH, f)?;
 
-                Display::fmt(&Self::AUDIT_REASON_LENGTH, f)
+                f.write_str(" characters long")
             }
         }
     }
@@ -134,7 +133,7 @@ impl Error for AuditLogReasonError {}
 #[non_exhaustive]
 pub enum AuditLogReasonErrorType {
     /// Returned when the reason is over 512 UTF-16 characters.
-    TooLarge { reason: String },
+    TooLarge,
 }
 
 #[cfg(test)]
@@ -159,35 +158,35 @@ mod test {
     };
     use static_assertions::{assert_impl_all, assert_obj_safe};
 
-    assert_obj_safe!(AuditLogReason);
+    assert_obj_safe!(AuditLogReason<'_>);
 
-    assert_impl_all!(CreateInvite<'_>: AuditLogReason);
-    assert_impl_all!(DeleteInvite<'_>: AuditLogReason);
-    assert_impl_all!(DeleteMessage<'_>: AuditLogReason);
-    assert_impl_all!(DeleteMessages<'_>: AuditLogReason);
-    assert_impl_all!(UpdateChannel<'_>: AuditLogReason);
-    assert_impl_all!(CreateWebhook<'_>: AuditLogReason);
-    assert_impl_all!(DeleteWebhook<'_>: AuditLogReason);
-    assert_impl_all!(UpdateWebhook<'_>: AuditLogReason);
-    assert_impl_all!(CreatePin<'_>: AuditLogReason);
-    assert_impl_all!(DeleteChannel<'_>: AuditLogReason);
-    assert_impl_all!(DeleteChannelPermissionConfigured<'_>: AuditLogReason);
-    assert_impl_all!(DeletePin<'_>: AuditLogReason);
-    assert_impl_all!(UpdateChannelPermissionConfigured<'_>: AuditLogReason);
-    assert_impl_all!(CreateBan<'_>: AuditLogReason);
-    assert_impl_all!(DeleteBan<'_>: AuditLogReason);
-    assert_impl_all!(CreateGuildChannel<'_>: AuditLogReason);
-    assert_impl_all!(CreateGuildPrune<'_>: AuditLogReason);
-    assert_impl_all!(CreateEmoji<'_>: AuditLogReason);
-    assert_impl_all!(DeleteEmoji<'_>: AuditLogReason);
-    assert_impl_all!(UpdateEmoji<'_>: AuditLogReason);
-    assert_impl_all!(DeleteGuildIntegration<'_>: AuditLogReason);
-    assert_impl_all!(UpdateGuildMember<'_>: AuditLogReason);
-    assert_impl_all!(AddRoleToMember<'_>: AuditLogReason);
-    assert_impl_all!(RemoveMember<'_>: AuditLogReason);
-    assert_impl_all!(RemoveRoleFromMember<'_>: AuditLogReason);
-    assert_impl_all!(CreateRole<'_>: AuditLogReason);
-    assert_impl_all!(DeleteRole<'_>: AuditLogReason);
-    assert_impl_all!(UpdateRole<'_>: AuditLogReason);
-    assert_impl_all!(UpdateGuild<'_>: AuditLogReason);
+    assert_impl_all!(CreateInvite<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteInvite<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteMessage<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteMessages<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateChannel<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateWebhook<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteWebhook<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateWebhook<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreatePin<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteChannel<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteChannelPermissionConfigured<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeletePin<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateChannelPermissionConfigured<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateBan<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteBan<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateGuildChannel<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateGuildPrune<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateEmoji<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteEmoji<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateEmoji<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteGuildIntegration<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateGuildMember<'_>: AuditLogReason<'static>);
+    assert_impl_all!(AddRoleToMember<'_>: AuditLogReason<'static>);
+    assert_impl_all!(RemoveMember<'_>: AuditLogReason<'static>);
+    assert_impl_all!(RemoveRoleFromMember<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateRole<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteRole<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateRole<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateGuild<'_>: AuditLogReason<'static>);
 }

--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -120,7 +120,7 @@ impl Display for AuditLogReasonError {
                 f.write_str("audit log reason is longer than ")?;
                 Display::fmt(&Self::AUDIT_REASON_LENGTH, f)?;
 
-                f.write_str(" characters long")
+                f.write_str(" characters")
             }
         }
     }

--- a/http/src/request/base.rs
+++ b/http/src/request/base.rs
@@ -1,11 +1,7 @@
-use super::{Form, Method};
-use crate::{
-    error::Error,
-    routing::{Path, Route},
-};
+use super::Form;
+use crate::{error::Error, routing::Route};
 use hyper::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::Serialize;
-use std::borrow::Cow;
 
 /// Builder to create a customized request.
 ///
@@ -26,61 +22,19 @@ use std::borrow::Cow;
 /// }).body(body).build();
 /// ```
 #[derive(Debug)]
-pub struct RequestBuilder(Request);
+pub struct RequestBuilder<'a>(Request<'a>);
 
-impl RequestBuilder {
+impl<'a> RequestBuilder<'a> {
     /// Create a new request builder.
     #[must_use = "request has not been fully built"]
-    pub fn new(route: Route) -> Self {
+    pub const fn new(route: Route<'a>) -> Self {
         Self(Request::from_route(route))
-    }
-
-    /// Create a request with raw information about the method, ratelimiting
-    /// path, and URL path and query.
-    ///
-    /// The path and query should not include the leading slash as that is
-    /// prefixed by the client. In the URL
-    /// `https://discord.com/api/vX/channels/123/pins` the "path and query"
-    /// is considered to be `channels/123/pins`.
-    ///
-    /// # Examples
-    ///
-    /// Create a request from a method and the URL path and query
-    /// `channels/123/pins`:
-    ///
-    /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use std::str::FromStr;
-    /// use twilight_http::{request::{Method, RequestBuilder}, routing::Path};
-    ///
-    /// let method = Method::Post;
-    /// let path_and_query = "channels/123/pins".to_owned();
-    /// let ratelimit_path = Path::from_str(&path_and_query)?;
-    ///
-    /// let _request = RequestBuilder::raw(
-    ///     method,
-    ///     ratelimit_path,
-    ///     path_and_query,
-    /// ).build();
-    /// # Ok(()) }
-    /// ```
-    #[must_use = "request has not been fully built"]
-    pub const fn raw(method: Method, path: Path, path_and_query: String) -> Self {
-        Self(Request {
-            body: None,
-            form: None,
-            headers: None,
-            method,
-            path,
-            path_str: Cow::Owned(path_and_query),
-            use_authorization_token: true,
-        })
     }
 
     /// Consume the builder, returning the built request.
     #[allow(clippy::missing_const_for_fn)]
     #[must_use = "request information is not useful on its own and must be acted on"]
-    pub fn build(self) -> Request {
+    pub fn build(self) -> Request<'a> {
         self.0
     }
 
@@ -135,48 +89,20 @@ impl RequestBuilder {
 }
 
 #[derive(Debug)]
-pub struct Request {
+pub struct Request<'a> {
     /// The body of the request, if any.
     pub body: Option<Vec<u8>>,
     /// The multipart form of the request, if any.
     pub form: Option<Form>,
     /// The headers to set in the request, if any.
     pub headers: Option<HeaderMap<HeaderValue>>,
-    /// The method of the request.
-    pub method: Method,
-    /// The ratelimiting bucket path.
-    pub path: Path,
-    /// The URI path to request.
-    pub path_str: Cow<'static, str>,
+    /// The route of the request.
+    pub route: Route<'a>,
     /// Whether to use the client's authorization token in the request.
     pub(crate) use_authorization_token: bool,
 }
 
-impl Request {
-    /// Create a simple `Request` with basic information.
-    ///
-    /// Use the [`RequestBuilder`] if you need to set a combination of
-    /// configurations in the request.
-    // `Route`'s methods have been changed to no longer consume itself, so we
-    // could pass the route by reference but we need to avoid breakage.
-    #[allow(clippy::needless_pass_by_value)]
-    #[deprecated(since = "0.4.0", note = "Use `Request::builder` instead")]
-    pub fn new(
-        body: Option<Vec<u8>>,
-        headers: Option<HeaderMap<HeaderValue>>,
-        route: Route,
-    ) -> Self {
-        Self {
-            body,
-            form: None,
-            headers,
-            method: route.method(),
-            path: route.path(),
-            path_str: Cow::Owned(route.display().to_string()),
-            use_authorization_token: true,
-        }
-    }
-
+impl<'a> Request<'a> {
     /// Create a new request builder.
     ///
     /// # Examples
@@ -195,7 +121,7 @@ impl Request {
     ///     channel_id: 1,
     /// }).body(body).build();
     /// ```
-    pub fn builder(route: Route) -> RequestBuilder {
+    pub const fn builder(route: Route<'a>) -> RequestBuilder<'a> {
         RequestBuilder::new(route)
     }
 
@@ -219,17 +145,12 @@ impl Request {
     /// ```
     ///
     /// [`builder`]: Self::builder
-    // `Route`'s methods have been changed to no longer consume itself, so we
-    // could pass the route by reference but we need to avoid breakage.
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn from_route(route: Route) -> Self {
+    pub const fn from_route(route: Route<'a>) -> Self {
         Self {
             body: None,
             form: None,
             headers: None,
-            method: route.method(),
-            path: route.path(),
-            path_str: Cow::Owned(route.display().to_string()),
+            route,
             use_authorization_token: true,
         }
     }
@@ -240,128 +161,11 @@ impl Request {
     }
 }
 
-impl From<Route> for Request {
-    fn from(route: Route) -> Self {
-        Self {
-            body: None,
-            form: None,
-            headers: None,
-            method: route.method(),
-            path: route.path(),
-            path_str: Cow::Owned(route.display().to_string()),
-            use_authorization_token: true,
-        }
-    }
-}
-
-impl From<(Vec<u8>, Route)> for Request {
-    fn from((body, route): (Vec<u8>, Route)) -> Self {
-        Self {
-            body: Some(body),
-            form: None,
-            headers: None,
-            method: route.method(),
-            path: route.path(),
-            path_str: Cow::Owned(route.display().to_string()),
-            use_authorization_token: true,
-        }
-    }
-}
-
-impl From<(Form, Route)> for Request {
-    fn from((form, route): (Form, Route)) -> Self {
-        Self {
-            body: None,
-            form: Some(form),
-            headers: None,
-            method: route.method(),
-            path: route.path(),
-            path_str: Cow::Owned(route.display().to_string()),
-            use_authorization_token: true,
-        }
-    }
-}
-
-impl From<(Vec<u8>, Form, Route)> for Request {
-    fn from((body, form, route): (Vec<u8>, Form, Route)) -> Self {
-        Self {
-            body: Some(body),
-            form: Some(form),
-            headers: None,
-            method: route.method(),
-            path: route.path(),
-            path_str: Cow::Owned(route.display().to_string()),
-            use_authorization_token: true,
-        }
-    }
-}
-
-impl From<(HeaderMap<HeaderValue>, Route)> for Request {
-    fn from((headers, route): (HeaderMap<HeaderValue>, Route)) -> Self {
-        Self {
-            body: None,
-            form: None,
-            headers: Some(headers),
-            method: route.method(),
-            path: route.path(),
-            path_str: Cow::Owned(route.display().to_string()),
-            use_authorization_token: true,
-        }
-    }
-}
-
-impl From<(Vec<u8>, HeaderMap<HeaderValue>, Route)> for Request {
-    fn from((body, headers, route): (Vec<u8>, HeaderMap<HeaderValue>, Route)) -> Self {
-        Self {
-            body: Some(body),
-            form: None,
-            headers: Some(headers),
-            method: route.method(),
-            path: route.path(),
-            path_str: Cow::Owned(route.display().to_string()),
-            use_authorization_token: true,
-        }
-    }
-}
-
-impl From<(Form, HeaderMap<HeaderValue>, Route)> for Request {
-    fn from((form, headers, route): (Form, HeaderMap<HeaderValue>, Route)) -> Self {
-        Self {
-            body: None,
-            form: Some(form),
-            headers: Some(headers),
-            method: route.method(),
-            path: route.path(),
-            path_str: Cow::Owned(route.display().to_string()),
-            use_authorization_token: true,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{super::Method, RequestBuilder};
-    use crate::routing::Path;
+    use super::RequestBuilder;
     use static_assertions::assert_impl_all;
-    use std::{error::Error, fmt::Debug, str::FromStr};
+    use std::fmt::Debug;
 
-    assert_impl_all!(RequestBuilder: Debug, Send, Sync);
-
-    /// Test the default request values from [`RequestBuilder::raw`].
-    #[test]
-    fn test_builder_raw() -> Result<(), Box<dyn Error>> {
-        let path_and_query = "guilds".to_owned();
-        let path = Path::from_str(&path_and_query)?;
-
-        let builder = RequestBuilder::raw(Method::Post, path, path_and_query);
-        assert!(builder.0.body.is_none());
-        assert!(builder.0.form.is_none());
-        assert!(builder.0.headers.is_none());
-        assert_eq!(Method::Post, builder.0.method);
-        assert_eq!(Path::Guilds, builder.0.path);
-        assert_eq!("guilds", builder.0.path_str.as_ref());
-        assert!(builder.0.use_authorization_token);
-
-        Ok(())
-    }
+    assert_impl_all!(RequestBuilder<'_>: Debug, Send, Sync);
 }

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -11,7 +11,7 @@ pub struct CreatePin<'a> {
     channel_id: ChannelId,
     http: &'a Client,
     message_id: MessageId,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> CreatePin<'a> {
@@ -50,10 +50,9 @@ impl<'a> CreatePin<'a> {
     }
 }
 
-impl<'a> AuditLogReason for CreatePin<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for CreatePin<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -10,7 +10,7 @@ use twilight_model::{channel::Channel, id::ChannelId};
 pub struct DeleteChannel<'a> {
     channel_id: ChannelId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> DeleteChannel<'a> {
@@ -43,10 +43,9 @@ impl<'a> DeleteChannel<'a> {
     }
 }
 
-impl<'a> AuditLogReason for DeleteChannel<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for DeleteChannel<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/channel/delete_channel_permission.rs
+++ b/http/src/request/channel/delete_channel_permission.rs
@@ -16,13 +16,13 @@ impl<'a> DeleteChannelPermission<'a> {
     }
 
     /// Delete an override for an member.
-    pub fn member(self, user_id: impl Into<UserId>) -> DeleteChannelPermissionConfigured<'a> {
-        self.configure(user_id.into().0)
+    pub const fn member(self, user_id: UserId) -> DeleteChannelPermissionConfigured<'a> {
+        self.configure(user_id.0)
     }
 
     /// Delete an override for an role.
-    pub fn role(self, role_id: impl Into<RoleId>) -> DeleteChannelPermissionConfigured<'a> {
-        self.configure(role_id.into().0)
+    pub const fn role(self, role_id: RoleId) -> DeleteChannelPermissionConfigured<'a> {
+        self.configure(role_id.0)
     }
 
     const fn configure(self, target_id: u64) -> DeleteChannelPermissionConfigured<'a> {

--- a/http/src/request/channel/delete_channel_permission_configured.rs
+++ b/http/src/request/channel/delete_channel_permission_configured.rs
@@ -12,7 +12,7 @@ use twilight_model::id::ChannelId;
 pub struct DeleteChannelPermissionConfigured<'a> {
     channel_id: ChannelId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<&'a str>,
     target_id: u64,
 }
 
@@ -48,10 +48,9 @@ impl<'a> DeleteChannelPermissionConfigured<'a> {
     }
 }
 
-impl<'a> AuditLogReason for DeleteChannelPermissionConfigured<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for DeleteChannelPermissionConfigured<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -11,7 +11,7 @@ pub struct DeletePin<'a> {
     channel_id: ChannelId,
     http: &'a Client,
     message_id: MessageId,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> DeletePin<'a> {
@@ -50,10 +50,9 @@ impl<'a> DeletePin<'a> {
     }
 }
 
-impl<'a> AuditLogReason for DeletePin<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for DeletePin<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/channel/get_channel.rs
+++ b/http/src/request/channel/get_channel.rs
@@ -13,7 +13,7 @@ use twilight_model::{channel::Channel, id::ChannelId};
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let channel_id = ChannelId(100);
 ///

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -13,15 +13,15 @@ use crate::{
 /// [`MANAGE_CHANNELS`]: twilight_model::guild::Permissions::MANAGE_CHANNELS
 /// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
 pub struct DeleteInvite<'a> {
-    code: String,
+    code: &'a str,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> DeleteInvite<'a> {
-    pub(crate) fn new(http: &'a Client, code: impl Into<String>) -> Self {
+    pub(crate) const fn new(http: &'a Client, code: &'a str) -> Self {
         Self {
-            code: code.into(),
+            code,
             http,
             reason: None,
         }
@@ -33,7 +33,7 @@ impl<'a> DeleteInvite<'a> {
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
         let mut request = Request::builder(Route::DeleteInvite { code: self.code });
 
-        if let Some(reason) = &self.reason {
+        if let Some(reason) = self.reason {
             let header = match request::audit_header(reason) {
                 Ok(header) => header,
                 Err(source) => return ResponseFuture::error(source),
@@ -46,10 +46,9 @@ impl<'a> DeleteInvite<'a> {
     }
 }
 
-impl<'a> AuditLogReason for DeleteInvite<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for DeleteInvite<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -20,7 +20,7 @@ struct GetInviteFields {
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let invite = client
 ///     .invite("code")
@@ -33,15 +33,15 @@ struct GetInviteFields {
 /// [`with_counts`]: Self::with_counts
 /// [`with_expiration`]: Self::with_expiration
 pub struct GetInvite<'a> {
-    code: String,
+    code: &'a str,
     fields: GetInviteFields,
     http: &'a Client,
 }
 
 impl<'a> GetInvite<'a> {
-    pub(crate) fn new(http: &'a Client, code: impl Into<String>) -> Self {
+    pub(crate) fn new(http: &'a Client, code: &'a str) -> Self {
         Self {
-            code: code.into(),
+            code,
             fields: GetInviteFields::default(),
             http,
         }

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -2,6 +2,7 @@ use crate::{
     client::Client,
     error::Error as HttpError,
     request::{
+        self,
         multipart::Form,
         validate::{self, EmbedValidationError},
         Request,
@@ -49,12 +50,9 @@ impl CreateMessageError {
         (self.kind, self.source)
     }
 
-    fn embed(source: EmbedValidationError, embed: Embed, idx: Option<usize>) -> Self {
+    fn embed(source: EmbedValidationError, idx: usize) -> Self {
         Self {
-            kind: CreateMessageErrorType::EmbedTooLarge {
-                embed: Box::new(embed),
-                idx,
-            },
+            kind: CreateMessageErrorType::EmbedTooLarge { idx },
             source: Some(Box::new(source)),
         }
     }
@@ -63,18 +61,12 @@ impl CreateMessageError {
 impl Display for CreateMessageError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            CreateMessageErrorType::ContentInvalid { .. } => {
-                f.write_str("the message content is invalid")
-            }
-            CreateMessageErrorType::EmbedTooLarge { idx, .. } => {
-                if let Some(idx) = idx {
-                    f.write_str("the embed at index ")?;
-                    Display::fmt(&idx, f)?;
+            CreateMessageErrorType::ContentInvalid => f.write_str("the message content is invalid"),
+            CreateMessageErrorType::EmbedTooLarge { idx } => {
+                f.write_str("the embed at index ")?;
+                Display::fmt(&idx, f)?;
 
-                    f.write_str("'s contents are too long")
-                } else {
-                    f.write_str("the embed's contents are too long")
-                }
+                f.write_str("'s contents are too long")
             }
         }
     }
@@ -93,31 +85,26 @@ impl Error for CreateMessageError {
 #[non_exhaustive]
 pub enum CreateMessageErrorType {
     /// Returned when the content is over 2000 UTF-16 characters.
-    ContentInvalid {
-        /// Provided content.
-        content: String,
-    },
+    ContentInvalid,
     /// Returned when the length of the embed is over 6000 characters.
     EmbedTooLarge {
-        /// Provided embed.
-        embed: Box<Embed>,
-        /// Index of the embed, if there is any.
-        idx: Option<usize>,
+        /// Index of the embed.
+        idx: usize,
     },
 }
 
 #[derive(Default, Serialize)]
-pub(crate) struct CreateMessageFields {
+pub(crate) struct CreateMessageFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    embeds: Vec<Embed>,
+    content: Option<&'a str>,
+    #[serde(skip_serializing_if = "request::slice_is_empty")]
+    embeds: &'a [Embed],
     #[serde(skip_serializing_if = "Option::is_none")]
     message_reference: Option<MessageReference>,
     #[serde(skip_serializing_if = "Option::is_none")]
     nonce: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payload_json: Option<Vec<u8>>,
+    payload_json: Option<&'a [u8]>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) allowed_mentions: Option<AllowedMentions>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -134,7 +121,7 @@ pub(crate) struct CreateMessageFields {
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let channel_id = ChannelId(123);
 /// let message = client
@@ -147,8 +134,8 @@ pub(crate) struct CreateMessageFields {
 /// ```
 pub struct CreateMessage<'a> {
     channel_id: ChannelId,
-    pub(crate) fields: CreateMessageFields,
-    files: Vec<(String, Vec<u8>)>,
+    pub(crate) fields: CreateMessageFields<'a>,
+    files: &'a [(&'a str, &'a [u8])],
     http: &'a Client,
 }
 
@@ -160,7 +147,7 @@ impl<'a> CreateMessage<'a> {
                 allowed_mentions: http.default_allowed_mentions(),
                 ..CreateMessageFields::default()
             },
-            files: Vec::new(),
+            files: &[],
             http,
         }
     }
@@ -180,45 +167,15 @@ impl<'a> CreateMessage<'a> {
     ///
     /// Returns a [`CreateMessageErrorType::ContentInvalid`] error type if the
     /// content length is too long.
-    pub fn content(self, content: impl Into<String>) -> Result<Self, CreateMessageError> {
-        self._content(content.into())
-    }
-
-    fn _content(mut self, content: String) -> Result<Self, CreateMessageError> {
-        if !validate::content_limit(&content) {
+    pub fn content(mut self, content: &'a str) -> Result<Self, CreateMessageError> {
+        if !validate::content_limit(content) {
             return Err(CreateMessageError {
-                kind: CreateMessageErrorType::ContentInvalid { content },
+                kind: CreateMessageErrorType::ContentInvalid,
                 source: None,
             });
         }
 
         self.fields.content.replace(content);
-
-        Ok(self)
-    }
-
-    /// Attach an embed to the message.
-    ///
-    /// Embed total character length must not exceed 6000 characters.
-    /// Additionally, the internal fields also have character limits. Refer to
-    /// [the discord docs] for more information.
-    ///
-    /// # Examples
-    ///
-    /// See [`EmbedBuilder`] for an example.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`CreateMessageErrorType::EmbedTooLarge`] error type if the
-    /// embed is too large.
-    ///
-    /// [the discord docs]: https://discord.com/developers/docs/resources/channel#embed-limits
-    /// [`EmbedBuilder`]: https://docs.rs/twilight-embed-builder/*/twilight_embed_builder
-    pub fn embed(mut self, embed: Embed) -> Result<Self, CreateMessageError> {
-        validate::embed(&embed)
-            .map_err(|source| CreateMessageError::embed(source, embed.clone(), None))?;
-
-        self.fields.embeds.push(embed);
 
         Ok(self)
     }
@@ -235,16 +192,12 @@ impl<'a> CreateMessage<'a> {
     /// embed is too large.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#embed-limits
-    pub fn embeds(
-        mut self,
-        embeds: impl IntoIterator<Item = Embed>,
-    ) -> Result<Self, CreateMessageError> {
-        for (idx, embed) in embeds.into_iter().enumerate() {
-            validate::embed(&embed)
-                .map_err(|source| CreateMessageError::embed(source, embed.clone(), Some(idx)))?;
-
-            self.fields.embeds.push(embed);
+    pub fn embeds(mut self, embeds: &'a [Embed]) -> Result<Self, CreateMessageError> {
+        for (idx, embed) in embeds.iter().enumerate() {
+            validate::embed(&embed).map_err(|source| CreateMessageError::embed(source, idx))?;
         }
+
+        self.fields.embeds = embeds;
 
         Ok(self)
     }
@@ -267,23 +220,11 @@ impl<'a> CreateMessage<'a> {
         self
     }
 
-    /// Attach a file to the message.
-    ///
-    /// The file is raw binary data. It can be an image, or any other kind of file.
-    pub fn file(mut self, name: impl Into<String>, file: impl Into<Vec<u8>>) -> Self {
-        self.files.push((name.into(), file.into()));
-
-        self
-    }
-
     /// Attach multiple files to the message.
-    pub fn files<N: Into<String>, F: Into<Vec<u8>>>(
-        mut self,
-        attachments: impl IntoIterator<Item = (N, F)>,
-    ) -> Self {
-        for (name, file) in attachments {
-            self = self.file(name, file);
-        }
+    ///
+    /// Calling this method multiple times will clear previously added files.
+    pub const fn files(mut self, files: &'a [(&'a str, &'a [u8])]) -> Self {
+        self.files = files;
 
         self
     }
@@ -298,12 +239,12 @@ impl<'a> CreateMessage<'a> {
     /// JSON encoded body of any additional request fields.
     ///
     /// If this method is called, all other fields are ignored, except for
-    /// [`file`]. See [Discord Docs/Create Message].
+    /// [`files`]. See [Discord Docs/Create Message].
     ///
-    /// [`file`]: Self::file
+    /// [`files`]: Self::files
     /// [Discord Docs/Create Message]: https://discord.com/developers/docs/resources/channel#create-message-params
-    pub fn payload_json(mut self, payload_json: impl Into<Vec<u8>>) -> Self {
-        self.fields.payload_json.replace(payload_json.into());
+    pub fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
+        self.fields.payload_json.replace(payload_json);
 
         self
     }

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -222,7 +222,7 @@ impl<'a> CreateMessage<'a> {
 
     /// Attach multiple files to the message.
     ///
-    /// Calling this method multiple times will clear previously added files.
+    /// Calling this method will clear any previous calls.
     pub const fn files(mut self, files: &'a [(&'a str, &'a [u8])]) -> Self {
         self.files = files;
 

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -11,7 +11,7 @@ pub struct DeleteMessage<'a> {
     channel_id: ChannelId,
     http: &'a Client,
     message_id: MessageId,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> DeleteMessage<'a> {
@@ -50,10 +50,9 @@ impl<'a> DeleteMessage<'a> {
     }
 }
 
-impl<'a> AuditLogReason for DeleteMessage<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for DeleteMessage<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -49,7 +49,7 @@ impl GetChannelMessagesError {
 impl Display for GetChannelMessagesError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            GetChannelMessagesErrorType::LimitInvalid { .. } => f.write_str("the limit is invalid"),
+            GetChannelMessagesErrorType::LimitInvalid => f.write_str("the limit is invalid"),
         }
     }
 }
@@ -61,10 +61,7 @@ impl Error for GetChannelMessagesError {}
 #[non_exhaustive]
 pub enum GetChannelMessagesErrorType {
     /// The maximum number of messages to retrieve is either 0 or more than 100.
-    LimitInvalid {
-        /// Provided maximum number of messages to retrieve.
-        limit: u64,
-    },
+    LimitInvalid,
 }
 
 #[derive(Default)]
@@ -87,7 +84,7 @@ struct GetChannelMessagesFields {
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 /// let channel_id = ChannelId(123);
 /// let message_id = MessageId(234);
 ///
@@ -165,7 +162,7 @@ impl<'a> GetChannelMessages<'a> {
     pub fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesError> {
         if !validate::get_channel_messages_limit(limit) {
             return Err(GetChannelMessagesError {
-                kind: GetChannelMessagesErrorType::LimitInvalid { limit },
+                kind: GetChannelMessagesErrorType::LimitInvalid,
             });
         }
 

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -62,10 +62,7 @@ impl Error for GetChannelMessagesConfiguredError {}
 #[non_exhaustive]
 pub enum GetChannelMessagesConfiguredErrorType {
     /// The maximum number of messages to retrieve is either 0 or more than 100.
-    LimitInvalid {
-        /// Provided maximum number of messages to retrieve.
-        limit: u64,
-    },
+    LimitInvalid,
 }
 
 struct GetChannelMessagesConfiguredFields {
@@ -118,7 +115,7 @@ impl<'a> GetChannelMessagesConfigured<'a> {
     pub fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesConfiguredError> {
         if !validate::get_channel_messages_limit(limit) {
             return Err(GetChannelMessagesConfiguredError {
-                kind: GetChannelMessagesConfiguredErrorType::LimitInvalid { limit },
+                kind: GetChannelMessagesConfiguredErrorType::LimitInvalid,
             });
         }
 

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -99,15 +99,6 @@ struct UpdateMessageFields<'a> {
     pub(crate) allowed_mentions: Option<AllowedMentions>,
     #[serde(skip_serializing_if = "request::slice_is_empty")]
     pub attachments: &'a [Attachment],
-    // We don't serialize if this is Option::None, to avoid overwriting the
-    // field without meaning to.
-    //
-    // So we use a nested Option, representing the following states:
-    //
-    // - Some(Some(str)): Modifying the "content" from one state to a string;
-    // - Some(None): Removing the "content" by giving the Discord API a written
-    //   `"content": null` in the JSON;
-    // - None: Don't serialize the field at all, not modifying the state.
     #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -178,7 +169,7 @@ impl<'a> UpdateMessage<'a> {
     /// If called, all unspecified attachments will be removed from the message.
     /// If not called, all attachments will be kept.
     ///
-    /// Calling this method will clear previous calls.
+    /// Calling this method will clear any previous calls.
     pub const fn attachments(mut self, attachments: &'a [Attachment]) -> Self {
         self.fields.attachments = attachments;
 
@@ -223,13 +214,12 @@ impl<'a> UpdateMessage<'a> {
     /// previous message, mutate them in place, then pass that list to this
     /// method.
     ///
-    /// To remove all embeds, pass an empty iterator via a function like
-    /// [`std::iter::empty`].
+    /// To remove all embeds pass an empty slice.
     ///
     /// Note that if there is no content or file then you will not be able to
     /// remove all of the embeds.
     ///
-    /// Calling this method again will clear previous calls.
+    /// Calling this method will clear any previous calls.
     ///
     /// # Errors
     ///

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -72,6 +72,8 @@ impl<'a> CreateReaction<'a> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::non_ascii_literal)]
+
     use super::CreateReaction;
     use crate::{
         request::{channel::reaction::RequestReactionType, Request},
@@ -84,14 +86,14 @@ mod tests {
     fn test_request() {
         let client = Client::new("foo".to_owned());
 
-        let emoji = RequestReactionType::Unicode { name: "\u{1f303}" };
+        let emoji = RequestReactionType::Unicode { name: "🌃" };
 
         let builder = CreateReaction::new(&client, ChannelId(123), MessageId(456), &emoji);
         let actual = builder.request();
 
         let expected = Request::from_route(Route::CreateReaction {
             channel_id: 123,
-            emoji: &RequestReactionType::Unicode { name: "\u{1f303}" },
+            emoji: &RequestReactionType::Unicode { name: "🌃" },
             message_id: 456,
         });
 

--- a/http/src/request/channel/reaction/delete_all_reaction.rs
+++ b/http/src/request/channel/reaction/delete_all_reaction.rs
@@ -10,7 +10,7 @@ use twilight_model::id::{ChannelId, MessageId};
 /// Remove all reactions of a specified emoji from a message.
 pub struct DeleteAllReaction<'a> {
     channel_id: ChannelId,
-    emoji: RequestReactionType,
+    emoji: &'a RequestReactionType<'a>,
     http: &'a Client,
     message_id: MessageId,
 }
@@ -20,7 +20,7 @@ impl<'a> DeleteAllReaction<'a> {
         http: &'a Client,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: RequestReactionType,
+        emoji: &'a RequestReactionType<'a>,
     ) -> Self {
         Self {
             channel_id,
@@ -37,7 +37,7 @@ impl<'a> DeleteAllReaction<'a> {
         let request = Request::from_route(Route::DeleteMessageSpecificReaction {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
-            emoji: self.emoji.display().to_string(),
+            emoji: self.emoji,
         });
 
         self.http.request(request)

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -74,7 +74,7 @@ struct GetReactionsFields {
 /// requests must be chained until all reactions are retireved.
 pub struct GetReactions<'a> {
     channel_id: ChannelId,
-    emoji: RequestReactionType,
+    emoji: &'a RequestReactionType<'a>,
     fields: GetReactionsFields,
     http: &'a Client,
     message_id: MessageId,
@@ -85,7 +85,7 @@ impl<'a> GetReactions<'a> {
         http: &'a Client,
         channel_id: ChannelId,
         message_id: MessageId,
-        emoji: RequestReactionType,
+        emoji: &'a RequestReactionType<'a>,
     ) -> Self {
         Self {
             channel_id,
@@ -131,7 +131,7 @@ impl<'a> GetReactions<'a> {
         let request = Request::from_route(Route::GetReactionUsers {
             after: self.fields.after.map(|x| x.0),
             channel_id: self.channel_id.0,
-            emoji: self.emoji.display().to_string(),
+            emoji: self.emoji,
             limit: self.fields.limit,
             message_id: self.message_id.0,
         });

--- a/http/src/request/channel/reaction/mod.rs
+++ b/http/src/request/channel/reaction/mod.rs
@@ -86,7 +86,7 @@ impl<'a> RequestReactionType<'a> {
 /// // And now format it into an acceptable string and then check it.
 /// assert_eq!("rarity:123", display.to_string());
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RequestReactionTypeDisplay<'a>(&'a RequestReactionType<'a>);
 
 impl Display for RequestReactionTypeDisplay<'_> {
@@ -118,13 +118,16 @@ mod tests {
 
     use super::{RequestReactionType, RequestReactionTypeDisplay};
     use static_assertions::{assert_fields, assert_impl_all};
-    use std::fmt::{Debug, Display};
+    use std::{
+        fmt::{Debug, Display},
+        hash::Hash,
+    };
     use twilight_model::id::EmojiId;
 
     assert_fields!(RequestReactionType::Custom: id, name);
     assert_fields!(RequestReactionType::Unicode: name);
-    assert_impl_all!(RequestReactionTypeDisplay<'_>: Clone, Debug, Display, Eq, PartialEq, Send, Sync);
-    assert_impl_all!(RequestReactionType<'_>: Clone, Debug, Eq, PartialEq, Send, Sync);
+    assert_impl_all!(RequestReactionTypeDisplay<'_>: Clone, Copy, Debug, Display, Eq, PartialEq, Send, Sync);
+    assert_impl_all!(RequestReactionType<'_>: Clone, Copy, Debug, Eq, Hash, PartialEq, Send, Sync);
 
     #[test]
     fn test_display_custom_with_name() {

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -62,18 +62,15 @@ impl Error for UpdateStageInstanceError {
 #[derive(Debug)]
 pub enum UpdateStageInstanceErrorType {
     /// Topic is not between 1 and 120 characters in length.
-    InvalidTopic {
-        /// Invalid topic.
-        topic: String,
-    },
+    InvalidTopic,
 }
 
 #[derive(Default, Serialize)]
-struct UpdateStageInstanceFields {
+struct UpdateStageInstanceFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     privacy_level: Option<PrivacyLevel>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    topic: Option<String>,
+    topic: Option<&'a str>,
 }
 
 /// Update fields of an existing stage instance.
@@ -81,7 +78,7 @@ struct UpdateStageInstanceFields {
 /// Requires the user to be a moderator of the stage channel.
 pub struct UpdateStageInstance<'a> {
     channel_id: ChannelId,
-    fields: UpdateStageInstanceFields,
+    fields: UpdateStageInstanceFields<'a>,
     http: &'a Client,
 }
 
@@ -102,14 +99,10 @@ impl<'a> UpdateStageInstance<'a> {
     }
 
     /// Set the new topic of the instance.
-    pub fn topic(self, topic: impl Into<String>) -> Result<Self, UpdateStageInstanceError> {
-        self._topic(topic.into())
-    }
-
-    fn _topic(mut self, topic: String) -> Result<Self, UpdateStageInstanceError> {
+    pub fn topic(mut self, topic: &'a str) -> Result<Self, UpdateStageInstanceError> {
         if !validate::stage_topic(&topic) {
             return Err(UpdateStageInstanceError {
-                kind: UpdateStageInstanceErrorType::InvalidTopic { topic },
+                kind: UpdateStageInstanceErrorType::InvalidTopic,
                 source: None,
             });
         }

--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -19,7 +19,7 @@ use twilight_model::{
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let channel_id = ChannelId(123);
 /// let allow = Permissions::VIEW_CHANNEL;
@@ -55,18 +55,18 @@ impl<'a> UpdateChannelPermission<'a> {
     }
 
     /// Specify this override to be for a member.
-    pub fn member(self, user_id: impl Into<UserId>) -> UpdateChannelPermissionConfigured<'a> {
-        self.configure(&PermissionOverwriteType::Member(user_id.into()))
+    pub const fn member(self, user_id: UserId) -> UpdateChannelPermissionConfigured<'a> {
+        self.configure(PermissionOverwriteType::Member(user_id))
     }
 
     /// Specify this override to be for a role.
-    pub fn role(self, role_id: impl Into<RoleId>) -> UpdateChannelPermissionConfigured<'a> {
-        self.configure(&PermissionOverwriteType::Role(role_id.into()))
+    pub const fn role(self, role_id: RoleId) -> UpdateChannelPermissionConfigured<'a> {
+        self.configure(PermissionOverwriteType::Role(role_id))
     }
 
     const fn configure(
         self,
-        target: &PermissionOverwriteType,
+        target: PermissionOverwriteType,
     ) -> UpdateChannelPermissionConfigured<'a> {
         UpdateChannelPermissionConfigured::new(
             self.http,

--- a/http/src/request/channel/webhook/delete_webhook.rs
+++ b/http/src/request/channel/webhook/delete_webhook.rs
@@ -6,16 +6,16 @@ use crate::{
 };
 use twilight_model::id::WebhookId;
 
-struct DeleteWebhookParams {
-    token: Option<String>,
+struct DeleteWebhookParams<'a> {
+    token: Option<&'a str>,
 }
 
 /// Delete a webhook by its ID.
 pub struct DeleteWebhook<'a> {
-    fields: DeleteWebhookParams,
+    fields: DeleteWebhookParams<'a>,
     http: &'a Client,
     id: WebhookId,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> DeleteWebhook<'a> {
@@ -29,8 +29,8 @@ impl<'a> DeleteWebhook<'a> {
     }
 
     /// Specify the token for auth, if not already authenticated with a Bot token.
-    pub fn token(mut self, token: impl Into<String>) -> Self {
-        self.fields.token.replace(token.into());
+    pub fn token(mut self, token: &'a str) -> Self {
+        self.fields.token.replace(token);
 
         self
     }
@@ -57,10 +57,9 @@ impl<'a> DeleteWebhook<'a> {
     }
 }
 
-impl<'a> AuditLogReason for DeleteWebhook<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for DeleteWebhook<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/channel/webhook/delete_webhook_message.rs
+++ b/http/src/request/channel/webhook/delete_webhook_message.rs
@@ -18,7 +18,7 @@ use twilight_model::id::{MessageId, WebhookId};
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # let client = Client::new("token");
+/// # let client = Client::new("token".to_owned());
 /// client
 ///     .delete_webhook_message(WebhookId(1), "token here", MessageId(2))
 ///     .reason("reason here")?
@@ -29,30 +29,30 @@ use twilight_model::id::{MessageId, WebhookId};
 pub struct DeleteWebhookMessage<'a> {
     http: &'a Client,
     message_id: MessageId,
-    reason: Option<String>,
-    token: String,
+    reason: Option<&'a str>,
+    token: &'a str,
     webhook_id: WebhookId,
 }
 
 impl<'a> DeleteWebhookMessage<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         webhook_id: WebhookId,
-        token: impl Into<String>,
+        token: &'a str,
         message_id: MessageId,
     ) -> Self {
         Self {
             http,
             message_id,
             reason: None,
-            token: token.into(),
+            token,
             webhook_id,
         }
     }
 
     // `self` needs to be consumed and the client returned due to parameters
     // being consumed in request construction.
-    fn request(self) -> Result<(Request, &'a Client), Error> {
+    fn request(&self) -> Result<Request<'a>, Error> {
         let mut request = Request::builder(Route::DeleteWebhookMessage {
             message_id: self.message_id.0,
             token: self.token,
@@ -64,7 +64,7 @@ impl<'a> DeleteWebhookMessage<'a> {
             request = request.headers(request::audit_header(reason)?);
         }
 
-        Ok((request.build(), self.http))
+        Ok(request.build())
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
@@ -72,16 +72,15 @@ impl<'a> DeleteWebhookMessage<'a> {
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
         match self.request() {
-            Ok((request, client)) => client.request(request),
+            Ok(request) => self.http.request(request),
             Err(source) => ResponseFuture::error(source),
         }
     }
 }
 
-impl<'a> AuditLogReason for DeleteWebhookMessage<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for DeleteWebhookMessage<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }
@@ -95,17 +94,17 @@ mod tests {
 
     #[test]
     fn test_request() {
-        let client = Client::new("token");
+        let client = Client::new("token".to_owned());
         let builder = DeleteWebhookMessage::new(&client, WebhookId(1), "token", MessageId(2));
-        let (actual, _) = builder.request().expect("failed to create request");
+        let actual = builder.request().expect("failed to create request");
 
         let expected = Request::from_route(Route::DeleteWebhookMessage {
             message_id: 2,
-            token: "token".to_owned(),
+            token: "token",
             webhook_id: 1,
         });
 
         assert_eq!(expected.body, actual.body);
-        assert_eq!(expected.path, actual.path);
+        assert_eq!(expected.route, actual.route);
     }
 }

--- a/http/src/request/channel/webhook/execute_webhook_and_wait.rs
+++ b/http/src/request/channel/webhook/execute_webhook_and_wait.rs
@@ -13,7 +13,7 @@ use twilight_model::channel::Message;
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 /// let id = WebhookId(432);
 ///
 /// let message = client
@@ -45,11 +45,9 @@ impl<'a> ExecuteWebhookAndWait<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Message> {
-        let (request, client) = match self.inner.request(false) {
-            Ok((request, client)) => (request, client),
-            Err(source) => return ResponseFuture::error(source),
-        };
-
-        client.request(request)
+        match self.inner.request(false) {
+            Ok(request) => self.inner.http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }

--- a/http/src/request/channel/webhook/get_webhook.rs
+++ b/http/src/request/channel/webhook/get_webhook.rs
@@ -2,13 +2,13 @@ use crate::{client::Client, request::Request, response::ResponseFuture, routing:
 use twilight_model::{channel::Webhook, id::WebhookId};
 
 #[derive(Default)]
-struct GetWebhookFields {
-    token: Option<String>,
+struct GetWebhookFields<'a> {
+    token: Option<&'a str>,
 }
 
 /// Get a webhook by ID.
 pub struct GetWebhook<'a> {
-    fields: GetWebhookFields,
+    fields: GetWebhookFields<'a>,
     http: &'a Client,
     id: WebhookId,
 }
@@ -24,8 +24,8 @@ impl<'a> GetWebhook<'a> {
 
     /// Specify the token for auth, if not already authenticated with a Bot
     /// token.
-    pub fn token(mut self, token: impl Into<String>) -> Self {
-        self.fields.token.replace(token.into());
+    pub fn token(mut self, token: &'a str) -> Self {
+        self.fields.token.replace(token);
 
         self
     }

--- a/http/src/request/channel/webhook/get_webhook_message.rs
+++ b/http/src/request/channel/webhook/get_webhook_message.rs
@@ -11,21 +11,21 @@ use twilight_model::{
 pub struct GetWebhookMessage<'a> {
     http: &'a Client,
     message_id: MessageId,
-    token: String,
+    token: &'a str,
     webhook_id: WebhookId,
 }
 
 impl<'a> GetWebhookMessage<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         webhook_id: WebhookId,
-        token: impl Into<String>,
+        token: &'a str,
         message_id: MessageId,
     ) -> Self {
         Self {
             http,
             message_id,
-            token: token.into(),
+            token,
             webhook_id,
         }
     }

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -11,21 +11,21 @@ use twilight_model::{
 };
 
 #[derive(Default, Serialize)]
-struct UpdateWebhookFields {
+struct UpdateWebhookFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<NullableField<String>>,
+    avatar: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     channel_id: Option<ChannelId>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<NullableField<String>>,
+    name: Option<NullableField<&'a str>>,
 }
 
 /// Update a webhook by ID.
 pub struct UpdateWebhook<'a> {
-    fields: UpdateWebhookFields,
+    fields: UpdateWebhookFields<'a>,
     http: &'a Client,
     webhook_id: WebhookId,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 /// Update a webhook by its ID.
@@ -46,26 +46,24 @@ impl<'a> UpdateWebhook<'a> {
     /// base64-encoded image.
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<Option<String>>) -> Self {
+    pub fn avatar(mut self, avatar: Option<&'a str>) -> Self {
         self.fields
             .avatar
-            .replace(NullableField::from_option(avatar.into()));
+            .replace(NullableField::from_option(avatar));
 
         self
     }
 
     /// Move this webhook to a new channel.
-    pub fn channel_id(mut self, channel_id: impl Into<ChannelId>) -> Self {
-        self.fields.channel_id.replace(channel_id.into());
+    pub fn channel_id(mut self, channel_id: ChannelId) -> Self {
+        self.fields.channel_id.replace(channel_id);
 
         self
     }
 
     /// Change the name of the webhook.
-    pub fn name(mut self, name: impl Into<Option<String>>) -> Self {
-        self.fields
-            .name
-            .replace(NullableField::from_option(name.into()));
+    pub fn name(mut self, name: Option<&'a str>) -> Self {
+        self.fields.name.replace(NullableField::from_option(name));
 
         self
     }
@@ -97,10 +95,9 @@ impl<'a> UpdateWebhook<'a> {
     }
 }
 
-impl<'a> AuditLogReason for UpdateWebhook<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for UpdateWebhook<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -83,9 +83,8 @@ pub enum UpdateWebhookMessageErrorType {
     EmbedTooLarge {
         /// Index of the embed that was too large.
         ///
-        /// This can be used to index into [`embeds`] to retrieve the bad embed.
-        ///
-        /// [`embeds`]: Self::EmbedTooLarge.embeds
+        /// This can be used to index into the provided embeds to retrieve the
+        /// invalid embed.
         index: usize,
     },
     /// Too many embeds were provided.
@@ -300,7 +299,7 @@ impl<'a> UpdateWebhookMessage<'a> {
 
     /// Attach multiple files to the webhook.
     ///
-    /// Calling this method again clears previous calls.
+    /// Calling this method will clear any previous calls.
     pub const fn files(mut self, files: &'a [(&'a str, &'a [u8])]) -> Self {
         self.files = files;
 

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -8,27 +8,27 @@ use serde::Serialize;
 use twilight_model::{channel::Webhook, id::WebhookId};
 
 #[derive(Default, Serialize)]
-struct UpdateWebhookWithTokenFields {
+struct UpdateWebhookWithTokenFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<NullableField<String>>,
+    avatar: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<NullableField<String>>,
+    name: Option<NullableField<&'a str>>,
 }
 
 /// Update a webhook, with a token, by ID.
 pub struct UpdateWebhookWithToken<'a> {
-    fields: UpdateWebhookWithTokenFields,
+    fields: UpdateWebhookWithTokenFields<'a>,
     http: &'a Client,
-    token: String,
+    token: &'a str,
     webhook_id: WebhookId,
 }
 
 impl<'a> UpdateWebhookWithToken<'a> {
-    pub(crate) fn new(http: &'a Client, webhook_id: WebhookId, token: impl Into<String>) -> Self {
+    pub(crate) fn new(http: &'a Client, webhook_id: WebhookId, token: &'a str) -> Self {
         Self {
             fields: UpdateWebhookWithTokenFields::default(),
             http,
-            token: token.into(),
+            token,
             webhook_id,
         }
     }
@@ -40,19 +40,17 @@ impl<'a> UpdateWebhookWithToken<'a> {
     /// base64-encoded image.
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<Option<String>>) -> Self {
+    pub fn avatar(mut self, avatar: Option<&'a str>) -> Self {
         self.fields
             .avatar
-            .replace(NullableField::from_option(avatar.into()));
+            .replace(NullableField::from_option(avatar));
 
         self
     }
 
     /// Change the name of the webhook.
-    pub fn name(mut self, name: impl Into<Option<String>>) -> Self {
-        self.fields
-            .name
-            .replace(NullableField::from_option(name.into()));
+    pub fn name(mut self, name: Option<&'a str>) -> Self {
+        self.fields.name.replace(NullableField::from_option(name));
 
         self
     }

--- a/http/src/request/get_gateway.rs
+++ b/http/src/request/get_gateway.rs
@@ -18,7 +18,7 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let info = client.gateway().exec().await?.model().await?;
 /// # Ok(()) }
@@ -32,7 +32,7 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let info = client.gateway().authed().exec().await?.model().await?;
 ///

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -18,7 +18,7 @@ use twilight_model::id::{GuildId, UserId};
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let guild_id = GuildId(100);
 /// let user_id = UserId(200);
@@ -30,7 +30,7 @@ pub struct DeleteBan<'a> {
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> DeleteBan<'a> {
@@ -65,10 +65,9 @@ impl<'a> DeleteBan<'a> {
     }
 }
 
-impl<'a> AuditLogReason for DeleteBan<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for DeleteBan<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/guild/ban/get_bans.rs
+++ b/http/src/request/guild/ban/get_bans.rs
@@ -18,7 +18,7 @@ use twilight_model::{guild::Ban, id::GuildId};
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let guild_id = GuildId(1);
 ///

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -83,13 +83,13 @@ impl RoleFieldsBuilder {
     const ROLE_ID: RoleId = RoleId(1);
 
     /// Create a new default role field builder.
-    pub fn new(name: impl Into<String>) -> Self {
+    pub const fn new(name: String) -> Self {
         Self(RoleFields {
             color: None,
             hoist: None,
             id: Self::ROLE_ID,
             mentionable: None,
-            name: name.into(),
+            name,
             permissions: None,
             position: None,
         })
@@ -294,11 +294,7 @@ impl TextFieldsBuilder {
     ///
     /// Returns a [`TextFieldsErrorType::NameTooLong`] error type if the name is
     /// too long.
-    pub fn new(name: impl Into<String>) -> Result<Self, TextFieldsError> {
-        Self::_new(name.into())
-    }
-
-    fn _new(name: String) -> Result<Self, TextFieldsError> {
+    pub fn new(name: String) -> Result<Self, TextFieldsError> {
         if name.len() < Self::MIN_NAME_LENGTH {
             return Err(TextFieldsError {
                 kind: TextFieldsErrorType::NameTooShort { name },
@@ -367,11 +363,7 @@ impl TextFieldsBuilder {
     ///
     /// Returns a [`TextFieldsErrorType::TopicTooLong`] error type if the topic
     /// is too long.
-    pub fn topic(self, topic: impl Into<String>) -> Result<Self, TextFieldsError> {
-        self._topic(topic.into())
-    }
-
-    fn _topic(mut self, topic: String) -> Result<Self, TextFieldsError> {
+    pub fn topic(mut self, topic: String) -> Result<Self, TextFieldsError> {
         if topic.len() > Self::MAX_TOPIC_LENGTH {
             return Err(TextFieldsError {
                 kind: TextFieldsErrorType::TopicTooLong { topic },
@@ -475,11 +467,7 @@ impl VoiceFieldsBuilder {
     ///
     /// Returns a [`VoiceFieldsErrorType::NameTooLong`] error type if the name
     /// is too long.
-    pub fn new(name: impl Into<String>) -> Result<Self, VoiceFieldsError> {
-        Self::_new(name.into())
-    }
-
-    fn _new(name: String) -> Result<Self, VoiceFieldsError> {
+    pub fn new(name: String) -> Result<Self, VoiceFieldsError> {
         if name.len() < Self::MIN_NAME_LENGTH {
             return Err(VoiceFieldsError {
                 kind: VoiceFieldsErrorType::NameTooShort { name },
@@ -630,11 +618,7 @@ impl CategoryFieldsBuilder {
     ///
     /// Returns a [`CategoryFieldsErrorType::NameTooLong`] error type if the
     /// name is too long.
-    pub fn new(name: impl Into<String>) -> Result<Self, CategoryFieldsError> {
-        Self::_new(name.into())
-    }
-
-    fn _new(name: String) -> Result<Self, CategoryFieldsError> {
+    pub fn new(name: String) -> Result<Self, CategoryFieldsError> {
         if name.len() < Self::MIN_NAME_LENGTH {
             return Err(CategoryFieldsError {
                 kind: CategoryFieldsErrorType::NameTooShort { name },
@@ -676,16 +660,15 @@ impl CategoryFieldsBuilder {
     }
 
     /// Add a child text channel.
-    pub fn add_text(mut self, channel: impl Into<TextFields>) -> Self {
-        self.channels.push(GuildChannelFields::Text(channel.into()));
+    pub fn add_text(mut self, channel: TextFields) -> Self {
+        self.channels.push(GuildChannelFields::Text(channel));
 
         self
     }
 
     /// add a child voice channel.
-    pub fn add_voice(mut self, channel: impl Into<VoiceFields>) -> Self {
-        self.channels
-            .push(GuildChannelFields::Voice(channel.into()));
+    pub fn add_voice(mut self, channel: VoiceFields) -> Self {
+        self.channels.push(GuildChannelFields::Voice(channel));
 
         self
     }
@@ -709,15 +692,15 @@ impl GuildChannelFieldsBuilder {
     }
 
     /// Add a text channel to the builder.
-    pub fn add_text(mut self, channel: impl Into<TextFields>) -> Self {
-        self.0.push(GuildChannelFields::Text(channel.into()));
+    pub fn add_text(mut self, channel: TextFields) -> Self {
+        self.0.push(GuildChannelFields::Text(channel));
 
         self
     }
 
     /// Add a voice channel to the builder.
-    pub fn add_voice(mut self, channel: impl Into<VoiceFields>) -> Self {
-        self.0.push(GuildChannelFields::Voice(channel.into()));
+    pub fn add_voice(mut self, channel: VoiceFields) -> Self {
+        self.0.push(GuildChannelFields::Voice(channel));
 
         self
     }
@@ -729,7 +712,7 @@ impl GuildChannelFieldsBuilder {
             .iter()
             .rev()
             .find(|c| matches!(c, GuildChannelFields::Category(_)))
-            .map_or(ChannelId(1), |c| c.clone().id());
+            .map_or(ChannelId(1), GuildChannelFields::id);
 
         let mut channels = channel.build(ChannelId(last_id.0 + 1));
 
@@ -768,25 +751,26 @@ mod tests {
         }
     }
 
-    fn voice() -> VoiceFieldsBuilder {
-        VoiceFieldsBuilder::new("voicename")
+    fn voice() -> VoiceFields {
+        VoiceFieldsBuilder::new("voicename".to_owned())
             .unwrap()
             .bitrate(96_000)
             .permission_overwrites(vec![overwrite()])
             .user_limit(40)
+            .build()
     }
 
     #[test]
     fn test_role_fields() {
         assert!(matches!(
-            RoleFieldsBuilder::new("role")
+            RoleFieldsBuilder::new("role".to_owned())
                 .color(123_123_123)
                 .unwrap_err()
                 .kind(),
             RoleFieldsErrorType::ColorNotRgb { color: 123_123_123 },
         ));
 
-        let fields = RoleFieldsBuilder::new("rolename")
+        let fields = RoleFieldsBuilder::new("rolename".to_owned())
             .color(0x12_34_56)
             .unwrap()
             .hoist()
@@ -813,15 +797,13 @@ mod tests {
     #[test]
     fn test_voice_fields() {
         assert!(matches!(
-            VoiceFieldsBuilder::new("c").unwrap_err().kind(),
+            VoiceFieldsBuilder::new("c".to_owned()).unwrap_err().kind(),
             VoiceFieldsErrorType::NameTooShort { name }
             if name == "c"
         ));
 
-        let fields = voice();
-
         assert_eq!(
-            fields.build(),
+            voice(),
             VoiceFields {
                 bitrate: Some(96_000),
                 id: ChannelId(1),
@@ -838,29 +820,28 @@ mod tests {
         );
     }
 
-    fn text() -> TextFieldsBuilder {
-        TextFieldsBuilder::new("textname")
+    fn text() -> TextFields {
+        TextFieldsBuilder::new("textname".to_owned())
             .unwrap()
             .nsfw()
             .permission_overwrites(vec![overwrite()])
             .rate_limit_per_user(4_000)
             .unwrap()
-            .topic("a topic")
+            .topic("a topic".to_owned())
             .unwrap()
+            .build()
     }
 
     #[test]
     fn test_text_fields() {
         assert!(matches!(
-            TextFieldsBuilder::new("b").unwrap_err().kind(),
+            TextFieldsBuilder::new("b".to_owned()).unwrap_err().kind(),
             TextFieldsErrorType::NameTooShort { name }
             if name == "b"
         ));
 
-        let fields = text();
-
         assert_eq!(
-            fields.build(),
+            text(),
             TextFields {
                 id: ChannelId(1),
                 kind: ChannelType::GuildText,
@@ -879,7 +860,7 @@ mod tests {
     }
 
     fn category() -> CategoryFieldsBuilder {
-        CategoryFieldsBuilder::new("category")
+        CategoryFieldsBuilder::new("category".to_owned())
             .unwrap()
             .add_text(text())
             .add_voice(voice())
@@ -888,7 +869,7 @@ mod tests {
     #[test]
     fn test_category_fields() {
         assert!(matches!(
-            CategoryFieldsBuilder::new("a").unwrap_err().kind(),
+            CategoryFieldsBuilder::new("a".to_owned()).unwrap_err().kind(),
             CategoryFieldsErrorType::NameTooShort { name }
             if name == "a"
         ));

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -11,11 +11,11 @@ use twilight_model::{
 };
 
 #[derive(Serialize)]
-struct CreateEmojiFields {
-    image: String,
-    name: String,
+struct CreateEmojiFields<'a> {
+    image: &'a str,
+    name: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
-    roles: Option<Vec<RoleId>>,
+    roles: Option<&'a [RoleId]>,
 }
 
 /// Create an emoji in a guild.
@@ -26,23 +26,23 @@ struct CreateEmojiFields {
 ///
 /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
 pub struct CreateEmoji<'a> {
-    fields: CreateEmojiFields,
+    fields: CreateEmojiFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> CreateEmoji<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         guild_id: GuildId,
-        name: impl Into<String>,
-        image: impl Into<String>,
+        name: &'a str,
+        image: &'a str,
     ) -> Self {
         Self {
             fields: CreateEmojiFields {
-                image: image.into(),
-                name: name.into(),
+                image,
+                name,
                 roles: None,
             },
             guild_id,
@@ -56,7 +56,7 @@ impl<'a> CreateEmoji<'a> {
     /// Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/emoji
-    pub fn roles(mut self, roles: Vec<RoleId>) -> Self {
+    pub fn roles(mut self, roles: &'a [RoleId]) -> Self {
         self.fields.roles.replace(roles);
 
         self
@@ -88,10 +88,9 @@ impl<'a> CreateEmoji<'a> {
     }
 }
 
-impl<'a> AuditLogReason for CreateEmoji<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for CreateEmoji<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -11,7 +11,7 @@ pub struct DeleteEmoji<'a> {
     emoji_id: EmojiId,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> DeleteEmoji<'a> {
@@ -46,10 +46,9 @@ impl<'a> DeleteEmoji<'a> {
     }
 }
 
-impl<'a> AuditLogReason for DeleteEmoji<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for DeleteEmoji<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/guild/emoji/get_emoji.rs
+++ b/http/src/request/guild/emoji/get_emoji.rs
@@ -16,7 +16,7 @@ use twilight_model::{
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let guild_id = GuildId(50);
 /// let emoji_id = EmojiId(100);

--- a/http/src/request/guild/emoji/get_emojis.rs
+++ b/http/src/request/guild/emoji/get_emojis.rs
@@ -18,7 +18,7 @@ use twilight_model::{guild::Emoji, id::GuildId};
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let guild_id = GuildId(100);
 ///

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -11,20 +11,20 @@ use twilight_model::{
 };
 
 #[derive(Default, Serialize)]
-struct UpdateEmojiFields {
+struct UpdateEmojiFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
+    name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    roles: Option<Vec<RoleId>>,
+    roles: Option<&'a [RoleId]>,
 }
 
 /// Update an emoji in a guild, by id.
 pub struct UpdateEmoji<'a> {
     emoji_id: EmojiId,
-    fields: UpdateEmojiFields,
+    fields: UpdateEmojiFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> UpdateEmoji<'a> {
@@ -39,14 +39,14 @@ impl<'a> UpdateEmoji<'a> {
     }
 
     /// Change the name of the emoji.
-    pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.fields.name.replace(name.into());
+    pub fn name(mut self, name: &'a str) -> Self {
+        self.fields.name.replace(name);
 
         self
     }
 
     /// Change the roles that the emoji is whitelisted to.
-    pub fn roles(mut self, roles: Vec<RoleId>) -> Self {
+    pub fn roles(mut self, roles: &'a [RoleId]) -> Self {
         self.fields.roles.replace(roles);
 
         self
@@ -79,10 +79,9 @@ impl<'a> UpdateEmoji<'a> {
     }
 }
 
-impl<'a> AuditLogReason for UpdateEmoji<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for UpdateEmoji<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -43,7 +43,7 @@ impl GetAuditLogError {
 impl Display for GetAuditLogError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            GetAuditLogErrorType::LimitInvalid { .. } => f.write_str("the limit is invalid"),
+            GetAuditLogErrorType::LimitInvalid => f.write_str("the limit is invalid"),
         }
     }
 }
@@ -55,10 +55,7 @@ impl Error for GetAuditLogError {}
 #[non_exhaustive]
 pub enum GetAuditLogErrorType {
     /// The limit is either 0 or more than 100.
-    LimitInvalid {
-        /// Provided maximum number of audit logs to get.
-        limit: u64,
-    },
+    LimitInvalid,
 }
 
 #[derive(Default)]
@@ -79,7 +76,7 @@ struct GetAuditLogFields {
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("token");
+/// let client = Client::new("token".to_owned());
 ///
 /// let guild_id = GuildId(101);
 /// let audit_log = client
@@ -140,7 +137,7 @@ impl<'a> GetAuditLog<'a> {
     pub fn limit(mut self, limit: u64) -> Result<Self, GetAuditLogError> {
         if !validate::get_audit_log_limit(limit) {
             return Err(GetAuditLogError {
-                kind: GetAuditLogErrorType::LimitInvalid { limit },
+                kind: GetAuditLogErrorType::LimitInvalid,
             });
         }
 

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -66,14 +66,14 @@ pub enum GetGuildPruneCountErrorType {
 }
 
 #[derive(Default)]
-struct GetGuildPruneCountFields {
+struct GetGuildPruneCountFields<'a> {
     days: Option<u64>,
-    include_roles: Vec<u64>,
+    include_roles: &'a [RoleId],
 }
 
 /// Get the counts of guild members to be pruned.
 pub struct GetGuildPruneCount<'a> {
-    fields: GetGuildPruneCountFields,
+    fields: GetGuildPruneCountFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
 }
@@ -109,9 +109,7 @@ impl<'a> GetGuildPruneCount<'a> {
     }
 
     /// List of roles to include when calculating prune count
-    pub fn include_roles(mut self, roles: impl Iterator<Item = RoleId>) -> Self {
-        let roles = roles.map(|e| e.0).collect::<Vec<_>>();
-
+    pub const fn include_roles(mut self, roles: &'a [RoleId]) -> Self {
         self.fields.include_roles = roles;
 
         self
@@ -140,7 +138,7 @@ mod test {
     #[test]
     fn test_days() {
         fn days_valid(days: u64) -> bool {
-            let client = Client::new("");
+            let client = Client::new("".to_owned());
             let count = GetGuildPruneCount::new(&client, GuildId(0));
             let days_result = count.days(days);
             days_result.is_ok()

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -11,7 +11,7 @@ pub struct DeleteGuildIntegration<'a> {
     guild_id: GuildId,
     http: &'a Client,
     integration_id: IntegrationId,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> DeleteGuildIntegration<'a> {
@@ -50,10 +50,9 @@ impl<'a> DeleteGuildIntegration<'a> {
     }
 }
 
-impl<'a> AuditLogReason for DeleteGuildIntegration<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for DeleteGuildIntegration<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -18,7 +18,7 @@ use twilight_model::id::{GuildId, RoleId, UserId};
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let guild_id = GuildId(1);
 /// let role_id = RoleId(2);
@@ -35,21 +35,21 @@ pub struct AddRoleToMember<'a> {
     http: &'a Client,
     role_id: RoleId,
     user_id: UserId,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> AddRoleToMember<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
-        guild_id: impl Into<GuildId>,
-        user_id: impl Into<UserId>,
-        role_id: impl Into<RoleId>,
+        guild_id: GuildId,
+        user_id: UserId,
+        role_id: RoleId,
     ) -> Self {
         Self {
-            guild_id: guild_id.into(),
+            guild_id,
             http,
-            role_id: role_id.into(),
-            user_id: user_id.into(),
+            role_id,
+            user_id,
             reason: None,
         }
     }
@@ -77,10 +77,9 @@ impl<'a> AddRoleToMember<'a> {
     }
 }
 
-impl<'a> AuditLogReason for AddRoleToMember<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for AddRoleToMember<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -85,7 +85,7 @@ struct GetGuildMembersFields {
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let guild_id = GuildId(100);
 /// let user_id = UserId(3000);

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -11,7 +11,7 @@ pub struct RemoveMember<'a> {
     guild_id: GuildId,
     http: &'a Client,
     user_id: UserId,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> RemoveMember<'a> {
@@ -46,10 +46,9 @@ impl<'a> RemoveMember<'a> {
     }
 }
 
-impl<'a> AuditLogReason for RemoveMember<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for RemoveMember<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -63,8 +63,8 @@ pub enum SearchGuildMembersErrorType {
     },
 }
 
-struct SearchGuildMembersFields {
-    query: String,
+struct SearchGuildMembersFields<'a> {
+    query: &'a str,
     limit: Option<u64>,
 }
 
@@ -82,10 +82,10 @@ struct SearchGuildMembersFields {
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let guild_id = GuildId(100);
-/// let members = client.search_guild_members(guild_id, String::from("Wumpus"))
+/// let members = client.search_guild_members(guild_id, "Wumpus")
 ///     .limit(10)?
 ///     .exec()
 ///     .await?;
@@ -99,17 +99,13 @@ struct SearchGuildMembersFields {
 ///
 /// [`GUILD_MEMBERS`]: twilight_model::gateway::Intents#GUILD_MEMBERS
 pub struct SearchGuildMembers<'a> {
-    fields: SearchGuildMembersFields,
+    fields: SearchGuildMembersFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> SearchGuildMembers<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId, query: impl Into<String>) -> Self {
-        Self::_new(http, guild_id, query.into())
-    }
-
-    const fn _new(http: &'a Client, guild_id: GuildId, query: String) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId, query: &'a str) -> Self {
         Self {
             fields: SearchGuildMembersFields { query, limit: None },
             guild_id,

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -11,7 +11,7 @@ use twilight_model::{
 };
 
 #[derive(Default, Serialize)]
-struct CreateRoleFields {
+struct CreateRoleFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -19,7 +19,7 @@ struct CreateRoleFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     mentionable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
+    name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     permissions: Option<Permissions>,
 }
@@ -34,7 +34,7 @@ struct CreateRoleFields {
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 /// let guild_id = GuildId(234);
 ///
 /// client.create_role(guild_id)
@@ -45,10 +45,10 @@ struct CreateRoleFields {
 /// # Ok(()) }
 /// ```
 pub struct CreateRole<'a> {
-    fields: CreateRoleFields,
+    fields: CreateRoleFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> CreateRole<'a> {
@@ -85,8 +85,8 @@ impl<'a> CreateRole<'a> {
     /// Set the name of the role.
     ///
     /// If none is specified, Discord sets this to `New Role`.
-    pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.fields.name.replace(name.into());
+    pub fn name(mut self, name: &'a str) -> Self {
+        self.fields.name.replace(name);
 
         self
     }
@@ -124,10 +124,9 @@ impl<'a> CreateRole<'a> {
     }
 }
 
-impl<'a> AuditLogReason for CreateRole<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for CreateRole<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -11,7 +11,7 @@ pub struct DeleteRole<'a> {
     guild_id: GuildId,
     http: &'a Client,
     role_id: RoleId,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> DeleteRole<'a> {
@@ -46,10 +46,9 @@ impl<'a> DeleteRole<'a> {
     }
 }
 
-impl<'a> AuditLogReason for DeleteRole<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for DeleteRole<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -11,7 +11,7 @@ use twilight_model::{
 };
 
 #[derive(Default, Serialize)]
-struct UpdateRoleFields {
+struct UpdateRoleFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<NullableField<u32>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -19,18 +19,18 @@ struct UpdateRoleFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     mentionable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<NullableField<String>>,
+    name: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     permissions: Option<Permissions>,
 }
 
 /// Update a role by guild id and its id.
 pub struct UpdateRole<'a> {
-    fields: UpdateRoleFields,
+    fields: UpdateRoleFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
     role_id: RoleId,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> UpdateRole<'a> {
@@ -45,10 +45,8 @@ impl<'a> UpdateRole<'a> {
     }
 
     /// Set the color of the role.
-    pub fn color(mut self, color: impl Into<Option<u32>>) -> Self {
-        self.fields
-            .color
-            .replace(NullableField::from_option(color.into()));
+    pub fn color(mut self, color: Option<u32>) -> Self {
+        self.fields.color.replace(NullableField::from_option(color));
 
         self
     }
@@ -68,10 +66,8 @@ impl<'a> UpdateRole<'a> {
     }
 
     /// Set the name of the role.
-    pub fn name(mut self, name: impl Into<Option<String>>) -> Self {
-        self.fields
-            .name
-            .replace(NullableField::from_option(name.into()));
+    pub fn name(mut self, name: Option<&'a str>) -> Self {
+        self.fields.name.replace(NullableField::from_option(name));
 
         self
     }
@@ -110,10 +106,9 @@ impl<'a> UpdateRole<'a> {
     }
 }
 
-impl<'a> AuditLogReason for UpdateRole<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for UpdateRole<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/guild/role/update_role_positions.rs
+++ b/http/src/request/guild/role/update_role_positions.rs
@@ -15,19 +15,19 @@ use twilight_model::{
 pub struct UpdateRolePositions<'a> {
     guild_id: GuildId,
     http: &'a Client,
-    roles: Vec<(RoleId, u64)>,
+    roles: &'a [(RoleId, u64)],
 }
 
 impl<'a> UpdateRolePositions<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         guild_id: GuildId,
-        roles: impl Iterator<Item = (RoleId, u64)>,
+        roles: &'a [(RoleId, u64)],
     ) -> Self {
         Self {
             guild_id,
             http,
-            roles: roles.collect(),
+            roles,
         }
     }
 

--- a/http/src/request/guild/update_current_user_nick.rs
+++ b/http/src/request/guild/update_current_user_nick.rs
@@ -8,21 +8,21 @@ use serde::Serialize;
 use twilight_model::id::GuildId;
 
 #[derive(Serialize)]
-struct UpdateCurrentUserNickFields {
-    nick: String,
+struct UpdateCurrentUserNickFields<'a> {
+    nick: &'a str,
 }
 
 /// Changes the user's nickname in a guild.
 pub struct UpdateCurrentUserNick<'a> {
-    fields: UpdateCurrentUserNickFields,
+    fields: UpdateCurrentUserNickFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
 }
 
 impl<'a> UpdateCurrentUserNick<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId, nick: impl Into<String>) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId, nick: &'a str) -> Self {
         Self {
-            fields: UpdateCurrentUserNickFields { nick: nick.into() },
+            fields: UpdateCurrentUserNickFields { nick },
             guild_id,
             http,
         }

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -47,7 +47,7 @@ impl UpdateGuildError {
 impl Display for UpdateGuildError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            UpdateGuildErrorType::NameInvalid { .. } => f.write_str("the name's length is invalid"),
+            UpdateGuildErrorType::NameInvalid => f.write_str("the name's length is invalid"),
         }
     }
 }
@@ -60,36 +60,33 @@ impl Error for UpdateGuildError {}
 pub enum UpdateGuildErrorType {
     /// The name length is either fewer than 2 UTF-16 characters or more than 100 UTF-16
     /// characters.
-    NameInvalid {
-        /// Provided name.
-        name: String,
-    },
+    NameInvalid,
 }
 
 #[derive(Default, Serialize)]
-struct UpdateGuildFields {
+struct UpdateGuildFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     afk_channel_id: Option<NullableField<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     afk_timeout: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    banner: Option<NullableField<String>>,
+    banner: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_message_notifications: Option<NullableField<DefaultMessageNotificationLevel>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discovery_splash: Option<NullableField<String>>,
+    discovery_splash: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     explicit_content_filter: Option<NullableField<ExplicitContentFilter>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    features: Option<Vec<String>>,
+    features: Option<&'a [&'a str]>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<NullableField<String>>,
+    icon: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
+    name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     owner_id: Option<UserId>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    splash: Option<NullableField<String>>,
+    splash: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     system_channel_id: Option<NullableField<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -101,7 +98,7 @@ struct UpdateGuildFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     public_updates_channel_id: Option<NullableField<ChannelId>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    preferred_locale: Option<NullableField<String>>,
+    preferred_locale: Option<NullableField<&'a str>>,
 }
 
 /// Update a guild.
@@ -110,10 +107,10 @@ struct UpdateGuildFields {
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild
 pub struct UpdateGuild<'a> {
-    fields: UpdateGuildFields,
+    fields: UpdateGuildFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
-    reason: Option<String>,
+    reason: Option<&'a str>,
 }
 
 impl<'a> UpdateGuild<'a> {
@@ -127,10 +124,10 @@ impl<'a> UpdateGuild<'a> {
     }
 
     /// Set the voice channel where AFK voice users are sent.
-    pub fn afk_channel_id(mut self, afk_channel_id: impl Into<Option<ChannelId>>) -> Self {
+    pub fn afk_channel_id(mut self, afk_channel_id: Option<ChannelId>) -> Self {
         self.fields
             .afk_channel_id
-            .replace(NullableField::from_option(afk_channel_id.into()));
+            .replace(NullableField::from_option(afk_channel_id));
 
         self
     }
@@ -148,10 +145,10 @@ impl<'a> UpdateGuild<'a> {
     /// the banner.
     ///
     /// The server must have the `BANNER` feature.
-    pub fn banner(mut self, banner: impl Into<Option<String>>) -> Self {
+    pub fn banner(mut self, banner: Option<&'a str>) -> Self {
         self.fields
             .banner
-            .replace(NullableField::from_option(banner.into()));
+            .replace(NullableField::from_option(banner));
 
         self
     }
@@ -162,13 +159,11 @@ impl<'a> UpdateGuild<'a> {
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#create-guild
     pub fn default_message_notifications(
         mut self,
-        default_message_notifications: impl Into<Option<DefaultMessageNotificationLevel>>,
+        default_message_notifications: Option<DefaultMessageNotificationLevel>,
     ) -> Self {
         self.fields
             .default_message_notifications
-            .replace(NullableField::from_option(
-                default_message_notifications.into(),
-            ));
+            .replace(NullableField::from_option(default_message_notifications));
 
         self
     }
@@ -176,10 +171,10 @@ impl<'a> UpdateGuild<'a> {
     /// Set the guild's discovery splash image.
     ///
     /// Requires the guild to have the `DISCOVERABLE` feature enabled.
-    pub fn discovery_splash(mut self, discovery_splash: impl Into<Option<String>>) -> Self {
+    pub fn discovery_splash(mut self, discovery_splash: Option<&'a str>) -> Self {
         self.fields
             .discovery_splash
-            .replace(NullableField::from_option(discovery_splash.into()));
+            .replace(NullableField::from_option(discovery_splash));
 
         self
     }
@@ -187,18 +182,18 @@ impl<'a> UpdateGuild<'a> {
     /// Set the explicit content filter level.
     pub fn explicit_content_filter(
         mut self,
-        explicit_content_filter: impl Into<Option<ExplicitContentFilter>>,
+        explicit_content_filter: Option<ExplicitContentFilter>,
     ) -> Self {
         self.fields
             .explicit_content_filter
-            .replace(NullableField::from_option(explicit_content_filter.into()));
+            .replace(NullableField::from_option(explicit_content_filter));
 
         self
     }
 
     /// Set the enabled features of the guild.
-    pub fn features(mut self, features: impl IntoIterator<Item = String>) -> Self {
-        self.fields.features.replace(features.into_iter().collect());
+    pub fn features(mut self, features: &'a [&'a str]) -> Self {
+        self.fields.features.replace(features);
 
         self
     }
@@ -210,10 +205,8 @@ impl<'a> UpdateGuild<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn icon(mut self, icon: impl Into<Option<String>>) -> Self {
-        self.fields
-            .icon
-            .replace(NullableField::from_option(icon.into()));
+    pub fn icon(mut self, icon: Option<&'a str>) -> Self {
+        self.fields.icon.replace(NullableField::from_option(icon));
 
         self
     }
@@ -227,14 +220,10 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// Returns an [`UpdateGuildErrorType::NameInvalid`] error type if the name
     /// length is too short or too long.
-    pub fn name(self, name: impl Into<String>) -> Result<Self, UpdateGuildError> {
-        self._name(name.into())
-    }
-
-    fn _name(mut self, name: String) -> Result<Self, UpdateGuildError> {
-        if !validate::guild_name(&name) {
+    pub fn name(mut self, name: &'a str) -> Result<Self, UpdateGuildError> {
+        if !validate::guild_name(name) {
             return Err(UpdateGuildError {
-                kind: UpdateGuildErrorType::NameInvalid { name },
+                kind: UpdateGuildErrorType::NameInvalid,
             });
         }
 
@@ -246,8 +235,8 @@ impl<'a> UpdateGuild<'a> {
     /// Transfer ownership to another user.
     ///
     /// Only works if the current user is the owner.
-    pub fn owner_id(mut self, owner_id: impl Into<UserId>) -> Self {
-        self.fields.owner_id.replace(owner_id.into());
+    pub fn owner_id(mut self, owner_id: UserId) -> Self {
+        self.fields.owner_id.replace(owner_id);
 
         self
     }
@@ -255,19 +244,19 @@ impl<'a> UpdateGuild<'a> {
     /// Set the guild's splash image.
     ///
     /// Requires the guild to have the `INVITE_SPLASH` feature enabled.
-    pub fn splash(mut self, splash: impl Into<Option<String>>) -> Self {
+    pub fn splash(mut self, splash: Option<&'a str>) -> Self {
         self.fields
             .splash
-            .replace(NullableField::from_option(splash.into()));
+            .replace(NullableField::from_option(splash));
 
         self
     }
 
     /// Set the channel where events such as welcome messages are posted.
-    pub fn system_channel(mut self, system_channel_id: impl Into<Option<ChannelId>>) -> Self {
+    pub fn system_channel(mut self, system_channel_id: Option<ChannelId>) -> Self {
         self.fields
             .system_channel_id
-            .replace(NullableField::from_option(system_channel_id.into()));
+            .replace(NullableField::from_option(system_channel_id));
 
         self
     }
@@ -275,11 +264,11 @@ impl<'a> UpdateGuild<'a> {
     /// Set the guild's [`SystemChannelFlags`].
     pub fn system_channel_flags(
         mut self,
-        system_channel_flags: impl Into<Option<SystemChannelFlags>>,
+        system_channel_flags: Option<SystemChannelFlags>,
     ) -> Self {
         self.fields
             .system_channel_flags
-            .replace(NullableField::from_option(system_channel_flags.into()));
+            .replace(NullableField::from_option(system_channel_flags));
 
         self
     }
@@ -289,10 +278,10 @@ impl<'a> UpdateGuild<'a> {
     /// Requires the guild to be `PUBLIC`. Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild
-    pub fn rules_channel(mut self, rules_channel_id: impl Into<Option<ChannelId>>) -> Self {
+    pub fn rules_channel(mut self, rules_channel_id: Option<ChannelId>) -> Self {
         self.fields
             .rules_channel_id
-            .replace(NullableField::from_option(rules_channel_id.into()));
+            .replace(NullableField::from_option(rules_channel_id));
 
         self
     }
@@ -300,13 +289,10 @@ impl<'a> UpdateGuild<'a> {
     /// Set the public updates channel.
     ///
     /// Requires the guild to be `PUBLIC`.
-    pub fn public_updates_channel(
-        mut self,
-        public_updates_channel_id: impl Into<Option<ChannelId>>,
-    ) -> Self {
+    pub fn public_updates_channel(mut self, public_updates_channel_id: Option<ChannelId>) -> Self {
         self.fields
             .public_updates_channel_id
-            .replace(NullableField::from_option(public_updates_channel_id.into()));
+            .replace(NullableField::from_option(public_updates_channel_id));
 
         self
     }
@@ -314,10 +300,10 @@ impl<'a> UpdateGuild<'a> {
     /// Set the preferred locale for the guild.
     ///
     /// Defaults to `en-US`. Requires the guild to be `PUBLIC`.
-    pub fn preferred_locale(mut self, preferred_locale: impl Into<Option<String>>) -> Self {
+    pub fn preferred_locale(mut self, preferred_locale: Option<&'a str>) -> Self {
         self.fields
             .preferred_locale
-            .replace(NullableField::from_option(preferred_locale.into()));
+            .replace(NullableField::from_option(preferred_locale));
 
         self
     }
@@ -325,13 +311,10 @@ impl<'a> UpdateGuild<'a> {
     /// Set the verification level. Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#guild-object-verification-level
-    pub fn verification_level(
-        mut self,
-        verification_level: impl Into<Option<VerificationLevel>>,
-    ) -> Self {
+    pub fn verification_level(mut self, verification_level: Option<VerificationLevel>) -> Self {
         self.fields
             .verification_level
-            .replace(NullableField::from_option(verification_level.into()));
+            .replace(NullableField::from_option(verification_level));
 
         self
     }
@@ -362,10 +345,9 @@ impl<'a> UpdateGuild<'a> {
     }
 }
 
-impl<'a> AuditLogReason for UpdateGuild<'a> {
-    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
-        self.reason
-            .replace(AuditLogReasonError::validate(reason.into())?);
+impl<'a> AuditLogReason<'a> for UpdateGuild<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
+        self.reason.replace(AuditLogReasonError::validate(reason)?);
 
         Ok(self)
     }

--- a/http/src/request/guild/update_guild_channel_positions.rs
+++ b/http/src/request/guild/update_guild_channel_positions.rs
@@ -38,21 +38,19 @@ impl From<(ChannelId, u64)> for Position {
 pub struct UpdateGuildChannelPositions<'a> {
     guild_id: GuildId,
     http: &'a Client,
-    positions: Vec<Position>,
+    positions: &'a [Position],
 }
 
 impl<'a> UpdateGuildChannelPositions<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         guild_id: GuildId,
-        channel_positions: impl Iterator<Item = impl Into<Position>>,
+        channel_positions: &'a [Position],
     ) -> Self {
-        let positions = channel_positions.map(Into::into).collect();
-
         Self {
             guild_id,
             http,
-            positions,
+            positions: channel_positions,
         }
     }
 

--- a/http/src/request/guild/update_guild_welcome_screen.rs
+++ b/http/src/request/guild/update_guild_welcome_screen.rs
@@ -1,4 +1,9 @@
-use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
+use crate::{
+    client::Client,
+    request::{self, Request},
+    response::ResponseFuture,
+    routing::Route,
+};
 use serde::Serialize;
 use twilight_model::{
     id::GuildId,
@@ -6,13 +11,13 @@ use twilight_model::{
 };
 
 #[derive(Default, Serialize)]
-struct UpdateGuildWelcomeScreenFields {
+struct UpdateGuildWelcomeScreenFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
+    description: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    welcome_channels: Vec<WelcomeScreenChannel>,
+    #[serde(skip_serializing_if = "request::slice_is_empty")]
+    welcome_channels: &'a [WelcomeScreenChannel],
 }
 
 /// Update the guild's welcome screen.
@@ -21,7 +26,7 @@ struct UpdateGuildWelcomeScreenFields {
 ///
 /// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
 pub struct UpdateGuildWelcomeScreen<'a> {
-    fields: UpdateGuildWelcomeScreenFields,
+    fields: UpdateGuildWelcomeScreenFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
 }
@@ -36,11 +41,7 @@ impl<'a> UpdateGuildWelcomeScreen<'a> {
     }
 
     /// Set the description of the welcome screen.
-    pub fn description(self, description: impl Into<String>) -> Self {
-        self._description(description.into())
-    }
-
-    fn _description(mut self, description: String) -> Self {
+    pub fn description(mut self, description: &'a str) -> Self {
         self.fields.description.replace(description);
 
         self
@@ -54,11 +55,8 @@ impl<'a> UpdateGuildWelcomeScreen<'a> {
     }
 
     /// Set the channels linked in the welcome screen, with associated metadata.
-    pub fn welcome_channels(
-        mut self,
-        welcome_channels: impl IntoIterator<Item = WelcomeScreenChannel>,
-    ) -> Self {
-        self.fields.welcome_channels = welcome_channels.into_iter().collect();
+    pub const fn welcome_channels(mut self, welcome_channels: &'a [WelcomeScreenChannel]) -> Self {
+        self.fields.welcome_channels = welcome_channels;
 
         self
     }

--- a/http/src/request/guild/update_guild_widget.rs
+++ b/http/src/request/guild/update_guild_widget.rs
@@ -35,8 +35,7 @@ impl<'a> UpdateGuildWidget<'a> {
     }
 
     /// Set which channel to display on the widget.
-    pub fn channel_id(mut self, channel_id: impl Into<Option<ChannelId>>) -> Self {
-        let channel_id = channel_id.into();
+    pub fn channel_id(mut self, channel_id: Option<ChannelId>) -> Self {
         self.fields
             .channel_id
             .replace(NullableField::from_option(channel_id));

--- a/http/src/request/guild/user/update_current_user_voice_state.rs
+++ b/http/src/request/guild/user/update_current_user_voice_state.rs
@@ -8,17 +8,17 @@ use serde::Serialize;
 use twilight_model::id::{ChannelId, GuildId};
 
 #[derive(Serialize)]
-struct UpdateCurrentUserVoiceStateFields {
+struct UpdateCurrentUserVoiceStateFields<'a> {
     channel_id: ChannelId,
     #[serde(skip_serializing_if = "Option::is_none")]
     suppress: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    request_to_speak_timestamp: Option<NullableField<String>>,
+    request_to_speak_timestamp: Option<NullableField<&'a str>>,
 }
 
 /// Update the current user's voice state.
 pub struct UpdateCurrentUserVoiceState<'a> {
-    fields: UpdateCurrentUserVoiceStateFields,
+    fields: UpdateCurrentUserVoiceStateFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
 }
@@ -44,11 +44,7 @@ impl<'a> UpdateCurrentUserVoiceState<'a> {
     ///
     /// - You are able to set `request_to_speak_timestamp` to any present or
     /// future time.
-    pub fn request_to_speak_timestamp(self, request_to_speak_timestamp: impl Into<String>) -> Self {
-        self._request_to_speak_timestamp(request_to_speak_timestamp.into())
-    }
-
-    fn _request_to_speak_timestamp(mut self, request_to_speak_timestamp: String) -> Self {
+    pub fn request_to_speak_timestamp(mut self, request_to_speak_timestamp: &'a str) -> Self {
         if request_to_speak_timestamp.is_empty() {
             self.fields
                 .request_to_speak_timestamp

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -110,6 +110,10 @@ pub(crate) fn audit_header(
     Ok(iter::once((header_name, header_value)))
 }
 
+const fn slice_is_empty<T>(slice: &[T]) -> bool {
+    slice.is_empty()
+}
+
 #[cfg(test)]
 mod tests {
     use super::Method;

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -60,16 +60,13 @@ impl Error for CreateGuildFromTemplateError {}
 pub enum CreateGuildFromTemplateErrorType {
     /// Name of the guild is either fewer than 2 UTF-16 characters or more than 100 UTF-16
     /// characters.
-    NameInvalid {
-        /// Provided name.
-        name: String,
-    },
+    NameInvalid,
 }
 
 #[derive(Serialize)]
-struct CreateGuildFromTemplateFields {
-    name: String,
-    icon: Option<String>,
+struct CreateGuildFromTemplateFields<'a> {
+    name: &'a str,
+    icon: Option<&'a str>,
 }
 
 /// Create a new guild based on a template.
@@ -81,28 +78,20 @@ struct CreateGuildFromTemplateFields {
 /// Returns a [`CreateGuildFromTemplateErrorType::NameInvalid`] error type if
 /// the name is invalid.
 pub struct CreateGuildFromTemplate<'a> {
-    fields: CreateGuildFromTemplateFields,
+    fields: CreateGuildFromTemplateFields<'a>,
     http: &'a Client,
-    template_code: String,
+    template_code: &'a str,
 }
 
 impl<'a> CreateGuildFromTemplate<'a> {
     pub(crate) fn new(
         http: &'a Client,
-        template_code: impl Into<String>,
-        name: impl Into<String>,
-    ) -> Result<Self, CreateGuildFromTemplateError> {
-        Self::_new(http, template_code.into(), name.into())
-    }
-
-    fn _new(
-        http: &'a Client,
-        template_code: String,
-        name: String,
+        template_code: &'a str,
+        name: &'a str,
     ) -> Result<Self, CreateGuildFromTemplateError> {
         if !validate::guild_name(&name) {
             return Err(CreateGuildFromTemplateError {
-                kind: CreateGuildFromTemplateErrorType::NameInvalid { name },
+                kind: CreateGuildFromTemplateErrorType::NameInvalid,
             });
         }
 
@@ -120,11 +109,7 @@ impl<'a> CreateGuildFromTemplate<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn icon(self, icon: impl Into<String>) -> Self {
-        self._icon(icon.into())
-    }
-
-    fn _icon(mut self, icon: String) -> Self {
+    pub fn icon(mut self, icon: &'a str) -> Self {
         self.fields.icon.replace(icon);
 
         self

--- a/http/src/request/template/create_template.rs
+++ b/http/src/request/template/create_template.rs
@@ -63,21 +63,15 @@ impl Error for CreateTemplateError {}
 #[non_exhaustive]
 pub enum CreateTemplateErrorType {
     /// Name of the template is invalid.
-    NameInvalid {
-        /// Provided name.
-        name: String,
-    },
+    NameInvalid,
     /// Description of the template is invalid.
-    DescriptionTooLarge {
-        /// Provided description.
-        description: String,
-    },
+    DescriptionTooLarge,
 }
 
 #[derive(Serialize)]
-struct CreateTemplateFields {
-    name: String,
-    description: Option<String>,
+struct CreateTemplateFields<'a> {
+    name: &'a str,
+    description: Option<&'a str>,
 }
 
 /// Create a template from the current state of the guild.
@@ -90,7 +84,7 @@ struct CreateTemplateFields {
 /// Returns a [`CreateTemplateErrorType::NameInvalid`] error type if the name is
 /// invalid.
 pub struct CreateTemplate<'a> {
-    fields: CreateTemplateFields,
+    fields: CreateTemplateFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
 }
@@ -99,19 +93,11 @@ impl<'a> CreateTemplate<'a> {
     pub(crate) fn new(
         http: &'a Client,
         guild_id: GuildId,
-        name: impl Into<String>,
+        name: &'a str,
     ) -> Result<Self, CreateTemplateError> {
-        Self::_new(http, guild_id, name.into())
-    }
-
-    fn _new(
-        http: &'a Client,
-        guild_id: GuildId,
-        name: String,
-    ) -> Result<Self, CreateTemplateError> {
-        if !validate::template_name(&name) {
+        if !validate::template_name(name) {
             return Err(CreateTemplateError {
-                kind: CreateTemplateErrorType::NameInvalid { name },
+                kind: CreateTemplateErrorType::NameInvalid,
             });
         }
 
@@ -133,14 +119,10 @@ impl<'a> CreateTemplate<'a> {
     ///
     /// Returns a [`CreateTemplateErrorType::DescriptionTooLarge`] error type if
     /// the description is too large.
-    pub fn description(self, description: impl Into<String>) -> Result<Self, CreateTemplateError> {
-        self._description(description.into())
-    }
-
-    fn _description(mut self, description: String) -> Result<Self, CreateTemplateError> {
-        if !validate::template_description(&description) {
+    pub fn description(mut self, description: &'a str) -> Result<Self, CreateTemplateError> {
+        if !validate::template_description(description) {
             return Err(CreateTemplateError {
-                kind: CreateTemplateErrorType::DescriptionTooLarge { description },
+                kind: CreateTemplateErrorType::DescriptionTooLarge,
             });
         }
 

--- a/http/src/request/template/delete_template.rs
+++ b/http/src/request/template/delete_template.rs
@@ -10,19 +10,11 @@ use twilight_model::id::GuildId;
 pub struct DeleteTemplate<'a> {
     guild_id: GuildId,
     http: &'a Client,
-    template_code: String,
+    template_code: &'a str,
 }
 
 impl<'a> DeleteTemplate<'a> {
-    pub(crate) fn new(
-        http: &'a Client,
-        guild_id: GuildId,
-        template_code: impl Into<String>,
-    ) -> Self {
-        Self::_new(http, guild_id, template_code.into())
-    }
-
-    const fn _new(http: &'a Client, guild_id: GuildId, template_code: String) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId, template_code: &'a str) -> Self {
         Self {
             guild_id,
             http,

--- a/http/src/request/template/get_template.rs
+++ b/http/src/request/template/get_template.rs
@@ -4,15 +4,11 @@ use twilight_model::template::Template;
 /// Get a template by its code.
 pub struct GetTemplate<'a> {
     http: &'a Client,
-    template_code: String,
+    template_code: &'a str,
 }
 
 impl<'a> GetTemplate<'a> {
-    pub(crate) fn new(http: &'a Client, template_code: impl Into<String>) -> Self {
-        Self::_new(http, template_code.into())
-    }
-
-    const fn _new(http: &'a Client, template_code: String) -> Self {
+    pub(crate) const fn new(http: &'a Client, template_code: &'a str) -> Self {
         Self {
             http,
             template_code,

--- a/http/src/request/template/sync_template.rs
+++ b/http/src/request/template/sync_template.rs
@@ -5,19 +5,11 @@ use twilight_model::{id::GuildId, template::Template};
 pub struct SyncTemplate<'a> {
     guild_id: GuildId,
     http: &'a Client,
-    template_code: String,
+    template_code: &'a str,
 }
 
 impl<'a> SyncTemplate<'a> {
-    pub(crate) fn new(
-        http: &'a Client,
-        guild_id: GuildId,
-        template_code: impl Into<String>,
-    ) -> Self {
-        Self::_new(http, guild_id, template_code.into())
-    }
-
-    const fn _new(http: &'a Client, guild_id: GuildId, template_code: String) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId, template_code: &'a str) -> Self {
         Self {
             guild_id,
             http,

--- a/http/src/request/template/update_template.rs
+++ b/http/src/request/template/update_template.rs
@@ -63,41 +63,27 @@ impl Error for UpdateTemplateError {}
 #[non_exhaustive]
 pub enum UpdateTemplateErrorType {
     /// Name of the template is invalid.
-    NameInvalid {
-        /// Provided name.
-        name: String,
-    },
+    NameInvalid,
     /// Description of the template is invalid.
-    DescriptionTooLarge {
-        /// Provided description.
-        description: String,
-    },
+    DescriptionTooLarge,
 }
 
 #[derive(Serialize)]
-struct UpdateTemplateFields {
-    name: Option<String>,
-    description: Option<String>,
+struct UpdateTemplateFields<'a> {
+    name: Option<&'a str>,
+    description: Option<&'a str>,
 }
 
 /// Update the template's metadata, by ID and code.
 pub struct UpdateTemplate<'a> {
-    fields: UpdateTemplateFields,
+    fields: UpdateTemplateFields<'a>,
     guild_id: GuildId,
     http: &'a Client,
-    template_code: String,
+    template_code: &'a str,
 }
 
 impl<'a> UpdateTemplate<'a> {
-    pub(crate) fn new(
-        http: &'a Client,
-        guild_id: GuildId,
-        template_code: impl Into<String>,
-    ) -> Self {
-        Self::_new(http, guild_id, template_code.into())
-    }
-
-    const fn _new(http: &'a Client, guild_id: GuildId, template_code: String) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId, template_code: &'a str) -> Self {
         Self {
             fields: UpdateTemplateFields {
                 name: None,
@@ -117,14 +103,10 @@ impl<'a> UpdateTemplate<'a> {
     ///
     /// Returns an [`UpdateTemplateErrorType::DescriptionTooLarge`] error type
     /// if the description is too large.
-    pub fn description(self, description: impl Into<String>) -> Result<Self, UpdateTemplateError> {
-        self._description(description.into())
-    }
-
-    fn _description(mut self, description: String) -> Result<Self, UpdateTemplateError> {
+    pub fn description(mut self, description: &'a str) -> Result<Self, UpdateTemplateError> {
         if !validate::template_description(&description) {
             return Err(UpdateTemplateError {
-                kind: UpdateTemplateErrorType::DescriptionTooLarge { description },
+                kind: UpdateTemplateErrorType::DescriptionTooLarge,
             });
         }
 
@@ -139,16 +121,12 @@ impl<'a> UpdateTemplate<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an [`UpdateTemplateErrorType::NameInvalid`] error type if the
+    /// Returns an [`UpdateTemplateErrorType::NameInvalid`] error type when the
     /// name is invalid.
-    pub fn name(self, name: impl Into<String>) -> Result<Self, UpdateTemplateError> {
-        self._name(name.into())
-    }
-
-    fn _name(mut self, name: String) -> Result<Self, UpdateTemplateError> {
-        if !validate::template_name(&name) {
+    pub fn name(mut self, name: &'a str) -> Result<Self, UpdateTemplateError> {
+        if !validate::template_name(name) {
             return Err(UpdateTemplateError {
-                kind: UpdateTemplateErrorType::NameInvalid { name },
+                kind: UpdateTemplateErrorType::NameInvalid,
             });
         }
 

--- a/http/src/request/user/get_current_user.rs
+++ b/http/src/request/user/get_current_user.rs
@@ -15,9 +15,7 @@ impl<'a> GetCurrentUser<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<CurrentUser> {
-        let request = Request::from_route(Route::GetUser {
-            target_user: "@me".to_owned(),
-        });
+        let request = Request::from_route(Route::GetCurrentUser);
 
         self.http.request(request)
     }

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -45,9 +45,7 @@ impl GetCurrentUserGuildsError {
 impl Display for GetCurrentUserGuildsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-            GetCurrentUserGuildsErrorType::LimitInvalid { .. } => {
-                f.write_str("the limit is invalid")
-            }
+            GetCurrentUserGuildsErrorType::LimitInvalid => f.write_str("the limit is invalid"),
         }
     }
 }
@@ -59,10 +57,7 @@ impl Error for GetCurrentUserGuildsError {}
 #[non_exhaustive]
 pub enum GetCurrentUserGuildsErrorType {
     /// The maximum number of guilds to retrieve is 0 or more than 100.
-    LimitInvalid {
-        /// Provided maximum number of guilds to retrieve.
-        limit: u64,
-    },
+    LimitInvalid,
 }
 
 struct GetCurrentUserGuildsFields {
@@ -84,7 +79,7 @@ struct GetCurrentUserGuildsFields {
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token");
+/// let client = Client::new("my token".to_owned());
 ///
 /// let after = GuildId(300);
 /// let before = GuildId(400);
@@ -140,7 +135,7 @@ impl<'a> GetCurrentUserGuilds<'a> {
     pub fn limit(mut self, limit: u64) -> Result<Self, GetCurrentUserGuildsError> {
         if !validate::get_current_user_guilds_limit(limit) {
             return Err(GetCurrentUserGuildsError {
-                kind: GetCurrentUserGuildsErrorType::LimitInvalid { limit },
+                kind: GetCurrentUserGuildsErrorType::LimitInvalid,
             });
         }
 

--- a/http/src/request/user/get_user.rs
+++ b/http/src/request/user/get_user.rs
@@ -1,18 +1,15 @@
 use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
-use twilight_model::user::User;
+use twilight_model::{id::UserId, user::User};
 
 /// Get a user's information by id.
 pub struct GetUser<'a> {
     http: &'a Client,
-    target_user: String,
+    user_id: UserId,
 }
 
 impl<'a> GetUser<'a> {
-    pub(crate) fn new(http: &'a Client, target_user: impl Into<String>) -> Self {
-        Self {
-            http,
-            target_user: target_user.into(),
-        }
+    pub(crate) const fn new(http: &'a Client, user_id: UserId) -> Self {
+        Self { http, user_id }
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
@@ -20,7 +17,7 @@ impl<'a> GetUser<'a> {
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<User> {
         let request = Request::from_route(Route::GetUser {
-            target_user: self.target_user,
+            user_id: self.user_id.0,
         });
 
         self.http.request(request)

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -61,18 +61,15 @@ impl Error for UpdateCurrentUserError {}
 pub enum UpdateCurrentUserErrorType {
     /// The length of the username is either fewer than 2 UTF-16 characters or more than 32 UTF-16
     /// characters.
-    UsernameInvalid {
-        /// Provided username.
-        username: String,
-    },
+    UsernameInvalid,
 }
 
 #[derive(Default, Serialize)]
-struct UpdateCurrentUserFields {
+struct UpdateCurrentUserFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<NullableField<String>>,
+    avatar: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    username: Option<String>,
+    username: Option<&'a str>,
 }
 
 /// Update the current user.
@@ -80,7 +77,7 @@ struct UpdateCurrentUserFields {
 /// All paramaters are optional. If the username is changed, it may cause the discriminator to be
 /// rnadomized.
 pub struct UpdateCurrentUser<'a> {
-    fields: UpdateCurrentUserFields,
+    fields: UpdateCurrentUserFields<'a>,
     http: &'a Client,
 }
 
@@ -99,10 +96,10 @@ impl<'a> UpdateCurrentUser<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: impl Into<Option<String>>) -> Self {
+    pub fn avatar(mut self, avatar: Option<&'a str>) -> Self {
         self.fields
             .avatar
-            .replace(NullableField::from_option(avatar.into()));
+            .replace(NullableField::from_option(avatar));
 
         self
     }
@@ -115,14 +112,10 @@ impl<'a> UpdateCurrentUser<'a> {
     ///
     /// Returns an [`UpdateCurrentUserErrorType::UsernameInvalid`] error type if
     /// the username length is too short or too long.
-    pub fn username(self, username: impl Into<String>) -> Result<Self, UpdateCurrentUserError> {
-        self._username(username.into())
-    }
-
-    fn _username(mut self, username: String) -> Result<Self, UpdateCurrentUserError> {
+    pub fn username(mut self, username: &'a str) -> Result<Self, UpdateCurrentUserError> {
         if !validate::username(&username) {
             return Err(UpdateCurrentUserError {
-                kind: UpdateCurrentUserErrorType::UsernameInvalid { username },
+                kind: UpdateCurrentUserErrorType::UsernameInvalid,
             });
         }
 

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -3,6 +3,7 @@
 /// This is in a centralised place so that the validation parameters can be kept
 /// up-to-date more easily and because some of the checks are re-used across
 /// different modules.
+use super::application::InteractionError;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -454,6 +455,15 @@ fn _command_description(value: &str) -> bool {
 pub fn command_permissions(len: usize) -> bool {
     // https://discord.com/developers/docs/interactions/slash-commands#edit-application-command-permissions
     (0..=10).contains(&len)
+}
+
+/// Validate the number of guild command permission overwrites.
+///
+/// The maximum number of commands allowed in a guild is defined by
+/// [`InteractionError::GUILD_COMMAND_PERMISSION_LIMIT`].
+pub const fn guild_command_permissions(count: usize) -> bool {
+    // https://discord.com/developers/docs/interactions/slash-commands#a-quick-note-on-limits
+    count <= InteractionError::GUILD_COMMAND_PERMISSION_LIMIT
 }
 
 #[cfg(test)]

--- a/http/src/routing/route.rs
+++ b/http/src/routing/route.rs
@@ -1,10 +1,10 @@
 use super::{path::Path, route_display::RouteDisplay};
-use crate::request::Method;
-use std::borrow::Cow;
+use crate::request::{channel::reaction::RequestReactionType, Method};
+use twilight_model::id::RoleId;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
-pub enum Route {
+pub enum Route<'a> {
     /// Route information to add a user to a guild.
     AddGuildMember { guild_id: u64, user_id: u64 },
     /// Route information to add a role to guild member.
@@ -24,7 +24,7 @@ pub enum Route {
         /// The ID of the guild.
         guild_id: u64,
         /// The reason for the ban.
-        reason: Option<String>,
+        reason: Option<&'a str>,
         /// The ID of the user.
         user_id: u64,
     },
@@ -55,7 +55,7 @@ pub enum Route {
     /// Route information to create a guild from a template.
     CreateGuildFromTemplate {
         /// Code of the template.
-        template_code: String,
+        template_code: &'a str,
     },
     /// Route information to create a guild's integration.
     CreateGuildIntegration {
@@ -75,7 +75,7 @@ pub enum Route {
         ///
         /// A user must have at least one of these roles to be able to be
         /// pruned.
-        include_roles: Vec<u64>,
+        include_roles: &'a [RoleId],
     },
     /// Route information to create an invite to a channel.
     CreateInvite {
@@ -94,7 +94,7 @@ pub enum Route {
         /// The ID of the channel.
         channel_id: u64,
         /// The URI encoded custom or unicode emoji.
-        emoji: String,
+        emoji: &'a RequestReactionType<'a>,
         /// The ID of the message.
         message_id: u64,
     },
@@ -177,14 +177,14 @@ pub enum Route {
     /// Route information to delete an invite.
     DeleteInvite {
         /// The unique invite code.
-        code: String,
+        code: &'a str,
     },
     /// Route information to delete the original interaction response.
     DeleteInteractionOriginal {
         /// The ID of the owner application
         application_id: u64,
         /// The token of the interaction.
-        interaction_token: String,
+        interaction_token: &'a str,
     },
     /// Route information to delete a channel's message.
     DeleteMessage {
@@ -211,7 +211,7 @@ pub enum Route {
         /// The ID of the channel.
         channel_id: u64,
         /// The URI encoded custom or unicode emoji.
-        emoji: String,
+        emoji: &'a RequestReactionType<'a>,
         /// The ID of the message.
         message_id: u64,
     },
@@ -223,16 +223,25 @@ pub enum Route {
         /// The ID of the target role or user.
         target_id: u64,
     },
+    /// Route information to delete the current user's reaction on a message.
+    DeleteReactionCurrentUser {
+        /// ID of the channel.
+        channel_id: u64,
+        /// URI encoded custom or unicode emoji.
+        emoji: &'a RequestReactionType<'a>,
+        /// ID of the message.
+        message_id: u64,
+    },
     /// Route information to delete a user's reaction on a message.
     DeleteReaction {
         /// The ID of the channel.
         channel_id: u64,
         /// The URI encoded custom or unicode emoji.
-        emoji: String,
+        emoji: &'a RequestReactionType<'a>,
         /// The ID of the message.
         message_id: u64,
-        /// The ID of the user. This can be `@me` to specify the current user.
-        user: String,
+        /// The ID of the user.
+        user_id: u64,
     },
     /// Route information to delete a guild's role.
     DeleteRole {
@@ -251,25 +260,25 @@ pub enum Route {
         /// The ID of the guild.
         guild_id: u64,
         /// The target template code.
-        template_code: String,
+        template_code: &'a str,
     },
     /// Route information to delete a message created by a webhook.
     DeleteWebhookMessage {
         message_id: u64,
-        token: String,
+        token: &'a str,
         webhook_id: u64,
     },
     /// Route information to delete a webhook.
     DeleteWebhook {
         /// The token of the webhook.
-        token: Option<String>,
+        token: Option<&'a str>,
         /// The ID of the webhook.
         webhook_id: u64,
     },
     /// Route information to execute a webhook by ID and token.
     ExecuteWebhook {
         /// The token of the webhook.
-        token: String,
+        token: &'a str,
         /// Whether to wait for a message response.
         wait: Option<bool>,
         /// The ID of the webhook.
@@ -336,6 +345,8 @@ pub enum Route {
     },
     /// Route information to get info about application the current bot user belongs to
     GetCurrentUserApplicationInfo,
+    /// Route information to get the current user.
+    GetCurrentUser,
     /// Route information to get an emoji by ID within a guild.
     GetEmoji {
         /// The ID of the emoji.
@@ -422,7 +433,7 @@ pub enum Route {
         ///
         /// A user must have at least one of these roles to be able to be
         /// pruned.
-        include_roles: Vec<u64>,
+        include_roles: &'a [RoleId],
     },
     /// Route information to get a guild's roles.
     GetGuildRoles {
@@ -461,14 +472,14 @@ pub enum Route {
     /// Route information to get an invite.
     GetInvite {
         /// The unique invite code.
-        code: String,
+        code: &'a str,
         /// Whether to retrieve statistics about the invite.
         with_counts: bool,
     },
     /// Route information to get an invite with an expiration.
     GetInviteWithExpiration {
         /// The unique invite code.
-        code: String,
+        code: &'a str,
         /// Whether to retrieve statistics about the invite.
         with_counts: bool,
         /// Whether to retrieve the expiration date of the invite.
@@ -514,7 +525,7 @@ pub enum Route {
         /// The ID of the channel.
         channel_id: u64,
         /// The URI encoded custom or unicode emoji.
-        emoji: String,
+        emoji: &'a RequestReactionType<'a>,
         /// The maximum number of users to retrieve.
         limit: Option<u64>,
         /// The ID of the message.
@@ -528,18 +539,17 @@ pub enum Route {
     /// Route information to get a template.
     GetTemplate {
         /// The template code.
-        template_code: String,
+        template_code: &'a str,
     },
     /// Route information to get a list of templates from a guild.
     GetTemplates {
         /// The ID of the guild.
         guild_id: u64,
     },
-    /// Route information to get the current user.
+    /// Route information to get a user.
     GetUser {
-        /// The ID of the target user. This can be `@me` to specify the current
-        /// user.
-        target_user: String,
+        /// ID of the target user.
+        user_id: u64,
     },
     /// Route information to get the current user's connections.
     GetUserConnections,
@@ -551,7 +561,7 @@ pub enum Route {
     /// current user doesn't have access to it.
     GetWebhook {
         /// The token of the webhook.
-        token: Option<String>,
+        token: Option<&'a str>,
         /// The ID of the webhook.
         webhook_id: u64,
     },
@@ -560,7 +570,7 @@ pub enum Route {
         /// ID of the message.
         message_id: u64,
         /// Token of the webhook.
-        token: String,
+        token: &'a str,
         /// ID of the webhook.
         webhook_id: u64,
     },
@@ -569,7 +579,7 @@ pub enum Route {
         /// The ID of the interaction.
         interaction_id: u64,
         /// The token for the interaction.
-        interaction_token: String,
+        interaction_token: &'a str,
     },
     /// Route information to leave the guild.
     LeaveGuild {
@@ -606,7 +616,7 @@ pub enum Route {
         /// Upper limit of members to query for.
         limit: Option<u64>,
         /// Query to search by.
-        query: String,
+        query: &'a str,
     },
     /// Route information to set permissions of commands in a guild.
     SetCommandPermissions {
@@ -639,7 +649,7 @@ pub enum Route {
         /// The ID of the guild.
         guild_id: u64,
         /// The template code.
-        template_code: String,
+        template_code: &'a str,
     },
     /// Route information to unpin a message from a channel.
     UnpinMessage {
@@ -724,7 +734,7 @@ pub enum Route {
         /// The ID of the owner application.
         application_id: u64,
         /// The token for the interaction.
-        interaction_token: String,
+        interaction_token: &'a str,
     },
     /// Route information to update a member.
     UpdateMember {
@@ -775,7 +785,7 @@ pub enum Route {
         /// The ID of the guild.
         guild_id: u64,
         /// The template code.
-        template_code: String,
+        template_code: &'a str,
     },
     /// Route information to update a user's voice state.
     UpdateUserVoiceState {
@@ -787,37 +797,19 @@ pub enum Route {
     /// Route information to update a message created by a webhook.
     UpdateWebhookMessage {
         message_id: u64,
-        token: String,
+        token: &'a str,
         webhook_id: u64,
     },
     /// Route information to update a webhook.
     UpdateWebhook {
         /// The token of the webhook.
-        token: Option<String>,
+        token: Option<&'a str>,
         /// The ID of the webhook.
         webhook_id: u64,
     },
 }
 
-impl Route {
-    /// Separate a route into its parts: the HTTP method, the path enum to use
-    /// for ratelimit buckets, and the URI path.
-    ///
-    /// The method and URI path are useful for actually performing requests,
-    /// while the returned path enum is useful for ratelimiting.
-    #[allow(clippy::cognitive_complexity, clippy::too_many_lines)]
-    #[deprecated(
-        since = "0.5.1",
-        note = "use the individual `display`, `method`, and `path` methods"
-    )]
-    pub fn into_parts(self) -> (Method, Path, Cow<'static, str>) {
-        (
-            self.method(),
-            self.path(),
-            Cow::Owned(self.display().to_string()),
-        )
-    }
-
+impl<'a> Route<'a> {
     /// Display formatter of the route portion of a URL.
     ///
     /// # Examples
@@ -840,7 +832,7 @@ impl Route {
     /// use twilight_http::routing::Route;
     ///
     /// let route = Route::GetInvite {
-    ///     code: "twilight-rs".to_owned(),
+    ///     code: "twilight-rs",
     ///     with_counts: true,
     /// };
     ///
@@ -852,7 +844,7 @@ impl Route {
     ///
     /// [`GetInvite`]: Self::GetInvite
     /// [`GetPins`]: Self::GetPins
-    pub const fn display(&self) -> RouteDisplay<'_> {
+    pub const fn display(&'a self) -> RouteDisplay<'a> {
         RouteDisplay::new(self)
     }
 
@@ -890,6 +882,7 @@ impl Route {
             | Self::DeleteMessageSpecificReaction { .. }
             | Self::DeleteMessage { .. }
             | Self::DeletePermissionOverwrite { .. }
+            | Self::DeleteReactionCurrentUser { .. }
             | Self::DeleteReaction { .. }
             | Self::DeleteRole { .. }
             | Self::DeleteStageInstance { .. }
@@ -910,6 +903,7 @@ impl Route {
             | Self::GetChannels { .. }
             | Self::GetCommandPermissions { .. }
             | Self::GetCurrentUserApplicationInfo
+            | Self::GetCurrentUser
             | Self::GetEmoji { .. }
             | Self::GetEmojis { .. }
             | Self::GetGateway
@@ -1078,7 +1072,9 @@ impl Route {
                 Path::ChannelsIdMessages(*channel_id)
             }
             Self::CreatePrivateChannel | Self::GetUserPrivateChannels => Path::UsersIdChannels,
-            Self::CreateReaction { channel_id, .. } | Self::DeleteReaction { channel_id, .. } => {
+            Self::CreateReaction { channel_id, .. }
+            | Self::DeleteReactionCurrentUser { channel_id, .. }
+            | Self::DeleteReaction { channel_id, .. } => {
                 Path::ChannelsIdMessagesIdReactionsUserIdType(*channel_id)
             }
             Self::CreateRole { guild_id } | Self::GetGuildRoles { guild_id } => {
@@ -1160,7 +1156,7 @@ impl Route {
                 Path::ApplicationGuildCommandId(*application_id)
             }
             Self::GetCurrentUserApplicationInfo => Path::OauthApplicationsMe,
-            Self::GetUser { .. } | Self::UpdateCurrentUser => Path::UsersId,
+            Self::GetCurrentUser | Self::GetUser { .. } | Self::UpdateCurrentUser => Path::UsersId,
             Self::GetEmoji { guild_id, .. } | Self::UpdateEmoji { guild_id, .. } => {
                 Path::GuildsIdEmojisId(*guild_id)
             }
@@ -1219,14 +1215,14 @@ mod tests {
         assert_eq!(
             Method::Delete,
             Route::DeleteInvite {
-                code: "twilight-rs".to_owned(),
+                code: "twilight-rs",
             }
             .method()
         );
         assert_eq!(
             Method::Get,
             Route::GetInvite {
-                code: "twilight-rs".to_owned(),
+                code: "twilight-rs",
                 with_counts: false,
             }
             .method()
@@ -1244,7 +1240,7 @@ mod tests {
             Method::Put,
             Route::SyncTemplate {
                 guild_id: 123,
-                template_code: "abc".to_owned(),
+                template_code: "abc",
             }
             .method()
         );

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
     let shard_count = 1u64;
 
-    let http = HttpClient::new(&token);
+    let http = HttpClient::new(token.clone());
     let user_id = http.current_user().exec().await?.model().await?.id;
 
     let lavalink = Lavalink::new(user_id, shard_count);

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
         let shard_count = 1u64;
 
-        let http = HttpClient::new(&token);
+        let http = HttpClient::new(token.clone());
         let user_id = http.current_user().exec().await?.model().await?.id;
 
         let lavalink = Lavalink::new(user_id, shard_count);
@@ -124,7 +124,7 @@ async fn join(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
     state
         .http
         .create_message(msg.channel_id)
-        .content(format!("Joined <#{}>!", channel_id))?
+        .content(&format!("Joined <#{}>!", channel_id))?
         .exec()
         .await?;
 
@@ -209,7 +209,7 @@ async fn play(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
         state
             .http
             .create_message(msg.channel_id)
-            .content(content)?
+            .content(&content)?
             .exec()
             .await?;
     } else {
@@ -241,7 +241,7 @@ async fn pause(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + 
     state
         .http
         .create_message(msg.channel_id)
-        .content(format!("{} the track", action))?
+        .content(&format!("{} the track", action))?
         .exec()
         .await?;
 
@@ -277,7 +277,7 @@ async fn seek(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
     state
         .http
         .create_message(msg.channel_id)
-        .content(format!("Seeked to {}s", position))?
+        .content(&format!("Seeked to {}s", position))?
         .exec()
         .await?;
 
@@ -345,7 +345,7 @@ async fn volume(msg: Message, state: State) -> Result<(), Box<dyn Error + Send +
     state
         .http
         .create_message(msg.channel_id)
-        .content(format!("Set the volume to {}", volume))?
+        .content(&format!("Set the volume to {}", volume))?
         .exec()
         .await?;
 

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -75,7 +75,7 @@
 //!     let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
 //!     let shard_count = 1u64;
 //!
-//!     let http = HttpClient::new(&token);
+//!     let http = HttpClient::new(token.clone());
 //!     let user_id = http.current_user().exec().await?.model().await?.id;
 //!
 //!     let lavalink = Lavalink::new(user_id, shard_count);

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -42,7 +42,7 @@ pub struct PermissionOverwrite {
     pub kind: PermissionOverwriteType,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum PermissionOverwriteType {
     Member(UserId),
     Role(RoleId),

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -59,7 +59,7 @@ struct PermissionOverwriteData {
 }
 
 /// Type of a permission overwrite target.
-#[derive(Clone, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionOverwriteTargetType {
@@ -127,7 +127,46 @@ mod tests {
         PermissionOverwrite, PermissionOverwriteTargetType, PermissionOverwriteType, Permissions,
     };
     use crate::id::UserId;
+    use serde::{Deserialize, Serialize};
     use serde_test::Token;
+    use static_assertions::{assert_fields, assert_impl_all, const_assert_eq};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_fields!(PermissionOverwrite: allow, deny, kind);
+    assert_impl_all!(
+        PermissionOverwriteTargetType: Clone,
+        Copy,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_impl_all!(
+        PermissionOverwriteType: Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_impl_all!(
+        PermissionOverwrite: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync
+    );
+    const_assert_eq!(0, PermissionOverwriteTargetType::Role as u8);
+    const_assert_eq!(1, PermissionOverwriteTargetType::Member as u8);
 
     #[test]
     fn test_overwrite() {

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -140,7 +140,7 @@
 //!     let scheme = ShardScheme::Auto;
 //!
 //!     // Use intents to only receive guild message events.
-//!     let (cluster, mut events) = Cluster::builder(&token, Intents::GUILD_MESSAGES)
+//!     let (cluster, mut events) = Cluster::builder(token.to_owned(), Intents::GUILD_MESSAGES)
 //!         .shard_scheme(scheme)
 //!         .build()
 //!         .await?;
@@ -154,7 +154,7 @@
 //!     });
 //!
 //!     // HTTP is separate from the gateway, so create a new client.
-//!     let http = HttpClient::new(&token);
+//!     let http = HttpClient::new(token);
 //!
 //!     // Since we only care about new messages, make the cache only
 //!     // cache new messages.


### PR DESCRIPTION
Instead of taking owned parameters take references in most places other than the `CreateGuild` request and some application requests. By taking references we can reduce the number of clones the user must do, as we don't truly need to own any of the data in the first place.

The remaining requests that haven't been converted to use references need some reworking to be done separately from this work.

For an example, the `CreateMessage::content` signature previously looked like this:

```rust
pub fn content(
    self,
    content: impl Into<String>,
) -> Result<Self, CreateMessageError>
```

But now looks like this:

```rust
pub fn content(
    mut self,
    content: &'a str,
) -> Result<Self, CreateMessageError>
```

~~Blocks on #1008.~~ #1008 has been merged.