### PR TITLE
Document the util `link` feature

### DIFF
--- a/util/README.md
+++ b/util/README.md
@@ -9,6 +9,11 @@ augment or enhance default functionality.
 
 ## Features
 
+### `link`
+
+Provides implementations for parsing and formatting entities' URLs, such as
+webhook URLs.
+
 ### `permission-calculator`
 
 Allows the use of a calculator to determine the permissions of a member in

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -7,6 +7,11 @@
 //!
 //! ## Features
 //!
+//! ### `link`
+//!
+//! Provides implementations for parsing and formatting entities' URLs, such as
+//! webhook URLs.
+//!
 //! ### `permission-calculator`
 //!
 //! Allows the use of a calculator to determine the permissions of a member in


### PR DESCRIPTION
Document the `link` feature by noting that it provides implementations for parsing and formatting entity URLs such as webhook URLs.

Closes #1004.