### PR TITLE
Update embed description limit to 4096

### DIFF
--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -105,7 +105,7 @@ pub enum EmbedErrorType {
         /// included.
         description: String,
     },
-    /// Description is longer than 2048 UTF-16 code points.
+    /// Description is longer than 4096 UTF-16 code points.
     DescriptionTooLong {
         /// Provided description.
         description: String,
@@ -200,7 +200,7 @@ impl EmbedBuilder {
     pub const COLOR_MAXIMUM: u32 = 0xff_ff_ff;
 
     /// The maximum number of UTF-16 code points that can be in a description.
-    pub const DESCRIPTION_LENGTH_LIMIT: usize = 2048;
+    pub const DESCRIPTION_LENGTH_LIMIT: usize = 4096;
 
     /// The maximum number of fields that can be in an embed.
     pub const EMBED_FIELD_LIMIT: usize = 25;
@@ -776,7 +776,7 @@ mod tests {
     assert_impl_all!(EmbedError: Error, Send, Sync);
     const_assert!(EmbedBuilder::AUTHOR_NAME_LENGTH_LIMIT == 256);
     const_assert!(EmbedBuilder::COLOR_MAXIMUM == 0xff_ff_ff);
-    const_assert!(EmbedBuilder::DESCRIPTION_LENGTH_LIMIT == 2048);
+    const_assert!(EmbedBuilder::DESCRIPTION_LENGTH_LIMIT == 4096);
     const_assert!(EmbedBuilder::EMBED_FIELD_LIMIT == 25);
     const_assert!(EmbedBuilder::EMBED_LENGTH_LIMIT == 6000);
     const_assert!(EmbedBuilder::FIELD_NAME_LENGTH_LIMIT == 256);

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -24,7 +24,7 @@ impl EmbedValidationError {
     pub const AUTHOR_NAME_LENGTH: usize = 256;
 
     /// The maximum embed description length in codepoints.
-    pub const DESCRIPTION_LENGTH: usize = 2048;
+    pub const DESCRIPTION_LENGTH: usize = 4096;
 
     /// The maximum combined embed length in codepoints.
     pub const EMBED_TOTAL_LENGTH: usize = 6000;
@@ -562,10 +562,13 @@ mod tests {
         embed.description.replace(str::repeat("a", 2048));
         assert!(super::embed(&embed).is_ok());
 
-        embed.description.replace(str::repeat("a", 2049));
+        embed.description.replace(str::repeat("a", 4096));
+        assert!(super::embed(&embed).is_ok());
+
+        embed.description.replace(str::repeat("a", 4097));
         assert!(matches!(
             super::embed(&embed).unwrap_err().kind(),
-            EmbedValidationErrorType::DescriptionTooLarge { chars: 2049 }
+            EmbedValidationErrorType::DescriptionTooLarge { chars: 4097 }
         ));
     }
 


### PR DESCRIPTION
Update the embed description length limit in the EmbedBuilder and in `request::validate` from 2048 to 4096.

Closes #991.