### PR TITLE
Update `tokio-tungstenite` to 0.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on: [push, pull_request]
 
 env:
-  minrust: 1.49.0
+  minrust: 1.51.0
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ functionality. Please use the individual crates listed below instead!
 
 ## Installation
 
-Twilight supports a MSRV of Rust 1.49+.
+Twilight supports a MSRV of Rust 1.51+.
 
 We recommend that most users start out with these crates added to your
 `Cargo.toml`'s `[dependencies]` section:
@@ -223,7 +223,7 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png
-[rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
 [`twilight-cache-inmemory`]: https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html
 [`twilight-command-parser`]: https://twilight.rs/chapter_1_crates/section_5_command_parser.html

--- a/cache/in-memory/README.md
+++ b/cache/in-memory/README.md
@@ -43,6 +43,6 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -57,7 +57,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(

--- a/command-parser/README.md
+++ b/command-parser/README.md
@@ -52,7 +52,7 @@ match parser.parse("!echo a message") {
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 [`twilight-rs`]: https://github.com/twilight-rs/twilight
 
 <!-- cargo-sync-readme end -->

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -50,7 +50,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 //! [`twilight-rs`]: https://github.com/twilight-rs/twilight
 
 #![deny(

--- a/embed-builder/README.md
+++ b/embed-builder/README.md
@@ -41,7 +41,7 @@ let embed = EmbedBuilder::new()
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 [the discord docs]: https://discord.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
 
 <!-- cargo-sync-readme end -->

--- a/embed-builder/src/lib.rs
+++ b/embed-builder/src/lib.rs
@@ -43,7 +43,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 //! [the discord docs]: https://discord.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
 
 #![deny(

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.5.4"
 
 [dependencies]
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.14" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.15" }
 bitflags = { default-features = false, version = "1" }
 twilight-gateway-queue = { default-features = false, path = "./queue" }
 twilight-http = { default-features = false, path = "../http" }

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -116,6 +116,6 @@ This is disabled by default.
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -114,7 +114,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/http/README.md
+++ b/http/README.md
@@ -80,6 +80,6 @@ This is enabled by default.
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -78,7 +78,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.5.2"
 
 [dependencies]
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.14" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.15" }
 dashmap = { default-features = false, version = "4.0" }
 futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }
 http = { default-features = false, optional = true, version = "0.2" }

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -108,6 +108,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [node]: Node
 [process]: Lavalink::process
-[rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -106,7 +106,7 @@
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [node]: Node
 //! [process]: Lavalink::process
-//! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/mention/README.md
+++ b/mention/README.md
@@ -29,6 +29,6 @@ let message = format!("Hey there, {}!", user_id.mention());
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/mention/src/lib.rs
+++ b/mention/src/lib.rs
@@ -27,7 +27,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/model/README.md
+++ b/model/README.md
@@ -35,6 +35,6 @@ or extended by other crates.
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -33,7 +33,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     clippy::all,

--- a/standby/README.md
+++ b/standby/README.md
@@ -126,6 +126,6 @@ For more examples, check out each of the methods on [`Standby`].
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 <!-- cargo-sync-readme end -->

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -126,7 +126,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 
 #![deny(
     broken_intra_doc_links,

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Installation
 //!
-//! Twilight supports a MSRV of Rust 1.49+.
+//! Twilight supports a MSRV of Rust 1.51+.
 //!
 //! We recommend that most users start out with these crates added to your
 //! `Cargo.toml`'s `[dependencies]` section:
@@ -223,7 +223,7 @@
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png
-//! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 //! [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
 //! [`twilight-cache-inmemory`]: https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html
 //! [`twilight-command-parser`]: https://twilight.rs/chapter_1_crates/section_5_command_parser.html

--- a/util/README.md
+++ b/util/README.md
@@ -31,7 +31,7 @@ structured information from [Discord snowflakes].
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 [Discord snowflakes]: https://discord.com/developers/docs/reference#snowflakes
 
 <!-- cargo-sync-readme end -->

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -29,7 +29,7 @@
 //! [github link]: https://github.com/twilight-rs/twilight
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-//! [rust badge]: https://img.shields.io/badge/rust-1.49+-93450a.svg?style=for-the-badge&logo=rust
+//! [rust badge]: https://img.shields.io/badge/rust-1.51+-93450a.svg?style=for-the-badge&logo=rust
 //! [Discord snowflakes]: https://discord.com/developers/docs/reference#snowflakes
 
 #![deny(


### PR DESCRIPTION
Update the `tokio-tungstenite` dependency of `gateway` and `lavalink` from 0.14 to 0.15. `tokio-tungstenite` 0.15 includes good performance improvements.

Bumps the MSRV to 1.51 due to `tokio-tungstenite`'s new MSRV of 1.51.