### PR TITLE
Reduce allocations for gateway queue

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -61,7 +61,7 @@ impl ClusterBuilder {
                 http_client,
                 shard_config: shard_config.0,
                 shard_scheme: ShardScheme::Auto,
-                queue: Arc::new(Box::new(LocalQueue::new())),
+                queue: Arc::new(LocalQueue::new()),
                 resume_sessions: HashMap::new(),
             },
             ShardBuilder::new(token, intents),
@@ -211,7 +211,7 @@ impl ClusterBuilder {
     /// Refer to the [`queue`] module for more information.
     ///
     /// [`queue`]: crate::queue
-    pub fn queue(mut self, queue: Arc<Box<dyn Queue>>) -> Self {
+    pub fn queue(mut self, queue: Arc<dyn Queue>) -> Self {
         self.0.queue = Arc::clone(&queue);
         self.1 = self.1.queue(queue);
 

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     pub(super) http_client: Client,
     pub(super) shard_config: ShardConfig,
     pub(super) shard_scheme: ShardScheme,
-    pub(super) queue: Arc<Box<dyn Queue>>,
+    pub(super) queue: Arc<dyn Queue>,
     pub(super) resume_sessions: HashMap<u64, ResumeSession>,
 }
 
@@ -56,7 +56,7 @@ impl Config {
 
     /// Return an immutable reference to the queue used for initiating shard
     /// sessions.
-    pub fn queue(&self) -> &Arc<Box<dyn Queue>> {
+    pub fn queue(&self) -> &Arc<dyn Queue> {
         &self.queue
     }
 }

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -180,7 +180,7 @@ impl ShardBuilder {
             intents,
             large_threshold: 250,
             presence: None,
-            queue: Arc::new(Box::new(LocalQueue::new())),
+            queue: Arc::new(LocalQueue::new()),
             shard: [0, 1],
             token: token.into_boxed_str(),
             session_id: None,
@@ -318,7 +318,7 @@ impl ShardBuilder {
     ///
     /// [`Cluster`]: crate::cluster::Cluster
     /// [`queue`]: crate::queue
-    pub fn queue(mut self, queue: Arc<Box<dyn Queue>>) -> Self {
+    pub fn queue(mut self, queue: Arc<dyn Queue>) -> Self {
         self.0.queue = queue;
 
         self

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -18,7 +18,7 @@ pub struct Config {
     pub(super) intents: Intents,
     pub(super) large_threshold: u64,
     pub(super) presence: Option<UpdatePresencePayload>,
-    pub(super) queue: Arc<Box<dyn Queue>>,
+    pub(super) queue: Arc<dyn Queue>,
     pub(crate) shard: [u64; 2],
     pub(super) token: Box<str>,
     pub(crate) session_id: Option<Box<str>>,


### PR DESCRIPTION
The nested inner `Box` is not needed at all since `Arc` can hold `dyn Trait` objects by itself.