### PR TITLE
Make many HTTP functions constant

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -239,7 +239,7 @@ impl Client {
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn audit_log(&self, guild_id: GuildId) -> GetAuditLog<'_> {
+    pub const fn audit_log(&self, guild_id: GuildId) -> GetAuditLog<'_> {
         GetAuditLog::new(self, guild_id)
     }
 
@@ -298,7 +298,7 @@ impl Client {
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn create_ban(&self, guild_id: GuildId, user_id: UserId) -> CreateBan<'_> {
+    pub const fn create_ban(&self, guild_id: GuildId, user_id: UserId) -> CreateBan<'_> {
         CreateBan::new(self, guild_id, user_id)
     }
 
@@ -358,7 +358,7 @@ impl Client {
     ///
     /// All fields are optional. The minimum length of the name is 2 UTF-16 characters and the
     /// maximum is 100 UTF-16 characters.
-    pub fn update_channel(&self, channel_id: ChannelId) -> UpdateChannel<'_> {
+    pub const fn update_channel(&self, channel_id: ChannelId) -> UpdateChannel<'_> {
         UpdateChannel::new(self, channel_id)
     }
 
@@ -427,7 +427,7 @@ impl Client {
     /// [`GetChannelMessagesConfigured`]: crate::request::channel::message::GetChannelMessagesConfigured
     /// [`limit`]: GetChannelMessages::limit
     /// [`GetChannelMessagesErrorType::LimitInvalid`]: crate::request::channel::message::get_channel_messages::GetChannelMessagesErrorType::LimitInvalid
-    pub fn channel_messages(&self, channel_id: ChannelId) -> GetChannelMessages<'_> {
+    pub const fn channel_messages(&self, channel_id: ChannelId) -> GetChannelMessages<'_> {
         GetChannelMessages::new(self, channel_id)
     }
 
@@ -492,7 +492,7 @@ impl Client {
     ///
     /// All paramaters are optional. If the username is changed, it may cause the discriminator to
     /// be randomized.
-    pub fn update_current_user(&self) -> UpdateCurrentUser<'_> {
+    pub const fn update_current_user(&self) -> UpdateCurrentUser<'_> {
         UpdateCurrentUser::new(self)
     }
 
@@ -626,7 +626,7 @@ impl Client {
     }
 
     /// Update an emoji in a guild, by id.
-    pub fn update_emoji(&self, guild_id: GuildId, emoji_id: EmojiId) -> UpdateEmoji<'_> {
+    pub const fn update_emoji(&self, guild_id: GuildId, emoji_id: EmojiId) -> UpdateEmoji<'_> {
         UpdateEmoji::new(self, guild_id, emoji_id)
     }
 
@@ -669,7 +669,7 @@ impl Client {
     }
 
     /// Get information about a guild.
-    pub fn guild(&self, guild_id: GuildId) -> GetGuild<'_> {
+    pub const fn guild(&self, guild_id: GuildId) -> GetGuild<'_> {
         GetGuild::new(self, guild_id)
     }
 
@@ -698,7 +698,7 @@ impl Client {
     /// All endpoints are optional. Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild
-    pub fn update_guild(&self, guild_id: GuildId) -> UpdateGuild<'_> {
+    pub const fn update_guild(&self, guild_id: GuildId) -> UpdateGuild<'_> {
         UpdateGuild::new(self, guild_id)
     }
 
@@ -763,7 +763,7 @@ impl Client {
     }
 
     /// Modify the guild widget.
-    pub fn update_guild_widget(&self, guild_id: GuildId) -> UpdateGuildWidget<'_> {
+    pub const fn update_guild_widget(&self, guild_id: GuildId) -> UpdateGuildWidget<'_> {
         UpdateGuildWidget::new(self, guild_id)
     }
 
@@ -819,7 +819,7 @@ impl Client {
     /// limit is invalid.
     ///
     /// [`GetGuildMembersErrorType::LimitInvalid`]: crate::request::guild::member::get_guild_members::GetGuildMembersErrorType::LimitInvalid
-    pub fn guild_members(&self, guild_id: GuildId) -> GetGuildMembers<'_> {
+    pub const fn guild_members(&self, guild_id: GuildId) -> GetGuildMembers<'_> {
         GetGuildMembers::new(self, guild_id)
     }
 
@@ -934,7 +934,11 @@ impl Client {
     /// [`UpdateGuildMemberErrorType::NicknameInvalid`]: crate::request::guild::member::update_guild_member::UpdateGuildMemberErrorType::NicknameInvalid
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild-member
-    pub fn update_guild_member(&self, guild_id: GuildId, user_id: UserId) -> UpdateGuildMember<'_> {
+    pub const fn update_guild_member(
+        &self,
+        guild_id: GuildId,
+        user_id: UserId,
+    ) -> UpdateGuildMember<'_> {
         UpdateGuildMember::new(self, guild_id, user_id)
     }
 
@@ -989,7 +993,7 @@ impl Client {
     }
 
     /// Get the counts of guild members to be pruned.
-    pub fn guild_prune_count(&self, guild_id: GuildId) -> GetGuildPruneCount<'_> {
+    pub const fn guild_prune_count(&self, guild_id: GuildId) -> GetGuildPruneCount<'_> {
         GetGuildPruneCount::new(self, guild_id)
     }
 
@@ -1029,7 +1033,10 @@ impl Client {
     /// Requires the [`MANAGE_GUILD`] permission.
     ///
     /// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
-    pub fn update_guild_welcome_screen(&self, guild_id: GuildId) -> UpdateGuildWelcomeScreen<'_> {
+    pub const fn update_guild_welcome_screen(
+        &self,
+        guild_id: GuildId,
+    ) -> UpdateGuildWelcomeScreen<'_> {
         UpdateGuildWelcomeScreen::new(self, guild_id)
     }
 
