### PR TITLE
Update minimum channel name length to 1 in all places

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -352,9 +352,6 @@ impl Client {
     }
 
     /// Update a channel.
-    ///
-    /// All fields are optional. The minimum length of the name is 2 UTF-16 characters and the
-    /// maximum is 100 UTF-16 characters.
     pub fn update_channel(&self, channel_id: ChannelId) -> UpdateChannel<'_> {
         UpdateChannel::new(self, channel_id)
     }
@@ -711,13 +708,14 @@ impl Client {
 
     /// Create a new request to create a guild channel.
     ///
-    /// All fields are optional except for name. The minimum length of the name is 2 UTF-16
-    /// characters and the maximum is 100 UTF-16 characters.
+    /// All fields are optional except for name. The minimum length of the name
+    /// is 1 UTF-16 character and the maximum is 100 UTF-16 characters.
     ///
     /// # Errors
     ///
     /// Returns a [`CreateGuildChannelErrorType::NameInvalid`] error type when
-    /// the length of the name is either fewer than 2 UTF-16 characters or more than 100 UTF-16 characters.
+    /// the length of the name is either fewer than 1 UTF-16 character or more
+    /// than 100 UTF-16 characters.
     ///
     /// Returns a [`CreateGuildChannelErrorType::RateLimitPerUserInvalid`] error
     /// type when the seconds of the rate limit per user is more than 21600.

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -62,8 +62,8 @@ impl Error for UpdateChannelError {}
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum UpdateChannelErrorType {
-    /// The length of the name is either fewer than 2 UTF-16 characters or
-    /// more than 100 UTF-16 characters.
+    /// The length of the name is either fewer than 1 UTF-16 character or more
+    /// than 100 UTF-16 characters.
     NameInvalid {
         /// Provided name.
         name: String,
@@ -111,8 +111,8 @@ struct UpdateChannelFields {
 
 /// Update a channel.
 ///
-/// All fields are optional. The minimum length of the name is 2 UTF-16 characters and the maximum
-/// is 100 UTF-16 characters.
+/// All fields are optional. The minimum length of the name is 1 UTF-16 character
+/// and the maximum is 100 UTF-16 characters.
 pub struct UpdateChannel<'a> {
     channel_id: ChannelId,
     fields: UpdateChannelFields,
@@ -141,7 +141,7 @@ impl<'a> UpdateChannel<'a> {
 
     /// Set the name.
     ///
-    /// The minimum length is 2 UTF-16 characters and the maximum is 100 UTF-16
+    /// The minimum length is 1 UTF-16 character and the maximum is 100 UTF-16
     /// characters.
     ///
     /// # Errors

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -813,9 +813,9 @@ mod tests {
     #[test]
     fn test_voice_fields() {
         assert!(matches!(
-            VoiceFieldsBuilder::new("c").unwrap_err().kind(),
+            VoiceFieldsBuilder::new("").unwrap_err().kind(),
             VoiceFieldsErrorType::NameTooShort { name }
-            if name == "c"
+            if name.is_empty()
         ));
 
         let fields = voice();
@@ -852,9 +852,9 @@ mod tests {
     #[test]
     fn test_text_fields() {
         assert!(matches!(
-            TextFieldsBuilder::new("b").unwrap_err().kind(),
+            TextFieldsBuilder::new("").unwrap_err().kind(),
             TextFieldsErrorType::NameTooShort { name }
-            if name == "b"
+            if name.is_empty()
         ));
 
         let fields = text();
@@ -888,9 +888,9 @@ mod tests {
     #[test]
     fn test_category_fields() {
         assert!(matches!(
-            CategoryFieldsBuilder::new("a").unwrap_err().kind(),
+            CategoryFieldsBuilder::new("").unwrap_err().kind(),
             CategoryFieldsErrorType::NameTooShort { name }
-            if name == "a"
+            if name.is_empty()
         ));
 
         let fields = category();

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -262,7 +262,7 @@ impl TextFieldsBuilder {
     /// This is used by [`new`].
     ///
     /// [`new`]: Self::new
-    pub const MIN_NAME_LENGTH: usize = 2;
+    pub const MIN_NAME_LENGTH: usize = 1;
 
     /// The maximum number of UTF-16 code points that can be in a channel name.
     ///
@@ -457,7 +457,7 @@ impl VoiceFieldsBuilder {
     /// This is used by [`new`].
     ///
     /// [`new`]: Self::new
-    pub const MIN_NAME_LENGTH: usize = 2;
+    pub const MIN_NAME_LENGTH: usize = 1;
 
     /// The maximum number of UTF-16 code points that can be in a channel name.
     ///
@@ -612,7 +612,7 @@ impl CategoryFieldsBuilder {
     /// This is used by [`new`].
     ///
     /// [`new`]: Self::new
-    pub const MIN_NAME_LENGTH: usize = 2;
+    pub const MIN_NAME_LENGTH: usize = 1;
 
     /// The maximum number of UTF-16 code points that can be in a channel name.
     ///

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -50,7 +50,7 @@ impl CreateGuildChannelError {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum CreateGuildChannelErrorType {
-    /// The length of the name is either fewer than 2 UTF-16 characters or
+    /// The length of the name is either fewer than 1 UTF-16 characters or
     /// more than 100 UTF-16 characters.
     NameInvalid {
         /// Provided name.
@@ -109,8 +109,8 @@ struct CreateGuildChannelFields {
 
 /// Create a new request to create a guild channel.
 ///
-/// All fields are optional except for name. The minimum length of the name is 2 UTF-16 characters
-/// and the maximum is 100 UTF-16 characters.
+/// All fields are optional except for name. The minimum length of the name is 1
+/// UTF-16 characters and the maximum is 100 UTF-16 characters.
 pub struct CreateGuildChannel<'a> {
     fields: CreateGuildChannelFields,
     fut: Option<Pending<'a, GuildChannel>>,

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -224,7 +224,7 @@ impl<'a> UpdateGuild<'a> {
 
     /// Set the name of the guild.
     ///
-    /// The minimum length is 2 UTF-16 characters and the maximum is 100 UTF-16
+    /// The minimum length is 1 UTF-16 character and the maximum is 100 UTF-16
     /// characters.
     ///
     /// # Errors

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -111,7 +111,7 @@ impl<'a> UpdateCurrentUser<'a> {
 
     /// Set the username.
     ///
-    /// The minimum length is 2 UTF-16 characters and the maximum is 32 UTF-16 characters.
+    /// The minimum length is 1 UTF-16 character and the maximum is 32 UTF-16 characters.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
The new minimum channel name length is 1 UTF-16 character.

Relates to #855 which updated the validation function to a minimum of 1 but did not update documentation and other places.

Closes #1007.

**PR note**: I believe I didn't miss anything but it's hard to tell. As an aside, maybe we should expose `validate` and constants describing the minimums and maximums of validations. We appear to have duplicated some of the checks through other exposed constants.