### PR TITLE
Add CI for spell checking and fix spelling mistakes

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = target
+ignore-words-list = crate,ser

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,3 +53,13 @@ jobs:
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
+
+  codespell:
+    name: Spelling
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout sources
+          uses: actions/checkout@v2
+
+        - name: Run Codespell
+          uses: codespell-project/actions-codespell@master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ impl Display for TwilightError {
 }
 
 impl Error for TwilightError {
-    fn source(&self) -> Optio<&(dyn Error + 'static)> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         self.source
             .as_ref()
             .map(|source| &**source as &(dyn Error + 'static))
@@ -199,7 +199,7 @@ struct Structy {
 Methods are to be documented as follows:
 ```rust
 impl Structy {
-    /// Short decription of the method, limited to one sentence.
+    /// Short description of the method, limited to one sentence.
     ///
     /// More important information or clarification.
     pub fn method(&self) -> Option<Something> {

--- a/cache/in-memory/src/event/voice_state.rs
+++ b/cache/in-memory/src/event/voice_state.rs
@@ -9,7 +9,7 @@ impl InMemoryCache {
     }
 
     fn cache_voice_state(&self, voice_state: VoiceState) {
-        // This should always exist, but just incase use a match
+        // This should always exist, but just in case use a match
         let guild_id = match voice_state.guild_id {
             Some(id) => id,
             None => return,
@@ -106,7 +106,7 @@ mod tests {
 
         // Note: Channel ids are `<guildid><idx>` where idx is the index of the channel id
         // This is done to prevent channel id collisions between guilds
-        // The other 2 ids are not special since they cant overlap
+        // The other 2 ids are not special since they can't overlap
 
         // User 1 joins guild 1's channel 11 (1 channel, 1 guild)
         {

--- a/gateway/examples/metrics/src/main.rs
+++ b/gateway/examples/metrics/src/main.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     cluster.up().await;
     println!("Started cluster");
 
-    // Start exporter in a seperate task
+    // Start exporter in a separate task
     tokio::task::spawn_blocking(move || exporter.run());
 
     while let Some(event) = events.next().await {

--- a/gateway/src/cluster/scheme.rs
+++ b/gateway/src/cluster/scheme.rs
@@ -278,7 +278,7 @@ impl ShardScheme {
                 let buckets = total / concurrency;
 
                 // Total is 1-indexed but shards are 0-indexed, so we need to
-                // substract 1 here.
+                // subtract 1 here.
                 Some(total - (buckets - bucket_id) - 1)
             }
             Self::Range { to, .. } => Some(*to),

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -490,7 +490,7 @@ impl Client {
 
     /// Update the current user.
     ///
-    /// All paramaters are optional. If the username is changed, it may cause the discriminator to
+    /// All parameters are optional. If the username is changed, it may cause the discriminator to
     /// be randomized.
     pub fn update_current_user(&self) -> UpdateCurrentUser<'_> {
         UpdateCurrentUser::new(self)
@@ -498,7 +498,7 @@ impl Client {
 
     /// Update the current user's voice state.
     ///
-    /// All paramaters are optional.
+    /// All parameters are optional.
     ///
     /// # Caveats
     ///

--- a/http/src/request/application/create_global_command.rs
+++ b/http/src/request/application/create_global_command.rs
@@ -60,7 +60,7 @@ impl<'a> CreateGlobalCommand<'a> {
     ///
     /// Errors
     ///
-    /// Retuns an [`InteractionErrorType::CommandOptionsRequiredFirst`]
+    /// Returns an [`InteractionErrorType::CommandOptionsRequiredFirst`]
     /// if a required option was added after an optional option. The problem
     /// option's index is provided.
     pub fn command_options(

--- a/http/src/request/application/create_guild_command.rs
+++ b/http/src/request/application/create_guild_command.rs
@@ -74,7 +74,7 @@ impl<'a> CreateGuildCommand<'a> {
     ///
     /// Errors
     ///
-    /// Retuns an [`InteractionErrorType::CommandOptionsRequiredFirst`]
+    /// Returns an [`InteractionErrorType::CommandOptionsRequiredFirst`]
     /// if a required option was added after an optional option. The problem
     /// option's index is provided.
     pub fn command_options(

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -12,7 +12,7 @@ struct DeleteMessagesFields<'a> {
     messages: &'a [MessageId],
 }
 
-/// Delete messgaes by [`ChannelId`] and a list of [`MessageId`]s.
+/// Delete messages by [`ChannelId`] and a list of [`MessageId`]s.
 ///
 /// The number of message IDs must be between 2 and 100. If the supplied message
 /// IDs are invalid, they still count towards the lower and upper limits. This

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -676,7 +676,7 @@ impl CategoryFieldsBuilder {
 
 /// A builder for a list of channels.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-#[must_use = "must be built into a list of channnels"]
+#[must_use = "must be built into a list of channels"]
 pub struct GuildChannelFieldsBuilder(Vec<GuildChannelFields>);
 
 impl GuildChannelFieldsBuilder {

--- a/http/src/request/template/update_template.rs
+++ b/http/src/request/template/update_template.rs
@@ -11,7 +11,7 @@ use std::{
 };
 use twilight_model::{id::GuildId, template::Template};
 
-/// Error emitted when the template can not be upated as configured.
+/// Error emitted when the template can not be updated as configured.
 #[derive(Debug)]
 pub struct UpdateTemplateError {
     kind: UpdateTemplateErrorType,

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -74,7 +74,7 @@ struct UpdateCurrentUserFields<'a> {
 
 /// Update the current user.
 ///
-/// All paramaters are optional. If the username is changed, it may cause the discriminator to be
+/// All parameters are optional. If the username is changed, it may cause the discriminator to be
 /// rnadomized.
 pub struct UpdateCurrentUser<'a> {
     fields: UpdateCurrentUserFields<'a>,

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -311,7 +311,7 @@ impl Lavalink {
     /// Remove a node from the list of nodes being managed by the Lavalink
     /// client and terminates the connection.
     ///
-    /// Use [`Lavalink::remove`] if detatching a node from a Lavalink instance
+    /// Use [`Lavalink::remove`] if detaching a node from a Lavalink instance
     /// is required without closing the underlying connection.
     ///
     /// Returns whether the node has been removed and disconnected.

--- a/lavalink/src/http.rs
+++ b/lavalink/src/http.rs
@@ -154,7 +154,7 @@ pub enum RoutePlanner {
 pub struct NanoIpRoutePlanner {
     /// The type of planner that is currently active.
     ///
-    /// For this planner, thsi is always [`RoutePlannerType::NanoIp`]
+    /// For this planner, this is always [`RoutePlannerType::NanoIp`]
     pub class: RoutePlannerType,
     /// The details of the currently active Nano IP route planner.
     pub details: NanoIpDetails,
@@ -180,7 +180,7 @@ pub struct NanoIpDetails {
 pub struct RotatingIpRoutePlanner {
     /// The type of planner that is currently active.
     ///
-    /// For this planner, thsi is always [`RoutePlannerType::RotatingIp`]
+    /// For this planner, this is always [`RoutePlannerType::RotatingIp`]
     pub class: RoutePlannerType,
     /// The details of the currently active rotating IP route planner.
     pub details: RotatingIpDetails,
@@ -210,7 +210,7 @@ pub struct RotatingIpDetails {
 pub struct RotatingNanoIpRoutePlanner {
     /// The type of planner that is currently active.
     ///
-    /// For this planner, thsi is always [`RoutePlannerType::RotatingNanoIp`]
+    /// For this planner, this is always [`RoutePlannerType::RotatingNanoIp`]
     pub class: RoutePlannerType,
     /// The details of the currently active rotating nano IP route planner.
     pub details: RotatingNanoIpDetails,

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -170,7 +170,7 @@ impl Error for NodeSenderError {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum NodeSenderErrorType {
-    /// Error occured while sending over the channel.
+    /// Error occurred while sending over the channel.
     Sending,
 }
 
@@ -686,7 +686,7 @@ async fn backoff(
                 }
 
                 tracing::debug!(
-                    "waiting {} sceonds before attempting to connect to node {} again",
+                    "waiting {} seconds before attempting to connect to node {} again",
                     seconds,
                     config.address,
                 );

--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -1,4 +1,4 @@
-//! Used when recieving interactions through gateway or webhooks.
+//! Used when receiving interactions through gateway or webhooks.
 
 pub mod application_command;
 mod interaction_type;

--- a/model/src/channel/reaction_type.rs
+++ b/model/src/channel/reaction_type.rs
@@ -12,7 +12,7 @@ pub enum ReactionType {
         // the reaction is a unicode emoji and then it is caught by
         // the other variant.
         id: EmojiId,
-        // Name is nil if the emoji data is no longer avaiable, for
+        // Name is nil if the emoji data is no longer available, for
         // example if the emoji have been deleted off the guild.
         name: Option<String>,
     },

--- a/model/src/gateway/payload/update_presence.rs
+++ b/model/src/gateway/payload/update_presence.rs
@@ -15,7 +15,7 @@ pub struct UpdatePresenceError {
 }
 
 impl UpdatePresenceError {
-    /// Immutable reference to the type of error that occured.
+    /// Immutable reference to the type of error that occurred.
     #[must_use = "retrieving the type has no effect if let unused"]
     pub const fn kind(&self) -> &UpdatePresenceErrorType {
         &self.kind
@@ -72,7 +72,7 @@ impl UpdatePresence {
     /// # Errors
     ///
     /// Returns an error of type [`UpdatePresenceErrorType::MissingActivity`] if
-    /// an empty set of activites is provided.
+    /// an empty set of activities is provided.
     pub fn new(
         activities: impl Into<Vec<Activity>>,
         afk: bool,
@@ -105,7 +105,7 @@ impl UpdatePresencePayload {
     /// # Errors
     ///
     /// Returns an [`UpdatePresenceErrorType::MissingActivity`] error type if an
-    /// empty set of activites is provided.
+    /// empty set of activities is provided.
     pub fn new(
         activities: impl Into<Vec<Activity>>,
         afk: bool,


### PR DESCRIPTION
This uses [codespell](https://github.com/codespell-project/codespell) to verify the docs won't have spelling mistakes. While I was on it, all errors that it found were fixed. The action used is the official [codespell action](https://github.com/codespell-project/actions-codespell) that features line annotations for issues found.