@@ -1058,7 +1065,7 @@ impl Client {
     ///
     /// [`with_counts`]: crate::request::channel::invite::GetInvite::with_counts
     /// [`with_expiration`]: crate::request::channel::invite::GetInvite::with_expiration
-    pub fn invite<'a>(&'a self, code: &'a str) -> GetInvite<'a> {
+    pub const fn invite<'a>(&'a self, code: &'a str) -> GetInvite<'a> {
         GetInvite::new(self, code)
     }
 
@@ -1086,7 +1093,7 @@ impl Client {
     /// ```
     ///
     /// [`CREATE_INVITE`]: twilight_model::guild::Permissions::CREATE_INVITE
-    pub fn create_invite(&self, channel_id: ChannelId) -> CreateInvite<'_> {
+    pub const fn create_invite(&self, channel_id: ChannelId) -> CreateInvite<'_> {
         CreateInvite::new(self, channel_id)
     }
 
@@ -1213,7 +1220,7 @@ impl Client {
     /// ```
     ///
     /// [embed]: Self::embed
-    pub fn update_message(
+    pub const fn update_message(
         &self,
         channel_id: ChannelId,
         message_id: MessageId,
@@ -1249,7 +1256,7 @@ impl Client {
     ///
     /// This endpoint is limited to 100 users maximum, so if a message has more than 100 reactions,
     /// requests must be chained until all reactions are retireved.
-    pub fn reactions<'a>(
+    pub const fn reactions<'a>(
         &'a self,
         channel_id: ChannelId,
         message_id: MessageId,
@@ -1369,7 +1376,7 @@ impl Client {
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn create_role(&self, guild_id: GuildId) -> CreateRole<'_> {
+    pub const fn create_role(&self, guild_id: GuildId) -> CreateRole<'_> {
         CreateRole::new(self, guild_id)
     }
 
@@ -1379,7 +1386,7 @@ impl Client {
     }
 
     /// Update a role by guild id and its id.
-    pub fn update_role(&self, guild_id: GuildId, role_id: RoleId) -> UpdateRole<'_> {
+    pub const fn update_role(&self, guild_id: GuildId, role_id: RoleId) -> UpdateRole<'_> {
         UpdateRole::new(self, guild_id, role_id)
     }
 
@@ -1420,7 +1427,7 @@ impl Client {
     /// Update fields of an existing stage instance.
     ///
     /// Requires the user to be a moderator of the stage channel.
-    pub fn update_stage_instance(&self, channel_id: ChannelId) -> UpdateStageInstance<'_> {
+    pub const fn update_stage_instance(&self, channel_id: ChannelId) -> UpdateStageInstance<'_> {
         UpdateStageInstance::new(self, channel_id)
     }
 
@@ -1531,7 +1538,7 @@ impl Client {
     }
 
     /// Get a webhook by ID.
-    pub fn webhook(&self, id: WebhookId) -> GetWebhook<'_> {
+    pub const fn webhook(&self, id: WebhookId) -> GetWebhook<'_> {
         GetWebhook::new(self, id)
     }
 
@@ -1568,12 +1575,12 @@ impl Client {
     }
 
     /// Update a webhook by ID.
-    pub fn update_webhook(&self, webhook_id: WebhookId) -> UpdateWebhook<'_> {
+    pub const fn update_webhook(&self, webhook_id: WebhookId) -> UpdateWebhook<'_> {
         UpdateWebhook::new(self, webhook_id)
     }
 
     /// Update a webhook, with a token, by ID.
-    pub fn update_webhook_with_token<'a>(
+    pub const fn update_webhook_with_token<'a>(
         &'a self,
         webhook_id: WebhookId,
         token: &'a str,
@@ -1607,7 +1614,7 @@ impl Client {
     /// [`content`]: crate::request::channel::webhook::ExecuteWebhook::content
     /// [`embeds`]: crate::request::channel::webhook::ExecuteWebhook::embeds
     /// [`files`]: crate::request::channel::webhook::ExecuteWebhook::files
-    pub fn execute_webhook<'a>(
+    pub const fn execute_webhook<'a>(
         &'a self,
         webhook_id: WebhookId,
         token: &'a str,

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1002,7 +1002,7 @@ impl Client {
     /// Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#begin-guild-prune
-    pub fn create_guild_prune(&self, guild_id: GuildId) -> CreateGuildPrune<'_> {
+    pub const fn create_guild_prune(&self, guild_id: GuildId) -> CreateGuildPrune<'_> {
         CreateGuildPrune::new(self, guild_id)
     }
 
@@ -1151,7 +1151,7 @@ impl Client {
     /// crate::request::channel::message::create_message::CreateMessageErrorType::ContentInvalid
     /// [`CreateMessageErrorType::EmbedTooLarge`]:
     /// crate::request::channel::message::create_message::CreateMessageErrorType::EmbedTooLarge
-    pub fn create_message(&self, channel_id: ChannelId) -> CreateMessage<'_> {
+    pub const fn create_message(&self, channel_id: ChannelId) -> CreateMessage<'_> {
         CreateMessage::new(self, channel_id)
     }
 
@@ -1652,7 +1652,7 @@ impl Client {
     ///     .await?;
     /// # Ok(()) }
     /// ```
-    pub fn update_webhook_message<'a>(
+    pub const fn update_webhook_message<'a>(
         &'a self,
         webhook_id: WebhookId,
         token: &'a str,

--- a/http/src/request/application/create_followup_message.rs
+++ b/http/src/request/application/create_followup_message.rs
@@ -80,15 +80,15 @@ impl<'a> CreateFollowupMessage<'a> {
     }
 
     /// Specify the [`AllowedMentions`] for the webhook message.
-    pub fn allowed_mentions(mut self, allowed_mentions: &'a AllowedMentions) -> Self {
-        self.fields.allowed_mentions.replace(allowed_mentions);
+    pub const fn allowed_mentions(mut self, allowed_mentions: &'a AllowedMentions) -> Self {
+        self.fields.allowed_mentions = Some(allowed_mentions);
 
         self
     }
 
     /// The URL of the avatar of the webhook.
-    pub fn avatar_url(mut self, avatar_url: &'a str) -> Self {
-        self.fields.avatar_url.replace(avatar_url);
+    pub const fn avatar_url(mut self, avatar_url: &'a str) -> Self {
+        self.fields.avatar_url = Some(avatar_url);
 
         self
     }
@@ -103,16 +103,16 @@ impl<'a> CreateFollowupMessage<'a> {
     }
 
     /// Set the list of embeds of the webhook's message.
-    pub fn embeds(mut self, embeds: &'a [Embed]) -> Self {
-        self.fields.embeds.replace(embeds);
+    pub const fn embeds(mut self, embeds: &'a [Embed]) -> Self {
+        self.fields.embeds = Some(embeds);
 
         self
     }
 
     /// Set if the followup should be ephemeral.
-    pub fn ephemeral(mut self, ephemeral: bool) -> Self {
+    pub const fn ephemeral(mut self, ephemeral: bool) -> Self {
         if ephemeral {
-            self.fields.flags.replace(MessageFlags::EPHEMERAL);
+            self.fields.flags = Some(MessageFlags::EPHEMERAL);
         } else {
             self.fields.flags = None;
         }
@@ -185,22 +185,22 @@ impl<'a> CreateFollowupMessage<'a> {
     ///
     /// [`payload_json`]: Self::payload_json
     /// [Discord Docs/Create Message]: https://discord.com/developers/docs/resources/channel#create-message-params
-    pub fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
-        self.fields.payload_json.replace(payload_json);
+    pub const fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
+        self.fields.payload_json = Some(payload_json);
 
         self
     }
 
     /// Specify true if the message is TTS.
-    pub fn tts(mut self, tts: bool) -> Self {
-        self.fields.tts.replace(tts);
+    pub const fn tts(mut self, tts: bool) -> Self {
+        self.fields.tts = Some(tts);
 
         self
     }
 
     /// Specify the username of the webhook's message.
-    pub fn username(mut self, username: &'a str) -> Self {
-        self.fields.username.replace(username);
+    pub const fn username(mut self, username: &'a str) -> Self {
+        self.fields.username = Some(username);
 
         self
     }

--- a/http/src/request/application/create_followup_message.rs
+++ b/http/src/request/application/create_followup_message.rs
@@ -15,7 +15,7 @@ use twilight_model::{
     id::ApplicationId,
 };
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 pub(crate) struct CreateFollowupMessageFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     avatar_url: Option<&'a str>,
@@ -69,9 +69,22 @@ pub struct CreateFollowupMessage<'a> {
 }
 
 impl<'a> CreateFollowupMessage<'a> {
-    pub(crate) fn new(http: &'a Client, application_id: ApplicationId, token: &'a str) -> Self {
+    pub(crate) const fn new(
+        http: &'a Client,
+        application_id: ApplicationId,
+        token: &'a str,
+    ) -> Self {
         Self {
-            fields: CreateFollowupMessageFields::default(),
+            fields: CreateFollowupMessageFields {
+                avatar_url: None,
+                content: None,
+                embeds: None,
+                payload_json: None,
+                tts: None,
+                username: None,
+                flags: None,
+                allowed_mentions: None,
+            },
             files: &[],
             http,
             token,
@@ -96,8 +109,8 @@ impl<'a> CreateFollowupMessage<'a> {
     /// The content of the webook's message.
     ///
     /// Up to 2000 UTF-16 codepoints.
-    pub fn content(mut self, content: &'a str) -> Self {
-        self.fields.content.replace(content);
+    pub const fn content(mut self, content: &'a str) -> Self {
+        self.fields.content = Some(content);
 
         self
     }

--- a/http/src/request/application/create_global_command.rs
+++ b/http/src/request/application/create_global_command.rs
@@ -87,8 +87,8 @@ impl<'a> CreateGlobalCommand<'a> {
     }
 
     /// Whether the command is enabled by default when the app is added to a guild.
-    pub fn default_permission(mut self, default: bool) -> Self {
-        self.default_permission.replace(default);
+    pub const fn default_permission(mut self, default: bool) -> Self {
+        self.default_permission = Some(default);
 
         self
     }

--- a/http/src/request/application/create_global_command.rs
+++ b/http/src/request/application/create_global_command.rs
@@ -63,13 +63,16 @@ impl<'a> CreateGlobalCommand<'a> {
     /// Retuns an [`InteractionErrorType::CommandOptionsRequiredFirst`]
     /// if a required option was added after an optional option. The problem
     /// option's index is provided.
-    pub fn command_options(
+    pub const fn command_options(
         mut self,
         options: &'a [CommandOption],
     ) -> Result<Self, InteractionError> {
         let mut optional_option_added = false;
+        let mut idx = 0;
 
-        for (idx, option) in options.iter().enumerate() {
+        while idx < options.len() {
+            let option = &options[idx];
+
             if !optional_option_added && !option.is_required() {
                 optional_option_added = true
             }
@@ -79,6 +82,8 @@ impl<'a> CreateGlobalCommand<'a> {
                     kind: InteractionErrorType::CommandOptionsRequiredFirst { index: idx },
                 });
             }
+
+            idx += 1;
         }
 
         self.options = Some(options);

--- a/http/src/request/application/create_guild_command.rs
+++ b/http/src/request/application/create_guild_command.rs
@@ -77,13 +77,16 @@ impl<'a> CreateGuildCommand<'a> {
     /// Retuns an [`InteractionErrorType::CommandOptionsRequiredFirst`]
     /// if a required option was added after an optional option. The problem
     /// option's index is provided.
-    pub fn command_options(
+    pub const fn command_options(
         mut self,
         options: &'a [CommandOption],
     ) -> Result<Self, InteractionError> {
         let mut optional_option_added = false;
+        let mut idx = 0;
 
-        for (idx, option) in options.iter().enumerate() {
+        while idx < options.len() {
+            let option = &options[idx];
+
             if !optional_option_added && !option.is_required() {
                 optional_option_added = true;
             }
@@ -93,6 +96,8 @@ impl<'a> CreateGuildCommand<'a> {
                     kind: InteractionErrorType::CommandOptionsRequiredFirst { index: idx },
                 });
             }
+
+            idx += 1;
         }
 
         self.options = Some(options);

--- a/http/src/request/application/update_command_permissions.rs
+++ b/http/src/request/application/update_command_permissions.rs
@@ -34,7 +34,7 @@ pub struct UpdateCommandPermissions<'a> {
 }
 
 impl<'a> UpdateCommandPermissions<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         application_id: ApplicationId,
         guild_id: GuildId,

--- a/http/src/request/application/update_followup_message.rs
+++ b/http/src/request/application/update_followup_message.rs
@@ -215,9 +215,7 @@ impl<'a> UpdateFollowupMessage<'a> {
             }
         }
 
-        self.fields
-            .content
-            .replace(NullableField::from_option(content));
+        self.fields.content = Some(NullableField(content));
 
         Ok(self)
     }
@@ -294,9 +292,7 @@ impl<'a> UpdateFollowupMessage<'a> {
             }
         }
 
-        self.fields
-            .embeds
-            .replace(NullableField::from_option(embeds));
+        self.fields.embeds = Some(NullableField(embeds));
 
         Ok(self)
     }
@@ -317,8 +313,8 @@ impl<'a> UpdateFollowupMessage<'a> {
     /// [`files`]: Self::files
     /// [`CreateFollowupMessage::payload_json`]: super::CreateFollowupMessage::payload_json
     /// [Discord Docs/Create Message]: https://discord.com/developers/docs/resources/channel#create-message-params
-    pub fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
-        self.fields.payload_json.replace(payload_json);
+    pub const fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
+        self.fields.payload_json = Some(payload_json);
 
         self
     }

--- a/http/src/request/application/update_followup_message.rs
+++ b/http/src/request/application/update_followup_message.rs
@@ -93,7 +93,7 @@ pub enum UpdateFollowupMessageErrorType {
     TooManyEmbeds,
 }
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct UpdateFollowupMessageFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     allowed_mentions: Option<AllowedMentions>,
@@ -156,7 +156,7 @@ impl<'a> UpdateFollowupMessage<'a> {
     /// Maximum number of embeds that a followup message may have.
     pub const EMBED_COUNT_LIMIT: usize = 10;
 
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         application_id: ApplicationId,
         token: &'a str,
@@ -164,8 +164,11 @@ impl<'a> UpdateFollowupMessage<'a> {
     ) -> Self {
         Self {
             fields: UpdateFollowupMessageFields {
-                allowed_mentions: http.default_allowed_mentions(),
-                ..UpdateFollowupMessageFields::default()
+                allowed_mentions: None,
+                attachments: &[],
+                content: None,
+                embeds: None,
+                payload_json: None,
             },
             files: &[],
             http,
@@ -321,7 +324,7 @@ impl<'a> UpdateFollowupMessage<'a> {
 
     // `self` needs to be consumed and the client returned due to parameters
     // being consumed in request construction.
-    fn request(&self) -> Result<Request<'a>, HttpError> {
+    fn request(&mut self) -> Result<Request<'a>, HttpError> {
         let mut request = Request::builder(Route::UpdateWebhookMessage {
             message_id: self.message_id.0,
             token: self.token,
@@ -335,22 +338,30 @@ impl<'a> UpdateFollowupMessage<'a> {
                 form.file(index.to_be_bytes().as_ref(), name.as_bytes(), file);
             }
 
-            if let Some(payload_json) = &self.fields.payload_json {
+            if let Some(payload_json) = self.fields.payload_json.as_deref() {
                 form.payload_json(payload_json);
             } else {
+                if self.fields.allowed_mentions.is_none() {
+                    self.fields.allowed_mentions = self.http.default_allowed_mentions();
+                }
+
                 let body = crate::json::to_vec(&self.fields).map_err(HttpError::json)?;
                 form.payload_json(&body);
             }
 
             request = request.form(form);
         } else {
+            if self.fields.allowed_mentions.is_none() {
+                self.fields.allowed_mentions = self.http.default_allowed_mentions();
+            }
+
             request = request.json(&self.fields)?;
         }
 
         Ok(request.build())
     }
 
-    pub fn exec(self) -> ResponseFuture<EmptyBody> {
+    pub fn exec(mut self) -> ResponseFuture<EmptyBody> {
         match self.request() {
             Ok(request) => self.http.request(request),
             Err(source) => ResponseFuture::error(source),

--- a/http/src/request/application/update_global_command.rs
+++ b/http/src/request/application/update_global_command.rs
@@ -5,12 +5,13 @@ use crate::{
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
+use serde::Serialize;
 use twilight_model::{
     application::command::CommandOption,
     id::{ApplicationId, CommandId},
 };
 
-#[derive(Debug, Default, serde::Serialize)]
+#[derive(Serialize)]
 struct UpdateGlobalCommandFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<&'a str>,
@@ -34,7 +35,7 @@ pub struct UpdateGlobalCommand<'a> {
 }
 
 impl<'a> UpdateGlobalCommand<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         application_id: ApplicationId,
         command_id: CommandId,
@@ -42,7 +43,11 @@ impl<'a> UpdateGlobalCommand<'a> {
         Self {
             application_id,
             command_id,
-            fields: UpdateGlobalCommandFields::default(),
+            fields: UpdateGlobalCommandFields {
+                description: None,
+                name: None,
+                options: None,
+            },
             http,
         }
     }

--- a/http/src/request/application/update_guild_command.rs
+++ b/http/src/request/application/update_guild_command.rs
@@ -5,12 +5,13 @@ use crate::{
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
+use serde::Serialize;
 use twilight_model::{
     application::command::CommandOption,
     id::{ApplicationId, CommandId, GuildId},
 };
 
-#[derive(Debug, Default, serde::Serialize)]
+#[derive(Serialize)]
 struct UpdateGuildCommandFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<&'a str>,
@@ -35,7 +36,7 @@ pub struct UpdateGuildCommand<'a> {
 }
 
 impl<'a> UpdateGuildCommand<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         application_id: ApplicationId,
         guild_id: GuildId,
@@ -44,7 +45,11 @@ impl<'a> UpdateGuildCommand<'a> {
         Self {
             application_id,
             command_id,
-            fields: UpdateGuildCommandFields::default(),
+            fields: UpdateGuildCommandFields {
+                description: None,
+                name: None,
+                options: None,
+            },
             guild_id,
             http,
         }

--- a/http/src/request/application/update_original_response.rs
+++ b/http/src/request/application/update_original_response.rs
@@ -215,9 +215,7 @@ impl<'a> UpdateOriginalResponse<'a> {
             }
         }
 
-        self.fields
-            .content
-            .replace(NullableField::from_option(content));
+        self.fields.content = Some(NullableField(content));
 
         Ok(self)
     }
@@ -295,9 +293,7 @@ impl<'a> UpdateOriginalResponse<'a> {
             }
         }
 
-        self.fields
-            .embeds
-            .replace(NullableField::from_option(embeds));
+        self.fields.embeds = Some(NullableField(embeds));
 
         Ok(self)
     }
@@ -318,8 +314,8 @@ impl<'a> UpdateOriginalResponse<'a> {
     /// [`files`]: Self::files
     /// [`CreateFollowupMessage::payload_json`]: super::CreateFollowupMessage::payload_json
     /// [Discord Docs/Create Message]: https://discord.com/developers/docs/resources/channel#create-message-params
-    pub fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
-        self.fields.payload_json.replace(payload_json);
+    pub const fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
+        self.fields.payload_json = Some(payload_json);
 
         self
     }

--- a/http/src/request/base.rs
+++ b/http/src/request/base.rs
@@ -41,15 +41,16 @@ impl<'a> RequestBuilder<'a> {
     /// Set the contents of the body.
     #[must_use = "request has not been fully built"]
     pub fn body(mut self, body: Vec<u8>) -> Self {
-        self.0.body.replace(body);
+        self.0.body = Some(body);
 
         self
     }
 
     /// Set the multipart form.
+    #[allow(clippy::missing_const_for_fn)]
     #[must_use = "request has not been fully built"]
     pub fn form(mut self, form: Form) -> Self {
-        self.0.form.replace(form);
+        self.0.form = Some(form);
 
         self
     }

--- a/http/src/request/channel/follow_news_channel.rs
+++ b/http/src/request/channel/follow_news_channel.rs
@@ -2,7 +2,7 @@ use crate::{client::Client, request::Request, response::ResponseFuture, routing:
 use serde::Serialize;
 use twilight_model::{channel::FollowedChannel, id::ChannelId};
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct FollowNewsChannelFields {
     webhook_channel_id: ChannelId,
 }

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -62,7 +62,7 @@ pub enum CreateInviteErrorType {
     MaxUsesTooLarge,
 }
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct CreateInviteFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     max_age: Option<u64>,
@@ -112,10 +112,18 @@ pub struct CreateInvite<'a> {
 }
 
 impl<'a> CreateInvite<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+    pub(crate) const fn new(http: &'a Client, channel_id: ChannelId) -> Self {
         Self {
             channel_id,
-            fields: CreateInviteFields::default(),
+            fields: CreateInviteFields {
+                max_age: None,
+                max_uses: None,
+                temporary: None,
+                target_application_id: None,
+                target_user_id: None,
+                target_type: None,
+                unique: None,
+            },
             http,
             reason: None,
         }
@@ -149,14 +157,14 @@ impl<'a> CreateInvite<'a> {
     /// println!("invite code: {}", invite.code);
     /// # Ok(()) }
     /// ```
-    pub fn max_age(mut self, max_age: u64) -> Result<Self, CreateInviteError> {
+    pub const fn max_age(mut self, max_age: u64) -> Result<Self, CreateInviteError> {
         if !validate::invite_max_age(max_age) {
             return Err(CreateInviteError {
                 kind: CreateInviteErrorType::MaxAgeTooOld,
             });
         }
 
-        self.fields.max_age.replace(max_age);
+        self.fields.max_age = Some(max_age);
 
         Ok(self)
     }
@@ -187,14 +195,14 @@ impl<'a> CreateInvite<'a> {
     /// println!("invite code: {}", invite.code);
     /// # Ok(()) }
     /// ```
-    pub fn max_uses(mut self, max_uses: u64) -> Result<Self, CreateInviteError> {
+    pub const fn max_uses(mut self, max_uses: u64) -> Result<Self, CreateInviteError> {
         if !validate::invite_max_uses(max_uses) {
             return Err(CreateInviteError {
                 kind: CreateInviteErrorType::MaxUsesTooLarge,
             });
         }
 
-        self.fields.max_uses.replace(max_uses);
+        self.fields.max_uses = Some(max_uses);
 
         Ok(self)
     }
@@ -204,24 +212,22 @@ impl<'a> CreateInvite<'a> {
     /// This only works if [`target_type`] is set to [`TargetType::EmbeddedApplication`].
     ///
     /// [`target_type`]: Self::target_type
-    pub fn target_application_id(mut self, target_application_id: ApplicationId) -> Self {
-        self.fields
-            .target_application_id
-            .replace(target_application_id);
+    pub const fn target_application_id(mut self, target_application_id: ApplicationId) -> Self {
+        self.fields.target_application_id = Some(target_application_id);
 
         self
     }
 
     /// Set the target user id for this invite.
-    pub fn target_user_id(mut self, target_user_id: UserId) -> Self {
-        self.fields.target_user_id.replace(target_user_id);
+    pub const fn target_user_id(mut self, target_user_id: UserId) -> Self {
+        self.fields.target_user_id = Some(target_user_id);
 
         self
     }
 
     /// Set the target type for this invite.
-    pub fn target_type(mut self, target_type: TargetType) -> Self {
-        self.fields.target_type.replace(target_type);
+    pub const fn target_type(mut self, target_type: TargetType) -> Self {
+        self.fields.target_type = Some(target_type);
 
         self
     }
@@ -229,8 +235,8 @@ impl<'a> CreateInvite<'a> {
     /// Specify true if the invite should grant temporary membership.
     ///
     /// Defaults to false.
-    pub fn temporary(mut self, temporary: bool) -> Self {
-        self.fields.temporary.replace(temporary);
+    pub const fn temporary(mut self, temporary: bool) -> Self {
+        self.fields.temporary = Some(temporary);
 
         self
     }
@@ -241,8 +247,8 @@ impl<'a> CreateInvite<'a> {
     /// invites). Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#create-channel-invite
-    pub fn unique(mut self, unique: bool) -> Self {
-        self.fields.unique.replace(unique);
+    pub const fn unique(mut self, unique: bool) -> Self {
+        self.fields.unique = Some(unique);
 
         self
     }

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -1,7 +1,6 @@
 use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::invite::Invite;
 
-#[derive(Default)]
 struct GetInviteFields {
     with_counts: bool,
     with_expiration: bool,
@@ -39,10 +38,13 @@ pub struct GetInvite<'a> {
 }
 
 impl<'a> GetInvite<'a> {
-    pub(crate) fn new(http: &'a Client, code: &'a str) -> Self {
+    pub(crate) const fn new(http: &'a Client, code: &'a str) -> Self {
         Self {
             code,
-            fields: GetInviteFields::default(),
+            fields: GetInviteFields {
+                with_counts: false,
+                with_expiration: false,
+            },
             http,
         }
     }

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -230,8 +230,8 @@ impl<'a> CreateMessage<'a> {
     }
 
     /// Attach a nonce to the message, for optimistic message sending.
-    pub fn nonce(mut self, nonce: u64) -> Self {
-        self.fields.nonce.replace(nonce);
+    pub const fn nonce(mut self, nonce: u64) -> Self {
+        self.fields.nonce = Some(nonce);
 
         self
     }
@@ -243,8 +243,8 @@ impl<'a> CreateMessage<'a> {
     ///
     /// [`files`]: Self::files
     /// [Discord Docs/Create Message]: https://discord.com/developers/docs/resources/channel#create-message-params
-    pub fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
-        self.fields.payload_json.replace(payload_json);
+    pub const fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
+        self.fields.payload_json = Some(payload_json);
 
         self
     }
@@ -271,8 +271,8 @@ impl<'a> CreateMessage<'a> {
     }
 
     /// Specify true if the message is TTS.
-    pub fn tts(mut self, tts: bool) -> Self {
-        self.fields.tts.replace(tts);
+    pub const fn tts(mut self, tts: bool) -> Self {
+        self.fields.tts = Some(tts);
 
         self
     }

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -110,10 +110,10 @@ pub struct GetChannelMessages<'a> {
 }
 
 impl<'a> GetChannelMessages<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+    pub(crate) const fn new(http: &'a Client, channel_id: ChannelId) -> Self {
         Self {
             channel_id,
-            fields: GetChannelMessagesFields::default(),
+            fields: GetChannelMessagesFields { limit: None },
             http,
         }
     }
@@ -159,14 +159,14 @@ impl<'a> GetChannelMessages<'a> {
     ///
     /// Returns a [`GetChannelMessagesErrorType::LimitInvalid`] error type if
     /// the amount is less than 1 or greater than 100.
-    pub fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesError> {
+    pub const fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesError> {
         if !validate::get_channel_messages_limit(limit) {
             return Err(GetChannelMessagesError {
                 kind: GetChannelMessagesErrorType::LimitInvalid,
             });
         }
 
-        self.fields.limit.replace(limit);
+        self.fields.limit = Some(limit);
 
         Ok(self)
     }

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -64,7 +64,6 @@ pub enum GetChannelMessagesErrorType {
     LimitInvalid,
 }
 
-#[derive(Default)]
 struct GetChannelMessagesFields {
     limit: Option<u64>,
 }

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -112,14 +112,14 @@ impl<'a> GetChannelMessagesConfigured<'a> {
     ///
     /// Returns a [`GetChannelMessagesConfiguredErrorType::LimitInvalid`] error
     /// type if the amount is greater than 21600.
-    pub fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesConfiguredError> {
+    pub const fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesConfiguredError> {
         if !validate::get_channel_messages_limit(limit) {
             return Err(GetChannelMessagesConfiguredError {
                 kind: GetChannelMessagesConfiguredErrorType::LimitInvalid,
             });
         }
 
-        self.fields.limit.replace(limit);
+        self.fields.limit = Some(limit);
 
         Ok(self)
     }

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -62,7 +62,6 @@ pub enum GetReactionsErrorType {
     },
 }
 
-#[derive(Default)]
 struct GetReactionsFields {
     after: Option<UserId>,
     limit: Option<u64>,
@@ -81,7 +80,7 @@ pub struct GetReactions<'a> {
 }
 
 impl<'a> GetReactions<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         channel_id: ChannelId,
         message_id: MessageId,
@@ -90,15 +89,18 @@ impl<'a> GetReactions<'a> {
         Self {
             channel_id,
             emoji,
-            fields: GetReactionsFields::default(),
+            fields: GetReactionsFields {
+                after: None,
+                limit: None,
+            },
             http,
             message_id,
         }
     }
 
     /// Get users after this id.
-    pub fn after(mut self, after: UserId) -> Self {
-        self.fields.after.replace(after);
+    pub const fn after(mut self, after: UserId) -> Self {
+        self.fields.after = Some(after);
 
         self
     }
@@ -112,14 +114,14 @@ impl<'a> GetReactions<'a> {
     ///
     /// Returns a [`GetReactionsErrorType::LimitInvalid`] error type if the
     /// amount is greater than 100.
-    pub fn limit(mut self, limit: u64) -> Result<Self, GetReactionsError> {
+    pub const fn limit(mut self, limit: u64) -> Result<Self, GetReactionsError> {
         if !validate::get_reactions_limit(limit) {
             return Err(GetReactionsError {
                 kind: GetReactionsErrorType::LimitInvalid { limit },
             });
         }
 
-        self.fields.limit.replace(limit);
+        self.fields.limit = Some(limit);
 
         Ok(self)
     }

--- a/http/src/request/channel/stage/create_stage_instance.rs
+++ b/http/src/request/channel/stage/create_stage_instance.rs
@@ -65,7 +65,7 @@ pub enum CreateStageInstanceErrorType {
     InvalidTopic,
 }
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct CreateStageInstanceFields<'a> {
     channel_id: ChannelId,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -97,16 +97,16 @@ impl<'a> CreateStageInstance<'a> {
         Ok(Self {
             fields: CreateStageInstanceFields {
                 channel_id,
+                privacy_level: None,
                 topic,
-                ..CreateStageInstanceFields::default()
             },
             http,
         })
     }
 
     /// Set the [`PrivacyLevel`] of the instance.
-    pub fn privacy_level(mut self, privacy_level: PrivacyLevel) -> Self {
-        self.fields.privacy_level.replace(privacy_level);
+    pub const fn privacy_level(mut self, privacy_level: PrivacyLevel) -> Self {
+        self.fields.privacy_level = Some(privacy_level);
 
         self
     }

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -65,7 +65,7 @@ pub enum UpdateStageInstanceErrorType {
     InvalidTopic,
 }
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct UpdateStageInstanceFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     privacy_level: Option<PrivacyLevel>,
@@ -83,17 +83,20 @@ pub struct UpdateStageInstance<'a> {
 }
 
 impl<'a> UpdateStageInstance<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+    pub(crate) const fn new(http: &'a Client, channel_id: ChannelId) -> Self {
         Self {
             channel_id,
-            fields: UpdateStageInstanceFields::default(),
+            fields: UpdateStageInstanceFields {
+                privacy_level: None,
+                topic: None,
+            },
             http,
         }
     }
 
     /// Set the [`PrivacyLevel`] of the instance.
-    pub fn privacy_level(mut self, privacy_level: PrivacyLevel) -> Self {
-        self.fields.privacy_level.replace(privacy_level);
+    pub const fn privacy_level(mut self, privacy_level: PrivacyLevel) -> Self {
+        self.fields.privacy_level = Some(privacy_level);
 
         self
     }

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -69,7 +69,7 @@ pub enum UpdateChannelErrorType {
 
 // The Discord API doesn't require the `name` and `kind` fields to be present,
 // but it does require them to be non-null.
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct UpdateChannelFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     bitrate: Option<u64>,
@@ -108,18 +108,30 @@ pub struct UpdateChannel<'a> {
 }
 
 impl<'a> UpdateChannel<'a> {
-    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+    pub(crate) const fn new(http: &'a Client, channel_id: ChannelId) -> Self {
         Self {
             channel_id,
-            fields: UpdateChannelFields::default(),
+            fields: UpdateChannelFields {
+                bitrate: None,
+                name: None,
+                nsfw: None,
+                parent_id: None,
+                permission_overwrites: None,
+                position: None,
+                rate_limit_per_user: None,
+                topic: None,
+                user_limit: None,
+                video_quality_mode: None,
+                kind: None,
+            },
             http,
             reason: None,
         }
     }
 
     /// Set the bitrate of the channel. Applicable to voice channels only.
-    pub fn bitrate(mut self, bitrate: u64) -> Self {
-        self.fields.bitrate.replace(bitrate);
+    pub const fn bitrate(mut self, bitrate: u64) -> Self {
+        self.fields.bitrate = Some(bitrate);
 
         self
     }
@@ -140,37 +152,33 @@ impl<'a> UpdateChannel<'a> {
             });
         }
 
-        self.fields.name.replace(name);
+        self.fields.name = Some(name);
 
         Ok(self)
     }
 
     /// Set whether the channel is marked as NSFW.
-    pub fn nsfw(mut self, nsfw: bool) -> Self {
-        self.fields.nsfw.replace(nsfw);
+    pub const fn nsfw(mut self, nsfw: bool) -> Self {
+        self.fields.nsfw = Some(nsfw);
 
         self
     }
 
     /// If this is specified, and the parent ID is a `ChannelType::CategoryChannel`, move this
     /// channel to a child of the category channel.
-    pub fn parent_id(mut self, parent_id: Option<ChannelId>) -> Self {
-        self.fields
-            .parent_id
-            .replace(NullableField::from_option(parent_id));
+    pub const fn parent_id(mut self, parent_id: Option<ChannelId>) -> Self {
+        self.fields.parent_id = Some(NullableField(parent_id));
 
         self
     }
 
     /// Set the permission overwrites of a channel. This will overwrite all permissions that the
     /// channel currently has, so use with caution!
-    pub fn permission_overwrites(
+    pub const fn permission_overwrites(
         mut self,
         permission_overwrites: &'a [PermissionOverwrite],
     ) -> Self {
-        self.fields
-            .permission_overwrites
-            .replace(permission_overwrites);
+        self.fields.permission_overwrites = Some(permission_overwrites);
 
         self
     }
@@ -179,8 +187,8 @@ impl<'a> UpdateChannel<'a> {
     ///
     /// Positions are numerical and zero-indexed. If you place a channel at position 2, channels
     /// 2-n will shift down one position and the initial channel will take its place.
-    pub fn position(mut self, position: u64) -> Self {
-        self.fields.position.replace(position);
+    pub const fn position(mut self, position: u64) -> Self {
+        self.fields.position = Some(position);
 
         self
     }
@@ -197,7 +205,7 @@ impl<'a> UpdateChannel<'a> {
     /// type if the amount is greater than 21600.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure>
-    pub fn rate_limit_per_user(
+    pub const fn rate_limit_per_user(
         mut self,
         rate_limit_per_user: u64,
     ) -> Result<Self, UpdateChannelError> {
@@ -207,7 +215,7 @@ impl<'a> UpdateChannel<'a> {
             });
         }
 
-        self.fields.rate_limit_per_user.replace(rate_limit_per_user);
+        self.fields.rate_limit_per_user = Some(rate_limit_per_user);
 
         Ok(self)
     }
@@ -240,15 +248,15 @@ impl<'a> UpdateChannel<'a> {
     /// discord docs] for more details.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#modify-channel-json-params
-    pub fn user_limit(mut self, user_limit: u64) -> Self {
-        self.fields.user_limit.replace(user_limit);
+    pub const fn user_limit(mut self, user_limit: u64) -> Self {
+        self.fields.user_limit = Some(user_limit);
 
         self
     }
 
     /// Set the [`VideoQualityMode`] for the voice channel.
-    pub fn video_quality_mode(mut self, video_quality_mode: VideoQualityMode) -> Self {
-        self.fields.video_quality_mode.replace(video_quality_mode);
+    pub const fn video_quality_mode(mut self, video_quality_mode: VideoQualityMode) -> Self {
+        self.fields.video_quality_mode = Some(video_quality_mode);
 
         self
     }
@@ -260,8 +268,8 @@ impl<'a> UpdateChannel<'a> {
     /// details.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#modify-channel-json-params
-    pub fn kind(mut self, kind: ChannelType) -> Self {
-        self.fields.kind.replace(kind);
+    pub const fn kind(mut self, kind: ChannelType) -> Self {
+        self.fields.kind = Some(kind);
 
         self
     }

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -57,8 +57,8 @@ impl<'a> CreateWebhook<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: &'a str) -> Self {
-        self.fields.avatar.replace(avatar);
+    pub const fn avatar(mut self, avatar: &'a str) -> Self {
+        self.fields.avatar = Some(avatar);
 
         self
     }

--- a/http/src/request/channel/webhook/delete_webhook.rs
+++ b/http/src/request/channel/webhook/delete_webhook.rs
@@ -29,8 +29,8 @@ impl<'a> DeleteWebhook<'a> {
     }
 
     /// Specify the token for auth, if not already authenticated with a Bot token.
-    pub fn token(mut self, token: &'a str) -> Self {
-        self.fields.token.replace(token);
+    pub const fn token(mut self, token: &'a str) -> Self {
+        self.fields.token = Some(token);
 
         self
     }

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -12,7 +12,7 @@ use twilight_model::{
     id::WebhookId,
 };
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 pub(crate) struct ExecuteWebhookFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     avatar_url: Option<&'a str>,
@@ -65,9 +65,17 @@ pub struct ExecuteWebhook<'a> {
 }
 
 impl<'a> ExecuteWebhook<'a> {
-    pub(crate) fn new(http: &'a Client, webhook_id: WebhookId, token: &'a str) -> Self {
+    pub(crate) const fn new(http: &'a Client, webhook_id: WebhookId, token: &'a str) -> Self {
         Self {
-            fields: ExecuteWebhookFields::default(),
+            fields: ExecuteWebhookFields {
+                avatar_url: None,
+                content: None,
+                embeds: None,
+                payload_json: None,
+                tts: None,
+                username: None,
+                allowed_mentions: None,
+            },
             files: &[],
             http,
             token,
@@ -83,8 +91,8 @@ impl<'a> ExecuteWebhook<'a> {
     }
 
     /// The URL of the avatar of the webhook.
-    pub fn avatar_url(mut self, avatar_url: &'a str) -> Self {
-        self.fields.avatar_url.replace(avatar_url);
+    pub const fn avatar_url(mut self, avatar_url: &'a str) -> Self {
+        self.fields.avatar_url = Some(avatar_url);
 
         self
     }
@@ -92,15 +100,15 @@ impl<'a> ExecuteWebhook<'a> {
     /// The content of the webook's message.
     ///
     /// Up to 2000 UTF-16 codepoints, same as a message.
-    pub fn content(mut self, content: &'a str) -> Self {
-        self.fields.content.replace(content);
+    pub const fn content(mut self, content: &'a str) -> Self {
+        self.fields.content = Some(content);
 
         self
     }
 
     /// Set the list of embeds of the webhook's message.
-    pub fn embeds(mut self, embeds: &'a [Embed]) -> Self {
-        self.fields.embeds.replace(embeds);
+    pub const fn embeds(mut self, embeds: &'a [Embed]) -> Self {
+        self.fields.embeds = Some(embeds);
 
         self
     }
@@ -166,22 +174,22 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// [`payload_json`]: Self::payload_json
     /// [Discord Docs/Create Message]: https://discord.com/developers/docs/resources/channel#create-message-params
-    pub fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
-        self.fields.payload_json.replace(payload_json);
+    pub const fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
+        self.fields.payload_json = Some(payload_json);
 
         self
     }
 
     /// Specify true if the message is TTS.
-    pub fn tts(mut self, tts: bool) -> Self {
-        self.fields.tts.replace(tts);
+    pub const fn tts(mut self, tts: bool) -> Self {
+        self.fields.tts = Some(tts);
 
         self
     }
 
     /// Specify the username of the webhook's message.
-    pub fn username(mut self, username: &'a str) -> Self {
-        self.fields.username.replace(username);
+    pub const fn username(mut self, username: &'a str) -> Self {
+        self.fields.username = Some(username);
 
         self
     }

--- a/http/src/request/channel/webhook/get_webhook.rs
+++ b/http/src/request/channel/webhook/get_webhook.rs
@@ -1,7 +1,6 @@
 use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::{channel::Webhook, id::WebhookId};
 
-#[derive(Default)]
 struct GetWebhookFields<'a> {
     token: Option<&'a str>,
 }
@@ -14,9 +13,9 @@ pub struct GetWebhook<'a> {
 }
 
 impl<'a> GetWebhook<'a> {
-    pub(crate) fn new(http: &'a Client, id: WebhookId) -> Self {
+    pub(crate) const fn new(http: &'a Client, id: WebhookId) -> Self {
         Self {
-            fields: GetWebhookFields::default(),
+            fields: GetWebhookFields { token: None },
             http,
             id,
         }
@@ -24,8 +23,8 @@ impl<'a> GetWebhook<'a> {
 
     /// Specify the token for auth, if not already authenticated with a Bot
     /// token.
-    pub fn token(mut self, token: &'a str) -> Self {
-        self.fields.token.replace(token);
+    pub const fn token(mut self, token: &'a str) -> Self {
+        self.fields.token = Some(token);
 
         self
     }

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -10,7 +10,7 @@ use twilight_model::{
     id::{ChannelId, WebhookId},
 };
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct UpdateWebhookFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     avatar: Option<NullableField<&'a str>>,
@@ -30,9 +30,13 @@ pub struct UpdateWebhook<'a> {
 
 /// Update a webhook by its ID.
 impl<'a> UpdateWebhook<'a> {
-    pub(crate) fn new(http: &'a Client, webhook_id: WebhookId) -> Self {
+    pub(crate) const fn new(http: &'a Client, webhook_id: WebhookId) -> Self {
         Self {
-            fields: UpdateWebhookFields::default(),
+            fields: UpdateWebhookFields {
+                avatar: None,
+                channel_id: None,
+                name: None,
+            },
             http,
             webhook_id,
             reason: None,
@@ -46,24 +50,22 @@ impl<'a> UpdateWebhook<'a> {
     /// base64-encoded image.
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: Option<&'a str>) -> Self {
-        self.fields
-            .avatar
-            .replace(NullableField::from_option(avatar));
+    pub const fn avatar(mut self, avatar: Option<&'a str>) -> Self {
+        self.fields.avatar = Some(NullableField(avatar));
 
         self
     }
 
     /// Move this webhook to a new channel.
-    pub fn channel_id(mut self, channel_id: ChannelId) -> Self {
-        self.fields.channel_id.replace(channel_id);
+    pub const fn channel_id(mut self, channel_id: ChannelId) -> Self {
+        self.fields.channel_id = Some(channel_id);
 
         self
     }
 
     /// Change the name of the webhook.
-    pub fn name(mut self, name: Option<&'a str>) -> Self {
-        self.fields.name.replace(NullableField::from_option(name));
+    pub const fn name(mut self, name: Option<&'a str>) -> Self {
+        self.fields.name = Some(NullableField(name));
 
         self
     }

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -214,9 +214,7 @@ impl<'a> UpdateWebhookMessage<'a> {
             }
         }
 
-        self.fields
-            .content
-            .replace(NullableField::from_option(content));
+        self.fields.content = Some(NullableField(content));
 
         Ok(self)
     }
@@ -290,9 +288,7 @@ impl<'a> UpdateWebhookMessage<'a> {
             }
         }
 
-        self.fields
-            .embeds
-            .replace(NullableField::from_option(embeds));
+        self.fields.embeds = Some(NullableField(embeds));
 
         Ok(self)
     }
@@ -315,8 +311,8 @@ impl<'a> UpdateWebhookMessage<'a> {
     /// [`files`]: Self::files
     /// [`ExecuteWebhook::payload_json`]: super::ExecuteWebhook::payload_json
     /// [Discord Docs/Create Message]: https://discord.com/developers/docs/resources/channel#create-message-params
-    pub fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
-        self.fields.payload_json.replace(payload_json);
+    pub const fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
+        self.fields.payload_json = Some(payload_json);
 
         self
     }
@@ -399,7 +395,7 @@ mod tests {
         let body = UpdateWebhookMessageFields {
             allowed_mentions: None,
             attachments: &[],
-            content: Some(NullableField::Value("test")),
+            content: Some(NullableField(Some("test"))),
             embeds: None,
             payload_json: None,
         };

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -7,7 +7,7 @@ use crate::{
 use serde::Serialize;
 use twilight_model::{channel::Webhook, id::WebhookId};
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct UpdateWebhookWithTokenFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     avatar: Option<NullableField<&'a str>>,
@@ -24,9 +24,12 @@ pub struct UpdateWebhookWithToken<'a> {
 }
 
 impl<'a> UpdateWebhookWithToken<'a> {
-    pub(crate) fn new(http: &'a Client, webhook_id: WebhookId, token: &'a str) -> Self {
+    pub(crate) const fn new(http: &'a Client, webhook_id: WebhookId, token: &'a str) -> Self {
         Self {
-            fields: UpdateWebhookWithTokenFields::default(),
+            fields: UpdateWebhookWithTokenFields {
+                avatar: None,
+                name: None,
+            },
             http,
             token,
             webhook_id,
@@ -40,17 +43,15 @@ impl<'a> UpdateWebhookWithToken<'a> {
     /// base64-encoded image.
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: Option<&'a str>) -> Self {
-        self.fields
-            .avatar
-            .replace(NullableField::from_option(avatar));
+    pub const fn avatar(mut self, avatar: Option<&'a str>) -> Self {
+        self.fields.avatar = Some(NullableField(avatar));
 
         self
     }
 
     /// Change the name of the webhook.
-    pub fn name(mut self, name: Option<&'a str>) -> Self {
-        self.fields.name.replace(NullableField::from_option(name));
+    pub const fn name(mut self, name: Option<&'a str>) -> Self {
+        self.fields.name = Some(NullableField(name));
 
         self
     }

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -57,7 +57,6 @@ pub enum CreateBanErrorType {
     DeleteMessageDaysInvalid,
 }
 
-#[derive(Default)]
 struct CreateBanFields<'a> {
     delete_message_days: Option<u64>,
     reason: Option<&'a str>,
@@ -96,9 +95,12 @@ pub struct CreateBan<'a> {
 }
 
 impl<'a> CreateBan<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId, user_id: UserId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId, user_id: UserId) -> Self {
         Self {
-            fields: CreateBanFields::default(),
+            fields: CreateBanFields {
+                delete_message_days: None,
+                reason: None,
+            },
             guild_id,
             http,
             user_id,
@@ -113,14 +115,14 @@ impl<'a> CreateBan<'a> {
     ///
     /// Returns a [`CreateBanErrorType::DeleteMessageDaysInvalid`] error type if
     /// the number of days is greater than 7.
-    pub fn delete_message_days(mut self, days: u64) -> Result<Self, CreateBanError> {
+    pub const fn delete_message_days(mut self, days: u64) -> Result<Self, CreateBanError> {
         if !validate::ban_delete_message_days(days) {
             return Err(CreateBanError {
                 kind: CreateBanErrorType::DeleteMessageDaysInvalid,
             });
         }
 
-        self.fields.delete_message_days.replace(days);
+        self.fields.delete_message_days = Some(days);
 
         Ok(self)
     }

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -122,8 +122,8 @@ impl RoleFieldsBuilder {
     }
 
     /// Show the role above other roles in the user list.
-    pub fn hoist(mut self) -> Self {
-        self.0.hoist.replace(true);
+    pub const fn hoist(mut self) -> Self {
+        self.0.hoist = Some(true);
 
         self
     }
@@ -147,22 +147,22 @@ impl RoleFieldsBuilder {
     }
 
     /// Allow the role to be @mentioned.
-    pub fn mentionable(mut self) -> Self {
-        self.0.mentionable.replace(true);
+    pub const fn mentionable(mut self) -> Self {
+        self.0.mentionable = Some(true);
 
         self
     }
 
     /// Set the permissions of the role.
-    pub fn permissions(mut self, permissions: Permissions) -> Self {
-        self.0.permissions.replace(permissions);
+    pub const fn permissions(mut self, permissions: Permissions) -> Self {
+        self.0.permissions = Some(permissions);
 
         self
     }
 
     /// Set the position of the role.
-    pub fn position(mut self, position: i64) -> Self {
-        self.0.position.replace(position);
+    pub const fn position(mut self, position: i64) -> Self {
+        self.0.position = Some(position);
 
         self
     }
@@ -326,15 +326,16 @@ impl TextFieldsBuilder {
     }
 
     /// Make the channel NSFW.
-    pub fn nsfw(mut self) -> Self {
-        self.0.nsfw.replace(true);
+    pub const fn nsfw(mut self) -> Self {
+        self.0.nsfw = Some(true);
 
         self
     }
 
     /// Set the channel's permission overwrites.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn permission_overwrites(mut self, overwrites: Vec<PermissionOverwrite>) -> Self {
-        self.0.permission_overwrites.replace(overwrites);
+        self.0.permission_overwrites = Some(overwrites);
 
         self
     }
@@ -345,6 +346,7 @@ impl TextFieldsBuilder {
     ///
     /// Returns a [`TextFieldsErrorType::RateLimitInvalid`] error type if the
     /// rate limit is invalid.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn rate_limit_per_user(mut self, limit: u64) -> Result<Self, TextFieldsError> {
         if limit > Self::MAX_RATE_LIMIT {
             return Err(TextFieldsError {
@@ -352,7 +354,7 @@ impl TextFieldsBuilder {
             });
         }
 
-        self.0.rate_limit_per_user.replace(limit);
+        self.0.rate_limit_per_user = Some(limit);
 
         Ok(self)
     }
@@ -498,8 +500,8 @@ impl VoiceFieldsBuilder {
     }
 
     /// Set the voice channel's bitrate.
-    pub fn bitrate(mut self, bitrate: u64) -> Self {
-        self.0.bitrate.replace(bitrate);
+    pub const fn bitrate(mut self, bitrate: u64) -> Self {
+        self.0.bitrate = Some(bitrate);
 
         self
     }
@@ -512,8 +514,8 @@ impl VoiceFieldsBuilder {
     }
 
     /// Set the voice channel's user limit.
-    pub fn user_limit(mut self, limit: u64) -> Self {
-        self.0.user_limit.replace(limit);
+    pub const fn user_limit(mut self, limit: u64) -> Self {
+        self.0.user_limit = Some(limit);
 
         self
     }

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -333,9 +333,8 @@ impl TextFieldsBuilder {
     }
 
     /// Set the channel's permission overwrites.
-    #[allow(clippy::missing_const_for_fn)]
     pub fn permission_overwrites(mut self, overwrites: Vec<PermissionOverwrite>) -> Self {
-        self.0.permission_overwrites = Some(overwrites);
+        self.0.permission_overwrites.replace(overwrites);
 
         self
     }
@@ -346,7 +345,6 @@ impl TextFieldsBuilder {
     ///
     /// Returns a [`TextFieldsErrorType::RateLimitInvalid`] error type if the
     /// rate limit is invalid.
-    #[allow(clippy::missing_const_for_fn)]
     pub fn rate_limit_per_user(mut self, limit: u64) -> Result<Self, TextFieldsError> {
         if limit > Self::MAX_RATE_LIMIT {
             return Err(TextFieldsError {
@@ -354,7 +352,7 @@ impl TextFieldsBuilder {
             });
         }
 
-        self.0.rate_limit_per_user = Some(limit);
+        self.0.rate_limit_per_user.replace(limit);
 
         Ok(self)
     }

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -264,15 +264,15 @@ impl<'a> CreateGuild<'a> {
     /// This must be an ID specified in [`channels`].
     ///
     /// [`channels`]: Self::channels
-    pub fn afk_channel_id(mut self, afk_channel_id: ChannelId) -> Self {
-        self.fields.afk_channel_id.replace(afk_channel_id);
+    pub const fn afk_channel_id(mut self, afk_channel_id: ChannelId) -> Self {
+        self.fields.afk_channel_id = Some(afk_channel_id);
 
         self
     }
 
     /// Set the AFK timeout, in seconds.
-    pub fn afk_timeout(mut self, afk_timeout: u64) -> Self {
-        self.fields.afk_timeout.replace(afk_timeout);
+    pub const fn afk_timeout(mut self, afk_timeout: u64) -> Self {
+        self.fields.afk_timeout = Some(afk_timeout);
 
         self
     }
@@ -338,25 +338,21 @@ impl<'a> CreateGuild<'a> {
     /// information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#create-guild
-    pub fn default_message_notifications(
+    pub const fn default_message_notifications(
         mut self,
         default_message_notifications: DefaultMessageNotificationLevel,
     ) -> Self {
-        self.fields
-            .default_message_notifications
-            .replace(default_message_notifications);
+        self.fields.default_message_notifications = Some(default_message_notifications);
 
         self
     }
 
     /// Set the explicit content filter level.
-    pub fn explicit_content_filter(
+    pub const fn explicit_content_filter(
         mut self,
         explicit_content_filter: ExplicitContentFilter,
     ) -> Self {
-        self.fields
-            .explicit_content_filter
-            .replace(explicit_content_filter);
+        self.fields.explicit_content_filter = Some(explicit_content_filter);
 
         self
     }
@@ -397,17 +393,15 @@ impl<'a> CreateGuild<'a> {
     /// This must be an ID specified in [`channels`].
     ///
     /// [`channels`]: Self::channels
-    pub fn system_channel_id(mut self, system_channel_id: ChannelId) -> Self {
-        self.fields.system_channel_id.replace(system_channel_id);
+    pub const fn system_channel_id(mut self, system_channel_id: ChannelId) -> Self {
+        self.fields.system_channel_id = Some(system_channel_id);
 
         self
     }
 
     /// Set the guild's [`SystemChannelFlags`].
-    pub fn system_channel_flags(mut self, system_channel_flags: SystemChannelFlags) -> Self {
-        self.fields
-            .system_channel_flags
-            .replace(system_channel_flags);
+    pub const fn system_channel_flags(mut self, system_channel_flags: SystemChannelFlags) -> Self {
+        self.fields.system_channel_flags = Some(system_channel_flags);
 
         self
     }

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -141,42 +141,40 @@ impl<'a> CreateGuildChannel<'a> {
     }
 
     /// Set the bitrate of the channel. Applicable to voice channels only.
-    pub fn bitrate(mut self, bitrate: u64) -> Self {
-        self.fields.bitrate.replace(bitrate);
+    pub const fn bitrate(mut self, bitrate: u64) -> Self {
+        self.fields.bitrate = Some(bitrate);
 
         self
     }
 
     /// Set the kind of channel.
-    pub fn kind(mut self, kind: ChannelType) -> Self {
-        self.fields.kind.replace(kind);
+    pub const fn kind(mut self, kind: ChannelType) -> Self {
+        self.fields.kind = Some(kind);
 
         self
     }
 
     /// Set whether the channel is marked as NSFW.
-    pub fn nsfw(mut self, nsfw: bool) -> Self {
-        self.fields.nsfw.replace(nsfw);
+    pub const fn nsfw(mut self, nsfw: bool) -> Self {
+        self.fields.nsfw = Some(nsfw);
 
         self
     }
 
     /// If this is specified, and the parent ID is a `ChannelType::CategoryChannel`, create this
     /// channel as a child of the category channel.
-    pub fn parent_id(mut self, parent_id: ChannelId) -> Self {
-        self.fields.parent_id.replace(parent_id);
+    pub const fn parent_id(mut self, parent_id: ChannelId) -> Self {
+        self.fields.parent_id = Some(parent_id);
 
         self
     }
 
     /// Set the permission overwrites of a channel.
-    pub fn permission_overwrites(
+    pub const fn permission_overwrites(
         mut self,
         permission_overwrites: &'a [PermissionOverwrite],
     ) -> Self {
-        self.fields
-            .permission_overwrites
-            .replace(permission_overwrites);
+        self.fields.permission_overwrites = Some(permission_overwrites);
 
         self
     }
@@ -185,8 +183,8 @@ impl<'a> CreateGuildChannel<'a> {
     ///
     /// Positions are numerical and zero-indexed. If you place a channel at position 2, channels
     /// 2-n will shift down one position and the initial channel will take its place.
-    pub fn position(mut self, position: u64) -> Self {
-        self.fields.position.replace(position);
+    pub const fn position(mut self, position: u64) -> Self {
+        self.fields.position = Some(position);
 
         self
     }
@@ -203,7 +201,7 @@ impl<'a> CreateGuildChannel<'a> {
     /// type if the amount is greater than 21600.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure
-    pub fn rate_limit_per_user(
+    pub const fn rate_limit_per_user(
         mut self,
         rate_limit_per_user: u64,
     ) -> Result<Self, CreateGuildChannelError> {
@@ -213,7 +211,7 @@ impl<'a> CreateGuildChannel<'a> {
             });
         }
 
-        self.fields.rate_limit_per_user.replace(rate_limit_per_user);
+        self.fields.rate_limit_per_user = Some(rate_limit_per_user);
 
         Ok(self)
     }
@@ -246,8 +244,8 @@ impl<'a> CreateGuildChannel<'a> {
     /// discord docs] for more details.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#modify-channel-json-params
-    pub fn user_limit(mut self, user_limit: u64) -> Self {
-        self.fields.user_limit.replace(user_limit);
+    pub const fn user_limit(mut self, user_limit: u64) -> Self {
+        self.fields.user_limit = Some(user_limit);
 
         self
     }

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -102,8 +102,8 @@ impl<'a> CreateGuildPrune<'a> {
     }
 
     /// Return the amount of pruned members. Discouraged for large guilds.
-    pub fn compute_prune_count(mut self, compute_prune_count: bool) -> Self {
-        self.fields.compute_prune_count.replace(compute_prune_count);
+    pub const fn compute_prune_count(mut self, compute_prune_count: bool) -> Self {
+        self.fields.compute_prune_count = Some(compute_prune_count);
 
         self
     }
@@ -116,14 +116,14 @@ impl<'a> CreateGuildPrune<'a> {
     ///
     /// Returns a [`CreateGuildPruneErrorType::DaysInvalid`] error type if the
     /// number of days is 0.
-    pub fn days(mut self, days: u64) -> Result<Self, CreateGuildPruneError> {
+    pub const fn days(mut self, days: u64) -> Result<Self, CreateGuildPruneError> {
         if !validate::guild_prune_days(days) {
             return Err(CreateGuildPruneError {
                 kind: CreateGuildPruneErrorType::DaysInvalid,
             });
         }
 
-        self.fields.days.replace(days);
+        self.fields.days = Some(days);
 
         Ok(self)
     }

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -65,7 +65,6 @@ pub enum CreateGuildPruneErrorType {
     DaysInvalid,
 }
 
-#[derive(Default)]
 struct CreateGuildPruneFields<'a> {
     compute_prune_count: Option<bool>,
     days: Option<u64>,
@@ -85,9 +84,13 @@ pub struct CreateGuildPrune<'a> {
 }
 
 impl<'a> CreateGuildPrune<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
         Self {
-            fields: CreateGuildPruneFields::default(),
+            fields: CreateGuildPruneFields {
+                compute_prune_count: None,
+                days: None,
+                include_roles: &[],
+            },
             guild_id,
             http,
             reason: None,

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -56,8 +56,8 @@ impl<'a> CreateEmoji<'a> {
     /// Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/emoji
-    pub fn roles(mut self, roles: &'a [RoleId]) -> Self {
-        self.fields.roles.replace(roles);
+    pub const fn roles(mut self, roles: &'a [RoleId]) -> Self {
+        self.fields.roles = Some(roles);
 
         self
     }

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -10,7 +10,7 @@ use twilight_model::{
     id::{EmojiId, GuildId, RoleId},
 };
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct UpdateEmojiFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
@@ -28,9 +28,12 @@ pub struct UpdateEmoji<'a> {
 }
 
 impl<'a> UpdateEmoji<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId, emoji_id: EmojiId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId, emoji_id: EmojiId) -> Self {
         Self {
-            fields: UpdateEmojiFields::default(),
+            fields: UpdateEmojiFields {
+                name: None,
+                roles: None,
+            },
             emoji_id,
             guild_id,
             http,
@@ -39,15 +42,15 @@ impl<'a> UpdateEmoji<'a> {
     }
 
     /// Change the name of the emoji.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.fields.name.replace(name);
+    pub const fn name(mut self, name: &'a str) -> Self {
+        self.fields.name = Some(name);
 
         self
     }
 
     /// Change the roles that the emoji is whitelisted to.
-    pub fn roles(mut self, roles: &'a [RoleId]) -> Self {
-        self.fields.roles.replace(roles);
+    pub const fn roles(mut self, roles: &'a [RoleId]) -> Self {
+        self.fields.roles = Some(roles);
 
         self
     }

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -58,7 +58,6 @@ pub enum GetAuditLogErrorType {
     LimitInvalid,
 }
 
-#[derive(Default)]
 struct GetAuditLogFields {
     action_type: Option<AuditLogEventType>,
     before: Option<u64>,
@@ -104,24 +103,29 @@ pub struct GetAuditLog<'a> {
 }
 
 impl<'a> GetAuditLog<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
         Self {
-            fields: GetAuditLogFields::default(),
+            fields: GetAuditLogFields {
+                action_type: None,
+                before: None,
+                limit: None,
+                user_id: None,
+            },
             guild_id,
             http,
         }
     }
 
     /// Filter by an action type.
-    pub fn action_type(mut self, action_type: AuditLogEventType) -> Self {
-        self.fields.action_type.replace(action_type);
+    pub const fn action_type(mut self, action_type: AuditLogEventType) -> Self {
+        self.fields.action_type = Some(action_type);
 
         self
     }
 
     /// Get audit log entries before the entry specified.
-    pub fn before(mut self, before: u64) -> Self {
-        self.fields.before.replace(before);
+    pub const fn before(mut self, before: u64) -> Self {
+        self.fields.before = Some(before);
 
         self
     }
@@ -134,14 +138,14 @@ impl<'a> GetAuditLog<'a> {
     ///
     /// Returns a [`GetAuditLogErrorType::LimitInvalid`] error type if the
     /// `limit` is 0 or greater than 100.
-    pub fn limit(mut self, limit: u64) -> Result<Self, GetAuditLogError> {
+    pub const fn limit(mut self, limit: u64) -> Result<Self, GetAuditLogError> {
         if !validate::get_audit_log_limit(limit) {
             return Err(GetAuditLogError {
                 kind: GetAuditLogErrorType::LimitInvalid,
             });
         }
 
-        self.fields.limit.replace(limit);
+        self.fields.limit = Some(limit);
 
         Ok(self)
     }
@@ -149,8 +153,8 @@ impl<'a> GetAuditLog<'a> {
     /// Filter audit log for entries from a user.
     ///
     /// This is the user who did the auditable action, not the target of the auditable action.
-    pub fn user_id(mut self, user_id: UserId) -> Self {
-        self.fields.user_id.replace(user_id);
+    pub const fn user_id(mut self, user_id: UserId) -> Self {
+        self.fields.user_id = Some(user_id);
 
         self
     }

--- a/http/src/request/guild/get_guild.rs
+++ b/http/src/request/guild/get_guild.rs
@@ -1,7 +1,6 @@
 use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::{guild::Guild, id::GuildId};
 
-#[derive(Default)]
 struct GetGuildFields {
     with_counts: bool,
 }
@@ -14,9 +13,9 @@ pub struct GetGuild<'a> {
 }
 
 impl<'a> GetGuild<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
         Self {
-            fields: GetGuildFields::default(),
+            fields: GetGuildFields { with_counts: false },
             guild_id,
             http,
         }

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -79,9 +79,12 @@ pub struct GetGuildPruneCount<'a> {
 }
 
 impl<'a> GetGuildPruneCount<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
         Self {
-            fields: GetGuildPruneCountFields::default(),
+            fields: GetGuildPruneCountFields {
+                days: None,
+                include_roles: &[],
+            },
             guild_id,
             http,
         }
@@ -96,14 +99,14 @@ impl<'a> GetGuildPruneCount<'a> {
     ///
     /// Returns a [`GetGuildPruneCountErrorType::DaysInvalid`] error type if the
     /// number of days is 0.
-    pub fn days(mut self, days: u64) -> Result<Self, GetGuildPruneCountError> {
+    pub const fn days(mut self, days: u64) -> Result<Self, GetGuildPruneCountError> {
         if !validate::guild_prune_days(days) {
             return Err(GetGuildPruneCountError {
                 kind: GetGuildPruneCountErrorType::DaysInvalid,
             });
         }
 
-        self.fields.days.replace(days);
+        self.fields.days = Some(days);
 
         Ok(self)
     }

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -65,7 +65,6 @@ pub enum GetGuildPruneCountErrorType {
     DaysInvalid,
 }
 
-#[derive(Default)]
 struct GetGuildPruneCountFields<'a> {
     days: Option<u64>,
     include_roles: &'a [RoleId],

--- a/http/src/request/guild/member/add_guild_member.rs
+++ b/http/src/request/guild/member/add_guild_member.rs
@@ -113,15 +113,15 @@ impl<'a> AddGuildMember<'a> {
 
     /// Whether the new member will be unable to hear audio when connected to a
     /// voice channel.
-    pub fn deaf(mut self, deaf: bool) -> Self {
-        self.fields.deaf.replace(deaf);
+    pub const fn deaf(mut self, deaf: bool) -> Self {
+        self.fields.deaf = Some(deaf);
 
         self
     }
 
     /// Whether the new member will be unable to speak in voice channels.
-    pub fn mute(mut self, mute: bool) -> Self {
-        self.fields.mute.replace(mute);
+    pub const fn mute(mut self, mute: bool) -> Self {
+        self.fields.mute = Some(mute);
 
         self
     }
@@ -148,8 +148,8 @@ impl<'a> AddGuildMember<'a> {
     }
 
     /// List of roles to assign the new member.
-    pub fn roles(mut self, roles: &'a [RoleId]) -> Self {
-        self.fields.roles.replace(roles);
+    pub const fn roles(mut self, roles: &'a [RoleId]) -> Self {
+        self.fields.roles = Some(roles);
 
         self
     }

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -63,7 +63,6 @@ pub enum GetGuildMembersErrorType {
     },
 }
 
-#[derive(Default)]
 struct GetGuildMembersFields {
     after: Option<UserId>,
     limit: Option<u64>,
@@ -99,17 +98,21 @@ pub struct GetGuildMembers<'a> {
 }
 
 impl<'a> GetGuildMembers<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
         Self {
-            fields: GetGuildMembersFields::default(),
+            fields: GetGuildMembersFields {
+                after: None,
+                limit: None,
+                presences: None,
+            },
             guild_id,
             http,
         }
     }
 
     /// Sets the user ID to get members after.
-    pub fn after(mut self, after: UserId) -> Self {
-        self.fields.after.replace(after);
+    pub const fn after(mut self, after: UserId) -> Self {
+        self.fields.after = Some(after);
 
         self
     }
@@ -122,21 +125,21 @@ impl<'a> GetGuildMembers<'a> {
     ///
     /// Returns a [`GetGuildMembersErrorType::LimitInvalid`] error type if the
     /// limit is 0 or greater than 1000.
-    pub fn limit(mut self, limit: u64) -> Result<Self, GetGuildMembersError> {
+    pub const fn limit(mut self, limit: u64) -> Result<Self, GetGuildMembersError> {
         if !validate::get_guild_members_limit(limit) {
             return Err(GetGuildMembersError {
                 kind: GetGuildMembersErrorType::LimitInvalid { limit },
             });
         }
 
-        self.fields.limit.replace(limit);
+        self.fields.limit = Some(limit);
 
         Ok(self)
     }
 
     /// Sets whether to retrieve matched member presences
-    pub fn presences(mut self, presences: bool) -> Self {
-        self.fields.presences.replace(presences);
+    pub const fn presences(mut self, presences: bool) -> Self {
+        self.fields.presences = Some(presences);
 
         self
     }

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -121,7 +121,7 @@ impl<'a> SearchGuildMembers<'a> {
     ///
     /// Returns a [`SearchGuildMembersErrorType::LimitInvalid`] error type if
     /// the limit is 0 or greater than 1000.
-    pub fn limit(mut self, limit: u64) -> Result<Self, SearchGuildMembersError> {
+    pub const fn limit(mut self, limit: u64) -> Result<Self, SearchGuildMembersError> {
         // Using get_guild_members_limit here as the limits are the same
         // and this endpoint is not officially documented yet.
         if !validate::search_guild_members_limit(limit) {
@@ -130,7 +130,7 @@ impl<'a> SearchGuildMembers<'a> {
             });
         }
 
-        self.fields.limit.replace(limit);
+        self.fields.limit = Some(limit);
 
         Ok(self)
     }

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -10,7 +10,7 @@ use twilight_model::{
     id::GuildId,
 };
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct CreateRoleFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<u32>,
@@ -52,9 +52,15 @@ pub struct CreateRole<'a> {
 }
 
 impl<'a> CreateRole<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
         Self {
-            fields: CreateRoleFields::default(),
+            fields: CreateRoleFields {
+                color: None,
+                hoist: None,
+                mentionable: None,
+                name: None,
+                permissions: None,
+            },
             guild_id,
             http,
             reason: None,
@@ -62,22 +68,22 @@ impl<'a> CreateRole<'a> {
     }
 
     /// Set the color of the role.
-    pub fn color(mut self, color: u32) -> Self {
-        self.fields.color.replace(color);
+    pub const fn color(mut self, color: u32) -> Self {
+        self.fields.color = Some(color);
 
         self
     }
 
     /// If true, display the role in the members list.
-    pub fn hoist(mut self, hoist: bool) -> Self {
-        self.fields.hoist.replace(hoist);
+    pub const fn hoist(mut self, hoist: bool) -> Self {
+        self.fields.hoist = Some(hoist);
 
         self
     }
 
     /// If true, the role can be @mentioned (pinged) in chat.
-    pub fn mentionable(mut self, mentionable: bool) -> Self {
-        self.fields.mentionable.replace(mentionable);
+    pub const fn mentionable(mut self, mentionable: bool) -> Self {
+        self.fields.mentionable = Some(mentionable);
 
         self
     }
@@ -85,15 +91,15 @@ impl<'a> CreateRole<'a> {
     /// Set the name of the role.
     ///
     /// If none is specified, Discord sets this to `New Role`.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.fields.name.replace(name);
+    pub const fn name(mut self, name: &'a str) -> Self {
+        self.fields.name = Some(name);
 
         self
     }
 
     /// Set the allowed permissions of this role.
-    pub fn permissions(mut self, permissions: Permissions) -> Self {
-        self.fields.permissions.replace(permissions);
+    pub const fn permissions(mut self, permissions: Permissions) -> Self {
+        self.fields.permissions = Some(permissions);
 
         self
     }

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -10,7 +10,7 @@ use twilight_model::{
     id::{GuildId, RoleId},
 };
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct UpdateRoleFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<NullableField<u32>>,
@@ -34,9 +34,15 @@ pub struct UpdateRole<'a> {
 }
 
 impl<'a> UpdateRole<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId, role_id: RoleId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId, role_id: RoleId) -> Self {
         Self {
-            fields: UpdateRoleFields::default(),
+            fields: UpdateRoleFields {
+                color: None,
+                hoist: None,
+                mentionable: None,
+                name: None,
+                permissions: None,
+            },
             guild_id,
             http,
             role_id,
@@ -45,36 +51,36 @@ impl<'a> UpdateRole<'a> {
     }
 
     /// Set the color of the role.
-    pub fn color(mut self, color: Option<u32>) -> Self {
-        self.fields.color.replace(NullableField::from_option(color));
+    pub const fn color(mut self, color: Option<u32>) -> Self {
+        self.fields.color = Some(NullableField(color));
 
         self
     }
 
     /// If true, display the role in the members list.
-    pub fn hoist(mut self, hoist: bool) -> Self {
-        self.fields.hoist.replace(hoist);
+    pub const fn hoist(mut self, hoist: bool) -> Self {
+        self.fields.hoist = Some(hoist);
 
         self
     }
 
     /// If true, the role can be @mentioned (pinged) in chat.
-    pub fn mentionable(mut self, mentionable: bool) -> Self {
-        self.fields.mentionable.replace(mentionable);
+    pub const fn mentionable(mut self, mentionable: bool) -> Self {
+        self.fields.mentionable = Some(mentionable);
 
         self
     }
 
     /// Set the name of the role.
-    pub fn name(mut self, name: Option<&'a str>) -> Self {
-        self.fields.name.replace(NullableField::from_option(name));
+    pub const fn name(mut self, name: Option<&'a str>) -> Self {
+        self.fields.name = Some(NullableField(name));
 
         self
     }
 
     /// Set the allowed permissions of this role.
-    pub fn permissions(mut self, permissions: Permissions) -> Self {
-        self.fields.permissions.replace(permissions);
+    pub const fn permissions(mut self, permissions: Permissions) -> Self {
+        self.fields.permissions = Some(permissions);
 
         self
     }

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -63,7 +63,7 @@ pub enum UpdateGuildErrorType {
     NameInvalid,
 }
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct UpdateGuildFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     afk_channel_id: Option<NullableField<ChannelId>>,
@@ -114,9 +114,27 @@ pub struct UpdateGuild<'a> {
 }
 
 impl<'a> UpdateGuild<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
         Self {
-            fields: UpdateGuildFields::default(),
+            fields: UpdateGuildFields {
+                afk_channel_id: None,
+                afk_timeout: None,
+                banner: None,
+                default_message_notifications: None,
+                discovery_splash: None,
+                explicit_content_filter: None,
+                features: None,
+                icon: None,
+                name: None,
+                owner_id: None,
+                splash: None,
+                system_channel_id: None,
+                system_channel_flags: None,
+                verification_level: None,
+                rules_channel_id: None,
+                public_updates_channel_id: None,
+                preferred_locale: None,
+            },
             guild_id,
             http,
             reason: None,
@@ -124,17 +142,15 @@ impl<'a> UpdateGuild<'a> {
     }
 
     /// Set the voice channel where AFK voice users are sent.
-    pub fn afk_channel_id(mut self, afk_channel_id: Option<ChannelId>) -> Self {
-        self.fields
-            .afk_channel_id
-            .replace(NullableField::from_option(afk_channel_id));
+    pub const fn afk_channel_id(mut self, afk_channel_id: Option<ChannelId>) -> Self {
+        self.fields.afk_channel_id = Some(NullableField(afk_channel_id));
 
         self
     }
 
     /// Set how much time it takes for a voice user to be considered AFK.
-    pub fn afk_timeout(mut self, afk_timeout: u64) -> Self {
-        self.fields.afk_timeout.replace(afk_timeout);
+    pub const fn afk_timeout(mut self, afk_timeout: u64) -> Self {
+        self.fields.afk_timeout = Some(afk_timeout);
 
         self
     }
@@ -145,10 +161,8 @@ impl<'a> UpdateGuild<'a> {
     /// the banner.
     ///
     /// The server must have the `BANNER` feature.
-    pub fn banner(mut self, banner: Option<&'a str>) -> Self {
-        self.fields
-            .banner
-            .replace(NullableField::from_option(banner));
+    pub const fn banner(mut self, banner: Option<&'a str>) -> Self {
+        self.fields.banner = Some(NullableField(banner));
 
         self
     }
@@ -157,13 +171,12 @@ impl<'a> UpdateGuild<'a> {
     /// information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#create-guild
-    pub fn default_message_notifications(
+    pub const fn default_message_notifications(
         mut self,
         default_message_notifications: Option<DefaultMessageNotificationLevel>,
     ) -> Self {
-        self.fields
-            .default_message_notifications
-            .replace(NullableField::from_option(default_message_notifications));
+        self.fields.default_message_notifications =
+            Some(NullableField(default_message_notifications));
 
         self
     }
@@ -171,29 +184,25 @@ impl<'a> UpdateGuild<'a> {
     /// Set the guild's discovery splash image.
     ///
     /// Requires the guild to have the `DISCOVERABLE` feature enabled.
-    pub fn discovery_splash(mut self, discovery_splash: Option<&'a str>) -> Self {
-        self.fields
-            .discovery_splash
-            .replace(NullableField::from_option(discovery_splash));
+    pub const fn discovery_splash(mut self, discovery_splash: Option<&'a str>) -> Self {
+        self.fields.discovery_splash = Some(NullableField(discovery_splash));
 
         self
     }
 
     /// Set the explicit content filter level.
-    pub fn explicit_content_filter(
+    pub const fn explicit_content_filter(
         mut self,
         explicit_content_filter: Option<ExplicitContentFilter>,
     ) -> Self {
-        self.fields
-            .explicit_content_filter
-            .replace(NullableField::from_option(explicit_content_filter));
+        self.fields.explicit_content_filter = Some(NullableField(explicit_content_filter));
 
         self
     }
 
     /// Set the enabled features of the guild.
-    pub fn features(mut self, features: &'a [&'a str]) -> Self {
-        self.fields.features.replace(features);
+    pub const fn features(mut self, features: &'a [&'a str]) -> Self {
+        self.fields.features = Some(features);
 
         self
     }
@@ -205,8 +214,8 @@ impl<'a> UpdateGuild<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn icon(mut self, icon: Option<&'a str>) -> Self {
-        self.fields.icon.replace(NullableField::from_option(icon));
+    pub const fn icon(mut self, icon: Option<&'a str>) -> Self {
+        self.fields.icon = Some(NullableField(icon));
 
         self
     }
@@ -235,8 +244,8 @@ impl<'a> UpdateGuild<'a> {
     /// Transfer ownership to another user.
     ///
     /// Only works if the current user is the owner.
-    pub fn owner_id(mut self, owner_id: UserId) -> Self {
-        self.fields.owner_id.replace(owner_id);
+    pub const fn owner_id(mut self, owner_id: UserId) -> Self {
+        self.fields.owner_id = Some(owner_id);
 
         self
     }
@@ -244,31 +253,25 @@ impl<'a> UpdateGuild<'a> {
     /// Set the guild's splash image.
     ///
     /// Requires the guild to have the `INVITE_SPLASH` feature enabled.
-    pub fn splash(mut self, splash: Option<&'a str>) -> Self {
-        self.fields
-            .splash
-            .replace(NullableField::from_option(splash));
+    pub const fn splash(mut self, splash: Option<&'a str>) -> Self {
+        self.fields.splash = Some(NullableField(splash));
 
         self
     }
 
     /// Set the channel where events such as welcome messages are posted.
-    pub fn system_channel(mut self, system_channel_id: Option<ChannelId>) -> Self {
-        self.fields
-            .system_channel_id
-            .replace(NullableField::from_option(system_channel_id));
+    pub const fn system_channel(mut self, system_channel_id: Option<ChannelId>) -> Self {
+        self.fields.system_channel_id = Some(NullableField(system_channel_id));
 
         self
     }
 
     /// Set the guild's [`SystemChannelFlags`].
-    pub fn system_channel_flags(
+    pub const fn system_channel_flags(
         mut self,
         system_channel_flags: Option<SystemChannelFlags>,
     ) -> Self {
-        self.fields
-            .system_channel_flags
-            .replace(NullableField::from_option(system_channel_flags));
+        self.fields.system_channel_flags = Some(NullableField(system_channel_flags));
 
         self
     }
@@ -278,10 +281,8 @@ impl<'a> UpdateGuild<'a> {
     /// Requires the guild to be `PUBLIC`. Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild
-    pub fn rules_channel(mut self, rules_channel_id: Option<ChannelId>) -> Self {
-        self.fields
-            .rules_channel_id
-            .replace(NullableField::from_option(rules_channel_id));
+    pub const fn rules_channel(mut self, rules_channel_id: Option<ChannelId>) -> Self {
+        self.fields.rules_channel_id = Some(NullableField(rules_channel_id));
 
         self
     }
@@ -289,10 +290,11 @@ impl<'a> UpdateGuild<'a> {
     /// Set the public updates channel.
     ///
     /// Requires the guild to be `PUBLIC`.
-    pub fn public_updates_channel(mut self, public_updates_channel_id: Option<ChannelId>) -> Self {
-        self.fields
-            .public_updates_channel_id
-            .replace(NullableField::from_option(public_updates_channel_id));
+    pub const fn public_updates_channel(
+        mut self,
+        public_updates_channel_id: Option<ChannelId>,
+    ) -> Self {
+        self.fields.public_updates_channel_id = Some(NullableField(public_updates_channel_id));
 
         self
     }
@@ -300,10 +302,8 @@ impl<'a> UpdateGuild<'a> {
     /// Set the preferred locale for the guild.
     ///
     /// Defaults to `en-US`. Requires the guild to be `PUBLIC`.
-    pub fn preferred_locale(mut self, preferred_locale: Option<&'a str>) -> Self {
-        self.fields
-            .preferred_locale
-            .replace(NullableField::from_option(preferred_locale));
+    pub const fn preferred_locale(mut self, preferred_locale: Option<&'a str>) -> Self {
+        self.fields.preferred_locale = Some(NullableField(preferred_locale));
 
         self
     }
@@ -311,10 +311,11 @@ impl<'a> UpdateGuild<'a> {
     /// Set the verification level. Refer to [the discord docs] for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/guild#guild-object-verification-level
-    pub fn verification_level(mut self, verification_level: Option<VerificationLevel>) -> Self {
-        self.fields
-            .verification_level
-            .replace(NullableField::from_option(verification_level));
+    pub const fn verification_level(
+        mut self,
+        verification_level: Option<VerificationLevel>,
+    ) -> Self {
+        self.fields.verification_level = Some(NullableField(verification_level));
 
         self
     }

--- a/http/src/request/guild/update_guild_welcome_screen.rs
+++ b/http/src/request/guild/update_guild_welcome_screen.rs
@@ -32,24 +32,28 @@ pub struct UpdateGuildWelcomeScreen<'a> {
 }
 
 impl<'a> UpdateGuildWelcomeScreen<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
         Self {
-            fields: UpdateGuildWelcomeScreenFields::default(),
+            fields: UpdateGuildWelcomeScreenFields {
+                description: None,
+                enabled: None,
+                welcome_channels: &[],
+            },
             guild_id,
             http,
         }
     }
 
     /// Set the description of the welcome screen.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.fields.description.replace(description);
+    pub const fn description(mut self, description: &'a str) -> Self {
+        self.fields.description = Some(description);
 
         self
     }
 
     /// Set whether the welcome screen is enabled.
-    pub fn enabled(mut self, enabled: bool) -> Self {
-        self.fields.enabled.replace(enabled);
+    pub const fn enabled(mut self, enabled: bool) -> Self {
+        self.fields.enabled = Some(enabled);
 
         self
     }

--- a/http/src/request/guild/update_guild_welcome_screen.rs
+++ b/http/src/request/guild/update_guild_welcome_screen.rs
@@ -10,7 +10,7 @@ use twilight_model::{
     invite::{WelcomeScreen, WelcomeScreenChannel},
 };
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct UpdateGuildWelcomeScreenFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<&'a str>,

--- a/http/src/request/guild/update_guild_widget.rs
+++ b/http/src/request/guild/update_guild_widget.rs
@@ -10,7 +10,7 @@ use twilight_model::{
     id::{ChannelId, GuildId},
 };
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct UpdateGuildWidgetFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     channel_id: Option<NullableField<ChannelId>>,
@@ -26,26 +26,27 @@ pub struct UpdateGuildWidget<'a> {
 }
 
 impl<'a> UpdateGuildWidget<'a> {
-    pub(crate) fn new(http: &'a Client, guild_id: GuildId) -> Self {
+    pub(crate) const fn new(http: &'a Client, guild_id: GuildId) -> Self {
         Self {
-            fields: UpdateGuildWidgetFields::default(),
+            fields: UpdateGuildWidgetFields {
+                channel_id: None,
+                enabled: None,
+            },
             guild_id,
             http,
         }
     }
 
     /// Set which channel to display on the widget.
-    pub fn channel_id(mut self, channel_id: Option<ChannelId>) -> Self {
-        self.fields
-            .channel_id
-            .replace(NullableField::from_option(channel_id));
+    pub const fn channel_id(mut self, channel_id: Option<ChannelId>) -> Self {
+        self.fields.channel_id = Some(NullableField(channel_id));
 
         self
     }
 
     /// Set to true to enable the guild widget.
-    pub fn enabled(mut self, enabled: bool) -> Self {
-        self.fields.enabled.replace(enabled);
+    pub const fn enabled(mut self, enabled: bool) -> Self {
+        self.fields.enabled = Some(enabled);
 
         self
     }

--- a/http/src/request/guild/user/update_current_user_voice_state.rs
+++ b/http/src/request/guild/user/update_current_user_voice_state.rs
@@ -44,15 +44,12 @@ impl<'a> UpdateCurrentUserVoiceState<'a> {
     ///
     /// - You are able to set `request_to_speak_timestamp` to any present or
     /// future time.
-    pub fn request_to_speak_timestamp(mut self, request_to_speak_timestamp: &'a str) -> Self {
+    pub const fn request_to_speak_timestamp(mut self, request_to_speak_timestamp: &'a str) -> Self {
         if request_to_speak_timestamp.is_empty() {
-            self.fields
-                .request_to_speak_timestamp
-                .replace(NullableField::Null);
+            self.fields.request_to_speak_timestamp = Some(NullableField(None));
         } else {
-            self.fields
-                .request_to_speak_timestamp
-                .replace(NullableField::Value(request_to_speak_timestamp));
+            self.fields.request_to_speak_timestamp =
+                Some(NullableField(Some(request_to_speak_timestamp)));
         }
 
         self
@@ -64,8 +61,8 @@ impl<'a> UpdateCurrentUserVoiceState<'a> {
     ///
     /// - You must have the `MUTE_MEMBERS` permission to unsuppress yourself.
     /// You can always suppress yourself.
-    pub fn suppress(mut self) -> Self {
-        self.fields.suppress.replace(true);
+    pub const fn suppress(mut self) -> Self {
+        self.fields.suppress = Some(true);
 
         self
     }

--- a/http/src/request/guild/user/update_user_voice_state.rs
+++ b/http/src/request/guild/user/update_user_voice_state.rs
@@ -52,8 +52,8 @@ impl<'a> UpdateUserVoiceState<'a> {
     /// removed.
     ///
     /// [`MUTE_MEMBERS`]: twilight_model::guild::Permissions::MUTE_MEMBERS
-    pub fn suppress(mut self) -> Self {
-        self.fields.suppress.replace(true);
+    pub const fn suppress(mut self) -> Self {
+        self.fields.suppress = Some(true);
 
         self
     }

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -109,8 +109,8 @@ impl<'a> CreateGuildFromTemplate<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn icon(mut self, icon: &'a str) -> Self {
-        self.fields.icon.replace(icon);
+    pub const fn icon(mut self, icon: &'a str) -> Self {
+        self.fields.icon = Some(icon);
 
         self
     }

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -109,15 +109,15 @@ impl<'a> GetCurrentUserGuilds<'a> {
     }
 
     /// Get guilds after this guild id.
-    pub fn after(mut self, guild_id: GuildId) -> Self {
-        self.fields.after.replace(guild_id);
+    pub const fn after(mut self, guild_id: GuildId) -> Self {
+        self.fields.after = Some(guild_id);
 
         self
     }
 
     /// Get guilds before this guild id.
-    pub fn before(mut self, guild_id: GuildId) -> Self {
-        self.fields.before.replace(guild_id);
+    pub const fn before(mut self, guild_id: GuildId) -> Self {
+        self.fields.before = Some(guild_id);
 
         self
     }
@@ -132,14 +132,14 @@ impl<'a> GetCurrentUserGuilds<'a> {
     /// the amount is greater than 100.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/user#get-current-user-guilds-query-string-params
-    pub fn limit(mut self, limit: u64) -> Result<Self, GetCurrentUserGuildsError> {
+    pub const fn limit(mut self, limit: u64) -> Result<Self, GetCurrentUserGuildsError> {
         if !validate::get_current_user_guilds_limit(limit) {
             return Err(GetCurrentUserGuildsError {
                 kind: GetCurrentUserGuildsErrorType::LimitInvalid,
             });
         }
 
-        self.fields.limit.replace(limit);
+        self.fields.limit = Some(limit);
 
         Ok(self)
     }

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -64,7 +64,7 @@ pub enum UpdateCurrentUserErrorType {
     UsernameInvalid,
 }
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct UpdateCurrentUserFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     avatar: Option<NullableField<&'a str>>,
@@ -82,9 +82,12 @@ pub struct UpdateCurrentUser<'a> {
 }
 
 impl<'a> UpdateCurrentUser<'a> {
-    pub(crate) fn new(http: &'a Client) -> Self {
+    pub(crate) const fn new(http: &'a Client) -> Self {
         Self {
-            fields: UpdateCurrentUserFields::default(),
+            fields: UpdateCurrentUserFields {
+                avatar: None,
+                username: None,
+            },
             http,
         }
     }
@@ -96,10 +99,8 @@ impl<'a> UpdateCurrentUser<'a> {
     /// for more information.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
-    pub fn avatar(mut self, avatar: Option<&'a str>) -> Self {
-        self.fields
-            .avatar
-            .replace(NullableField::from_option(avatar));
+    pub const fn avatar(mut self, avatar: Option<&'a str>) -> Self {
+        self.fields.avatar = Some(NullableField(avatar));
 
         self
     }

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -452,9 +452,9 @@ fn _command_description(value: &str) -> bool {
     (1..=100).contains(&len)
 }
 
-pub fn command_permissions(len: usize) -> bool {
+pub const fn command_permissions(len: usize) -> bool {
     // https://discord.com/developers/docs/interactions/slash-commands#edit-application-command-permissions
-    (0..=10).contains(&len)
+    len <= 10
 }
 
 /// Validate the number of guild command permission overwrites.

--- a/http/src/response/mod.rs
+++ b/http/src/response/mod.rs
@@ -293,7 +293,7 @@ impl<T> Response<T> {
     ///
     /// Necessary for [`MemberBody`] and [`MemberListBody`] deserialization.
     pub(crate) fn set_guild_id(&mut self, guild_id: GuildId) {
-        self.guild_id.replace(guild_id);
+        self.guild_id = Some(guild_id);
     }
 
     /// ID of the configured guild.


### PR DESCRIPTION
Make many request and client methods constant by primarily removing `Default` implementation usage on fields and removing `Option::replace` usage.

~~Blocks on #1009.~~ #1009 has been merged.