### PR TITLE
Remove thread metadata `archiver_id` field

### DIFF
--- a/cache/in-memory/src/event/guild.rs
+++ b/cache/in-memory/src/event/guild.rs
@@ -247,7 +247,6 @@ mod tests {
             member_count: 0,
             thread_metadata: ThreadMetadata {
                 archived: false,
-                archiver_id: None,
                 auto_archive_duration: AutoArchiveDuration::Hour,
                 archive_timestamp: "".to_string(),
                 locked: false,

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -957,7 +957,6 @@ mod tests {
             rate_limit_per_user: Some(1000_u64),
             thread_metadata: ThreadMetadata {
                 archived: false,
-                archiver_id: Some(UserId(5)),
                 auto_archive_duration: AutoArchiveDuration::Day,
                 archive_timestamp: "archivetimestamp".into(),
                 locked: false,
@@ -986,7 +985,6 @@ mod tests {
                 "thread_metadata": {
                     "archive_timestamp": "archivetimestamp",
                     "archived": false,
-                    "archiver_id": "5",
                     "auto_archive_duration": AutoArchiveDuration::Day,
                     "locked": false
                 }
@@ -1016,7 +1014,6 @@ mod tests {
             rate_limit_per_user: Some(1000_u64),
             thread_metadata: ThreadMetadata {
                 archived: false,
-                archiver_id: Some(UserId(5)),
                 auto_archive_duration: AutoArchiveDuration::Day,
                 archive_timestamp: "archivetimestamp".into(),
                 locked: false,
@@ -1045,7 +1042,6 @@ mod tests {
                 "thread_metadata": {
                     "archive_timestamp": "archivetimestamp",
                     "archived": false,
-                    "archiver_id": "5",
                     "auto_archive_duration": AutoArchiveDuration::Day,
                     "locked": false
                 }
@@ -1075,7 +1071,6 @@ mod tests {
             rate_limit_per_user: Some(1000_u64),
             thread_metadata: ThreadMetadata {
                 archived: false,
-                archiver_id: Some(UserId(5)),
                 auto_archive_duration: AutoArchiveDuration::Day,
                 archive_timestamp: "archivetimestamp".into(),
                 locked: false,
@@ -1109,7 +1104,6 @@ mod tests {
                 "thread_metadata": {
                     "archive_timestamp": "archivetimestamp",
                     "archived": false,
-                    "archiver_id": "5",
                     "auto_archive_duration": AutoArchiveDuration::Day,
                     "locked": false
                 },

--- a/model/src/channel/thread/metadata.rs
+++ b/model/src/channel/thread/metadata.rs
@@ -1,4 +1,4 @@
-use crate::{channel::thread::AutoArchiveDuration, id::UserId};
+use super::AutoArchiveDuration;
 use serde::{Deserialize, Serialize};
 
 /// The thread metadata object contains a number of thread-specific channel fields
@@ -6,8 +6,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ThreadMetadata {
     pub archived: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub archiver_id: Option<UserId>,
     pub auto_archive_duration: AutoArchiveDuration,
     pub archive_timestamp: String,
     #[serde(default)]
@@ -16,14 +14,13 @@ pub struct ThreadMetadata {
 
 #[cfg(test)]
 mod tests {
-    use super::{AutoArchiveDuration, ThreadMetadata, UserId};
+    use super::{AutoArchiveDuration, ThreadMetadata};
     use serde_test::Token;
 
     #[test]
     fn test_thread_metadata() {
         let value = ThreadMetadata {
             archived: true,
-            archiver_id: Some(UserId(1)),
             auto_archive_duration: AutoArchiveDuration::Day,
             archive_timestamp: "123".to_owned(),
             locked: false,
@@ -34,14 +31,10 @@ mod tests {
             &[
                 Token::Struct {
                     name: "ThreadMetadata",
-                    len: 5,
+                    len: 4,
                 },
                 Token::Str("archived"),
                 Token::Bool(true),
-                Token::Str("archiver_id"),
-                Token::Some,
-                Token::NewtypeStruct { name: "UserId" },
-                Token::Str("1"),
                 Token::Str("auto_archive_duration"),
                 Token::U16(1440),
                 Token::Str("archive_timestamp"),

--- a/model/src/channel/thread/news.rs
+++ b/model/src/channel/thread/news.rs
@@ -58,7 +58,6 @@ mod tests {
             rate_limit_per_user: Some(8),
             thread_metadata: ThreadMetadata {
                 archived: true,
-                archiver_id: Some(UserId(9)),
                 auto_archive_duration: AutoArchiveDuration::Hour,
                 archive_timestamp: "123".to_string(),
                 locked: true,
@@ -124,14 +123,10 @@ mod tests {
                 Token::Str("thread_metadata"),
                 Token::Struct {
                     name: "ThreadMetadata",
-                    len: 5,
+                    len: 4,
                 },
                 Token::Str("archived"),
                 Token::Bool(true),
-                Token::Str("archiver_id"),
-                Token::Some,
-                Token::NewtypeStruct { name: "UserId" },
-                Token::Str("9"),
                 Token::Str("auto_archive_duration"),
                 Token::U16(60),
                 Token::Str("archive_timestamp"),

--- a/model/src/channel/thread/private.rs
+++ b/model/src/channel/thread/private.rs
@@ -61,7 +61,6 @@ mod tests {
             permission_overwrites: Vec::new(),
             thread_metadata: ThreadMetadata {
                 archived: true,
-                archiver_id: Some(UserId(9)),
                 auto_archive_duration: AutoArchiveDuration::Hour,
                 archive_timestamp: "123".to_string(),
                 locked: true,
@@ -130,14 +129,10 @@ mod tests {
                 Token::Str("thread_metadata"),
                 Token::Struct {
                     name: "ThreadMetadata",
-                    len: 5,
+                    len: 4,
                 },
                 Token::Str("archived"),
                 Token::Bool(true),
-                Token::Str("archiver_id"),
-                Token::Some,
-                Token::NewtypeStruct { name: "UserId" },
-                Token::Str("9"),
                 Token::Str("auto_archive_duration"),
                 Token::U16(60),
                 Token::Str("archive_timestamp"),

--- a/model/src/channel/thread/public.rs
+++ b/model/src/channel/thread/public.rs
@@ -58,7 +58,6 @@ mod tests {
             rate_limit_per_user: Some(8),
             thread_metadata: ThreadMetadata {
                 archived: true,
-                archiver_id: Some(UserId(9)),
                 auto_archive_duration: AutoArchiveDuration::Hour,
                 archive_timestamp: "123".to_string(),
                 locked: true,
@@ -124,14 +123,10 @@ mod tests {
                 Token::Str("thread_metadata"),
                 Token::Struct {
                     name: "ThreadMetadata",
-                    len: 5,
+                    len: 4,
                 },
                 Token::Str("archived"),
                 Token::Bool(true),
-                Token::Str("archiver_id"),
-                Token::Some,
-                Token::NewtypeStruct { name: "UserId" },
-                Token::Str("9"),
                 Token::Str("auto_archive_duration"),
                 Token::U16(60),
                 Token::Str("archive_timestamp"),


### PR DESCRIPTION
Remove the `channel::thread::ThreadMetadata::archiver_id` field, which is no longer available per the API docs: <https://github.com/discord/discord-api-docs/commit/82c98ba5699b69706cfb493a7c6e08b67ae1a8f3>

Closes #974.