### PR TITLE
feat(http): add http route to get an original interaction response message

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -10,10 +10,10 @@ use crate::{
         application::{
             CreateFollowupMessage, CreateGlobalCommand, CreateGuildCommand, DeleteFollowupMessage,
             DeleteGlobalCommand, DeleteGuildCommand, DeleteOriginalResponse, GetCommandPermissions,
-            GetGlobalCommands, GetGuildCommandPermissions, GetGuildCommands, InteractionCallback,
-            InteractionError, InteractionErrorType, SetCommandPermissions, SetGlobalCommands,
-            SetGuildCommands, UpdateCommandPermissions, UpdateFollowupMessage, UpdateGlobalCommand,
-            UpdateGuildCommand, UpdateOriginalResponse,
+            GetGlobalCommands, GetGuildCommandPermissions, GetGuildCommands, GetOriginalResponse,
+            InteractionCallback, InteractionError, InteractionErrorType, SetCommandPermissions,
+            SetGlobalCommands, SetGuildCommands, UpdateCommandPermissions, UpdateFollowupMessage,
+            UpdateGlobalCommand, UpdateGuildCommand, UpdateOriginalResponse,
         },
         channel::stage::create_stage_instance::CreateStageInstanceError,
         guild::{
@@ -1661,6 +1661,28 @@ impl Client {
         response: InteractionResponse,
     ) -> InteractionCallback<'_> {
         InteractionCallback::new(self, interaction_id, interaction_token, response)
+    }
+
+    /// Get the original message, by its token.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
+    /// error type if an application ID has not been configured via
+    /// [`Client::set_application_id`].
+    pub fn get_interaction_original(
+        &self,
+        interaction_token: impl Into<String>,
+    ) -> Result<GetOriginalResponse<'_>, InteractionError> {
+        let application_id = self.application_id().ok_or(InteractionError {
+            kind: InteractionErrorType::ApplicationIdNotPresent,
+        })?;
+
+        Ok(GetOriginalResponse::new(
+            self,
+            application_id,
+            interaction_token,
+        ))
     }
 
     /// Edit the original message, by its token.

--- a/http/src/request/application/get_original_response.rs
+++ b/http/src/request/application/get_original_response.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use twilight_model::{channel::Message, id::ApplicationId};
 
-/// Get an original interaction response.
+/// Get the original message, by its token.
 ///
 /// # Examples
 ///

--- a/http/src/request/application/get_original_response.rs
+++ b/http/src/request/application/get_original_response.rs
@@ -1,0 +1,67 @@
+use crate::{
+    client::Client,
+    error::Error,
+    request::{PendingOption, Request},
+    routing::Route,
+};
+use twilight_model::{channel::Message, id::ApplicationId};
+
+/// Get an original interaction response.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::env;
+/// use twilight_http::Client;
+/// use twilight_http::request::AuditLogReason;
+/// use twilight_model::id::ApplicationId;
+///
+/// let client = Client::new(env::var("DISCORD_TOKEN")?);
+/// client.set_application_id(ApplicationId(1));
+///
+/// let message = client
+///     .get_interaction_original("token here")?
+///     .await?;
+/// # Ok(()) }
+/// ```
+pub struct GetOriginalResponse<'a> {
+    application_id: ApplicationId,
+    fut: Option<PendingOption<'a>>,
+    http: &'a Client,
+    token: String,
+}
+
+impl<'a> GetOriginalResponse<'a> {
+    pub(crate) fn new(
+        http: &'a Client,
+        application_id: ApplicationId,
+        token: impl Into<String>,
+    ) -> Self {
+        Self {
+            application_id,
+            fut: None,
+            http,
+            token: token.into(),
+        }
+    }
+
+    fn request(&self) -> Result<Request, Error> {
+        let request = Request::from_route(Route::GetInteractionOriginal {
+            application_id: self.application_id.0,
+            interaction_token: self.token.clone(),
+        });
+
+        Ok(request)
+    }
+
+    fn start(&mut self) -> Result<(), Error> {
+        let request = self.request()?;
+        self.fut.replace(Box::pin(self.http.request_bytes(request)));
+
+        Ok(())
+    }
+}
+
+poll_req!(opt, GetOriginalResponse<'_>, Message);

--- a/http/src/request/application/mod.rs
+++ b/http/src/request/application/mod.rs
@@ -9,6 +9,7 @@ mod get_command_permissions;
 mod get_global_commands;
 mod get_guild_command_permissions;
 mod get_guild_commands;
+mod get_original_response;
 mod interaction_callback;
 mod set_command_permissions;
 mod set_global_commands;
@@ -31,6 +32,7 @@ pub use self::{
     get_global_commands::GetGlobalCommands,
     get_guild_command_permissions::GetGuildCommandPermissions,
     get_guild_commands::GetGuildCommands,
+    get_original_response::GetOriginalResponse,
     interaction_callback::InteractionCallback,
     set_command_permissions::SetCommandPermissions,
     set_global_commands::SetGlobalCommands,

--- a/http/src/routing/route.rs
+++ b/http/src/routing/route.rs
@@ -460,9 +460,9 @@ pub enum Route {
     },
     /// Route information to get an original interaction response message.
     GetInteractionOriginal {
-        /// The ID of the owner application.
+        /// ID of the owner application.
         application_id: u64,
-        /// The token for the interaction.
+        /// Token of the interaction.
         interaction_token: String,
     },
     /// Route information to get an invite.

--- a/http/src/routing/route.rs
+++ b/http/src/routing/route.rs
@@ -458,6 +458,13 @@ pub enum Route {
         /// The maximum number of guilds to get.
         limit: Option<u64>,
     },
+    /// Route information to get an original interaction response message.
+    GetInteractionOriginal {
+        /// The ID of the owner application.
+        application_id: u64,
+        /// The token for the interaction.
+        interaction_token: String,
+    },
     /// Route information to get an invite.
     GetInvite {
         /// The unique invite code.
@@ -929,6 +936,7 @@ impl Route {
             | Self::GetGuildWebhooks { .. }
             | Self::GetGuildWidget { .. }
             | Self::GetGuilds { .. }
+            | Self::GetInteractionOriginal { .. }
             | Self::GetInvite { .. }
             | Self::GetInviteWithExpiration { .. }
             | Self::GetMember { .. }
@@ -1110,6 +1118,7 @@ impl Route {
                 Path::GuildsIdIntegrationsId(*guild_id)
             }
             Self::DeleteInteractionOriginal { application_id, .. }
+            | Self::GetInteractionOriginal { application_id, .. }
             | Self::UpdateInteractionOriginal { application_id, .. } => {
                 Path::WebhooksIdTokenMessagesId(*application_id)
             }

--- a/http/src/routing/route_display.rs
+++ b/http/src/routing/route_display.rs
@@ -335,6 +335,10 @@ impl Display for RouteDisplay<'_> {
                 application_id,
                 interaction_token,
             }
+            | Route::GetInteractionOriginal {
+                application_id,
+                interaction_token,
+            }
             | Route::UpdateInteractionOriginal {
                 application_id,
                 interaction_token,


### PR DESCRIPTION
I've been doing some work on a personal bot that makes use of slash commands and I had no way to get the original interaction response message id. This PR adds a http client function to fetch it. Just like `DeleteOriginalResponse` but instead it requests data and returns it as a `Message`.