### PR TITLE
feat(http): thread methods

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1530,7 +1530,7 @@ impl Client {
     /// When called on a [`GuildText`] channel, this creates a
     /// [`GuildPublicThread`].
     ///
-    /// When called on a [`GuildNews`] channel. this creates a
+    /// When called on a [`GuildNews`] channel, this creates a
     /// [`GuildNewsThread`].
     ///
     /// To use auto archive durations of [`ThreeDays`] or [`Week`], the guild

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -15,7 +15,15 @@ use crate::{
             SetGuildCommands, UpdateCommandPermissions, UpdateFollowupMessage, UpdateGlobalCommand,
             UpdateGuildCommand, UpdateOriginalResponse,
         },
-        channel::stage::create_stage_instance::CreateStageInstanceError,
+        channel::{
+            stage::create_stage_instance::CreateStageInstanceError,
+            thread::{
+                AddThreadMember, CreateThread, CreateThreadFromMessage, GetActiveThreads,
+                GetJoinedPrivateArchivedThreads, GetPrivateArchivedThreads,
+                GetPublicArchivedThreads, GetThreadMembers, JoinThread, LeaveThread,
+                RemoveThreadMember, ThreadValidationError, UpdateThread,
+            },
+        },
         guild::{
             create_guild::CreateGuildError, create_guild_channel::CreateGuildChannelError,
             update_guild_channel_positions::Position,
@@ -48,7 +56,9 @@ use twilight_model::{
         callback::InteractionResponse,
         command::{permissions::CommandPermissions, Command},
     },
-    channel::message::allowed_mentions::AllowedMentions,
+    channel::{
+        message::allowed_mentions::AllowedMentions, thread::AutoArchiveDuration, ChannelType,
+    },
     guild::Permissions,
     id::{
         ApplicationId, ChannelId, CommandId, EmojiId, GuildId, IntegrationId, InteractionId,
@@ -1480,6 +1490,155 @@ impl Client {
         template_code: impl Into<String>,
     ) -> UpdateTemplate<'_> {
         UpdateTemplate::new(self, guild_id, template_code)
+    }
+
+    /// Returns all active threads in the channel.
+    ///
+    /// Includes public and private threads. Threads are ordered by their ID in
+    /// descending order.
+    pub fn active_threads(&self, channel_id: ChannelId) -> GetActiveThreads<'_> {
+        GetActiveThreads::new(self, channel_id)
+    }
+
+    /// Add another member to a thread.
+    ///
+    /// Requires the ability to send messages in the thread, and that the thread
+    /// is not archived.
+    pub fn add_thread_member(&self, channel_id: ChannelId, user_id: UserId) -> AddThreadMember<'_> {
+        AddThreadMember::new(self, channel_id, user_id)
+    }
+
+    /// Start a thread that is not connected to a message.
+    ///
+    /// To use auto archive durations of [`ThreeDays`] or [`Week`], the guild
+    /// must be boosted.
+    ///
+    /// [`ThreeDays`]: twilight_model::channel::thread::AutoArchiveDuration::ThreeDays
+    /// [`Week`]: twilight_model::channel::thread::AutoArchiveDuration::Week
+    pub fn create_thread(
+        &self,
+        channel_id: ChannelId,
+        name: impl Into<String>,
+        auto_archive_duration: AutoArchiveDuration,
+        kind: ChannelType,
+    ) -> Result<CreateThread<'_>, ThreadValidationError> {
+        CreateThread::new(self, channel_id, name, auto_archive_duration, kind)
+    }
+
+    /// Create a new thread from an existing message.
+    ///
+    /// When called on a [`GuildText`] channel, this creates a
+    /// [`GuildPublicThread`].
+    ///
+    /// When called on a [`GuildNews`] channel. this creates a
+    /// [`GuildNewsThread`].
+    ///
+    /// To use auto archive durations of [`ThreeDays`] or [`Week`], the guild
+    /// must be boosted.
+    ///
+    /// The thread's ID will be the same as its parent message. This ensures
+    /// only one thread can be created per message.
+    ///
+    /// [`GuildNewsThread`]: twilight_model::channel::ChannelType::GuildNewsThread
+    /// [`GuildNews`]: twilight_model::channel::ChannelType::GuildNews
+    /// [`GuildPublicThread`]: twilight_model::channel::ChannelType::GuildPublicThread
+    /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
+    /// [`ThreeDays`]: twilight_model::channel::thread::AutoArchiveDuration::ThreeDays
+    /// [`Week`]: twilight_model::channel::thread::AutoArchiveDuration::Week
+    pub fn create_thread_from_message(
+        &self,
+        channel_id: ChannelId,
+        message_id: MessageId,
+        name: impl Into<String>,
+        auto_archive_duration: AutoArchiveDuration,
+    ) -> Result<CreateThreadFromMessage<'_>, ThreadValidationError> {
+        CreateThreadFromMessage::new(self, channel_id, message_id, name, auto_archive_duration)
+    }
+
+    /// Add the current user to a thread.
+    pub fn join_thread(&self, channel_id: ChannelId) -> JoinThread<'_> {
+        JoinThread::new(self, channel_id)
+    }
+
+    /// Returns archived private threads in the channel that the current user
+    /// has joined.
+    ///
+    /// Threads are ordered by their ID in descending order.
+    pub fn joined_private_archived_threads(
+        &self,
+        channel_id: ChannelId,
+    ) -> GetJoinedPrivateArchivedThreads<'_> {
+        GetJoinedPrivateArchivedThreads::new(self, channel_id)
+    }
+
+    /// Remove the current user from a thread.
+    ///
+    /// Requires that the thread is not archived.
+    pub fn leave_thread(&self, channel_id: ChannelId) -> LeaveThread<'_> {
+        LeaveThread::new(self, channel_id)
+    }
+
+    /// Returns archived private threads in the channel.
+    ///
+    /// Requires both [`READ_MESSAGE_HISTORY`] and [`MANAGE_THREADS`].
+    ///
+    /// [`MANAGE_THREADS`]: twilight_model::guild::Permissions::MANAGE_THREADS
+    /// [`READ_MESSAGE_HISTORY`]: twilight_model::guild::Permissions::READ_MESSAGE_HISTORY
+    pub fn private_archived_threads(&self, channel_id: ChannelId) -> GetPrivateArchivedThreads<'_> {
+        GetPrivateArchivedThreads::new(self, channel_id)
+    }
+
+    /// Returns archived public threads in the channel.
+    ///
+    /// Requires the [`READ_MESSAGE_HISTORY`] permission.
+    ///
+    /// Threads are ordered by [`archive_timestamp`] in descending order.
+    ///
+    /// When called in a [`GuildText`] channel, returns [`GuildPublicThread`]s.
+    ///
+    /// When called in a [`GuildNews`] channel, returns [`GuildNewsThread`]s.
+    ///
+    /// [`archive_timestamp`]: twilight_model::channel::thread::ThreadMetadata::archive_timestamp
+    /// [`GuildNews`]: twilight_model::channel::ChannelType::GuildNews
+    /// [`GuildNewsThread`]: twilight_model::channel::ChannelType::GuildNewsThread
+    /// [`GuildPublicThread`]: twilight_model::channel::ChannelType::GuildPublicThread
+    /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
+    /// [`READ_MESSAGE_HISTORY`]: twilight_model::guild::Permissions::READ_MESSAGE_HISTORY
+    pub fn public_archived_threads(&self, channel_id: ChannelId) -> GetPublicArchivedThreads<'_> {
+        GetPublicArchivedThreads::new(self, channel_id)
+    }
+
+    /// Remove another member from a thread.
+    ///
+    /// Requires that the thread is not archived.
+    ///
+    /// Requires the [`MANAGE_THREADS`] permission, unless both the thread is a
+    /// [`GuildPrivateThread`], and the current user is the creator of the
+    /// thread.
+    ///
+    /// [`GuildPrivateThread`]: twilight_model::channel::ChannelType::GuildPrivateThread
+    /// [`MANAGE_THREADS`]: twilight_model::guild::Permissions::MANAGE_THREADS
+    pub fn remove_thread_member(
+        &self,
+        channel_id: ChannelId,
+        user_id: UserId,
+    ) -> RemoveThreadMember<'_> {
+        RemoveThreadMember::new(self, channel_id, user_id)
+    }
+
+    /// Returns the [`ThreadMember`]s of the thread.
+    ///
+    /// [`ThreadMember`]: twilight_model::channel::thread::ThreadMember
+    pub fn thread_members(&self, channel_id: ChannelId) -> GetThreadMembers<'_> {
+        GetThreadMembers::new(self, channel_id)
+    }
+
+    /// Update a thread.
+    ///
+    /// All fields are optional. The minimum length of the name is 1 UTF-16
+    /// characters and the maximum is 100 UTF-16 characters.
+    pub fn update_thread(&self, channel_id: ChannelId) -> UpdateThread<'_> {
+        UpdateThread::new(self, channel_id)
     }
 
     /// Get a user's information by id.

