### PR TITLE
Add concrete cluster events type

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -1,13 +1,13 @@
 use super::{
     config::Config as ClusterConfig,
+    event::Events,
     r#impl::{Cluster, ClusterStartError},
     scheme::ShardScheme,
 };
 use crate::{
     shard::{LargeThresholdError, ResumeSession, ShardBuilder},
-    Event, EventTypeFlags,
+    EventTypeFlags,
 };
-use futures_util::stream::Stream;
 use std::{collections::HashMap, sync::Arc};
 use twilight_gateway_queue::{LocalQueue, Queue};
 use twilight_http::Client;
@@ -81,7 +81,7 @@ impl ClusterBuilder {
     ) -> Result<
         (
             Cluster,
-            impl Stream<Item = (u64, Event)> + Send + Sync + Unpin + 'static,
+            Events,
         ),
         ClusterStartError,
     > {

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -76,15 +76,7 @@ impl ClusterBuilder {
     /// there was an HTTP error Retrieving the gateway information.
     ///
     /// [`ClusterStartErrorType::RetrievingGatewayInfo`]: super::ClusterStartErrorType::RetrievingGatewayInfo
-    pub async fn build(
-        mut self,
-    ) -> Result<
-        (
-            Cluster,
-            Events,
-        ),
-        ClusterStartError,
-    > {
+    pub async fn build(mut self) -> Result<(Cluster, Events), ClusterStartError> {
         if (self.1).0.gateway_url.is_none() {
             let gateway_url = (self.1)
                 .0

--- a/gateway/src/cluster/event.rs
+++ b/gateway/src/cluster/event.rs
@@ -1,0 +1,93 @@
+//! Events that the cluster emits to event streams.
+//!
+//! Included is the larger [`Event`] exposed to event streams. It contains
+//! variants with all of the possible events that can come in: new channels,
+//! heartbeat acknowledgements, "meta" events of when a shard disconnects or
+//! connects, etc.
+//!
+//! Also included is the [`EventType`] bitflags, which can be used to identify
+//! the type of an event and to filter events from event streams via
+//! [`ClusterBuilder::event_types`].
+//!
+//! [`EventType`]: ::twilight_model::gateway::event::EventType
+//! [`ClusterBuilder::event_types`]: crate::cluster::ClusterBuilder::event_types
+
+use crate::shard::Events as ShardEvents;
+use futures_util::stream::{SelectAll, Stream};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use twilight_model::gateway::event::Event;
+
+/// Stream of events from a [`Cluster`].
+///
+/// Unlike the shard's [`Events`] stream this does not include the event types
+/// that may produce events; refer to the event types of each individual shard
+/// for their event types.
+///
+/// This implements [`futures_util::stream::Stream`].
+///
+/// # Examples
+///
+/// Refer to [`Cluster`] for an example of how to use this.
+///
+/// [`Cluster`]: super::Cluster
+/// [`Events`]: crate::shard::Events
+#[derive(Debug)]
+pub struct Events {
+    stream: SelectAll<ShardEventsWithId>,
+}
+
+impl Events {
+    /// Create a new stream of shards' events.
+    pub(super) const fn new(stream: SelectAll<ShardEventsWithId>) -> Self {
+        Self { stream }
+    }
+}
+
+impl Stream for Events {
+    type Item = (u64, Event);
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.stream).poll_next(cx)
+    }
+}
+
+/// Poll a shard's [`Events`] stream, mapping the result to the shard's ID.
+///
+/// [`Events`]: crate::shard::Events
+#[derive(Debug)]
+pub struct ShardEventsWithId {
+    id: u64,
+    stream: ShardEvents,
+}
+
+impl ShardEventsWithId {
+    /// Create a new stream with shard's ID and event stream.
+    pub(super) const fn new(id: u64, stream: ShardEvents) -> Self {
+        Self { id, stream }
+    }
+}
+
+impl Stream for ShardEventsWithId {
+    type Item = (u64, Event);
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.stream).poll_next(cx) {
+            Poll::Ready(Some(event)) => Poll::Ready(Some((self.id, event))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Events;
+    use futures_util::stream::Stream;
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(Events: Debug, Send, Stream, Sync);
+}

--- a/gateway/src/cluster/event.rs
+++ b/gateway/src/cluster/event.rs
@@ -9,7 +9,7 @@
 //! the type of an event and to filter events from event streams via
 //! [`ClusterBuilder::event_types`].
 //!
-//! [`EventType`]: ::twilight_model::gateway::event::EventType
+//! [`EventType`]: twilight_model::gateway::event::EventType
 //! [`ClusterBuilder::event_types`]: crate::cluster::ClusterBuilder::event_types
 
 use crate::shard::Events as ShardEvents;

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -1,9 +1,10 @@
 use super::{builder::ClusterBuilder, config::Config, event::Events, scheme::ShardScheme};
-use crate::{Intents, cluster::event::ShardEventsWithId, shard::{raw_message::Message, Information, ResumeSession, Shard}};
-use futures_util::{
-    future,
-    stream::SelectAll,
+use crate::{
+    cluster::event::ShardEventsWithId,
+    shard::{raw_message::Message, Information, ResumeSession, Shard},
+    Intents,
 };
+use futures_util::{future, stream::SelectAll};
 use std::{
     collections::HashMap,
     error::Error,
@@ -290,25 +291,13 @@ impl Cluster {
     pub async fn new(
         token: impl Into<String>,
         intents: Intents,
-    ) -> Result<
-        (
-            Self,
-            Events,
-        ),
-        ClusterStartError,
-    > {
+    ) -> Result<(Self, Events), ClusterStartError> {
         Self::builder(token, intents).build().await
     }
 
     pub(super) async fn new_with_config(
         mut config: Config,
-    ) -> Result<
-        (
-            Self,
-            Events,
-        ),
-        ClusterStartError,
-    > {
+    ) -> Result<(Self, Events), ClusterStartError> {
         #[derive(Default)]
         struct ShardFold {
             shards: HashMap<u64, Shard>,

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -1,11 +1,8 @@
-use super::{builder::ClusterBuilder, config::Config, scheme::ShardScheme};
-use crate::{
-    shard::{raw_message::Message, Events, Information, ResumeSession, Shard},
-    Intents,
-};
+use super::{builder::ClusterBuilder, config::Config, event::Events, scheme::ShardScheme};
+use crate::{Intents, cluster::event::ShardEventsWithId, shard::{raw_message::Message, Information, ResumeSession, Shard}};
 use futures_util::{
     future,
-    stream::{SelectAll, Stream, StreamExt},
+    stream::SelectAll,
 };
 use std::{
     collections::HashMap,
@@ -15,7 +12,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 use twilight_http::Client as HttpClient;
-use twilight_model::gateway::event::Event;
 
 /// Sending a command to a shard failed.
 #[derive(Debug)]
@@ -297,7 +293,7 @@ impl Cluster {
     ) -> Result<
         (
             Self,
-            impl Stream<Item = (u64, Event)> + Send + Sync + Unpin + 'static,
+            Events,
         ),
         ClusterStartError,
     > {
@@ -309,14 +305,14 @@ impl Cluster {
     ) -> Result<
         (
             Self,
-            impl Stream<Item = (u64, Event)> + Send + Sync + Unpin + 'static,
+            Events,
         ),
         ClusterStartError,
     > {
         #[derive(Default)]
         struct ShardFold {
             shards: HashMap<u64, Shard>,
-            streams: Vec<(u64, Events)>,
+            streams: Vec<ShardEventsWithId>,
         }
 
         let scheme = match config.shard_scheme() {
@@ -345,17 +341,13 @@ impl Cluster {
             let (shard, stream) = Shard::new_with_config(shard_config);
 
             fold.shards.insert(idx, shard);
-            fold.streams.push((idx, stream));
+            fold.streams.push(ShardEventsWithId::new(idx, stream));
 
             fold
         });
 
-        let combined = streams
-            .into_iter()
-            .map(|(id, stream)| stream.map(move |e| (id, e)));
-
         #[allow(clippy::from_iter_instead_of_collect)]
-        let select_all = SelectAll::from_iter(combined);
+        let select_all = SelectAll::from_iter(streams);
 
         Ok((
             Self(Arc::new(ClusterRef {
@@ -364,7 +356,7 @@ impl Cluster {
                 shard_to: scheme.to().expect("shard scheme is not auto"),
                 shards: Mutex::new(shards),
             })),
-            select_all,
+            Events::new(select_all),
         ))
     }
 

--- a/gateway/src/cluster/mod.rs
+++ b/gateway/src/cluster/mod.rs
@@ -87,11 +87,13 @@ pub mod scheme;
 
 mod builder;
 mod config;
+mod event;
 mod r#impl;
 
 pub use self::{
     builder::ClusterBuilder,
     config::Config,
+    event::Events,
     r#impl::{
         Cluster, ClusterCommandError, ClusterCommandErrorType, ClusterStartError,
         ClusterStartErrorType,

--- a/gateway/src/shard/event.rs
+++ b/gateway/src/shard/event.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::wildcard_imports)]
 //! Events that the shard emits to event streams.
 //!
 //! Included is the larger [`Event`] exposed to event streams. It contains
@@ -37,6 +36,7 @@ use twilight_model::gateway::event::Event;
 /// [`Events::event_types`]: Self::event_types
 /// [`Shard`]: super::Shard
 /// [`futures::stream::Stream`]: https://docs.rs/futures/*/futures/stream/trait.Stream.html
+#[derive(Debug)]
 pub struct Events {
     event_types: EventTypeFlags,
     rx: UnboundedReceiver<Event>,
@@ -66,6 +66,7 @@ mod tests {
     use super::Events;
     use futures_util::stream::Stream;
     use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
 
-    assert_impl_all!(Events: Send, Stream, Sync);
+    assert_impl_all!(Events: Debug, Send, Stream, Sync);
 }


### PR DESCRIPTION
Add a concrete `cluster::Events` type wrapping a `SelectAll` of the shards' events. Like the previous cluster events stream the `Events` type is `Send` and `Sync` and returns `Stream` items with a type of `(u64, Event)`.

This is useful for being able to name the return type.