### PR TITLE
Deprecate singlular message setters

### DIFF
--- a/http/src/request/application/create_followup_message.rs
+++ b/http/src/request/application/create_followup_message.rs
@@ -127,6 +127,7 @@ impl<'a> CreateFollowupMessage<'a> {
     /// Attach a file to the webhook.
     ///
     /// This method is repeatable.
+    #[deprecated(since = "0.5.5", note = "will be removed in favor of `files`")]
     pub fn file(mut self, name: impl Into<String>, file: impl Into<Vec<u8>>) -> Self {
         self.files.push((name.into(), file.into()));
 
@@ -138,9 +139,11 @@ impl<'a> CreateFollowupMessage<'a> {
         mut self,
         attachments: impl IntoIterator<Item = (N, F)>,
     ) -> Self {
-        for (name, file) in attachments {
-            self = self.file(name, file);
-        }
+        self.files.extend(
+            attachments
+                .into_iter()
+                .map(|(name, file)| (name.into(), file.into())),
+        );
 
         self
     }

--- a/http/src/request/application/update_followup_message.rs
+++ b/http/src/request/application/update_followup_message.rs
@@ -197,6 +197,7 @@ impl<'a> UpdateFollowupMessage<'a> {
     ///
     /// If called, all unspecified attachments will be removed from the message.
     /// If not called, all attachments will be kept.
+    #[deprecated(since = "0.5.5", note = "will be removed in favor of `attachments`")]
     pub fn attachment(mut self, attachment: Attachment) -> Self {
         self.fields.attachments.push(attachment);
 
@@ -333,6 +334,7 @@ impl<'a> UpdateFollowupMessage<'a> {
     /// Attach a file to the followup message.
     ///
     /// This method is repeatable.
+    #[deprecated(since = "0.5.5", note = "will be removed in favor of `files`")]
     pub fn file(mut self, name: impl Into<String>, file: impl Into<Vec<u8>>) -> Self {
         self.files.push((name.into(), file.into()));
 
@@ -342,11 +344,13 @@ impl<'a> UpdateFollowupMessage<'a> {
     /// Attach multiple files to the followup message.
     pub fn files<N: Into<String>, F: Into<Vec<u8>>>(
         mut self,
-        attachments: impl IntoIterator<Item = (N, F)>,
+        files: impl IntoIterator<Item = (N, F)>,
     ) -> Self {
-        for (name, file) in attachments {
-            self = self.file(name, file);
-        }
+        self.files.extend(
+            files
+                .into_iter()
+                .map(|(name, file)| (name.into(), file.into())),
+        );
 
         self
     }

--- a/http/src/request/application/update_original_response.rs
+++ b/http/src/request/application/update_original_response.rs
@@ -194,6 +194,7 @@ impl<'a> UpdateOriginalResponse<'a> {
     ///
     /// If called, all unspecified attachments will be removed from the message.
     /// If not called, all attachments will be kept.
+    #[deprecated(since = "0.5.5", note = "will be removed in favor of `attachments`")]
     pub fn attachment(mut self, attachment: Attachment) -> Self {
         self.fields.attachments.push(attachment);
 
@@ -331,6 +332,7 @@ impl<'a> UpdateOriginalResponse<'a> {
     /// Attach a file to the original response.
     ///
     /// This method is repeatable.
+    #[deprecated(since = "0.5.5", note = "will be removed in favor of `files`")]
     pub fn file(mut self, name: impl Into<String>, file: impl Into<Vec<u8>>) -> Self {
         self.files.push((name.into(), file.into()));
 
@@ -340,11 +342,13 @@ impl<'a> UpdateOriginalResponse<'a> {
     /// Attach multiple files to the original response.
     pub fn files<N: Into<String>, F: Into<Vec<u8>>>(
         mut self,
-        attachments: impl IntoIterator<Item = (N, F)>,
+        files: impl IntoIterator<Item = (N, F)>,
     ) -> Self {
-        for (name, file) in attachments {
-            self = self.file(name, file);
-        }
+        self.files.extend(
+            files
+                .into_iter()
+                .map(|(name, file)| (name.into(), file.into())),
+        );
 
         self
     }

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -214,6 +214,7 @@ impl<'a> CreateMessage<'a> {
     ///
     /// [the discord docs]: https://discord.com/developers/docs/resources/channel#embed-limits
     /// [`EmbedBuilder`]: https://docs.rs/twilight-embed-builder/*/twilight_embed_builder
+    #[deprecated(since = "0.5.5", note = "will be removed in favor of `embeds`")]
     pub fn embed(mut self, embed: Embed) -> Result<Self, CreateMessageError> {
         validate::embed(&embed)
             .map_err(|source| CreateMessageError::embed(source, embed.clone(), None))?;
@@ -270,6 +271,7 @@ impl<'a> CreateMessage<'a> {
     /// Attach a file to the message.
     ///
     /// The file is raw binary data. It can be an image, or any other kind of file.
+    #[deprecated(since = "0.5.5", note = "will be removed in favor of `files`")]
     pub fn file(mut self, name: impl Into<String>, file: impl Into<Vec<u8>>) -> Self {
         self.files.push((name.into(), file.into()));
 
@@ -279,11 +281,13 @@ impl<'a> CreateMessage<'a> {
     /// Attach multiple files to the message.
     pub fn files<N: Into<String>, F: Into<Vec<u8>>>(
         mut self,
-        attachments: impl IntoIterator<Item = (N, F)>,
+        files: impl IntoIterator<Item = (N, F)>,
     ) -> Self {
-        for (name, file) in attachments {
-            self = self.file(name, file);
-        }
+        self.files.extend(
+            files
+                .into_iter()
+                .map(|(name, file)| (name.into(), file.into())),
+        );
 
         self
     }

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -187,6 +187,7 @@ impl<'a> UpdateMessage<'a> {
     ///
     /// If called, all unspecified attachments will be removed from the message.
     /// If not called, all attachments will be kept.
+    #[deprecated(since = "0.5.5", note = "will be removed in favor of `attachments`")]
     pub fn attachment(mut self, attachment: Attachment) -> Self {
         self.fields.attachments.push(attachment);
 
@@ -257,6 +258,7 @@ impl<'a> UpdateMessage<'a> {
     /// embed is too large.
     ///
     /// [`embeds`]: Self::embeds
+    #[deprecated(since = "0.5.5", note = "will be removed in favor of `embeds`")]
     pub fn embed(self, embed: impl Into<Option<Embed>>) -> Result<Self, UpdateMessageError> {
         self._embed(embed.into())
     }

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -115,6 +115,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// Attach a file to the webhook.
     ///
     /// This method is repeatable.
+    #[deprecated(since = "0.5.5", note = "will be removed in favor of `files`")]
     pub fn file(mut self, name: impl Into<String>, file: impl Into<Vec<u8>>) -> Self {
         self.files.push((name.into(), file.into()));
 
@@ -124,11 +125,13 @@ impl<'a> ExecuteWebhook<'a> {
     /// Attach multiple files to the webhook.
     pub fn files<N: Into<String>, F: Into<Vec<u8>>>(
         mut self,
-        attachments: impl IntoIterator<Item = (N, F)>,
+        files: impl IntoIterator<Item = (N, F)>,
     ) -> Self {
-        for (name, file) in attachments {
-            self = self.file(name, file);
-        }
+        self.files.extend(
+            files
+                .into_iter()
+                .map(|(name, file)| (name.into(), file.into())),
+        );
 
         self
     }

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -198,6 +198,7 @@ impl<'a> UpdateWebhookMessage<'a> {
     ///
     /// If called, all unspecified attachments will be removed from the message.
     /// If not called, all attachments will be kept.
+    #[deprecated(since = "0.5.5", note = "will be removed in favor of `attachments`")]
     pub fn attachment(mut self, attachment: Attachment) -> Self {
         self.fields.attachments.push(attachment);
 
@@ -328,6 +329,7 @@ impl<'a> UpdateWebhookMessage<'a> {
     /// Attach a file to the webhook.
     ///
     /// This method is repeatable.
+    #[deprecated(since = "0.5.5", note = "will be removed in favor of `files`")]
     pub fn file(mut self, name: impl Into<String>, file: impl Into<Vec<u8>>) -> Self {
         self.files.push((name.into(), file.into()));
 
@@ -337,11 +339,13 @@ impl<'a> UpdateWebhookMessage<'a> {
     /// Attach multiple files to the webhook.
     pub fn files<N: Into<String>, F: Into<Vec<u8>>>(
         mut self,
-        attachments: impl IntoIterator<Item = (N, F)>,
+        files: impl IntoIterator<Item = (N, F)>,
     ) -> Self {
-        for (name, file) in attachments {
-            self = self.file(name, file);
-        }
+        self.files.extend(
+            files
+                .into_iter()
+                .map(|(name, file)| (name.into(), file.into())),
+        );
 
         self
     }


### PR DESCRIPTION
Deprecate the `attachment`, `embed`, and `file` message setters in favor of their plural forms of `attachments`, `embeds`, and `files`, respectively. This is due to #1009 removing the possibility for these methods.