--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -14,6 +14,7 @@ mod private {
         channel::{
             invite::{CreateInvite, DeleteInvite},
             message::{DeleteMessage, DeleteMessages},
+            thread::UpdateThread,
             webhook::{
                 CreateWebhook, DeleteWebhook, DeleteWebhookMessage, UpdateWebhook,
                 UpdateWebhookMessage,
@@ -63,6 +64,7 @@ mod private {
     impl<'a> Sealed for DeleteRole<'a> {}
     impl<'a> Sealed for UpdateRole<'a> {}
     impl<'a> Sealed for UpdateGuild<'a> {}
+    impl<'a> Sealed for UpdateThread<'a> {}
     impl Sealed for UpdateWebhookMessage<'_> {}
 }
 

--- a/http/src/request/channel/mod.rs
+++ b/http/src/request/channel/mod.rs
@@ -2,6 +2,7 @@ pub mod invite;
 pub mod message;
 pub mod reaction;
 pub mod stage;
+pub mod thread;
 pub mod update_channel;
 pub mod webhook;
 

--- a/http/src/request/channel/thread/add_thread_member.rs
+++ b/http/src/request/channel/thread/add_thread_member.rs
@@ -1,0 +1,42 @@
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use twilight_model::id::{ChannelId, UserId};
+
+/// Add another member to a thread.
+///
+/// Requires the ability to send messages in the thread, and that the thread is
+/// not archived.
+pub struct AddThreadMember<'a> {
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, ()>>,
+    http: &'a Client,
+    user_id: UserId,
+}
+
+impl<'a> AddThreadMember<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId, user_id: UserId) -> Self {
+        Self {
+            channel_id,
+            fut: None,
+            http,
+            user_id,
+        }
+    }
+
+    fn start(&mut self) -> Result<(), Error> {
+        let request = Request::from_route(Route::AddThreadMember {
+            channel_id: self.channel_id.0,
+            user_id: self.user_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
+
+        Ok(())
+    }
+}
+
+poll_req!(AddThreadMember<'_>, ());

--- a/http/src/request/channel/thread/create_thread.rs
+++ b/http/src/request/channel/thread/create_thread.rs
@@ -1,0 +1,91 @@
+use super::{ThreadValidationError, ThreadValidationErrorType};
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
+use twilight_model::{
+    channel::{thread::AutoArchiveDuration, Channel, ChannelType},
+    id::ChannelId,
+};
+
+#[derive(Serialize)]
+struct CreateThreadFields {
+    auto_archive_duration: AutoArchiveDuration,
+    #[serde(rename = "type")]
+    kind: ChannelType,
+    name: String,
+}
+
+/// Start a thread that is not connected to a message.
+///
+/// To use auto archive durations of [`ThreeDays`] or [`Week`], the guild must
+/// be boosted.
+///
+/// [`ThreeDays`]: twilight_model::channel::thread::AutoArchiveDuration::ThreeDays
+/// [`Week`]: twilight_model::channel::thread::AutoArchiveDuration::Week
+pub struct CreateThread<'a> {
+    channel_id: ChannelId,
+    fields: CreateThreadFields,
+    fut: Option<Pending<'a, Channel>>,
+    http: &'a Client,
+}
+
+impl<'a> CreateThread<'a> {
+    pub(crate) fn new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        name: impl Into<String>,
+        auto_archive_duration: AutoArchiveDuration,
+        kind: ChannelType,
+    ) -> Result<Self, ThreadValidationError> {
+        Self::_new(http, channel_id, name.into(), auto_archive_duration, kind)
+    }
+
+    fn _new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        name: String,
+        auto_archive_duration: AutoArchiveDuration,
+        kind: ChannelType,
+    ) -> Result<Self, ThreadValidationError> {
+        if !validate::channel_name(&name) {
+            return Err(ThreadValidationError {
+                kind: ThreadValidationErrorType::NameInvalid { name },
+            });
+        }
+
+        if !validate::is_thread(kind) {
+            return Err(ThreadValidationError {
+                kind: ThreadValidationErrorType::TypeInvalid { kind },
+            });
+        }
+
+        Ok(Self {
+            channel_id,
+            fields: CreateThreadFields {
+                auto_archive_duration,
+                kind,
+                name,
+            },
+            fut: None,
+            http,
+        })
+    }
+
+    fn start(&mut self) -> Result<(), HttpError> {
+        let request = Request::builder(Route::CreateThread {
+            channel_id: self.channel_id.0,
+        })
+        .json(&self.fields)?;
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
+
+        Ok(())
+    }
+}
+
+poll_req!(CreateThread<'_>, Channel);

--- a/http/src/request/channel/thread/create_thread_from_message.rs
+++ b/http/src/request/channel/thread/create_thread_from_message.rs
@@ -22,7 +22,7 @@ struct CreateThreadFromMessageFields {
 /// When called on a [`GuildText`] channel, this creates a
 /// [`GuildPublicThread`].
 ///
-/// When called on a [`GuildNews`] channel. this creates a [`GuildNewsThread`].
+/// When called on a [`GuildNews`] channel, this creates a [`GuildNewsThread`].
 ///
 /// To use auto archive durations of [`ThreeDays`] or [`Week`], the guild must
 /// be boosted.

--- a/http/src/request/channel/thread/create_thread_from_message.rs
+++ b/http/src/request/channel/thread/create_thread_from_message.rs
@@ -1,0 +1,103 @@
+use super::{ThreadValidationError, ThreadValidationErrorType};
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{validate, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
+use twilight_model::{
+    channel::{thread::AutoArchiveDuration, Channel},
+    id::{ChannelId, MessageId},
+};
+
+#[derive(Serialize)]
+struct CreateThreadFromMessageFields {
+    auto_archive_duration: AutoArchiveDuration,
+    name: String,
+}
+
+/// Create a new thread from an existing message.
+///
+/// When called on a [`GuildText`] channel, this creates a
+/// [`GuildPublicThread`].
+///
+/// When called on a [`GuildNews`] channel. this creates a [`GuildNewsThread`].
+///
+/// To use auto archive durations of [`ThreeDays`] or [`Week`], the guild must
+/// be boosted.
+///
+/// The thread's ID will be the same as its parent message. This ensures only
+/// one thread can be created per message.
+///
+/// [`GuildNewsThread`]: twilight_model::channel::ChannelType::GuildNewsThread
+/// [`GuildNews`]: twilight_model::channel::ChannelType::GuildNews
+/// [`GuildPublicThread`]: twilight_model::channel::ChannelType::GuildPublicThread
+/// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
+/// [`ThreeDays`]: twilight_model::channel::thread::AutoArchiveDuration::ThreeDays
+/// [`Week`]: twilight_model::channel::thread::AutoArchiveDuration::Week
+pub struct CreateThreadFromMessage<'a> {
+    channel_id: ChannelId,
+    fields: CreateThreadFromMessageFields,
+    fut: Option<Pending<'a, Channel>>,
+    http: &'a Client,
+    message_id: MessageId,
+}
+
+impl<'a> CreateThreadFromMessage<'a> {
+    pub(crate) fn new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        message_id: MessageId,
+        name: impl Into<String>,
+        auto_archive_duration: AutoArchiveDuration,
+    ) -> Result<Self, ThreadValidationError> {
+        Self::_new(
+            http,
+            channel_id,
+            message_id,
+            name.into(),
+            auto_archive_duration,
+        )
+    }
+
+    fn _new(
+        http: &'a Client,
+        channel_id: ChannelId,
+        message_id: MessageId,
+        name: String,
+        auto_archive_duration: AutoArchiveDuration,
+    ) -> Result<Self, ThreadValidationError> {
+        if !validate::channel_name(&name) {
+            return Err(ThreadValidationError {
+                kind: ThreadValidationErrorType::NameInvalid { name },
+            });
+        }
+
+        Ok(Self {
+            channel_id,
+            fields: CreateThreadFromMessageFields {
+                auto_archive_duration,
+                name,
+            },
+            fut: None,
+            http,
+            message_id,
+        })
+    }
+
+    fn start(&mut self) -> Result<(), HttpError> {
+        let request = Request::builder(Route::CreateThreadFromMessage {
+            channel_id: self.channel_id.0,
+            message_id: self.message_id.0,
+        })
+        .json(&self.fields)?;
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
+
+        Ok(())
+    }
+}
+
+poll_req!(CreateThreadFromMessage<'_>, Channel);

--- a/http/src/request/channel/thread/get_active_threads.rs
+++ b/http/src/request/channel/thread/get_active_threads.rs
@@ -1,0 +1,39 @@
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use twilight_model::{channel::thread::ThreadsListing, id::ChannelId};
+
+/// Returns all active threads in the channel.
+///
+/// Includes public and private threads. Threads are ordered by their ID in
+/// descending order.
+pub struct GetActiveThreads<'a> {
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, ThreadsListing>>,
+    http: &'a Client,
+}
+
+impl<'a> GetActiveThreads<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self {
+            channel_id,
+            fut: None,
+            http,
+        }
+    }
+
+    fn start(&mut self) -> Result<(), Error> {
+        let request = Request::from_route(Route::GetActiveThreads {
+            channel_id: self.channel_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
+
+        Ok(())
+    }
+}
+
+poll_req!(GetActiveThreads<'_>, ThreadsListing);

--- a/http/src/request/channel/thread/get_joined_private_archived_threads.rs
+++ b/http/src/request/channel/thread/get_joined_private_archived_threads.rs
@@ -1,0 +1,59 @@
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use twilight_model::{channel::thread::ThreadsListing, id::ChannelId};
+
+/// Returns archived private threads in the channel that the current user has
+/// joined.
+///
+/// Threads are ordered by their ID in descending order.
+pub struct GetJoinedPrivateArchivedThreads<'a> {
+    before: Option<ChannelId>,
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, ThreadsListing>>,
+    http: &'a Client,
+    limit: Option<u64>,
+}
+
+impl<'a> GetJoinedPrivateArchivedThreads<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self {
+            before: None,
+            channel_id,
+            fut: None,
+            http,
+            limit: None,
+        }
+    }
+
+    /// Return threads before this ID.
+    pub fn before(mut self, before: ChannelId) -> Self {
+        self.before.replace(before);
+
+        self
+    }
+
+    /// Maximum number of threads to return.
+    pub fn limit(mut self, limit: u64) -> Self {
+        self.limit.replace(limit);
+
+        self
+    }
+
+    fn start(&mut self) -> Result<(), Error> {
+        let request = Request::from_route(Route::GetJoinedPrivateArchivedThreads {
+            before: self.before.map(|id| id.0),
+            channel_id: self.channel_id.0,
+            limit: self.limit,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
+
+        Ok(())
+    }
+}
+
+poll_req!(GetJoinedPrivateArchivedThreads<'_>, ThreadsListing);

--- a/http/src/request/channel/thread/get_private_archived_threads.rs
+++ b/http/src/request/channel/thread/get_private_archived_threads.rs
@@ -1,0 +1,65 @@
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use twilight_model::{channel::thread::ThreadsListing, id::ChannelId};
+
+/// Returns archived private threads in the channel.
+///
+/// Requires both [`READ_MESSAGE_HISTORY`] and [`MANAGE_THREADS`].
+///
+/// [`MANAGE_THREADS`]: twilight_model::guild::Permissions::MANAGE_THREADS
+/// [`READ_MESSAGE_HISTORY`]: twilight_model::guild::Permissions::READ_MESSAGE_HISTORY
+pub struct GetPrivateArchivedThreads<'a> {
+    before: Option<String>,
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, ThreadsListing>>,
+    http: &'a Client,
+    limit: Option<u64>,
+}
+
+impl<'a> GetPrivateArchivedThreads<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self {
+            before: None,
+            channel_id,
+            fut: None,
+            http,
+            limit: None,
+        }
+    }
+
+    /// Return threads before this ISO 8601 timestamp.
+    pub fn before(self, before: impl Into<String>) -> Self {
+        self._before(before.into())
+    }
+
+    fn _before(mut self, before: String) -> Self {
+        self.before.replace(before);
+
+        self
+    }
+
+    /// Maximum number of threads to return.
+    pub fn limit(mut self, limit: u64) -> Self {
+        self.limit.replace(limit);
+
+        self
+    }
+
+    fn start(&mut self) -> Result<(), Error> {
+        let request = Request::from_route(Route::GetPrivateArchivedThreads {
+            before: self.before.clone(),
+            channel_id: self.channel_id.0,
+            limit: self.limit,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
+
+        Ok(())
+    }
+}
+
+poll_req!(GetPrivateArchivedThreads<'_>, ThreadsListing);

--- a/http/src/request/channel/thread/get_public_archived_threads.rs
+++ b/http/src/request/channel/thread/get_public_archived_threads.rs
@@ -1,0 +1,75 @@
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use twilight_model::{channel::thread::ThreadsListing, id::ChannelId};
+
+/// Returns archived public threads in the channel.
+///
+/// Requires the [`READ_MESSAGE_HISTORY`] permission.
+///
+/// Threads are ordered by [`archive_timestamp`] in descending order.
+///
+/// When called in a [`GuildText`] channel, returns [`GuildPublicThread`]s.
+///
+/// When called in a [`GuildNews`] channel, returns [`GuildNewsThread`]s.
+///
+/// [`archive_timestamp`]: twilight_model::channel::thread::ThreadMetadata::archive_timestamp
+/// [`GuildNews`]: twilight_model::channel::ChannelType::GuildNews
+/// [`GuildNewsThread`]: twilight_model::channel::ChannelType::GuildNewsThread
+/// [`GuildPublicThread`]: twilight_model::channel::ChannelType::GuildPublicThread
+/// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
+/// [`READ_MESSAGE_HISTORY`]: twilight_model::guild::Permissions::READ_MESSAGE_HISTORY
+pub struct GetPublicArchivedThreads<'a> {
+    before: Option<String>,
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, ThreadsListing>>,
+    http: &'a Client,
+    limit: Option<u64>,
+}
+
+impl<'a> GetPublicArchivedThreads<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self {
+            before: None,
+            channel_id,
+            fut: None,
+            http,
+            limit: None,
+        }
+    }
+
+    /// Return threads before this ISO 8601 timestamp.
+    pub fn before(self, before: impl Into<String>) -> Self {
+        self._before(before.into())
+    }
+
+    fn _before(mut self, before: String) -> Self {
+        self.before.replace(before);
+
+        self
+    }
+
+    /// Maximum number of threads to return.
+    pub fn limit(mut self, limit: u64) -> Self {
+        self.limit.replace(limit);
+
+        self
+    }
+
+    fn start(&mut self) -> Result<(), Error> {
+        let request = Request::from_route(Route::GetPublicArchivedThreads {
+            before: self.before.clone(),
+            channel_id: self.channel_id.0,
+            limit: self.limit,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
+
+        Ok(())
+    }
+}
+
+poll_req!(GetPublicArchivedThreads<'_>, ThreadsListing);

--- a/http/src/request/channel/thread/get_thread_members.rs
+++ b/http/src/request/channel/thread/get_thread_members.rs
@@ -1,0 +1,38 @@
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use twilight_model::{channel::thread::ThreadMember, id::ChannelId};
+
+/// Returns the [`ThreadMember`]s of the thread.
+///
+/// [`ThreadMember`]: twilight_model::channel::thread::ThreadMember
+pub struct GetThreadMembers<'a> {
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, Vec<ThreadMember>>>,
+    http: &'a Client,
+}
+
+impl<'a> GetThreadMembers<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self {
+            channel_id,
+            fut: None,
+            http,
+        }
+    }
+
+    fn start(&mut self) -> Result<(), Error> {
+        let request = Request::from_route(Route::GetThreadMembers {
+            channel_id: self.channel_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.request(request)));
+
+        Ok(())
+    }
+}
+
+poll_req!(GetThreadMembers<'_>, Vec<ThreadMember>);

--- a/http/src/request/channel/thread/join_thread.rs
+++ b/http/src/request/channel/thread/join_thread.rs
@@ -1,0 +1,36 @@
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use twilight_model::id::ChannelId;
+
+/// Add the current user to a thread.
+pub struct JoinThread<'a> {
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, ()>>,
+    http: &'a Client,
+}
+
+impl<'a> JoinThread<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self {
+            channel_id,
+            fut: None,
+            http,
+        }
+    }
+
+    fn start(&mut self) -> Result<(), Error> {
+        let request = Request::from_route(Route::JoinThread {
+            channel_id: self.channel_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
+
+        Ok(())
+    }
+}
+
+poll_req!(JoinThread<'_>, ());

--- a/http/src/request/channel/thread/leave_thread.rs
+++ b/http/src/request/channel/thread/leave_thread.rs
@@ -1,0 +1,38 @@
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use twilight_model::id::ChannelId;
+
+/// Remove the current user from a thread.
+///
+/// Requires that the thread is not archived.
+pub struct LeaveThread<'a> {
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, ()>>,
+    http: &'a Client,
+}
+
+impl<'a> LeaveThread<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self {
+            channel_id,
+            fut: None,
+            http,
+        }
+    }
+
+    fn start(&mut self) -> Result<(), Error> {
+        let request = Request::from_route(Route::LeaveThread {
+            channel_id: self.channel_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
+
+        Ok(())
+    }
+}
+
+poll_req!(LeaveThread<'_>, ());

--- a/http/src/request/channel/thread/mod.rs
+++ b/http/src/request/channel/thread/mod.rs
@@ -1,0 +1,102 @@
+pub mod add_thread_member;
+pub mod create_thread;
+pub mod create_thread_from_message;
+pub mod get_active_threads;
+pub mod get_joined_private_archived_threads;
+pub mod get_private_archived_threads;
+pub mod get_public_archived_threads;
+pub mod get_thread_members;
+pub mod join_thread;
+pub mod leave_thread;
+pub mod remove_thread_member;
+pub mod update_thread;
+
+pub use self::{
+    add_thread_member::AddThreadMember, create_thread::CreateThread,
+    create_thread_from_message::CreateThreadFromMessage, get_active_threads::GetActiveThreads,
+    get_joined_private_archived_threads::GetJoinedPrivateArchivedThreads,
+    get_private_archived_threads::GetPrivateArchivedThreads,
+    get_public_archived_threads::GetPublicArchivedThreads, get_thread_members::GetThreadMembers,
+    join_thread::JoinThread, leave_thread::LeaveThread, remove_thread_member::RemoveThreadMember,
+    update_thread::UpdateThread,
+};
+
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+use twilight_model::channel::ChannelType;
+
+/// Returned when the thread can not be updated as configured.
+#[derive(Debug)]
+pub struct ThreadValidationError {
+    kind: ThreadValidationErrorType,
+}
+
+impl ThreadValidationError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "retrieving the type has no effect if left unused"]
+    pub const fn kind(&self) -> &ThreadValidationErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[allow(clippy::unused_self)]
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
+        None
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        ThreadValidationErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for ThreadValidationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            ThreadValidationErrorType::NameInvalid { .. } => {
+                f.write_str("the length of the name is invalid")
+            }
+            ThreadValidationErrorType::RateLimitPerUserInvalid { .. } => {
+                f.write_str("the rate limit per user is invalid")
+            }
+            ThreadValidationErrorType::TypeInvalid { kind } => {
+                Display::fmt(kind.name(), f)?;
+
+                f.write_str(" is not a thread")
+            }
+        }
+    }
+}
+
+impl Error for ThreadValidationError {}
+
+/// Type of error that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ThreadValidationErrorType {
+    /// The length of the name is either fewer than 2 UTF-16 characters or
+    /// more than 100 UTF-16 characters.
+    NameInvalid {
+        /// Provided name.
+        name: String,
+    },
+    /// The seconds of the rate limit per user is more than 21600.
+    RateLimitPerUserInvalid {
+        /// Provided ratelimit is invalid.
+        rate_limit_per_user: u64,
+    },
+    /// Provided type was not a thread.
+    TypeInvalid {
+        /// Provided type.
+        kind: ChannelType,
+    },
+}

