### PR TITLE
Build docs with all features enabled

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           RUSTDOCFLAGS: --cfg docsrs -D broken_intra_doc_links
         run: |
-          cargo doc --workspace --no-deps
+          cargo doc --workspace --no-deps --all-features
           cargo doc -p twilight-util --no-deps --all-features
 
   sync-readme:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           RUSTDOCFLAGS: --cfg docsrs -D broken_intra_doc_links
         run: |
-          cargo doc --workspace --no-deps --all-features
+          cargo doc --workspace --no-deps --features=permission-calculator
           cargo doc -p twilight-util --no-deps --all-features
 
   sync-readme:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           RUSTDOCFLAGS: --cfg docsrs -D broken_intra_doc_links
         run: |
           exclude_examples=($(grep -h '^name' **/examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
-          cargo doc --workspace --no-deps "${exclude_examples[@]}"
+          cargo doc --workspace --no-deps --all-features "${exclude_examples[@]}"
           cargo doc -p twilight-util --no-deps --all-features
 
       - name: Prepare docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           RUSTDOCFLAGS: --cfg docsrs -D broken_intra_doc_links
         run: |
           exclude_examples=($(grep -h '^name' **/examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
-          cargo doc --workspace --no-deps --all-features "${exclude_examples[@]}"
+          cargo doc --workspace --no-deps --features=permission-calculator "${exclude_examples[@]}"
           cargo doc -p twilight-util --no-deps --all-features
 
       - name: Prepare docs


### PR DESCRIPTION
This fixes the permission module not appearing for the `cache-inmemory` docs and any future feature flags getting added to crates that are not `twilight-util`.