### PR TITLE
Support message components

### DIFF
--- a/cache/in-memory/src/event/message.rs
+++ b/cache/in-memory/src/event/message.rs
@@ -151,6 +151,7 @@ mod tests {
                 verified: None,
             },
             channel_id: ChannelId(2),
+            components: Vec::new(),
             content: "ping".to_owned(),
             edited_timestamp: None,
             embeds: Vec::new(),

--- a/cache/in-memory/src/test.rs
+++ b/cache/in-memory/src/test.rs
@@ -35,6 +35,7 @@ pub fn cache_with_message_and_reactions() -> InMemoryCache {
             verified: None,
         },
         channel_id: ChannelId(2),
+        components: Vec::new(),
         content: "ping".to_owned(),
         edited_timestamp: None,
         embeds: Vec::new(),

--- a/http/src/request/application/create_global_command.rs
+++ b/http/src/request/application/create_global_command.rs
@@ -3,7 +3,7 @@ use crate::{
     error::Error as HttpError,
     request::{
         application::{InteractionError, InteractionErrorType},
-        validate, Pending, Request,
+        validate_inner, Pending, Request,
     },
     routing::Route,
 };
@@ -38,12 +38,12 @@ impl<'a> CreateGlobalCommand<'a> {
         let name = name.into();
         let description = description.into();
 
-        if !validate::command_name(&name) {
+        if !validate_inner::command_name(&name) {
             return Err(InteractionError {
                 kind: InteractionErrorType::CommandNameValidationFailed { name },
             });
         }
-        if !validate::command_description(&description) {
+        if !validate_inner::command_description(&description) {
             return Err(InteractionError {
                 kind: InteractionErrorType::CommandDescriptionValidationFailed { description },
             });

--- a/http/src/request/application/create_guild_command.rs
+++ b/http/src/request/application/create_guild_command.rs
@@ -3,7 +3,7 @@ use crate::{
     error::Error as HttpError,
     request::{
         application::{InteractionError, InteractionErrorType},
-        validate, Pending, Request,
+        validate_inner, Pending, Request,
     },
     routing::Route,
 };
@@ -40,13 +40,13 @@ impl<'a> CreateGuildCommand<'a> {
         let name = name.into();
         let description = description.into();
 
-        if !validate::command_name(&name) {
+        if !validate_inner::command_name(&name) {
             return Err(InteractionError {
                 kind: InteractionErrorType::CommandNameValidationFailed { name },
             });
         }
 
-        if !validate::command_description(&description) {
+        if !validate_inner::command_description(&description) {
             return Err(InteractionError {
                 kind: InteractionErrorType::CommandDescriptionValidationFailed { description },
             });

--- a/http/src/request/application/mod.rs
+++ b/http/src/request/application/mod.rs
@@ -1,4 +1,5 @@
-mod create_followup_message;
+pub mod create_followup_message;
+
 mod create_global_command;
 mod create_guild_command;
 mod delete_followup_message;

--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -3,7 +3,7 @@ use crate::{
     error::Error,
     request::{
         application::{InteractionError, InteractionErrorType},
-        validate, Pending, Request,
+        validate_inner, Pending, Request,
     },
     routing::Route,
 };
@@ -58,7 +58,7 @@ impl<'a> SetCommandPermissions<'a> {
                 acc
             })
             .iter()
-            .all(|permission| validate::command_permissions(*permission.1))
+            .all(|permission| validate_inner::command_permissions(*permission.1))
         {
             return Err(InteractionError {
                 kind: InteractionErrorType::TooManyCommandPermissions,

--- a/http/src/request/application/update_command_permissions.rs
+++ b/http/src/request/application/update_command_permissions.rs
@@ -3,7 +3,7 @@ use crate::{
     error::Error,
     request::{
         application::{InteractionError, InteractionErrorType},
-        validate, Pending, Request,
+        validate_inner, Pending, Request,
     },
     routing::Route,
 };
@@ -41,7 +41,7 @@ impl<'a> UpdateCommandPermissions<'a> {
         command_id: CommandId,
         permissions: Vec<CommandPermissions>,
     ) -> Result<Self, InteractionError> {
-        if !validate::command_permissions(permissions.len()) {
+        if !validate_inner::command_permissions(permissions.len()) {
             return Err(InteractionError {
                 kind: InteractionErrorType::TooManyCommandPermissions,
             });

--- a/http/src/request/application/update_followup_message.rs
+++ b/http/src/request/application/update_followup_message.rs
@@ -3,7 +3,10 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Form, NullableField, Pending, Request},
+    request::{
+        validate_inner::{self, ComponentValidationError, ComponentValidationErrorType},
+        Form, NullableField, Pending, Request,
+    },
     routing::Route,
 };
 use serde::Serialize;
@@ -12,6 +15,7 @@ use std::{
     fmt::{Display, Formatter, Result as FmtResult},
 };
 use twilight_model::{
+    application::component::Component,
     channel::{embed::Embed, message::AllowedMentions, Attachment},
     id::{ApplicationId, MessageId},
 };
@@ -51,6 +55,16 @@ impl UpdateFollowupMessageError {
 impl Display for UpdateFollowupMessageError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
+            UpdateFollowupMessageErrorType::ComponentCount { count } => {
+                Display::fmt(count, f)?;
+                f.write_str(" components were provided, but only ")?;
+                Display::fmt(&ComponentValidationError::COMPONENT_COUNT, f)?;
+
+                f.write_str(" root components are allowed")
+            }
+            UpdateFollowupMessageErrorType::ComponentInvalid { .. } => {
+                f.write_str("a provided component is invalid")
+            }
             UpdateFollowupMessageErrorType::ContentInvalid { .. } => {
                 f.write_str("message content is invalid")
             }
@@ -78,6 +92,16 @@ impl Error for UpdateFollowupMessageError {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum UpdateFollowupMessageErrorType {
+    /// An invalid message component was provided.
+    ComponentInvalid {
+        /// Additional details about the validation failure type.
+        kind: ComponentValidationErrorType,
+    },
+    /// Too many message components were provided.
+    ComponentCount {
+        /// Number of components that were provided.
+        count: usize,
+    },
     /// Content is over 2000 UTF-16 characters.
     ContentInvalid {
         /// Provided content.
@@ -109,6 +133,8 @@ struct UpdateFollowupMessageFields {
     allowed_mentions: Option<AllowedMentions>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     attachments: Vec<Attachment>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    components: Option<Vec<Component>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -215,6 +241,43 @@ impl<'a> UpdateFollowupMessage<'a> {
         self
     }
 
+    /// Add multiple [`Component`]s to a message.
+    ///
+    /// Calling this method multiple times will clear previous calls.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`UpdateFollowupMessageErrorType::ComponentCount`] error type
+    /// if too many components are provided.
+    ///
+    /// Returns an [`UpdateFollowupMessageErrorType::ComponentInvalid`] error
+    /// type if one of the provided components is invalid.
+    pub fn components(
+        mut self,
+        components: Vec<Component>,
+    ) -> Result<Self, UpdateFollowupMessageError> {
+        validate_inner::components(&components).map_err(|source| {
+            let (kind, inner_source) = source.into_parts();
+
+            match kind {
+                ComponentValidationErrorType::ComponentCount { count } => {
+                    UpdateFollowupMessageError {
+                        kind: UpdateFollowupMessageErrorType::ComponentCount { count },
+                        source: inner_source,
+                    }
+                }
+                other => UpdateFollowupMessageError {
+                    kind: UpdateFollowupMessageErrorType::ComponentInvalid { kind: other },
+                    source: inner_source,
+                },
+            }
+        })?;
+
+        self.fields.components.replace(components);
+
+        Ok(self)
+    }
+
     /// Set the content of the message.
     ///
     /// Pass `None` if you want to remove the message content.
@@ -230,7 +293,7 @@ impl<'a> UpdateFollowupMessage<'a> {
     /// the content length is too long.
     pub fn content(mut self, content: Option<String>) -> Result<Self, UpdateFollowupMessageError> {
         if let Some(content_ref) = content.as_ref() {
-            if !validate::content_limit(content_ref) {
+            if !validate_inner::content_limit(content_ref) {
                 return Err(UpdateFollowupMessageError {
                     kind: UpdateFollowupMessageErrorType::ContentInvalid {
                         content: content.expect("content is known to be some"),
@@ -311,7 +374,7 @@ impl<'a> UpdateFollowupMessage<'a> {
             }
 
             for (idx, embed) in embeds_present.iter().enumerate() {
-                if let Err(source) = validate::embed(&embed) {
+                if let Err(source) = validate_inner::embed(&embed) {
                     return Err(UpdateFollowupMessageError {
                         kind: UpdateFollowupMessageErrorType::EmbedTooLarge {
                             embeds: embeds.expect("embeds are known to be present"),

--- a/http/src/request/application/update_followup_message.rs
+++ b/http/src/request/application/update_followup_message.rs
@@ -134,7 +134,7 @@ struct UpdateFollowupMessageFields {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     attachments: Vec<Attachment>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    components: Option<Vec<Component>>,
+    components: Option<NullableField<Vec<Component>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -245,6 +245,8 @@ impl<'a> UpdateFollowupMessage<'a> {
     ///
     /// Calling this method multiple times will clear previous calls.
     ///
+    /// Pass `None` to clear existing components.
+    ///
     /// # Errors
     ///
     /// Returns an [`UpdateFollowupMessageErrorType::ComponentCount`] error type
@@ -254,26 +256,30 @@ impl<'a> UpdateFollowupMessage<'a> {
     /// type if one of the provided components is invalid.
     pub fn components(
         mut self,
-        components: Vec<Component>,
+        components: Option<Vec<Component>>,
     ) -> Result<Self, UpdateFollowupMessageError> {
-        validate_inner::components(&components).map_err(|source| {
-            let (kind, inner_source) = source.into_parts();
+        if let Some(components) = components.as_ref() {
+            validate_inner::components(&components).map_err(|source| {
+                let (kind, inner_source) = source.into_parts();
 
-            match kind {
-                ComponentValidationErrorType::ComponentCount { count } => {
-                    UpdateFollowupMessageError {
-                        kind: UpdateFollowupMessageErrorType::ComponentCount { count },
-                        source: inner_source,
+                match kind {
+                    ComponentValidationErrorType::ComponentCount { count } => {
+                        UpdateFollowupMessageError {
+                            kind: UpdateFollowupMessageErrorType::ComponentCount { count },
+                            source: inner_source,
+                        }
                     }
+                    other => UpdateFollowupMessageError {
+                        kind: UpdateFollowupMessageErrorType::ComponentInvalid { kind: other },
+                        source: inner_source,
+                    },
                 }
-                other => UpdateFollowupMessageError {
-                    kind: UpdateFollowupMessageErrorType::ComponentInvalid { kind: other },
-                    source: inner_source,
-                },
-            }
-        })?;
+            })?;
+        }
 
-        self.fields.components.replace(components);
+        self.fields
+            .components
+            .replace(NullableField::from_option(components));
 
         Ok(self)
     }

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    request::{self, validate_inner, AuditLogReason, AuditLogReasonError, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -152,7 +152,7 @@ impl<'a> CreateInvite<'a> {
     /// # Ok(()) }
     /// ```
     pub fn max_age(mut self, max_age: u64) -> Result<Self, CreateInviteError> {
-        if !validate::invite_max_age(max_age) {
+        if !validate_inner::invite_max_age(max_age) {
             return Err(CreateInviteError {
                 kind: CreateInviteErrorType::MaxAgeTooOld { provided: max_age },
             });
@@ -185,7 +185,7 @@ impl<'a> CreateInvite<'a> {
     /// # Ok(()) }
     /// ```
     pub fn max_uses(mut self, max_uses: u64) -> Result<Self, CreateInviteError> {
-        if !validate::invite_max_uses(max_uses) {
+        if !validate_inner::invite_max_uses(max_uses) {
             return Err(CreateInviteError {
                 kind: CreateInviteErrorType::MaxUsesTooLarge { provided: max_uses },
             });

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -2,7 +2,7 @@ use super::GetChannelMessagesConfigured;
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use std::{
@@ -164,7 +164,7 @@ impl<'a> GetChannelMessages<'a> {
     /// Returns a [`GetChannelMessagesErrorType::LimitInvalid`] error type if
     /// the amount is less than 1 or greater than 100.
     pub fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesError> {
-        if !validate::get_channel_messages_limit(limit) {
+        if !validate_inner::get_channel_messages_limit(limit) {
             return Err(GetChannelMessagesError {
                 kind: GetChannelMessagesErrorType::LimitInvalid { limit },
             });

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use std::{
@@ -118,7 +118,7 @@ impl<'a> GetChannelMessagesConfigured<'a> {
     /// Returns a [`GetChannelMessagesConfiguredErrorType::LimitInvalid`] error
     /// type if the amount is greater than 21600.
     pub fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesConfiguredError> {
-        if !validate::get_channel_messages_limit(limit) {
+        if !validate_inner::get_channel_messages_limit(limit) {
             return Err(GetChannelMessagesConfiguredError {
                 kind: GetChannelMessagesConfiguredErrorType::LimitInvalid { limit },
             });

--- a/http/src/request/channel/message/mod.rs
+++ b/http/src/request/channel/message/mod.rs
@@ -15,4 +15,4 @@ pub use self::{
     get_channel_messages_configured::GetChannelMessagesConfigured, get_message::GetMessage,
     update_message::UpdateMessage,
 };
-pub use super::super::validate::EmbedValidationError;
+pub use super::super::validate_inner::EmbedValidationError;

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -2,7 +2,9 @@ use crate::{
     client::Client,
     error::Error as HttpError,
     request::{
-        validate::{self, EmbedValidationError},
+        validate_inner::{
+            self, ComponentValidationError, ComponentValidationErrorType, EmbedValidationError,
+        },
         NullableField, Pending, Request,
     },
     routing::Route,
@@ -13,6 +15,7 @@ use std::{
     fmt::{Display, Formatter, Result as FmtResult},
 };
 use twilight_model::{
+    application::component::Component,
     channel::{
         embed::Embed,
         message::{AllowedMentions, MessageFlags},
@@ -61,6 +64,16 @@ impl UpdateMessageError {
 impl Display for UpdateMessageError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
+            UpdateMessageErrorType::ComponentCount { count } => {
+                Display::fmt(count, f)?;
+                f.write_str(" components were provided, but only ")?;
+                Display::fmt(&ComponentValidationError::COMPONENT_COUNT, f)?;
+
+                f.write_str(" root components are allowed")
+            }
+            UpdateMessageErrorType::ComponentInvalid { .. } => {
+                f.write_str("a provided component is invalid")
+            }
             UpdateMessageErrorType::ContentInvalid { .. } => {
                 f.write_str("the message content is invalid")
             }
@@ -90,6 +103,16 @@ impl Error for UpdateMessageError {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum UpdateMessageErrorType {
+    /// Too many message components were provided.
+    ComponentCount {
+        /// Number of components that were provided.
+        count: usize,
+    },
+    /// An invalid message component was provided.
+    ComponentInvalid {
+        /// Additional details about the validation failure type.
+        kind: ComponentValidationErrorType,
+    },
     /// Returned when the content is over 2000 UTF-16 characters.
     ContentInvalid {
         /// Provided content.
@@ -110,6 +133,8 @@ struct UpdateMessageFields {
     pub(crate) allowed_mentions: Option<AllowedMentions>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub attachments: Vec<Attachment>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub components: Option<Vec<Component>>,
     // We don't serialize if this is Option::None, to avoid overwriting the
     // field without meaning to.
     //
@@ -205,6 +230,38 @@ impl<'a> UpdateMessage<'a> {
         self
     }
 
+    /// Add multiple [`Component`]s to a message.
+    ///
+    /// Calling this method multiple times will clear previous calls.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`UpdateMessageErrorType::ComponentCount`] error type if
+    /// too many components are provided.
+    ///
+    /// Returns an [`UpdateMessageErrorType::ComponentInvalid`] error type if
+    /// one of the provided components is invalid.
+    pub fn components(mut self, components: Vec<Component>) -> Result<Self, UpdateMessageError> {
+        validate_inner::components(&components).map_err(|source| {
+            let (kind, inner_source) = source.into_parts();
+
+            match kind {
+                ComponentValidationErrorType::ComponentCount { count } => UpdateMessageError {
+                    kind: UpdateMessageErrorType::ComponentCount { count },
+                    source: inner_source,
+                },
+                other => UpdateMessageError {
+                    kind: UpdateMessageErrorType::ComponentInvalid { kind: other },
+                    source: inner_source,
+                },
+            }
+        })?;
+
+        self.fields.components.replace(components);
+
+        Ok(self)
+    }
+
     /// Set the content of the message.
     ///
     /// Pass `None` if you want to remove the message content.
@@ -224,7 +281,7 @@ impl<'a> UpdateMessage<'a> {
 
     fn _content(mut self, content: Option<String>) -> Result<Self, UpdateMessageError> {
         if let Some(content_ref) = content.as_ref() {
-            if !validate::content_limit(content_ref) {
+            if !validate_inner::content_limit(content_ref) {
                 return Err(UpdateMessageError {
                     kind: UpdateMessageErrorType::ContentInvalid {
                         content: content.expect("content is known to be some"),
@@ -263,7 +320,7 @@ impl<'a> UpdateMessage<'a> {
 
     fn _embed(mut self, embed: Option<Embed>) -> Result<Self, UpdateMessageError> {
         if let Some(embed_ref) = embed.as_ref() {
-            validate::embed(&embed_ref)
+            validate_inner::embed(&embed_ref)
                 .map_err(|source| UpdateMessageError::embed(source, embed_ref.clone(), None))?;
         }
 
@@ -303,7 +360,7 @@ impl<'a> UpdateMessage<'a> {
         embeds: impl IntoIterator<Item = Embed>,
     ) -> Result<Self, UpdateMessageError> {
         for (idx, embed) in embeds.into_iter().enumerate() {
-            validate::embed(&embed)
+            validate_inner::embed(&embed)
                 .map_err(|source| UpdateMessageError::embed(source, embed.clone(), Some(idx)))?;
 
             if let Some(embeds) = &mut self.fields.embeds {

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -2,7 +2,7 @@ use super::RequestReactionType;
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use std::{
@@ -115,7 +115,7 @@ impl<'a> GetReactions<'a> {
     /// Returns a [`GetReactionsErrorType::LimitInvalid`] error type if the
     /// amount is greater than 100.
     pub fn limit(mut self, limit: u64) -> Result<Self, GetReactionsError> {
-        if !validate::get_reactions_limit(limit) {
+        if !validate_inner::get_reactions_limit(limit) {
             return Err(GetReactionsError {
                 kind: GetReactionsErrorType::LimitInvalid { limit },
             });

--- a/http/src/request/channel/stage/create_stage_instance.rs
+++ b/http/src/request/channel/stage/create_stage_instance.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -99,7 +99,7 @@ impl<'a> CreateStageInstance<'a> {
         channel_id: ChannelId,
         topic: String,
     ) -> Result<Self, CreateStageInstanceError> {
-        if !validate::stage_topic(&topic) {
+        if !validate_inner::stage_topic(&topic) {
             return Err(CreateStageInstanceError {
                 kind: CreateStageInstanceErrorType::InvalidTopic { topic },
                 source: None,

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -109,7 +109,7 @@ impl<'a> UpdateStageInstance<'a> {
     }
 
     fn _topic(mut self, topic: String) -> Result<Self, UpdateStageInstanceError> {
-        if !validate::stage_topic(&topic) {
+        if !validate_inner::stage_topic(&topic) {
             return Err(UpdateStageInstanceError {
                 kind: UpdateStageInstanceErrorType::InvalidTopic { topic },
                 source: None,

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error as HttpError,
     request::{
-        self, validate, AuditLogReason, AuditLogReasonError, NullableField, Pending, Request,
+        self, validate_inner, AuditLogReason, AuditLogReasonError, NullableField, Pending, Request,
     },
     routing::Route,
 };
@@ -153,7 +153,7 @@ impl<'a> UpdateChannel<'a> {
     }
 
     fn _name(mut self, name: String) -> Result<Self, UpdateChannelError> {
-        if !validate::channel_name(&name) {
+        if !validate_inner::channel_name(&name) {
             return Err(UpdateChannelError {
                 kind: UpdateChannelErrorType::NameInvalid { name },
             });

--- a/http/src/request/channel/webhook/mod.rs
+++ b/http/src/request/channel/webhook/mod.rs
@@ -1,9 +1,9 @@
+pub mod execute_webhook;
 pub mod update_webhook_message;
 
 mod create_webhook;
 mod delete_webhook;
 mod delete_webhook_message;
-mod execute_webhook;
 mod get_channel_webhooks;
 mod get_webhook;
 mod get_webhook_message;

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -4,7 +4,9 @@ use crate::{
     client::Client,
     error::Error as HttpError,
     request::{
-        self, validate, AuditLogReason, AuditLogReasonError, Form, NullableField, Pending, Request,
+        self,
+        validate_inner::{self, ComponentValidationError, ComponentValidationErrorType},
+        AuditLogReason, AuditLogReasonError, Form, NullableField, Pending, Request,
     },
     routing::Route,
 };
@@ -14,6 +16,7 @@ use std::{
     fmt::{Display, Formatter, Result as FmtResult},
 };
 use twilight_model::{
+    application::component::Component,
     channel::{embed::Embed, message::AllowedMentions, Attachment},
     id::{MessageId, WebhookId},
 };
@@ -53,6 +56,16 @@ impl UpdateWebhookMessageError {
 impl Display for UpdateWebhookMessageError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
+            UpdateWebhookMessageErrorType::ComponentCount { count } => {
+                Display::fmt(count, f)?;
+                f.write_str(" components were provided, but only ")?;
+                Display::fmt(&ComponentValidationError::COMPONENT_COUNT, f)?;
+
+                f.write_str(" root components are allowed")
+            }
+            UpdateWebhookMessageErrorType::ComponentInvalid { .. } => {
+                f.write_str("a provided component is invalid")
+            }
             UpdateWebhookMessageErrorType::ContentInvalid { .. } => {
                 f.write_str("message content is invalid")
             }
@@ -96,6 +109,16 @@ pub enum UpdateWebhookMessageErrorType {
         /// [`embeds`]: Self::EmbedTooLarge.embeds
         index: usize,
     },
+    /// An invalid message component was provided.
+    ComponentInvalid {
+        /// Additional details about the validation failure type.
+        kind: ComponentValidationErrorType,
+    },
+    /// Too many message components were provided.
+    ComponentCount {
+        /// Number of components that were provided.
+        count: usize,
+    },
     /// Too many embeds were provided.
     ///
     /// A webhook can have up to 10 embeds.
@@ -111,6 +134,8 @@ struct UpdateWebhookMessageFields {
     allowed_mentions: Option<AllowedMentions>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     attachments: Vec<Attachment>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    components: Option<Vec<Component>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<NullableField<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -216,6 +241,43 @@ impl<'a> UpdateWebhookMessage<'a> {
         self
     }
 
+    /// Add multiple [`Component`]s to a message.
+    ///
+    /// Calling this method multiple times will clear previous calls.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`UpdateWebhookMessageErrorType::ComponentCount`] error
+    /// type if too many components are provided.
+    ///
+    /// Returns an [`UpdateWebhookMessageErrorType::ComponentInvalid`] error
+    /// type if one of the provided components is invalid.
+    pub fn components(
+        mut self,
+        components: Vec<Component>,
+    ) -> Result<Self, UpdateWebhookMessageError> {
+        validate_inner::components(&components).map_err(|source| {
+            let (kind, inner_source) = source.into_parts();
+
+            match kind {
+                ComponentValidationErrorType::ComponentCount { count } => {
+                    UpdateWebhookMessageError {
+                        kind: UpdateWebhookMessageErrorType::ComponentCount { count },
+                        source: inner_source,
+                    }
+                }
+                other => UpdateWebhookMessageError {
+                    kind: UpdateWebhookMessageErrorType::ComponentInvalid { kind: other },
+                    source: inner_source,
+                },
+            }
+        })?;
+
+        self.fields.components.replace(components);
+
+        Ok(self)
+    }
+
     /// Set the content of the message.
     ///
     /// Pass `None` if you want to remove the message content.
@@ -231,7 +293,7 @@ impl<'a> UpdateWebhookMessage<'a> {
     /// the content length is too long.
     pub fn content(mut self, content: Option<String>) -> Result<Self, UpdateWebhookMessageError> {
         if let Some(content_ref) = content.as_ref() {
-            if !validate::content_limit(content_ref) {
+            if !validate_inner::content_limit(content_ref) {
                 return Err(UpdateWebhookMessageError {
                     kind: UpdateWebhookMessageErrorType::ContentInvalid {
                         content: content.expect("content is known to be some"),
@@ -306,7 +368,7 @@ impl<'a> UpdateWebhookMessage<'a> {
             }
 
             for (idx, embed) in embeds_present.iter().enumerate() {
-                if let Err(source) = validate::embed(&embed) {
+                if let Err(source) = validate_inner::embed(&embed) {
                     return Err(UpdateWebhookMessageError {
                         kind: UpdateWebhookMessageErrorType::EmbedTooLarge {
                             embeds: embeds.expect("embeds are known to be present"),
@@ -437,6 +499,7 @@ mod tests {
         let body = UpdateWebhookMessageFields {
             allowed_mentions: None,
             attachments: Vec::new(),
+            components: None,
             content: Some(NullableField::Value("test".to_owned())),
             embeds: None,
             payload_json: None,

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    request::{validate_inner, AuditLogReason, AuditLogReasonError, Pending, Request},
     routing::Route,
 };
 use std::{
@@ -118,7 +118,7 @@ impl<'a> CreateBan<'a> {
     /// Returns a [`CreateBanErrorType::DeleteMessageDaysInvalid`] error type if
     /// the number of days is greater than 7.
     pub fn delete_message_days(mut self, days: u64) -> Result<Self, CreateBanError> {
-        if !validate::ban_delete_message_days(days) {
+        if !validate_inner::ban_delete_message_days(days) {
             return Err(CreateBanError {
                 kind: CreateBanErrorType::DeleteMessageDaysInvalid { days },
             });

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -248,7 +248,7 @@ impl<'a> CreateGuild<'a> {
     }
 
     fn _new(http: &'a Client, name: String) -> Result<Self, CreateGuildError> {
-        if !validate::guild_name(&name) {
+        if !validate_inner::guild_name(&name) {
             return Err(CreateGuildError {
                 kind: CreateGuildErrorType::NameInvalid { name },
             });

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    request::{self, validate_inner, AuditLogReason, AuditLogReasonError, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -133,7 +133,7 @@ impl<'a> CreateGuildChannel<'a> {
         guild_id: GuildId,
         name: String,
     ) -> Result<Self, CreateGuildChannelError> {
-        if !validate::channel_name(&name) {
+        if !validate_inner::channel_name(&name) {
             return Err(CreateGuildChannelError {
                 kind: CreateGuildChannelErrorType::NameInvalid { name },
             });

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, validate, AuditLogReason, AuditLogReasonError, Pending, Request},
+    request::{self, validate_inner, AuditLogReason, AuditLogReasonError, Pending, Request},
     routing::Route,
 };
 use std::{
@@ -121,7 +121,7 @@ impl<'a> CreateGuildPrune<'a> {
     /// Returns a [`CreateGuildPruneErrorType::DaysInvalid`] error type if the
     /// number of days is 0.
     pub fn days(mut self, days: u64) -> Result<Self, CreateGuildPruneError> {
-        if !validate::guild_prune_days(days) {
+        if !validate_inner::guild_prune_days(days) {
             return Err(CreateGuildPruneError {
                 kind: CreateGuildPruneErrorType::DaysInvalid,
             });

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use std::{
@@ -128,7 +128,7 @@ impl<'a> GetAuditLog<'a> {
     /// Returns a [`GetAuditLogErrorType::LimitInvalid`] error type if the
     /// `limit` is 0 or greater than 100.
     pub fn limit(mut self, limit: u64) -> Result<Self, GetAuditLogError> {
-        if !validate::get_audit_log_limit(limit) {
+        if !validate_inner::get_audit_log_limit(limit) {
             return Err(GetAuditLogError {
                 kind: GetAuditLogErrorType::LimitInvalid { limit },
             });

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use std::{
@@ -99,7 +99,7 @@ impl<'a> GetGuildPruneCount<'a> {
     /// Returns a [`GetGuildPruneCountErrorType::DaysInvalid`] error type if the
     /// number of days is 0.
     pub fn days(mut self, days: u64) -> Result<Self, GetGuildPruneCountError> {
-        if !validate::guild_prune_days(days) {
+        if !validate_inner::guild_prune_days(days) {
             return Err(GetGuildPruneCountError {
                 kind: GetGuildPruneCountErrorType::DaysInvalid,
             });

--- a/http/src/request/guild/member/add_guild_member.rs
+++ b/http/src/request/guild/member/add_guild_member.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, PendingOption, Request},
+    request::{validate_inner, PendingOption, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -151,7 +151,7 @@ impl<'a> AddGuildMember<'a> {
     }
 
     fn _nick(mut self, nick: String) -> Result<Self, AddGuildMemberError> {
-        if !validate::nickname(&nick) {
+        if !validate_inner::nickname(&nick) {
             return Err(AddGuildMemberError {
                 kind: AddGuildMemberErrorType::NicknameInvalid { nickname: nick },
             });

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use hyper::body::Bytes;
@@ -138,7 +138,7 @@ impl<'a> GetGuildMembers<'a> {
     /// Returns a [`GetGuildMembersErrorType::LimitInvalid`] error type if the
     /// limit is 0 or greater than 1000.
     pub fn limit(mut self, limit: u64) -> Result<Self, GetGuildMembersError> {
-        if !validate::get_guild_members_limit(limit) {
+        if !validate_inner::get_guild_members_limit(limit) {
             return Err(GetGuildMembersError {
                 kind: GetGuildMembersErrorType::LimitInvalid { limit },
             });

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use hyper::body::Bytes;
@@ -140,7 +140,7 @@ impl<'a> SearchGuildMembers<'a> {
     pub fn limit(mut self, limit: u64) -> Result<Self, SearchGuildMembersError> {
         // Using get_guild_members_limit here as the limits are the same
         // and this endpoint is not officially documented yet.
-        if !validate::search_guild_members_limit(limit) {
+        if !validate_inner::search_guild_members_limit(limit) {
             return Err(SearchGuildMembersError {
                 kind: SearchGuildMembersErrorType::LimitInvalid { limit },
             });

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error as HttpError,
     request::{
-        self, validate, AuditLogReason, AuditLogReasonError, NullableField, Pending, Request,
+        self, validate_inner, AuditLogReason, AuditLogReasonError, NullableField, Pending, Request,
     },
     routing::Route,
 };
@@ -155,7 +155,7 @@ impl<'a> UpdateGuildMember<'a> {
 
     fn _nick(mut self, nick: Option<String>) -> Result<Self, UpdateGuildMemberError> {
         if let Some(nick) = nick {
-            if !validate::nickname(&nick) {
+            if !validate_inner::nickname(&nick) {
                 return Err(UpdateGuildMemberError {
                     kind: UpdateGuildMemberErrorType::NicknameInvalid { nickname: nick },
                 });

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error as HttpError,
     request::{
-        self, validate, AuditLogReason, AuditLogReasonError, NullableField, Pending, Request,
+        self, validate_inner, AuditLogReason, AuditLogReasonError, NullableField, Pending, Request,
     },
     routing::Route,
 };
@@ -236,7 +236,7 @@ impl<'a> UpdateGuild<'a> {
     }
 
     fn _name(mut self, name: String) -> Result<Self, UpdateGuildError> {
-        if !validate::guild_name(&name) {
+        if !validate_inner::guild_name(&name) {
             return Err(UpdateGuildError {
                 kind: UpdateGuildErrorType::NameInvalid { name },
             });

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -55,6 +55,13 @@ macro_rules! poll_req {
     };
 }
 
+/// Types for validating request parameters.
+pub mod validate {
+    // Exposed so request error types can expose information about the inner
+    // validation error type.
+    pub use super::validate_inner::{ComponentValidationError, ComponentValidationErrorType};
+}
+
 pub mod application;
 pub mod channel;
 pub mod guild;
@@ -69,7 +76,13 @@ mod get_gateway_authed;
 mod get_user_application;
 mod get_voice_regions;
 mod multipart;
-mod validate;
+
+// Rename this module so we can expose a select amount of validation types.
+//
+// Work to prepare the validation module will need to be done individually, so
+// for now only a select number of types are exposed until prepared.
+#[path = "validate.rs"]
+mod validate_inner;
 
 pub use self::{
     audit_reason::{AuditLogReason, AuditLogReasonError},

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -101,7 +101,7 @@ impl<'a> CreateGuildFromTemplate<'a> {
         template_code: String,
         name: String,
     ) -> Result<Self, CreateGuildFromTemplateError> {
-        if !validate::guild_name(&name) {
+        if !validate_inner::guild_name(&name) {
             return Err(CreateGuildFromTemplateError {
                 kind: CreateGuildFromTemplateErrorType::NameInvalid { name },
             });

--- a/http/src/request/template/create_template.rs
+++ b/http/src/request/template/create_template.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -110,7 +110,7 @@ impl<'a> CreateTemplate<'a> {
         guild_id: GuildId,
         name: String,
     ) -> Result<Self, CreateTemplateError> {
-        if !validate::template_name(&name) {
+        if !validate_inner::template_name(&name) {
             return Err(CreateTemplateError {
                 kind: CreateTemplateErrorType::NameInvalid { name },
             });
@@ -140,7 +140,7 @@ impl<'a> CreateTemplate<'a> {
     }
 
     fn _description(mut self, description: String) -> Result<Self, CreateTemplateError> {
-        if !validate::template_description(&description) {
+        if !validate_inner::template_description(&description) {
             return Err(CreateTemplateError {
                 kind: CreateTemplateErrorType::DescriptionTooLarge { description },
             });

--- a/http/src/request/template/update_template.rs
+++ b/http/src/request/template/update_template.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -124,7 +124,7 @@ impl<'a> UpdateTemplate<'a> {
     }
 
     fn _description(mut self, description: String) -> Result<Self, UpdateTemplateError> {
-        if !validate::template_description(&description) {
+        if !validate_inner::template_description(&description) {
             return Err(UpdateTemplateError {
                 kind: UpdateTemplateErrorType::DescriptionTooLarge { description },
             });
@@ -148,7 +148,7 @@ impl<'a> UpdateTemplate<'a> {
     }
 
     fn _name(mut self, name: String) -> Result<Self, UpdateTemplateError> {
-        if !validate::template_name(&name) {
+        if !validate_inner::template_name(&name) {
             return Err(UpdateTemplateError {
                 kind: UpdateTemplateErrorType::NameInvalid { name },
             });

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, Pending, Request},
+    request::{validate_inner, Pending, Request},
     routing::Route,
 };
 use std::{
@@ -139,7 +139,7 @@ impl<'a> GetCurrentUserGuilds<'a> {
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/user#get-current-user-guilds-query-string-params
     pub fn limit(mut self, limit: u64) -> Result<Self, GetCurrentUserGuildsError> {
-        if !validate::get_current_user_guilds_limit(limit) {
+        if !validate_inner::get_current_user_guilds_limit(limit) {
             return Err(GetCurrentUserGuildsError {
                 kind: GetCurrentUserGuildsErrorType::LimitInvalid { limit },
             });

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{validate, NullableField, Pending, Request},
+    request::{validate_inner, NullableField, Pending, Request},
     routing::Route,
 };
 use serde::Serialize;
@@ -122,7 +122,7 @@ impl<'a> UpdateCurrentUser<'a> {
     }
 
     fn _username(mut self, username: String) -> Result<Self, UpdateCurrentUserError> {
-        if !validate::username(&username) {
+        if !validate_inner::username(&username) {
             return Err(UpdateCurrentUserError {
                 kind: UpdateCurrentUserErrorType::UsernameInvalid { username },
             });

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -1186,7 +1186,7 @@ mod tests {
     const_assert_eq!(100, ComponentValidationError::SELECT_OPTION_VALUE_LENGTH);
     const_assert_eq!(100, ComponentValidationError::SELECT_PLACEHOLDER_LENGTH);
     const_assert_eq!(256, EmbedValidationError::AUTHOR_NAME_LENGTH);
-    const_assert_eq!(2048, EmbedValidationError::DESCRIPTION_LENGTH);
+    const_assert_eq!(4096, EmbedValidationError::DESCRIPTION_LENGTH);
     const_assert_eq!(6000, EmbedValidationError::EMBED_TOTAL_LENGTH);
     const_assert_eq!(25, EmbedValidationError::FIELD_COUNT);
     const_assert_eq!(256, EmbedValidationError::FIELD_NAME_LENGTH);

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -7,7 +7,288 @@ use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
-use twilight_model::channel::embed::Embed;
+use twilight_model::{
+    application::component::{select_menu::SelectMenuOption, Component, ComponentType},
+    channel::embed::Embed,
+};
+
+/// A provided [`Component`] is invalid.
+///
+/// While multiple components may be invalid, validation will short-circuit on
+/// the first invalid component.
+#[derive(Debug)]
+pub struct ComponentValidationError {
+    kind: ComponentValidationErrorType,
+}
+
+impl ComponentValidationError {
+    /// Maximum number of [`Component`]s allowed inside an [`ActionRow`].
+    ///
+    /// This is defined in Discord's documentation, per
+    /// [Discord Docs/Action Rows][1].
+    ///
+    /// [`ActionRow`]: twilight_model::application::component::ActionRow
+    /// [1]: https://discord.com/developers/docs/interactions/message-components#action-rows
+    pub const ACTION_ROW_COMPONENT_COUNT: usize = 5;
+
+    /// Maximum number of root [`Component`]s in a message.
+    ///
+    /// This is defined in Discord's documentation, per
+    /// [Discord Docs/Action Row][1].
+    ///
+    /// [1]: https://discord.com/developers/docs/interactions/message-components#action-rows
+    pub const COMPONENT_COUNT: usize = 5;
+
+    /// Maximum length of a [`Component`] custom ID in codepoints.
+    ///
+    /// An example of a component with a custom ID is the
+    /// [`Button`][`Button::custom_id`].
+    ///
+    /// This is defined in Discord's documentation, per
+    /// [Discord Docs/Components][1].
+    ///
+    /// [`Button::custom_id`]: twilight_model::application::component::button::Button::custom_id
+    /// [1]: https://discord.com/developers/docs/interactions/message-components#component-object-component-structure
+    pub const COMPONENT_CUSTOM_ID_LENGTH: usize = 100;
+
+    /// Maximum [`Component`] label length in codepoints.
+    ///
+    /// An example of a component with a label is the [`Button`][`Button::label`].
+    ///
+    /// This is defined in Discord's documentation, per
+    /// [Discord Docs/Components][1].
+    ///
+    /// [`Button::label`]: twilight_model::application::component::button::Button::label
+    /// [1]: https://discord.com/developers/docs/interactions/message-components#component-object-component-structure
+    pub const COMPONENT_LABEL_LENGTH: usize = 80;
+
+    /// Maximum number of [`SelectMenuOption`]s in a [`SelectMenu`].
+    ///
+    /// This is defined in Discord's documentation, per
+    /// [Discord Docs/Select Menu][1].
+    ///
+    /// [`SelectMenuOption`]: twilight_model::application::component::select_menu::SelectMenuOption
+    /// [`SelectMenu`]: twilight_model::application::component::select_menu::SelectMenu
+    /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure
+    pub const SELECT_OPTION_COUNT: usize = 25;
+
+    /// Maximum length of a [`SelectMenuOption::description`] in codepoints.
+    ///
+    /// This is defined in Discord's documentation, per
+    /// [Discord Docs/Select Menu Option][1].
+    ///
+    /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
+    pub const SELECT_OPTION_DESCRIPTION_LENGTH: usize = 50;
+
+    /// Maximum length of a [`SelectMenuOption::label`] in codepoints.
+    ///
+    /// This is defined in Discord's documentation, per
+    /// [Discord Docs/Select Menu Option][1].
+    ///
+    /// [`SelectMenuOption::label`]: twilight_model::application::component::select_menu::SelectMenuOption::label
+    /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
+    pub const SELECT_OPTION_LABEL_LENGTH: usize = 25;
+
+    /// Maximum length of a [`SelectMenuOption::value`] in codepoints.
+    ///
+    /// This is defined in Discord's documentation, per
+    /// [Discord Docs/Select Menu Option][1].
+    ///
+    /// [`SelectMenuOption::value`]: twilight_model::application::component::select_menu::SelectMenuOption::value
+    /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
+    pub const SELECT_OPTION_VALUE_LENGTH: usize = 100;
+
+    /// Maximum length of a [`SelectMenu::placeholder`] in codepoints.
+    ///
+    /// This is defined in Discord's documentation, per
+    /// [Discord Docs/Select Menu][1].
+    ///
+    /// [`SelectMenu::placeholder`]: twilight_model::application::component::select_menu::SelectMenu::placeholder
+    /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure
+    pub const SELECT_PLACEHOLDER_LENGTH: usize = 100;
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(
+        self,
+    ) -> (
+        ComponentValidationErrorType,
+        Option<Box<dyn Error + Send + Sync>>,
+    ) {
+        (self.kind, None)
+    }
+}
+
+impl Display for ComponentValidationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            ComponentValidationErrorType::ActionRowComponentCount { count } => {
+                f.write_str("an action row has ")?;
+                Display::fmt(&count, f)?;
+                f.write_str(" children, but the max is ")?;
+
+                Display::fmt(&Self::ACTION_ROW_COMPONENT_COUNT, f)
+            }
+            ComponentValidationErrorType::ComponentCount { count } => {
+                Display::fmt(count, f)?;
+                f.write_str(" components were provided, but the max is ")?;
+
+                Display::fmt(&Self::COMPONENT_COUNT, f)
+            }
+            ComponentValidationErrorType::ComponentCustomIdLength { chars } => {
+                f.write_str("a component's custom id is ")?;
+                Display::fmt(&chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::COMPONENT_CUSTOM_ID_LENGTH, f)
+            }
+            ComponentValidationErrorType::ComponentLabelLength { chars } => {
+                f.write_str("a component's label is ")?;
+                Display::fmt(&chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::COMPONENT_LABEL_LENGTH, f)
+            }
+            ComponentValidationErrorType::InvalidChildComponent { kind } => {
+                f.write_str("a '")?;
+                Display::fmt(&kind, f)?;
+
+                f.write_str(" component was provided, but can not be a child component")
+            }
+            ComponentValidationErrorType::InvalidRootComponent { kind } => {
+                f.write_str("a '")?;
+                Display::fmt(kind, f)?;
+
+                f.write_str("' component was provided, but can not be a root component")
+            }
+            ComponentValidationErrorType::SelectOptionDescriptionLength { chars } => {
+                f.write_str("a select menu option's description is ")?;
+                Display::fmt(&chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::SELECT_OPTION_DESCRIPTION_LENGTH, f)
+            }
+            ComponentValidationErrorType::SelectOptionLabelLength { chars } => {
+                f.write_str("a select menu option's label is ")?;
+                Display::fmt(&chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::SELECT_OPTION_LABEL_LENGTH, f)
+            }
+            ComponentValidationErrorType::SelectOptionValueLength { chars } => {
+                f.write_str("a select menu option's value is ")?;
+                Display::fmt(&chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::SELECT_OPTION_VALUE_LENGTH, f)
+            }
+            ComponentValidationErrorType::SelectPlaceholderLength { chars } => {
+                f.write_str("a select menu's placeholder is ")?;
+                Display::fmt(&chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&Self::SELECT_PLACEHOLDER_LENGTH, f)
+            }
+            ComponentValidationErrorType::SelectOptionCount { count } => {
+                f.write_str("a select menu has ")?;
+                Display::fmt(&count, f)?;
+                f.write_str(" options, but the max is ")?;
+
+                Display::fmt(&Self::SELECT_OPTION_COUNT, f)
+            }
+        }
+    }
+}
+
+impl Error for ComponentValidationError {}
+
+/// Type of [`ComponentValidationError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ComponentValidationErrorType {
+    /// Number of components a provided [`ActionRow`] is larger than
+    /// [the maximum][`ACTION_ROW_COMPONENT_COUNT`].
+    ///
+    /// [`ActionRow`]: twilight_model::application::component::ActionRow
+    /// [`ACTION_ROW_COMPONENT_COUNT`]: ComponentValidationError::ACTION_ROW_COMPONENT_COUNT
+    ActionRowComponentCount {
+        /// Number of components within the action row.
+        count: usize,
+    },
+    /// Number of components provided is larger than
+    /// [the maximum][`COMPONENT_COUNT`].
+    ///
+    /// [`COMPONENT_COUNT`]: ComponentValidationError::COMPONENT_COUNT
+    ComponentCount {
+        /// Number of components that were provided.
+        count: usize,
+    },
+    /// Component custom ID is larger than the
+    /// [the maximum][`COMPONENT_CUSTOM_ID_LENGTH`].
+    ///
+    /// [`COMPONENT_CUSTOM_ID_LENGTH`]: ComponentValidationError::COMPONENT_CUSTOM_ID_LENGTH
+    ComponentCustomIdLength {
+        /// Number of codepoints that were provided.
+        chars: usize,
+    },
+    /// Component label is larger than [the maximum][`COMPONENT_LABEL_LENGTH`].
+    ///
+    /// [`COMPONENT_LABEL_LENGTH`]: ComponentValidationError::COMPONENT_LABEL_LENGTH
+    ComponentLabelLength {
+        /// Number of codepoints that were provided.
+        chars: usize,
+    },
+    /// Provided component cannot be a child component.
+    InvalidChildComponent {
+        /// Type of provided component.
+        kind: ComponentType,
+    },
+    /// Provided component cannot be a root component.
+    InvalidRootComponent {
+        /// Type of provided component.
+        kind: ComponentType,
+    },
+    /// Number of select menu options provided is larger than
+    /// [the maximum][`SELECT_OPTION_COUNT`].
+    ///
+    /// [`SELECT_OPTION_COUNT`]: ComponentValidationError::SELECT_OPTION_COUNT
+    SelectOptionCount {
+        /// Number of options that were provided.
+        count: usize,
+    },
+    /// Description of a select menu option is larger than
+    /// [the maximum][`SELECT_OPTION_DESCRIPTION_LENGTH`].
+    ///
+    /// [`SELECT_OPTION_DESCRIPTION_LENGTH`]: ComponentValidationError::SELECT_OPTION_DESCRIPTION_LENGTH
+    SelectOptionDescriptionLength {
+        /// Number of codepoints that were provided.
+        chars: usize,
+    },
+    /// Label of a select menu option is larger than
+    /// [the maximum][`SELECT_OPTION_LABEL_LENGTH`].
+    ///
+    /// [`SELECT_OPTION_LABEL_LENGTH`]: ComponentValidationError::SELECT_OPTION_LABEL_LENGTH
+    SelectOptionLabelLength {
+        /// Number of codepoints that were provided.
+        chars: usize,
+    },
+    /// Value of a select menu option is larger than
+    /// [the maximum][`SELECT_OPTION_VALUE_LENGTH`].
+    ///
+    /// [`SELECT_OPTION_VALUE_LENGTH`]: ComponentValidationError::SELECT_OPTION_VALUE_LENGTH
+    SelectOptionValueLength {
+        /// Number of codepoints that were provided.
+        chars: usize,
+    },
+    /// Placeholder of a component is larger than the
+    /// [maximum][`SELECT_PLACEHOLDER_LENGTH`].
+    ///
+    /// [`SELECT_PLACEHOLDER_LENGTH`]: ComponentValidationError::SELECT_PLACEHOLDER_LENGTH
+    SelectPlaceholderLength {
+        /// Number of codepoints that were provided.
+        chars: usize,
+    },
+}
 
 /// An embed is not valid.
 ///
@@ -215,6 +496,289 @@ fn _channel_name(value: &str) -> bool {
 
     // <https://discordapp.com/developers/docs/resources/channel#channel-object-channel-structure>
     (1..=100).contains(&len)
+}
+
+/// Validate a list of components.
+///
+/// # Errors
+///
+/// Returns a [`ComponentValidationErrorType::ComponentCount`] if there are
+/// too many components in the provided list.
+///
+/// Refer to the errors section of [`component`] for a list of errors that may
+/// be returned as a result of validating each provided component.
+pub fn components(components: &[Component]) -> Result<(), ComponentValidationError> {
+    let count = components.len();
+
+    if count > ComponentValidationError::COMPONENT_COUNT {
+        return Err(ComponentValidationError {
+            kind: ComponentValidationErrorType::ComponentCount { count },
+        });
+    }
+
+    for component in components {
+        self::component(component)?;
+    }
+
+    Ok(())
+}
+
+/// Validate the contents of a component.
+///
+/// # Errors
+///
+/// Returns a [`ComponentValidationErrorType::ActionRowComponentCount`] error
+/// type if the provided list of components is too many for an [`ActionRow`].
+///
+/// Returns a [`ComponentValidationErrorType::InvalidChildComponent`] if the
+/// provided nested component is an [`ActionRow`]. Action rows can not
+/// contain another action row.
+///
+/// [`ActionRow`]: twilight_model::application::component::ActionRow
+pub fn component(component: &Component) -> Result<(), ComponentValidationError> {
+    match component {
+        Component::ActionRow(action_row) => {
+            component_action_row_components(&action_row.components)?;
+
+            for inner in &action_row.components {
+                self::component_inner(inner)?;
+            }
+        }
+        other => {
+            return Err(ComponentValidationError {
+                kind: ComponentValidationErrorType::InvalidRootComponent { kind: other.kind() },
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate the contents of a component that is within another component, i.e.
+/// one that is not a root component.
+///
+/// # Errors
+///
+/// Returns a [`ComponentValidationErrorType::InvalidChildComponent`] if a
+/// provided nested component is a [`Component::ActionRow`]. Action rows can not
+/// contain another action row.
+///
+/// Returns a [`ComponentValidationErrorType::OptionDescriptionLength`] error
+/// type if a provided select option description is too long.
+///
+/// Returns a [`ComponentValidationErrorType::OptionLabelLength`] error type if
+/// a provided select option label is too long.
+///
+/// Returns a [`ComponentValidationErrorType::OptionValueLength`] error type if
+/// a provided select option value is too long.
+///
+/// Returns a [`ComponentValidationErrorType::SelectPlaceholderLength`] error type if
+/// a provided select placeholder is too long.
+fn component_inner(component: &Component) -> Result<(), ComponentValidationError> {
+    match component {
+        Component::ActionRow(_) => {
+            return Err(ComponentValidationError {
+                kind: ComponentValidationErrorType::InvalidChildComponent {
+                    kind: ComponentType::ActionRow,
+                },
+            })
+        }
+        Component::Button(button) => {
+            if let Some(custom_id) = button.custom_id.as_ref() {
+                component_custom_id(custom_id)?;
+            }
+
+            if let Some(label) = button.label.as_ref() {
+                component_label(label)?;
+            }
+        }
+        Component::SelectMenu(select_menu) => {
+            component_custom_id(&select_menu.custom_id)?;
+
+            if let Some(placeholder) = select_menu.placeholder.as_ref() {
+                component_select_placeholder(placeholder)?;
+            }
+
+            component_select_options(&select_menu.options)?;
+
+            for option in &select_menu.options {
+                component_select_option_label(&option.label)?;
+                component_select_option_value(&option.value)?;
+
+                if let Some(description) = option.description.as_ref() {
+                    component_option_description(description)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate that an [`ActionRow`] does not contain too many components.
+///
+/// [`ActionRow`]s may only have so many components within it, defined by
+/// [`ComponentValidationError::ACTION_ROW_COMPONENT_COUNT`].
+///
+/// # Errors
+///
+/// Returns a [`ComponentValidationErrorType::ActionRowComponentCount`] error
+/// type if the provided list of components is too many for an [`ActionRow`].
+const fn component_action_row_components(
+    components: &[Component],
+) -> Result<(), ComponentValidationError> {
+    let count = components.len();
+
+    if count > ComponentValidationError::COMPONENT_COUNT {
+        return Err(ComponentValidationError {
+            kind: ComponentValidationErrorType::ActionRowComponentCount { count },
+        });
+    }
+
+    Ok(())
+}
+
+/// Validate that a [`Component`]s label is not too long.
+///
+/// # Errors
+///
+/// Returns a [`ComponentValidationErrorType::ComponentLabelLength`] if the
+/// provided component label is too long.
+fn component_label(label: &str) -> Result<(), ComponentValidationError> {
+    let chars = label.chars().count();
+
+    if chars > ComponentValidationError::COMPONENT_LABEL_LENGTH {
+        return Err(ComponentValidationError {
+            kind: ComponentValidationErrorType::ComponentLabelLength { chars },
+        });
+    }
+
+    Ok(())
+}
+
+/// Validate that a custom ID is not too long.
+///
+/// # Errors
+///
+/// Returns a [`ComponentValidationErrorType::ComponentCustomIdLength`] if the provided
+/// custom ID is too long.
+fn component_custom_id(custom_id: &str) -> Result<(), ComponentValidationError> {
+    let chars = custom_id.chars().count();
+
+    if chars > ComponentValidationError::COMPONENT_CUSTOM_ID_LENGTH {
+        return Err(ComponentValidationError {
+            kind: ComponentValidationErrorType::ComponentCustomIdLength { chars },
+        });
+    }
+
+    Ok(())
+}
+
+/// Validate a [`SelectMenuOption::description`]'s length.
+///
+/// # Errors
+///
+/// Returns a [`ComponentValidationErrorType::SelectOptionDescriptionLength`] if the
+/// provided select option description is too long.
+///
+/// [`SelectMenuOption::description`]: twilight_model::application::component::select_menu::SelectMenuOption::description
+fn component_option_description(description: &str) -> Result<(), ComponentValidationError> {
+    let chars = description.chars().count();
+
+    if chars > ComponentValidationError::SELECT_OPTION_DESCRIPTION_LENGTH {
+        return Err(ComponentValidationError {
+            kind: ComponentValidationErrorType::SelectOptionDescriptionLength { chars },
+        });
+    }
+
+    Ok(())
+}
+
+/// Validate a [`SelectMenuOption::label`]'s length.
+///
+/// # Errors
+///
+/// Returns a [`ComponentValidationErrorType::SelectOptionLabelLength`] if the
+/// provided select option label is too long.
+///
+/// [`SelectMenuOption::label`]: twilight_model::application::component::select_menu::SelectMenuOption::label
+fn component_select_option_label(label: &str) -> Result<(), ComponentValidationError> {
+    let chars = label.chars().count();
+
+    if chars > ComponentValidationError::SELECT_OPTION_LABEL_LENGTH {
+        return Err(ComponentValidationError {
+            kind: ComponentValidationErrorType::SelectOptionLabelLength { chars },
+        });
+    }
+
+    Ok(())
+}
+
+/// Validate a [`SelectMenuOption::value`]'s length.
+///
+/// # Errors
+///
+/// Returns a [`ComponentValidationErrorType::SelectOptionValueLength`] if the
+/// provided select option value is too long.
+///
+/// [`SelectMenuOption::value`]: twilight_model::application::component::select_menu::SelectMenuOption::value
+fn component_select_option_value(value: &str) -> Result<(), ComponentValidationError> {
+    let chars = value.chars().count();
+
+    if chars > ComponentValidationError::SELECT_OPTION_VALUE_LENGTH {
+        return Err(ComponentValidationError {
+            kind: ComponentValidationErrorType::SelectOptionValueLength { chars },
+        });
+    }
+
+    Ok(())
+}
+
+/// Validate a [`SelectMenu`]s number of [`options`].
+///
+/// [`Component::SelectMenu`]s may only have so many options within it, defined
+/// by [`ComponentValidationError::SELECT_OPTION_COUNT`].
+///
+/// # Errors
+///
+/// Returns a [`ComponentValidationErrorType::SelectOptionCount`] error type if
+/// the provided list of [`SelectMenuOption`]s is too many for a [`SelectMenu`].
+///
+/// [`SelectMenuOption`]: twilight_model::application::component::select_menu::SelectMenuOption
+/// [`SelectMenu::options`]: twilight_model::application::component::select_menu::SelectMenu::options
+/// [`SelectMenu`]: twilight_model::application::component::select_menu::SelectMenu
+const fn component_select_options(
+    options: &[SelectMenuOption],
+) -> Result<(), ComponentValidationError> {
+    let count = options.len();
+
+    if count > ComponentValidationError::SELECT_OPTION_COUNT {
+        return Err(ComponentValidationError {
+            kind: ComponentValidationErrorType::SelectOptionCount { count },
+        });
+    }
+
+    Ok(())
+}
+
+/// Validate a [`SelectMenu::placeholder`]'s length.
+///
+/// # Errors
+///
+/// Returns a [`ComponentValidationErrorType::SelectPlaceholderLength`] if the
+/// provided select placeholder is too long.
+///
+/// [`SelectMenu::placeholder`]: twilight_model::application::component::select_menu::SelectMenu::placeholder
+fn component_select_placeholder(placeholder: &str) -> Result<(), ComponentValidationError> {
+    let chars = placeholder.chars().count();
+
+    if chars > ComponentValidationError::SELECT_PLACEHOLDER_LENGTH {
+        return Err(ComponentValidationError {
+            kind: ComponentValidationErrorType::SelectPlaceholderLength { chars },
+        });
+    }
+
+    Ok(())
 }
 
 pub fn content_limit(value: impl AsRef<str>) -> bool {
@@ -459,7 +1023,44 @@ pub fn command_permissions(len: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use static_assertions::{assert_fields, assert_impl_all, const_assert_eq};
+    use std::fmt::Debug;
     use twilight_model::channel::embed::{EmbedAuthor, EmbedField, EmbedFooter};
+
+    assert_fields!(ComponentValidationErrorType::ActionRowComponentCount: count);
+    assert_fields!(ComponentValidationErrorType::ComponentCount: count);
+    assert_fields!(ComponentValidationErrorType::ComponentCustomIdLength: chars);
+    assert_fields!(ComponentValidationErrorType::ComponentLabelLength: chars);
+    assert_fields!(ComponentValidationErrorType::InvalidChildComponent: kind);
+    assert_fields!(ComponentValidationErrorType::InvalidRootComponent: kind);
+    assert_fields!(ComponentValidationErrorType::SelectOptionDescriptionLength: chars);
+    assert_fields!(ComponentValidationErrorType::SelectOptionLabelLength: chars);
+    assert_fields!(ComponentValidationErrorType::SelectOptionValueLength: chars);
+    assert_fields!(ComponentValidationErrorType::SelectPlaceholderLength: chars);
+    assert_impl_all!(ComponentValidationErrorType: Debug, Send, Sync);
+    assert_impl_all!(ComponentValidationError: Debug, Send, Sync);
+    assert_impl_all!(EmbedValidationErrorType: Debug, Send, Sync);
+    assert_impl_all!(EmbedValidationError: Debug, Send, Sync);
+    const_assert_eq!(5, ComponentValidationError::ACTION_ROW_COMPONENT_COUNT);
+    const_assert_eq!(5, ComponentValidationError::COMPONENT_COUNT);
+    const_assert_eq!(100, ComponentValidationError::COMPONENT_CUSTOM_ID_LENGTH);
+    const_assert_eq!(80, ComponentValidationError::COMPONENT_LABEL_LENGTH);
+    const_assert_eq!(25, ComponentValidationError::SELECT_OPTION_COUNT);
+    const_assert_eq!(
+        50,
+        ComponentValidationError::SELECT_OPTION_DESCRIPTION_LENGTH
+    );
+    const_assert_eq!(25, ComponentValidationError::SELECT_OPTION_LABEL_LENGTH);
+    const_assert_eq!(100, ComponentValidationError::SELECT_OPTION_VALUE_LENGTH);
+    const_assert_eq!(100, ComponentValidationError::SELECT_PLACEHOLDER_LENGTH);
+    const_assert_eq!(256, EmbedValidationError::AUTHOR_NAME_LENGTH);
+    const_assert_eq!(2048, EmbedValidationError::DESCRIPTION_LENGTH);
+    const_assert_eq!(6000, EmbedValidationError::EMBED_TOTAL_LENGTH);
+    const_assert_eq!(25, EmbedValidationError::FIELD_COUNT);
+    const_assert_eq!(256, EmbedValidationError::FIELD_NAME_LENGTH);
+    const_assert_eq!(1024, EmbedValidationError::FIELD_VALUE_LENGTH);
+    const_assert_eq!(2048, EmbedValidationError::FOOTER_TEXT_LENGTH);
+    const_assert_eq!(256, EmbedValidationError::TITLE_LENGTH);
 
     fn base_embed() -> Embed {
         Embed {

--- a/model/src/application/callback/callback_data.rs
+++ b/model/src/application/callback/callback_data.rs
@@ -1,6 +1,9 @@
-use crate::channel::{
-    embed::Embed,
-    message::{AllowedMentions, MessageFlags},
+use crate::{
+    application::component::Component,
+    channel::{
+        embed::Embed,
+        message::{AllowedMentions, MessageFlags},
+    },
 };
 
 use serde::{Deserialize, Serialize};
@@ -16,6 +19,9 @@ use serde::{Deserialize, Serialize};
 pub struct CallbackData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_mentions: Option<AllowedMentions>,
+    /// List of components to include in the callback response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub components: Option<Vec<Component>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -24,4 +30,32 @@ pub struct CallbackData {
     pub flags: Option<MessageFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tts: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CallbackData;
+    use serde::{Deserialize, Serialize};
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_fields!(
+        CallbackData: allowed_mentions,
+        components,
+        content,
+        embeds,
+        flags,
+        tts
+    );
+    assert_impl_all!(
+        CallbackData: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync
+    );
 }

--- a/model/src/application/callback/response_type.rs
+++ b/model/src/application/callback/response_type.rs
@@ -9,14 +9,85 @@ pub enum ResponseType {
     Pong = 1,
     ChannelMessageWithSource = 4,
     DeferredChannelMessageWithSource = 5,
+    /// Ack an interaction and edit the original message later.
+    ///
+    /// This is only valid for components.
+    DeferredUpdateMessage = 6,
+    /// Edit the message a component is attached to.
+    UpdateMessage = 7,
 }
 
 impl ResponseType {
+    /// Name of the variant.
+    ///
+    /// The returned name is equivalent to the variant name.
+    ///
+    /// # Examples
+    ///
+    /// Check the names of the [`Pong`] and [`UpdateMessage`] variants:
+    ///
+    /// ```
+    /// use twilight_model::application::callback::ResponseType;
+    ///
+    /// assert_eq!("Pong", ResponseType::Pong.name());
+    /// assert_eq!("UpdateMessage", ResponseType::UpdateMessage.name());
+    /// ```
+    ///
+    /// [`Pong`]: Self::Pong
+    /// [`UpdateMessage`]: Self::UpdateMessage
     pub const fn name(self) -> &'static str {
         match self {
             Self::Pong => "Pong",
             Self::ChannelMessageWithSource => "ChannelMessageWithSource",
             Self::DeferredChannelMessageWithSource => "DeferredChannelMessageWithSource",
+            Self::DeferredUpdateMessage => "DeferredUpdateMessage",
+            Self::UpdateMessage => "UpdateMessage",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ResponseType;
+    use serde::{Deserialize, Serialize};
+    use static_assertions::{assert_impl_all, const_assert_eq};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_impl_all!(
+        ResponseType: Clone,
+        Copy,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        Serialize,
+        Send,
+        Sync
+    );
+    const_assert_eq!(1, ResponseType::Pong as u8);
+    const_assert_eq!(4, ResponseType::ChannelMessageWithSource as u8);
+    const_assert_eq!(5, ResponseType::DeferredChannelMessageWithSource as u8);
+    const_assert_eq!(6, ResponseType::DeferredUpdateMessage as u8);
+    const_assert_eq!(7, ResponseType::UpdateMessage as u8);
+
+    #[test]
+    fn test_name() {
+        assert_eq!("Pong", ResponseType::Pong.name());
+        assert_eq!(
+            "ChannelMessageWithSource",
+            ResponseType::ChannelMessageWithSource.name()
+        );
+        assert_eq!(
+            "DeferredChannelMessageWithSource",
+            ResponseType::DeferredChannelMessageWithSource.name()
+        );
+        assert_eq!(
+            "DeferredUpdateMessage",
+            ResponseType::DeferredUpdateMessage.name()
+        );
+        assert_eq!("UpdateMessage", ResponseType::UpdateMessage.name());
     }
 }

--- a/model/src/application/component/action_row.rs
+++ b/model/src/application/component/action_row.rs
@@ -1,0 +1,52 @@
+use super::{Component, ComponentType};
+use serde::{
+    ser::{SerializeStruct, Serializer},
+    Deserialize, Serialize,
+};
+
+/// A non-interactive component that acts as a container for other components.
+///
+/// Refer to [Discord Docs/Message Components] for additional information.
+///
+/// [Discord Docs/Message Components]: https://discord.com/developers/docs/interactions/message-components#action-rows
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+pub struct ActionRow {
+    /// List of components in the action row.
+    pub components: Vec<Component>,
+}
+
+impl Serialize for ActionRow {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let field_count = 1 + usize::from(!self.components.is_empty());
+        let mut state = serializer.serialize_struct("ActionRow", field_count)?;
+
+        if !self.components.is_empty() {
+            state.serialize_field("components", &self.components)?;
+        }
+
+        state.serialize_field("type", &ComponentType::ActionRow)?;
+
+        state.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ActionRow;
+    use serde::{Deserialize, Serialize};
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_fields!(ActionRow: components);
+    assert_impl_all!(
+        ActionRow: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync
+    );
+}

--- a/model/src/application/component/button.rs
+++ b/model/src/application/component/button.rs
@@ -1,0 +1,220 @@
+use crate::channel::ReactionType;
+
+use super::ComponentType;
+use serde::{
+    ser::{SerializeStruct, Serializer},
+    Deserialize, Serialize,
+};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+/// Clickable interactive components that render on messages.
+///
+/// Refer to [Discord Docs/Message Components] for additional information.
+///
+/// [Discord Docs/Message Components]: https://discord.com/developers/docs/interactions/message-components#button-object-button-structure
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+pub struct Button {
+    /// User defined identifier for the button.
+    ///
+    /// This field is required when using the following [`ButtonStyle`]s:
+    ///
+    /// - [`ButtonStyle::Danger`]
+    /// - [`ButtonStyle::Primary`]
+    /// - [`ButtonStyle::Secondary`]
+    /// - [`ButtonStyle::Success`]
+    pub custom_id: Option<String>,
+    /// Whether the button is disabled.
+    ///
+    /// Defaults to `false`.
+    #[serde(default)]
+    pub disabled: bool,
+    /// Visual emoji for clients to display with the button.
+    pub emoji: Option<ReactionType>,
+    /// Text appearing on the button.
+    pub label: Option<String>,
+    /// Style variant of the button.
+    pub style: ButtonStyle,
+    /// URL for buttons of a [`ButtonStyle::Link`] style.
+    pub url: Option<String>,
+}
+
+/// Style of a [`Button`].
+///
+/// Refer to [the discord docs] for additional information.
+///
+/// [the discord docs]: https://discord.com/developers/docs/interactions/message-components#button-object-button-styles
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Serialize_repr)]
+#[repr(u8)]
+pub enum ButtonStyle {
+    /// Button indicates a primary action.
+    ///
+    /// Selecting this button style requires specifying the
+    /// [`Button::custom_id`] field.
+    Primary = 1,
+    /// Button indicates a secondary action.
+    ///
+    /// Selecting this button style requires specifying the
+    /// [`Button::custom_id`] field.
+    Secondary = 2,
+    /// Button indicates a successful action.
+    ///
+    /// Selecting this button style requires specifying the
+    /// [`Button::custom_id`] field.
+    Success = 3,
+    /// Button indicates a dangerous action.
+    ///
+    /// Selecting this button style requires specifying the
+    /// [`Button::custom_id`] field.
+    Danger = 4,
+    /// Button indicates an action with a link.
+    ///
+    /// Selecting this button style requires specifying the [`Button::url`]
+    /// field.
+    Link = 5,
+}
+
+impl Serialize for Button {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Base of 3 to account for the fields that are always present:
+        //
+        // - `disabled`
+        // - `style`
+        // - `type`
+        let field_count = 3
+            + usize::from(self.custom_id.is_some())
+            + usize::from(self.emoji.is_some())
+            + usize::from(self.label.is_some())
+            + usize::from(self.url.is_some());
+        let mut state = serializer.serialize_struct("Button", field_count)?;
+
+        if self.custom_id.is_some() {
+            state.serialize_field("custom_id", &self.custom_id)?;
+        }
+
+        state.serialize_field("disabled", &self.disabled)?;
+
+        if self.emoji.is_some() {
+            state.serialize_field("emoji", &self.emoji)?;
+        }
+
+        if self.label.is_some() {
+            state.serialize_field("label", &self.label)?;
+        }
+
+        state.serialize_field("style", &self.style)?;
+        state.serialize_field("type", &ComponentType::Button)?;
+
+        if self.url.is_some() {
+            state.serialize_field("url", &self.url)?;
+        }
+
+        state.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Required due to the use of a unicode emoji in a constant.
+    #![allow(clippy::non_ascii_literal)]
+
+    use super::{Button, ButtonStyle};
+    use crate::{application::component::ComponentType, channel::ReactionType};
+    use serde::{Deserialize, Serialize};
+    use serde_test::Token;
+    use static_assertions::{assert_fields, assert_impl_all, const_assert_eq};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_fields!(Button: custom_id, disabled, emoji, label, style, url);
+    assert_impl_all!(
+        ButtonStyle: Clone,
+        Copy,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        PartialOrd,
+        Send,
+        Serialize,
+        Sync
+    );
+    assert_impl_all!(
+        Button: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync
+    );
+    const_assert_eq!(1, ButtonStyle::Primary as u8);
+    const_assert_eq!(2, ButtonStyle::Secondary as u8);
+    const_assert_eq!(3, ButtonStyle::Success as u8);
+    const_assert_eq!(4, ButtonStyle::Danger as u8);
+    const_assert_eq!(5, ButtonStyle::Link as u8);
+
+    #[test]
+    fn test_button_style() {
+        serde_test::assert_tokens(&ButtonStyle::Primary, &[Token::U8(1)]);
+        serde_test::assert_tokens(&ButtonStyle::Secondary, &[Token::U8(2)]);
+        serde_test::assert_tokens(&ButtonStyle::Success, &[Token::U8(3)]);
+        serde_test::assert_tokens(&ButtonStyle::Danger, &[Token::U8(4)]);
+        serde_test::assert_tokens(&ButtonStyle::Link, &[Token::U8(5)]);
+    }
+
+    #[test]
+    fn test_button() {
+        // Free Palestine.
+        //
+        // Palestinian Flag.
+        const FLAG: &str = "🇵🇸";
+
+        let value = Button {
+            custom_id: Some("test".to_owned()),
+            disabled: false,
+            emoji: Some(ReactionType::Unicode {
+                name: FLAG.to_owned(),
+            }),
+            label: Some("Test".to_owned()),
+            style: ButtonStyle::Link,
+            url: Some("https://twilight.rs".to_owned()),
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "Button",
+                    len: 7,
+                },
+                Token::String("custom_id"),
+                Token::Some,
+                Token::String("test"),
+                Token::String("disabled"),
+                Token::Bool(false),
+                Token::String("emoji"),
+                Token::Some,
+                Token::Struct {
+                    name: "ReactionType",
+                    len: 1,
+                },
+                Token::String("name"),
+                Token::String(FLAG),
+                Token::StructEnd,
+                Token::String("label"),
+                Token::Some,
+                Token::String("Test"),
+                Token::String("style"),
+                Token::U8(ButtonStyle::Link as u8),
+                Token::String("type"),
+                Token::U8(ComponentType::Button as u8),
+                Token::String("url"),
+                Token::Some,
+                Token::String("https://twilight.rs"),
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/application/component/kind.rs
+++ b/model/src/application/component/kind.rs
@@ -1,0 +1,100 @@
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+/// Type of Component.
+///
+/// Refer to [Discord Docs/Message Components] for more information.
+///
+/// [Discord Docs/Message Components]: https://discord.com/developers/docs/interactions/message-components#component-types
+#[derive(
+    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
+)]
+#[repr(u8)]
+pub enum ComponentType {
+    /// Component is an [`ActionRow`].
+    ///
+    /// [`ActionRow`]: super::ActionRow
+    ActionRow = 1,
+
+    /// Component is an [`Button`].
+    ///
+    /// [`Button`]: super::Button
+    Button = 2,
+
+    /// Component is an [`SelectMenu`].
+    ///
+    /// [`SelectMenu`]: super::SelectMenu
+    SelectMenu = 3,
+}
+
+impl ComponentType {
+    /// Name of the component type.
+    ///
+    /// Variants have a name equivalent to the variant name itself.
+    ///
+    /// # Examples
+    ///
+    /// Check the [`ActionRow`] variant's name:
+    ///
+    /// ```
+    /// use twilight_model::application::component::ComponentType;
+    ///
+    /// assert_eq!("ActionRow", ComponentType::ActionRow.name());
+    /// ```
+    ///
+    /// [`ActionRow`]: Self::ActionRow
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::ActionRow => "ActionRow",
+            Self::Button => "Button",
+            Self::SelectMenu => "SelectMenu",
+        }
+    }
+}
+
+impl Display for ComponentType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str(self.name())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ComponentType;
+    use serde::{Deserialize, Serialize};
+    use serde_test::Token;
+    use static_assertions::{assert_impl_all, const_assert_eq};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_impl_all!(
+        ComponentType: Clone,
+        Copy,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        Send,
+        Serialize,
+        Sync
+    );
+    const_assert_eq!(1, ComponentType::ActionRow as u8);
+    const_assert_eq!(2, ComponentType::Button as u8);
+    const_assert_eq!(3, ComponentType::SelectMenu as u8);
+
+    #[test]
+    fn test_variants() {
+        serde_test::assert_tokens(&ComponentType::ActionRow, &[Token::U8(1)]);
+        serde_test::assert_tokens(&ComponentType::Button, &[Token::U8(2)]);
+        serde_test::assert_tokens(&ComponentType::SelectMenu, &[Token::U8(3)]);
+    }
+
+    #[test]
+    fn test_names() {
+        assert_eq!("ActionRow", ComponentType::ActionRow.name());
+        assert_eq!("Button", ComponentType::Button.name());
+        assert_eq!("SelectMenu", ComponentType::SelectMenu.name());
+    }
+}

--- a/model/src/application/component/mod.rs
+++ b/model/src/application/component/mod.rs
@@ -1,0 +1,171 @@
+//! Types for Message [`Component`] support.
+//!
+//! Message components are a Discord API framework for adding interactive
+//! elements to created [`Message`]s.
+//!
+//! Refer to [Discord Docs/Message Components] for additional information.
+//!
+//! [`Message`]: crate::channel::Message
+//! [Discord Docs/Message Components]: https://discord.com/developers/docs/interactions/message-components
+
+pub mod action_row;
+pub mod button;
+pub mod select_menu;
+
+mod kind;
+
+pub use self::{
+    action_row::ActionRow, button::Button, kind::ComponentType, select_menu::SelectMenu,
+};
+
+use serde::{Deserialize, Serialize};
+
+/// Interactive element of a message that an application uses.
+///
+/// Refer to [Discord Docs/Message Components] for additional information.
+///
+/// [Discord Docs/Message Components]: https://discord.com/developers/docs/interactions/message-components#what-are-components
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum Component {
+    ActionRow(ActionRow),
+    Button(Button),
+    SelectMenu(SelectMenu),
+}
+
+impl Component {
+    /// Type of component that this is.
+    ///
+    /// ```
+    /// use twilight_model::application::component::{
+    ///     button::{ButtonStyle, Button},
+    ///     ComponentType,
+    ///     Component,
+    /// };
+    ///
+    /// let component = Component::Button(Button {
+    ///     custom_id: None,
+    ///     disabled: false,
+    ///     emoji: None,
+    ///     label: Some("ping".to_owned()),
+    ///     style: ButtonStyle::Primary,
+    ///     url: None,
+    /// });
+    ///
+    /// assert_eq!(ComponentType::Button, component.kind());
+    /// ```
+    pub const fn kind(&self) -> ComponentType {
+        match self {
+            Self::ActionRow(_) => ComponentType::ActionRow,
+            Self::Button(_) => ComponentType::Button,
+            Self::SelectMenu(_) => ComponentType::SelectMenu,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        button::{Button, ButtonStyle},
+        select_menu::{SelectMenu, SelectMenuOption},
+        ActionRow, Component, ComponentType,
+    };
+    use serde_test::Token;
+
+    #[test]
+    fn test_component_full() {
+        let component = Component::ActionRow(ActionRow {
+            components: Vec::from([
+                Component::Button(Button {
+                    style: ButtonStyle::Primary,
+                    emoji: None,
+                    label: Some("test label".into()),
+                    custom_id: Some("test custom id".into()),
+                    url: None,
+                    disabled: false,
+                }),
+                Component::SelectMenu(SelectMenu {
+                    custom_id: "test custom id 2".into(),
+                    placeholder: Some("test placeholder".into()),
+                    min_values: Some(5),
+                    max_values: Some(25),
+                    options: Vec::from([SelectMenuOption {
+                        label: "test option label".into(),
+                        value: "test option value".into(),
+                        description: Some("test description".into()),
+                        emoji: None,
+                        default: false,
+                    }]),
+                }),
+            ]),
+        });
+
+        serde_test::assert_tokens(
+            &component,
+            &[
+                Token::Struct {
+                    name: "ActionRow",
+                    len: 2,
+                },
+                Token::Str("components"),
+                Token::Seq { len: Some(2) },
+                Token::Struct {
+                    name: "Button",
+                    len: 5,
+                },
+                Token::Str("custom_id"),
+                Token::Some,
+                Token::Str("test custom id"),
+                Token::Str("disabled"),
+                Token::Bool(false),
+                Token::Str("label"),
+                Token::Some,
+                Token::Str("test label"),
+                Token::Str("style"),
+                Token::U8(ButtonStyle::Primary as u8),
+                Token::Str("type"),
+                Token::U8(ComponentType::Button as u8),
+                Token::StructEnd,
+                Token::Struct {
+                    name: "SelectMenu",
+                    len: 6,
+                },
+                Token::Str("custom_id"),
+                Token::Str("test custom id 2"),
+                Token::Str("max_values"),
+                Token::Some,
+                Token::U8(25),
+                Token::Str("min_values"),
+                Token::Some,
+                Token::U8(5),
+                Token::Str("options"),
+                Token::Seq { len: Some(1) },
+                Token::Struct {
+                    name: "SelectMenuOption",
+                    len: 4,
+                },
+                Token::Str("default"),
+                Token::Bool(false),
+                Token::Str("description"),
+                Token::Some,
+                Token::Str("test description"),
+                Token::Str("label"),
+                Token::Str("test option label"),
+                Token::Str("value"),
+                Token::Str("test option value"),
+                Token::StructEnd,
+                Token::SeqEnd,
+                Token::Str("placeholder"),
+                Token::Some,
+                Token::Str("test placeholder"),
+                Token::Str("type"),
+                Token::U8(ComponentType::SelectMenu as u8),
+                Token::StructEnd,
+                Token::SeqEnd,
+                Token::Str("type"),
+                Token::U8(1),
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/application/component/mod.rs
+++ b/model/src/application/component/mod.rs
@@ -163,7 +163,7 @@ mod tests {
                 Token::StructEnd,
                 Token::SeqEnd,
                 Token::Str("type"),
-                Token::U8(1),
+                Token::U8(ComponentType::ActionRow as u8),
                 Token::StructEnd,
             ],
         );

--- a/model/src/application/component/select_menu.rs
+++ b/model/src/application/component/select_menu.rs
@@ -1,0 +1,121 @@
+use serde::{
+    ser::{SerializeStruct, Serializer},
+    Deserialize, Serialize,
+};
+
+use super::ComponentType;
+use crate::channel::ReactionType;
+
+/// Dropdown-style interactive components that render on messages.
+///
+/// Refer to [Discord Docs/Message Components] for additional information.
+///
+/// [Discord Docs/Message Components]: https://discord.com/developers/docs/interactions/message-components#select-menus
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+pub struct SelectMenu {
+    /// Developer defined identifier.
+    pub custom_id: String,
+    /// Maximum number of options that may be chosen.
+    pub max_values: Option<u8>,
+    /// Minimum number of options that must be chosen.
+    pub min_values: Option<u8>,
+    /// List of available choices.
+    pub options: Vec<SelectMenuOption>,
+    /// Custom placeholder text if no option is selected.
+    pub placeholder: Option<String>,
+}
+
+/// Dropdown options that are part of [`SelectMenu`].
+///
+/// Refer to [Discord Docs/Message Components] for additional information.
+///
+/// [Discord Docs/Message Components]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct SelectMenuOption {
+    /// Whether the option will be selected by default.
+    #[serde(default)]
+    pub default: bool,
+    /// Additional description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub emoji: Option<ReactionType>,
+    /// User-facing name.
+    pub label: String,
+    /// Developer defined value.
+    pub value: String,
+}
+
+impl Serialize for SelectMenu {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Base of 3 to account for the fields that are always present:
+        //
+        // - `custom_id`
+        // - `options`
+        // - `type`
+        let field_count = 3
+            + usize::from(self.placeholder.is_some())
+            + usize::from(self.min_values.is_some())
+            + usize::from(self.max_values.is_some());
+        let mut state = serializer.serialize_struct("SelectMenu", field_count)?;
+
+        state.serialize_field("custom_id", &self.custom_id)?;
+
+        if self.max_values.is_some() {
+            state.serialize_field("max_values", &self.max_values)?;
+        }
+
+        if self.min_values.is_some() {
+            state.serialize_field("min_values", &self.min_values)?;
+        }
+
+        state.serialize_field("options", &self.options)?;
+
+        if self.placeholder.is_some() {
+            state.serialize_field("placeholder", &self.placeholder)?;
+        }
+
+        state.serialize_field("type", &ComponentType::SelectMenu)?;
+
+        state.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SelectMenu, SelectMenuOption};
+    use serde::{Deserialize, Serialize};
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_fields!(SelectMenuOption: default, description, emoji, label, value);
+    assert_fields!(
+        SelectMenu: custom_id,
+        max_values,
+        min_values,
+        options,
+        placeholder
+    );
+    assert_impl_all!(
+        SelectMenuOption: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync
+    );
+    assert_impl_all!(
+        SelectMenu: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync
+    );
+}

--- a/model/src/application/interaction/interaction_type.rs
+++ b/model/src/application/interaction/interaction_type.rs
@@ -15,6 +15,10 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 pub enum InteractionType {
     Ping = 1,
     ApplicationCommand = 2,
+    /// Interaction involves a message [`Component`].
+    ///
+    /// [`Component`]: super::super::component::Component
+    MessageComponent = 3,
 }
 
 impl InteractionType {
@@ -22,6 +26,7 @@ impl InteractionType {
         match self {
             Self::Ping => "Ping",
             Self::ApplicationCommand => "ApplicationCommand",
+            Self::MessageComponent => "MessageComponent",
         }
     }
 }
@@ -46,7 +51,60 @@ impl TryFrom<u8> for InteractionType {
         match i {
             1 => Ok(Self::Ping),
             2 => Ok(Self::ApplicationCommand),
+            3 => Ok(Self::MessageComponent),
             other => Err(UnknownInteractionTypeError { value: other }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InteractionType, UnknownInteractionTypeError};
+    use serde::{Deserialize, Serialize};
+    use static_assertions::{assert_impl_all, const_assert_eq};
+    use std::{convert::TryFrom, fmt::Debug, hash::Hash};
+
+    assert_impl_all!(
+        InteractionType: Clone,
+        Copy,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        Serialize,
+        Send,
+        Sync
+    );
+    const_assert_eq!(1, InteractionType::Ping as u8);
+    const_assert_eq!(2, InteractionType::ApplicationCommand as u8);
+    const_assert_eq!(3, InteractionType::MessageComponent as u8);
+
+    #[test]
+    fn test_kind() {
+        assert_eq!("Ping", InteractionType::Ping.kind());
+        assert_eq!(
+            "ApplicationCommand",
+            InteractionType::ApplicationCommand.kind()
+        );
+        assert_eq!("MessageComponent", InteractionType::MessageComponent.kind());
+    }
+
+    #[test]
+    fn test_try_from() -> Result<(), UnknownInteractionTypeError> {
+        assert_eq!(InteractionType::Ping, InteractionType::try_from(1)?);
+        assert_eq!(
+            InteractionType::ApplicationCommand,
+            InteractionType::try_from(2)?
+        );
+        assert_eq!(
+            InteractionType::MessageComponent,
+            InteractionType::try_from(3)?
+        );
+        assert!(InteractionType::try_from(u8::MAX).is_err());
+
+        Ok(())
     }
 }

--- a/model/src/application/interaction/message_component/data.rs
+++ b/model/src/application/interaction/message_component/data.rs
@@ -1,0 +1,71 @@
+use crate::application::component::ComponentType;
+use serde::{Deserialize, Serialize};
+
+/// Data received when an [`MessageComponent`] interaction is executed.
+///
+/// Refer to [the discord docs] for more information.
+///
+/// [`MessageComponent`]: crate::application::interaction::Interaction::MessageComponent
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct MessageComponentInteractionData {
+    pub custom_id: String,
+    pub component_type: ComponentType,
+    #[serde(default)]
+    pub values: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MessageComponentInteractionData;
+    use crate::application::component::ComponentType;
+    use serde::{Deserialize, Serialize};
+    use serde_test::Token;
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_fields!(
+        MessageComponentInteractionData: custom_id,
+        component_type,
+        values
+    );
+    assert_impl_all!(
+        MessageComponentInteractionData: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync
+    );
+
+    #[test]
+    fn test_message_component_interaction_data() {
+        let value = MessageComponentInteractionData {
+            custom_id: "test".to_owned(),
+            component_type: ComponentType::Button,
+            values: Vec::from(["1".to_owned(), "2".to_owned()]),
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "MessageComponentInteractionData",
+                    len: 3,
+                },
+                Token::String("custom_id"),
+                Token::String("test"),
+                Token::String("component_type"),
+                Token::U8(ComponentType::Button as u8),
+                Token::String("values"),
+                Token::Seq { len: Some(2) },
+                Token::String("1"),
+                Token::String("2"),
+                Token::SeqEnd,
+                Token::StructEnd,
+            ],
+        )
+    }
+}

--- a/model/src/application/interaction/message_component/mod.rs
+++ b/model/src/application/interaction/message_component/mod.rs
@@ -1,0 +1,81 @@
+mod data;
+
+pub use self::data::MessageComponentInteractionData;
+
+use super::InteractionType;
+use crate::{
+    channel::Message,
+    guild::PartialMember,
+    id::{ApplicationId, ChannelId, GuildId, InteractionId},
+    user::User,
+};
+use serde::Serialize;
+
+/// Information present in an [`Interaction::MessageComponent`].
+///
+/// [`Interaction::MessageComponent`]: super::Interaction::MessageComponent
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename(serialize = "Interaction"))]
+pub struct MessageComponentInteraction {
+    /// ID of the associated application.
+    pub application_id: ApplicationId,
+    /// ID of the channel the interaction was triggered from.
+    pub channel_id: ChannelId,
+    /// Data from the invoked command.
+    pub data: MessageComponentInteractionData,
+    /// ID of the guild the interaction was triggered from.
+    pub guild_id: Option<GuildId>,
+    /// ID of the interaction.
+    pub id: InteractionId,
+    /// Type of the interaction.
+    #[serde(rename = "type")]
+    pub kind: InteractionType,
+    /// Member that triggered the interaction.
+    ///
+    /// Present when the command is used in a guild.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub member: Option<PartialMember>,
+    /// Message object for the message this button belongs to.
+    ///
+    /// This is currently *not* validated by the discord API and may be spoofed
+    /// by malicious users.
+    pub message: Message,
+    /// Token of the interaction.
+    pub token: String,
+    /// User that triggered the interaction.
+    ///
+    /// Present when the command is used in a direct message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<User>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MessageComponentInteraction;
+    use serde::Serialize;
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_fields!(
+        MessageComponentInteraction: application_id,
+        channel_id,
+        data,
+        guild_id,
+        id,
+        kind,
+        member,
+        message,
+        token,
+        user
+    );
+    assert_impl_all!(
+        MessageComponentInteraction: Clone,
+        Debug,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync
+    );
+}

--- a/model/src/application/mod.rs
+++ b/model/src/application/mod.rs
@@ -1,3 +1,4 @@
 pub mod callback;
 pub mod command;
+pub mod component;
 pub mod interaction;

--- a/model/src/channel/attachment.rs
+++ b/model/src/channel/attachment.rs
@@ -1,7 +1,7 @@
 use crate::id::AttachmentId;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Attachment {
     /// Attachment's [media type].
     ///

--- a/model/src/channel/message/interaction.rs
+++ b/model/src/channel/message/interaction.rs
@@ -1,7 +1,7 @@
 use crate::{application::interaction::InteractionType, id::InteractionId, user::User};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct MessageInteraction {
     pub id: InteractionId,
     #[serde(rename = "type")]

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -19,6 +19,7 @@ pub use self::{
 };
 
 use crate::{
+    application::component::Component,
     channel::{embed::Embed, Attachment, ChannelMention},
     guild::PartialMember,
     id::{ApplicationId, ChannelId, GuildId, MessageId, RoleId, WebhookId},
@@ -26,7 +27,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Message {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub activity: Option<MessageActivity>,
@@ -40,6 +41,9 @@ pub struct Message {
     pub attachments: Vec<Attachment>,
     pub author: User,
     pub channel_id: ChannelId,
+    /// List of provided message components.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub components: Vec<Component>,
     pub content: String,
     pub edited_timestamp: Option<String>,
     pub embeds: Vec<Embed>,
@@ -118,6 +122,7 @@ mod tests {
                 verified: None,
             },
             channel_id: ChannelId(2),
+            components: Vec::new(),
             content: "ping".to_owned(),
             edited_timestamp: None,
             embeds: Vec::new(),
@@ -311,6 +316,7 @@ mod tests {
                 verified: None,
             },
             channel_id: ChannelId(2),
+            components: Vec::new(),
             content: "ping".to_owned(),
             edited_timestamp: Some("123".to_owned()),
             embeds: Vec::new(),

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -911,6 +911,7 @@ mod tests {
                 verified: None,
             },
             channel_id: ChannelId(1),
+            components: Vec::new(),
             content: "test".to_owned(),
             edited_timestamp: None,
             embeds: Vec::new(),


### PR DESCRIPTION
**PR note**: would be nice to have people test this PR. I have not done much of it myself, mostly adding documentation and tests to previous work.

Add support for the new Message Components[1] Discord API framework. This work includes support for the Action Row[2], Button[3], and Select Menu[4] components.

Requests that can have message components attached to them have new `components` methods, which return errors that can have `ComponentCount` and `ComponentInvalid` variants, which correlate to specifying either too many components or a component being invalid with a reason why, respectively.

One issue with this implementation is that the `InteractionVisitor` for `Interaction`'s `Deserialize` implementation uses `serde_value::Value`, but this can be resolved with another PR and will most likely require a dedicated deserializer like with gateway events.

This is the culmination of work done by @AEnterprise, @AsianIntel, and myself.

Closes #835 and #1003.

[1]: https://discord.com/developers/docs/interactions/message-components
[2]: https://discord.com/developers/docs/interactions/message-components#action-rows
[3]: https://discord.com/developers/docs/interactions/message-components#buttons
[4]: https://discord.com/developers/docs/interactions/message-components#select-menus