--- a/http/src/request/channel/thread/remove_thread_member.rs
+++ b/http/src/request/channel/thread/remove_thread_member.rs
@@ -1,0 +1,47 @@
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Pending, Request},
+    routing::Route,
+};
+use twilight_model::id::{ChannelId, UserId};
+
+/// Remove another member from a thread.
+///
+/// Requires that the thread is not archived.
+///
+/// Requires the [`MANAGE_THREADS`] permission, unless both the thread is a
+/// [`GuildPrivateThread`], and the current user is the creator of the thread.
+///
+/// [`GuildPrivateThread`]: twilight_model::channel::ChannelType::GuildPrivateThread
+/// [`MANAGE_THREADS`]: twilight_model::guild::Permissions::MANAGE_THREADS
+pub struct RemoveThreadMember<'a> {
+    channel_id: ChannelId,
+    fut: Option<Pending<'a, ()>>,
+    http: &'a Client,
+    user_id: UserId,
+}
+
+impl<'a> RemoveThreadMember<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId, user_id: UserId) -> Self {
+        Self {
+            channel_id,
+            fut: None,
+            http,
+            user_id,
+        }
+    }
+
+    fn start(&mut self) -> Result<(), Error> {
+        let request = Request::from_route(Route::RemoveThreadMember {
+            channel_id: self.channel_id.0,
+            user_id: self.user_id.0,
+        });
+
+        self.fut.replace(Box::pin(self.http.verify(request)));
+
+        Ok(())
+    }
+}
+
+poll_req!(RemoveThreadMember<'_>, ());

--- a/http/src/request/channel/thread/update_thread.rs
+++ b/http/src/request/channel/thread/update_thread.rs
@@ -1,0 +1,141 @@
+use super::{ThreadValidationError, ThreadValidationErrorType};
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    routing::Route,
+};
+use serde::Serialize;
+use twilight_model::{
+    channel::{thread::AutoArchiveDuration, Channel},
+    id::ChannelId,
+};
+
+#[derive(Default, Serialize)]
+struct UpdateThreadFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    archived: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auto_archive_duration: Option<AutoArchiveDuration>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    locked: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rate_limit_per_user: Option<u64>,
+}
+
+/// Update a thread.
+///
+/// All fields are optional. The minimum length of the name is 1 UTF-16
+/// characters and the maximum is 100 UTF-16 characters.
+pub struct UpdateThread<'a> {
+    channel_id: ChannelId,
+    fields: UpdateThreadFields,
+    fut: Option<Pending<'a, Channel>>,
+    http: &'a Client,
+    reason: Option<String>,
+}
+
+impl<'a> UpdateThread<'a> {
+    pub(crate) fn new(http: &'a Client, channel_id: ChannelId) -> Self {
+        Self {
+            channel_id,
+            fields: UpdateThreadFields::default(),
+            fut: None,
+            http,
+            reason: None,
+        }
+    }
+
+    pub fn archived(mut self, archived: bool) -> Self {
+        self.fields.archived.replace(archived);
+
+        self
+    }
+
+    pub fn auto_archive_duration(mut self, auto_archive_duration: AutoArchiveDuration) -> Self {
+        self.fields
+            .auto_archive_duration
+            .replace(auto_archive_duration);
+
+        self
+    }
+
+    pub fn locked(mut self, locked: bool) -> Self {
+        self.fields.locked.replace(locked);
+
+        self
+    }
+
+    pub fn name(self, name: impl Into<String>) -> Result<Self, ThreadValidationError> {
+        self._name(name.into())
+    }
+
+    fn _name(mut self, name: String) -> Result<Self, ThreadValidationError> {
+        if !validate::channel_name(&name) {
+            return Err(ThreadValidationError {
+                kind: ThreadValidationErrorType::NameInvalid { name },
+            });
+        }
+
+        self.fields.name.replace(name);
+
+        Ok(self)
+    }
+
+    /// Set the number of seconds that a user must wait before before they are
+    /// able to send another message.
+    ///
+    /// The minimum is 0 and the maximum is 21600. Refer to [the discord docs]
+    /// for more details.  This is also known as "Slow Mode".
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`ThreadValidationErrorType::RateLimitPerUserInvalid`] error type
+    /// if the amount is greater than 21600.
+    ///
+    /// [the discord docs]: https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure>
+    pub fn rate_limit_per_user(
+        mut self,
+        rate_limit_per_user: u64,
+    ) -> Result<Self, ThreadValidationError> {
+        if rate_limit_per_user > 21600 {
+            return Err(ThreadValidationError {
+                kind: ThreadValidationErrorType::RateLimitPerUserInvalid {
+                    rate_limit_per_user,
+                },
+            });
+        }
+
+        self.fields.rate_limit_per_user.replace(rate_limit_per_user);
+
+        Ok(self)
+    }
+
+    fn start(&mut self) -> Result<(), HttpError> {
+        let mut request = Request::builder(Route::UpdateChannel {
+            channel_id: self.channel_id.0,
+        });
+
+        if let Some(reason) = &self.reason {
+            request = request.headers(request::audit_header(reason)?);
+        }
+
+        self.fut
+            .replace(Box::pin(self.http.request(request.build())));
+
+        Ok(())
+    }
+}
+
+impl<'a> AuditLogReason for UpdateThread<'a> {
+    fn reason(mut self, reason: impl Into<String>) -> Result<Self, AuditLogReasonError> {
+        self.reason
+            .replace(AuditLogReasonError::validate(reason.into())?);
+
+        Ok(self)
+    }
+}
+
+poll_req!(UpdateThread<'_>, Channel);

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -7,7 +7,7 @@ use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
-use twilight_model::channel::embed::Embed;
+use twilight_model::channel::{embed::Embed, ChannelType};
 
 /// An embed is not valid.
 ///
@@ -454,6 +454,15 @@ fn _command_description(value: &str) -> bool {
 pub fn command_permissions(len: usize) -> bool {
     // https://discord.com/developers/docs/interactions/slash-commands#edit-application-command-permissions
     (0..=10).contains(&len)
+}
+
+pub const fn is_thread(channel_type: ChannelType) -> bool {
+    matches!(
+        channel_type,
+        ChannelType::GuildNewsThread
+            | ChannelType::GuildPublicThread
+            | ChannelType::GuildPrivateThread
+    )
 }
 
 #[cfg(test)]

--- a/http/src/routing/path.rs
+++ b/http/src/routing/path.rs
@@ -99,6 +99,8 @@ pub enum Path {
     /// Operating on an individual channel's message's reactions while
     /// specifying the user ID and emoji type.
     ChannelsIdMessagesIdReactionsUserIdType(u64),
+    /// Operating on an individual channel's message's threads.
+    ChannelsIdMessagesIdThreads(u64),
     /// Operating on a channel's permission overwrites by ID.
     ChannelsIdPermissionsOverwriteId(u64),
     /// Operating on a channel's pins.
@@ -107,6 +109,10 @@ pub enum Path {
     ChannelsIdPinsMessageId(u64),
     /// Operating on a group DM's recipients.
     ChannelsIdRecipients(u64),
+    /// Operating on a thread's members.
+    ChannelsIdThreadMembers(u64),
+    /// Operating on a channel's threads.
+    ChannelsIdThreads(u64),
     /// Operating on a channel's typing indicator.
     ChannelsIdTyping(u64),
     /// Operating on a channel's webhooks.
@@ -243,12 +249,17 @@ impl FromStr for Path {
             ["channels", id, "messages", _, "reactions", _, _] => {
                 ChannelsIdMessagesIdReactionsUserIdType(parse_id(id)?)
             }
+            ["channels", id, "messages", _, "threads"] => {
+                ChannelsIdMessagesIdThreads(parse_id(id)?)
+            }
             ["channels", id, "permissions", _] => ChannelsIdPermissionsOverwriteId(parse_id(id)?),
             ["channels", id, "pins"] => ChannelsIdPins(parse_id(id)?),
             ["channels", id, "pins", _] => ChannelsIdPinsMessageId(parse_id(id)?),
             ["channels", id, "recipients"] | ["channels", id, "recipients", _] => {
                 ChannelsIdRecipients(parse_id(id)?)
             }
+            ["channels", id, "thread-members"] => ChannelsIdThreadMembers(parse_id(id)?),
+            ["channels", id, "threads"] => ChannelsIdThreads(parse_id(id)?),
             ["channels", id, "typing"] => ChannelsIdTyping(parse_id(id)?),
             ["channels", id, "webhooks"] | ["channels", id, "webhooks", _] => {
                 ChannelsIdWebhooks(parse_id(id)?)

--- a/http/src/routing/route.rs
+++ b/http/src/routing/route.rs
@@ -16,6 +16,13 @@ pub enum Route {
         /// The ID of the user.
         user_id: u64,
     },
+    /// Route information to add a member to a thread.
+    AddThreadMember {
+        /// ID of the thread.
+        channel_id: u64,
+        /// ID of the member.
+        user_id: u64,
+    },
     /// Route information to create a ban on a user in a guild.
     CreateBan {
         /// The number of days' worth of the user's messages to delete in the
@@ -89,6 +96,18 @@ pub enum Route {
     },
     /// Route information to create a private channel.
     CreatePrivateChannel,
+    /// Route information to create a thread in a channel.
+    CreateThread {
+        /// ID of the channel.
+        channel_id: u64,
+    },
+    /// Route information to create a thread from a message.
+    CreateThreadFromMessage {
+        /// ID of the channel.
+        channel_id: u64,
+        /// ID of the message.
+        message_id: u64,
+    },
     /// Route information to create a reaction on a message.
     CreateReaction {
         /// The ID of the channel.
@@ -278,6 +297,11 @@ pub enum Route {
     /// Route information to follow a news channel.
     FollowNewsChannel {
         /// The ID of the channel to follow.
+        channel_id: u64,
+    },
+    /// Route information to get active threads in a channel.
+    GetActiveThreads {
+        /// ID of the channel.
         channel_id: u64,
     },
     /// Route information to get a paginated list of audit logs in a guild.
@@ -506,6 +530,33 @@ pub enum Route {
         /// The ID of the channel.
         channel_id: u64,
     },
+    /// Route information to get joined private archived threads in a channel.
+    GetJoinedPrivateArchivedThreads {
+        /// Optional timestamp to return threads before.
+        before: Option<u64>,
+        /// ID of the channel.
+        channel_id: u64,
+        /// Optional maximum number of threads to return.
+        limit: Option<u64>,
+    },
+    /// Route information to get private archived threads in a channel.
+    GetPrivateArchivedThreads {
+        /// Optional timestamp to return threads before.
+        before: Option<String>,
+        /// ID of the channel.
+        channel_id: u64,
+        /// Optional maximum number of threads to return.
+        limit: Option<u64>,
+    },
+    /// Route information to get public archived threads in a channel.
+    GetPublicArchivedThreads {
+        /// Optional timestamp to return threads before.
+        before: Option<String>,
+        /// ID of the channel.
+        channel_id: u64,
+        /// Optional maximum number of threads to return.
+        limit: Option<u64>,
+    },
     /// Route information to get the users who reacted to a message with a
     /// specified emoji.
     GetReactionUsers {
@@ -534,6 +585,11 @@ pub enum Route {
     GetTemplates {
         /// The ID of the guild.
         guild_id: u64,
+    },
+    /// Route information to get members of a thread.
+    GetThreadMembers {
+        /// ID of the thread.
+        channel_id: u64,
     },
     /// Route information to get the current user.
     GetUser {
@@ -571,10 +627,20 @@ pub enum Route {
         /// The token for the interaction.
         interaction_token: String,
     },
+    /// Route information to join a thread as the current user.
+    JoinThread {
+        /// ID of the thread.
+        channel_id: u64,
+    },
     /// Route information to leave the guild.
     LeaveGuild {
         /// The ID of the guild.
         guild_id: u64,
+    },
+    /// Route information to leave a thread as the current user.
+    LeaveThread {
+        /// ID of the thread.
+        channel_id: u64,
     },
     /// Route information to pin a message to a channel.
     PinMessage {
@@ -597,6 +663,13 @@ pub enum Route {
         /// The ID of the role.
         role_id: u64,
         /// The ID of the user.
+        user_id: u64,
+    },
+    /// Route information to remove a member from a thread.
+    RemoveThreadMember {
+        /// ID of the thread.
+        channel_id: u64,
+        /// ID of the member.
         user_id: u64,
     },
     /// Route information to search for members in a guild.
@@ -897,10 +970,13 @@ impl Route {
             | Self::DeleteWebhookMessage { .. }
             | Self::DeleteWebhook { .. }
             | Self::LeaveGuild { .. }
+            | Self::LeaveThread { .. }
             | Self::RemoveMember { .. }
             | Self::RemoveMemberRole { .. }
+            | Self::RemoveThreadMember { .. }
             | Self::UnpinMessage { .. } => Method::Delete,
-            Self::GetAuditLogs { .. }
+            Self::GetActiveThreads { .. }
+            | Self::GetAuditLogs { .. }
             | Self::GetBan { .. }
             | Self::GetBans { .. }
             | Self::GetGatewayBot
@@ -935,10 +1011,14 @@ impl Route {
             | Self::GetMessage { .. }
             | Self::GetMessages { .. }
             | Self::GetPins { .. }
+            | Self::GetJoinedPrivateArchivedThreads { .. }
+            | Self::GetPrivateArchivedThreads { .. }
+            | Self::GetPublicArchivedThreads { .. }
             | Self::GetReactionUsers { .. }
             | Self::GetStageInstance { .. }
             | Self::GetTemplate { .. }
             | Self::GetTemplates { .. }
+            | Self::GetThreadMembers { .. }
             | Self::GetUserConnections
             | Self::GetUserPrivateChannels
             | Self::GetUser { .. }
@@ -979,6 +1059,8 @@ impl Route {
             | Self::CreateInvite { .. }
             | Self::CreateMessage { .. }
             | Self::CreatePrivateChannel
+            | Self::CreateThread { .. }
+            | Self::CreateThreadFromMessage { .. }
             | Self::CreateRole { .. }
             | Self::CreateStageInstance { .. }
             | Self::CreateTemplate { .. }
@@ -992,8 +1074,10 @@ impl Route {
             | Self::SyncGuildIntegration { .. } => Method::Post,
             Self::AddGuildMember { .. }
             | Self::AddMemberRole { .. }
+            | Self::AddThreadMember { .. }
             | Self::CreateBan { .. }
             | Self::CreateReaction { .. }
+            | Self::JoinThread { .. }
             | Self::PinMessage { .. }
             | Self::SetCommandPermissions { .. }
             | Self::SetGlobalCommands { .. }
@@ -1043,6 +1127,13 @@ impl Route {
             Self::AddMemberRole { guild_id, .. } | Self::RemoveMemberRole { guild_id, .. } => {
                 Path::GuildsIdMembersIdRolesId(*guild_id)
             }
+            Self::AddThreadMember { channel_id, .. }
+            | Self::GetThreadMembers { channel_id, .. }
+            | Self::JoinThread { channel_id, .. }
+            | Self::LeaveThread { channel_id, .. }
+            | Self::RemoveThreadMember { channel_id, .. } => {
+                Path::ChannelsIdThreadMembers(*channel_id)
+            }
             Self::CreateBan { guild_id, .. } | Self::DeleteBan { guild_id, .. } => {
                 Path::GuildsIdBansUserId(*guild_id)
             }
@@ -1090,6 +1181,10 @@ impl Route {
             | Self::UpdateStageInstance { .. } => Path::StageInstances,
             Self::CreateTemplate { guild_id } | Self::GetTemplates { guild_id } => {
                 Path::GuildsIdTemplates(*guild_id)
+            }
+            Self::CreateThread { channel_id, .. } => Path::ChannelsIdThreads(*channel_id),
+            Self::CreateThreadFromMessage { channel_id, .. } => {
+                Path::ChannelsIdMessagesIdThreads(*channel_id)
             }
             Self::CreateTypingTrigger { channel_id } => Path::ChannelsIdTyping(*channel_id),
             Self::CreateWebhook { channel_id } | Self::GetChannelWebhooks { channel_id } => {
@@ -1145,6 +1240,12 @@ impl Route {
             | Self::GetWebhook { webhook_id, .. }
             | Self::UpdateWebhook { webhook_id, .. } => (Path::WebhooksId(*webhook_id)),
             Self::FollowNewsChannel { channel_id } => Path::ChannelsIdFollowers(*channel_id),
+            Self::GetActiveThreads { channel_id, .. }
+            | Self::GetJoinedPrivateArchivedThreads { channel_id, .. }
+            | Self::GetPrivateArchivedThreads { channel_id, .. }
+            | Self::GetPublicArchivedThreads { channel_id, .. } => {
+                Path::ChannelsIdThreads(*channel_id)
+            }
             Self::GetAuditLogs { guild_id, .. } => Path::GuildsIdAuditLogs(*guild_id),
             Self::GetBan { guild_id, .. } => Path::GuildsIdBansId(*guild_id),
             Self::GetBans { guild_id } => Path::GuildsIdBans(*guild_id),

--- a/http/src/routing/route_display.rs
+++ b/http/src/routing/route_display.rs
@@ -69,6 +69,20 @@ impl Display for RouteDisplay<'_> {
 
                 Display::fmt(role_id, f)
             }
+            Route::AddThreadMember {
+                channel_id,
+                user_id,
+            }
+            | Route::RemoveThreadMember {
+                channel_id,
+                user_id,
+            } => {
+                f.write_str("channels/")?;
+                Display::fmt(channel_id, f)?;
+                f.write_str("/thread-members/")?;
+
+                Display::fmt(user_id, f)
+            }
             Route::CreateBan {
                 guild_id,
                 delete_message_days,
@@ -233,6 +247,23 @@ impl Display for RouteDisplay<'_> {
                 Display::fmt(guild_id, f)?;
 
                 f.write_str("/templates")
+            }
+            Route::CreateThread { channel_id } => {
+                f.write_str("channels/")?;
+                Display::fmt(channel_id, f)?;
+
+                f.write_str("/threads")
+            }
+            Route::CreateThreadFromMessage {
+                channel_id,
+                message_id,
+            } => {
+                f.write_str("channels/")?;
+                Display::fmt(channel_id, f)?;
+                f.write_str("/messages/")?;
+                Display::fmt(message_id, f)?;
+
+                f.write_str("/threads")
             }
             Route::CreateTypingTrigger { channel_id } => {
                 f.write_str("channels/")?;
@@ -520,6 +551,12 @@ impl Display for RouteDisplay<'_> {
 
                 f.write_str("/followers")
             }
+            Route::GetActiveThreads { channel_id } => {
+                f.write_str("channels/")?;
+                Display::fmt(channel_id, f)?;
+
+                f.write_str("/threads/active")
+            }
             Route::GetAuditLogs {
                 action_type,
                 before,
@@ -802,6 +839,69 @@ impl Display for RouteDisplay<'_> {
 
                 f.write_str("/pins")
             }
+            Route::GetJoinedPrivateArchivedThreads {
+                before,
+                channel_id,
+                limit,
+            } => {
+                f.write_str("channels/")?;
+                Display::fmt(channel_id, f)?;
+                f.write_str("/users/@me/threads/archived/private?")?;
+
+                if let Some(before) = before {
+                    f.write_str("before=")?;
+                    Display::fmt(before, f)?;
+                }
+
+                if let Some(limit) = limit {
+                    f.write_str("&limit=")?;
+                    Display::fmt(limit, f)?;
+                }
+
+                Ok(())
+            }
+            Route::GetPrivateArchivedThreads {
+                before,
+                channel_id,
+                limit,
+            } => {
+                f.write_str("channels/")?;
+                Display::fmt(channel_id, f)?;
+                f.write_str("/threads/archived/private?")?;
+
+                if let Some(before) = before {
+                    f.write_str("before=")?;
+                    Display::fmt(before, f)?;
+                }
+
+                if let Some(limit) = limit {
+                    f.write_str("&limit=")?;
+                    Display::fmt(limit, f)?;
+                }
+
+                Ok(())
+            }
+            Route::GetPublicArchivedThreads {
+                before,
+                channel_id,
+                limit,
+            } => {
+                f.write_str("channels/")?;
+                Display::fmt(channel_id, f)?;
+                f.write_str("/threads/archived/public")?;
+
+                if let Some(before) = before {
+                    f.write_str("before=")?;
+                    Display::fmt(before, f)?;
+                }
+
+                if let Some(limit) = limit {
+                    f.write_str("&limit=")?;
+                    Display::fmt(limit, f)?;
+                }
+
+                Ok(())
+            }
             Route::GetReactionUsers {
                 after,
                 channel_id,
@@ -829,6 +929,12 @@ impl Display for RouteDisplay<'_> {
 
                 Ok(())
             }
+            Route::GetThreadMembers { channel_id } => {
+                f.write_str("channels/")?;
+                Display::fmt(channel_id, f)?;
+
+                f.write_str("/thread-members")
+            }
             Route::GetUserConnections => f.write_str("users/@me/connections"),
             Route::GetUser { target_user } => {
                 f.write_str("users/")?;
@@ -846,6 +952,12 @@ impl Display for RouteDisplay<'_> {
                 f.write_str(interaction_token)?;
 
                 f.write_str("/callback")
+            }
+            Route::JoinThread { channel_id } | Route::LeaveThread { channel_id } => {
+                f.write_str("channels/")?;
+                Display::fmt(channel_id, f)?;
+
+                f.write_str("/thread-members/@me")
             }
             Route::LeaveGuild { guild_id } => {
                 f.write_str("users/@me/guilds/")?;

--- a/model/src/channel/thread/listing.rs
+++ b/model/src/channel/thread/listing.rs
@@ -1,0 +1,13 @@
+use crate::channel::{thread::ThreadMember, Channel};
+use serde::{Deserialize, Serialize};
+
+/// Response body returned in thread listing methods.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct ThreadsListing {
+    /// Whether there are potentially more threads that could be returned.
+    pub has_more: bool,
+    /// A thread member object for each returned thread the current user has joined.
+    pub members: Vec<ThreadMember>,
+    /// List of threads.
+    pub threads: Vec<Channel>,
+}

--- a/model/src/channel/thread/mod.rs
+++ b/model/src/channel/thread/mod.rs
@@ -1,4 +1,5 @@
 mod auto_archive_duration;
+mod listing;
 mod member;
 mod metadata;
 mod news;
@@ -6,6 +7,6 @@ mod private;
 mod public;
 
 pub use self::{
-    auto_archive_duration::AutoArchiveDuration, member::ThreadMember, metadata::ThreadMetadata,
-    news::NewsThread, private::PrivateThread, public::PublicThread,
+    auto_archive_duration::AutoArchiveDuration, listing::ThreadsListing, member::ThreadMember,
+    metadata::ThreadMetadata, news::NewsThread, private::PrivateThread, public::PublicThread,
 };


### PR DESCRIPTION
Adds the current thread methods to the client. This has been tested.

Fixes #973.

Blocks on #1015.