### PR TITLE
feat(model): bring stickers up to date

### DIFF
--- a/cache/in-memory/src/event/message.rs
+++ b/cache/in-memory/src/event/message.rs
@@ -176,7 +176,7 @@ mod tests {
             pinned: false,
             reactions: Vec::new(),
             reference: None,
-            stickers: Vec::new(),
+            sticker_items: Vec::new(),
             referenced_message: None,
             timestamp: String::new(),
             tts: false,

--- a/cache/in-memory/src/model/message.rs
+++ b/cache/in-memory/src/model/message.rs
@@ -3,8 +3,8 @@ use twilight_model::{
     channel::{
         embed::Embed,
         message::{
-            Message, MessageActivity, MessageApplication, MessageFlags, MessageReaction,
-            MessageReference, MessageType, Sticker,
+            sticker::MessageSticker, Message, MessageActivity, MessageApplication, MessageFlags,
+            MessageReaction, MessageReference, MessageType, Sticker,
         },
         Attachment, ChannelMention,
     },
@@ -60,7 +60,10 @@ pub struct CachedMessage {
     /// Message reference.
     pub reference: Option<MessageReference>,
     #[allow(missing_docs)]
+    #[deprecated(since = "0.5.2", note = "use `sticker_items`")]
     pub stickers: Vec<Sticker>,
+    /// Stickers within the message.
+    pub sticker_items: Vec<MessageSticker>,
     /// ISO 8601 timestamp of the date the message was sent.
     pub timestamp: String,
     /// Whether the message is text-to-speech.
@@ -71,6 +74,7 @@ pub struct CachedMessage {
 
 impl From<Message> for CachedMessage {
     fn from(msg: Message) -> Self {
+        #[allow(deprecated)]
         Self {
             id: msg.id,
             activity: msg.activity,
@@ -92,7 +96,8 @@ impl From<Message> for CachedMessage {
             pinned: msg.pinned,
             reactions: msg.reactions,
             reference: msg.reference,
-            stickers: msg.stickers,
+            stickers: Vec::new(),
+            sticker_items: msg.sticker_items,
             timestamp: msg.timestamp,
             tts: msg.tts,
             webhook_id: msg.webhook_id,

--- a/cache/in-memory/src/test.rs
+++ b/cache/in-memory/src/test.rs
@@ -60,7 +60,7 @@ pub fn cache_with_message_and_reactions() -> InMemoryCache {
         pinned: false,
         reactions: Vec::new(),
         reference: None,
-        stickers: Vec::new(),
+        sticker_items: Vec::new(),
         referenced_message: None,
         timestamp: String::new(),
         tts: false,

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -18,6 +18,7 @@ pub use self::{
     reaction::MessageReaction, reference::MessageReference, sticker::Sticker,
 };
 
+use self::sticker::MessageSticker;
 use crate::{
     channel::{embed::Embed, Attachment, ChannelMention},
     guild::PartialMember,
@@ -72,7 +73,7 @@ pub struct Message {
     pub referenced_message: Option<Box<Message>>,
     /// Stickers within the message.
     #[serde(default)]
-    pub stickers: Vec<Sticker>,
+    pub sticker_items: Vec<MessageSticker>,
     pub timestamp: String,
     pub tts: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -82,7 +83,7 @@ pub struct Message {
 #[cfg(test)]
 mod tests {
     use super::{
-        sticker::{Sticker, StickerFormatType, StickerId, StickerPackId},
+        sticker::{MessageSticker, StickerFormatType, StickerId},
         ChannelMention, Message, MessageActivity, MessageActivityType, MessageApplication,
         MessageFlags, MessageReaction, MessageReference, MessageType, WebhookId,
     };
@@ -143,14 +144,10 @@ mod tests {
             pinned: false,
             reactions: Vec::new(),
             reference: None,
-            stickers: vec![Sticker {
-                asset: "foo1".to_owned(),
-                description: "foo2".to_owned(),
+            sticker_items: vec![MessageSticker {
                 format_type: StickerFormatType::Png,
                 id: StickerId(1),
                 name: "sticker name".to_owned(),
-                pack_id: StickerPackId(2),
-                tags: Some("foo,bar,baz".to_owned()),
             }],
             referenced_message: None,
             timestamp: "2020-02-02T02:02:02.020000+00:00".to_owned(),
@@ -242,16 +239,12 @@ mod tests {
                 Token::SeqEnd,
                 Token::Str("pinned"),
                 Token::Bool(false),
-                Token::Str("stickers"),
+                Token::Str("sticker_items"),
                 Token::Seq { len: Some(1) },
                 Token::Struct {
-                    name: "Sticker",
-                    len: 7,
+                    name: "MessageSticker",
+                    len: 3,
                 },
-                Token::Str("asset"),
-                Token::Str("foo1"),
-                Token::Str("description"),
-                Token::Str("foo2"),
                 Token::Str("format_type"),
                 Token::U8(1),
                 Token::Str("id"),
@@ -259,14 +252,6 @@ mod tests {
                 Token::Str("1"),
                 Token::Str("name"),
                 Token::Str("sticker name"),
-                Token::Str("pack_id"),
-                Token::NewtypeStruct {
-                    name: "StickerPackId",
-                },
-                Token::Str("2"),
-                Token::Str("tags"),
-                Token::Some,
-                Token::Str("foo,bar,baz"),
                 Token::StructEnd,
                 Token::SeqEnd,
                 Token::Str("timestamp"),
@@ -352,14 +337,10 @@ mod tests {
                 message_id: None,
                 fail_if_not_exists: None,
             }),
-            stickers: vec![Sticker {
-                asset: "foo1".to_owned(),
-                description: "foo2".to_owned(),
+            sticker_items: vec![MessageSticker {
                 format_type: StickerFormatType::Png,
                 id: StickerId(1),
                 name: "sticker name".to_owned(),
-                pack_id: StickerPackId(2),
-                tags: Some("foo,bar,baz".to_owned()),
             }],
             referenced_message: None,
             timestamp: "2020-02-02T02:02:02.020000+00:00".to_owned(),
@@ -538,16 +519,12 @@ mod tests {
                 Token::NewtypeStruct { name: "ChannelId" },
                 Token::Str("1"),
                 Token::StructEnd,
-                Token::Str("stickers"),
+                Token::Str("sticker_items"),
                 Token::Seq { len: Some(1) },
                 Token::Struct {
-                    name: "Sticker",
-                    len: 7,
+                    name: "MessageSticker",
+                    len: 3,
                 },
-                Token::Str("asset"),
-                Token::Str("foo1"),
-                Token::Str("description"),
-                Token::Str("foo2"),
                 Token::Str("format_type"),
                 Token::U8(1),
                 Token::Str("id"),
@@ -555,14 +532,6 @@ mod tests {
                 Token::Str("1"),
                 Token::Str("name"),
                 Token::Str("sticker name"),
-                Token::Str("pack_id"),
-                Token::NewtypeStruct {
-                    name: "StickerPackId",
-                },
-                Token::Str("2"),
-                Token::Str("tags"),
-                Token::Some,
-                Token::Str("foo,bar,baz"),
                 Token::StructEnd,
                 Token::SeqEnd,
                 Token::Str("timestamp"),

--- a/model/src/channel/message/sticker/message.rs
+++ b/model/src/channel/message/sticker/message.rs
@@ -1,0 +1,58 @@
+use super::{StickerFormatType, StickerId};
+use serde::{Deserialize, Serialize};
+
+/// Smallest amount of data required to render a sticker.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct MessageSticker {
+    pub format_type: StickerFormatType,
+    pub id: StickerId,
+    pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MessageSticker, StickerFormatType, StickerId};
+    use serde::{Deserialize, Serialize};
+    use serde_test::Token;
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_fields!(MessageSticker: format_type, id, name);
+
+    assert_impl_all!(
+        MessageSticker: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        Serialize
+    );
+
+    #[test]
+    fn test_full() {
+        let value = MessageSticker {
+            format_type: StickerFormatType::Lottie,
+            id: StickerId(1),
+            name: "sticker".into(),
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "MessageSticker",
+                    len: 3,
+                },
+                Token::Str("format_type"),
+                Token::U8(StickerFormatType::Lottie as u8),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "StickerId" },
+                Token::Str("1"),
+                Token::Str("name"),
+                Token::Str("sticker"),
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/channel/message/sticker/message.rs
+++ b/model/src/channel/message/sticker/message.rs
@@ -26,7 +26,9 @@ mod tests {
         Eq,
         Hash,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
 
     #[test]

--- a/model/src/channel/message/sticker/mod.rs
+++ b/model/src/channel/message/sticker/mod.rs
@@ -6,49 +6,95 @@
 
 mod id;
 mod kind;
+mod message;
 
 pub use self::{
     id::{StickerId, StickerPackId},
     kind::{StickerFormatType, StickerFormatTypeConversionError},
+    message::MessageSticker,
 };
 
+use crate::{id::GuildId, user::User, util::is_false};
 use serde::{Deserialize, Serialize};
 
 /// Message sticker.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Sticker {
-    /// Hash of the asset.
-    pub asset: String,
+    /// Whether the sticker is available.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub available: bool,
     /// Description of the sticker.
     pub description: String,
     /// Format type.
     pub format_type: StickerFormatType,
+    /// ID of the guild that owns the sticker.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guild_id: Option<GuildId>,
     /// Unique ID of the sticker.
     pub id: StickerId,
     /// Name of the sticker.
     pub name: String,
     /// Unique ID of the pack the sticker is in.
-    pub pack_id: StickerPackId,
-    /// CSV list of tags the sticker is assigned to, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tags: Option<String>,
+    pub pack_id: Option<StickerPackId>,
+    /// Sticker's sort order within a pack.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_value: Option<u64>,
+    /// CSV list of tags the sticker is assigned to, if any.
+    pub tags: String,
+    /// ID of the user that uploaded the sticker.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<User>,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Sticker, StickerFormatType, StickerId, StickerPackId};
+    use super::{GuildId, Sticker, StickerFormatType, StickerId, StickerPackId, User};
+    use crate::{
+        id::UserId,
+        user::{PremiumType, UserFlags},
+    };
+    use serde::{Deserialize, Serialize};
     use serde_test::Token;
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_fields!(
+        Sticker: available,
+        description,
+        format_type,
+        guild_id,
+        id,
+        name,
+        pack_id,
+        sort_value,
+        tags,
+        user
+    );
+
+    assert_impl_all!(
+        Sticker: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        Serialize
+    );
 
     #[test]
     fn test_minimal() {
         let value = Sticker {
-            asset: "foo1".to_owned(),
+            available: false,
             description: "foo2".to_owned(),
             format_type: StickerFormatType::Png,
+            guild_id: None,
             id: StickerId(1),
             name: "sticker name".to_owned(),
-            pack_id: StickerPackId(2),
-            tags: Some("foo,bar,baz".to_owned()),
+            pack_id: None,
+            sort_value: None,
+            tags: "foo,bar,baz".to_owned(),
+            user: None,
         };
 
         serde_test::assert_tokens(
@@ -56,27 +102,129 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Sticker",
-                    len: 7,
+                    len: 5,
                 },
-                Token::Str("asset"),
-                Token::Str("foo1"),
                 Token::Str("description"),
                 Token::Str("foo2"),
                 Token::Str("format_type"),
-                Token::U8(1),
+                Token::U8(StickerFormatType::Png as u8),
                 Token::Str("id"),
                 Token::NewtypeStruct { name: "StickerId" },
                 Token::Str("1"),
                 Token::Str("name"),
                 Token::Str("sticker name"),
+                Token::Str("tags"),
+                Token::Str("foo,bar,baz"),
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn test_full() {
+        let value = Sticker {
+            available: true,
+            description: "sticker".into(),
+            format_type: StickerFormatType::Png,
+            guild_id: Some(GuildId(1)),
+            id: StickerId(2),
+            name: "stick".into(),
+            pack_id: Some(StickerPackId(3)),
+            sort_value: Some(1),
+            tags: "foo,bar,baz".into(),
+            user: Some(User {
+                avatar: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned()),
+                bot: false,
+                discriminator: "0001".to_owned(),
+                email: Some("address@example.com".to_owned()),
+                flags: Some(UserFlags::EARLY_SUPPORTER | UserFlags::VERIFIED_BOT_DEVELOPER),
+                id: UserId(1),
+                locale: Some("en-us".to_owned()),
+                mfa_enabled: Some(true),
+                name: "test".to_owned(),
+                premium_type: Some(PremiumType::Nitro),
+                public_flags: Some(UserFlags::EARLY_SUPPORTER | UserFlags::VERIFIED_BOT_DEVELOPER),
+                system: Some(true),
+                verified: Some(true),
+            }),
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "Sticker",
+                    len: 10,
+                },
+                Token::Str("available"),
+                Token::Bool(true),
+                Token::Str("description"),
+                Token::Str("sticker"),
+                Token::Str("format_type"),
+                Token::U8(StickerFormatType::Png as u8),
+                Token::Str("guild_id"),
+                Token::Some,
+                Token::NewtypeStruct { name: "GuildId" },
+                Token::Str("1"),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "StickerId" },
+                Token::Str("2"),
+                Token::Str("name"),
+                Token::Str("stick"),
                 Token::Str("pack_id"),
+                Token::Some,
                 Token::NewtypeStruct {
                     name: "StickerPackId",
                 },
-                Token::Str("2"),
-                Token::Str("tags"),
+                Token::Str("3"),
+                Token::Str("sort_value"),
                 Token::Some,
+                Token::U64(1),
+                Token::Str("tags"),
                 Token::Str("foo,bar,baz"),
+                Token::Str("user"),
+                Token::Some,
+                Token::Struct {
+                    name: "User",
+                    len: 13,
+                },
+                Token::Str("avatar"),
+                Token::Some,
+                Token::Str("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                Token::Str("bot"),
+                Token::Bool(false),
+                Token::Str("discriminator"),
+                Token::Str("0001"),
+                Token::Str("email"),
+                Token::Some,
+                Token::Str("address@example.com"),
+                Token::Str("flags"),
+                Token::Some,
+                Token::U64(131_584),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "UserId" },
+                Token::Str("1"),
+                Token::Str("locale"),
+                Token::Some,
+                Token::Str("en-us"),
+                Token::Str("mfa_enabled"),
+                Token::Some,
+                Token::Bool(true),
+                Token::Str("username"),
+                Token::Str("test"),
+                Token::Str("premium_type"),
+                Token::Some,
+                Token::U8(2),
+                Token::Str("public_flags"),
+                Token::Some,
+                Token::U64(131_584),
+                Token::Str("system"),
+                Token::Some,
+                Token::Bool(true),
+                Token::Str("verified"),
+                Token::Some,
+                Token::Bool(true),
+                Token::StructEnd,
                 Token::StructEnd,
             ],
         );

--- a/model/src/channel/message/sticker/mod.rs
+++ b/model/src/channel/message/sticker/mod.rs
@@ -120,6 +120,7 @@ mod tests {
         );
     }
 
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn test_full() {
         let value = Sticker {

--- a/model/src/channel/message/sticker/mod.rs
+++ b/model/src/channel/message/sticker/mod.rs
@@ -79,7 +79,9 @@ mod tests {
         Eq,
         Hash,
         PartialEq,
-        Serialize
+        Send,
+        Serialize,
+        Sync,
     );
 
     #[test]

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -926,7 +926,7 @@ mod tests {
             pinned: false,
             reactions: Vec::new(),
             reference: None,
-            stickers: Vec::new(),
+            sticker_items: Vec::new(),
             referenced_message: None,
             timestamp: String::new(),
             tts: false,


### PR DESCRIPTION
Adds the `available`, `guild_id`, `sort_value`, and `user` fields to
`Sticker`. Adds the `MessageSticker` struct. Replaces `stickers` with
`sticker_items` in message instantiations.

Fixes #940.
