### PR TITLE
Remove unsafe code in gateway

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -65,6 +65,7 @@
     clippy::missing_const_for_fn,
     missing_docs,
     rust_2018_idioms,
+    unsafe_code,
     unused,
     warnings
 )]

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -61,6 +61,7 @@
     missing_docs,
     nonstandard_style,
     rust_2018_idioms,
+    unsafe_code,
     unused,
     warnings
 )]

--- a/gateway/queue/src/lib.rs
+++ b/gateway/queue/src/lib.rs
@@ -32,6 +32,8 @@
 //!
 //! [Sharding for Very Large Bots]: https://discord.com/developers/docs/topics/gateway#sharding-for-very-large-bots
 
+#![deny(unsafe_code)]
+
 mod day_limiter;
 mod large_bot_queue;
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -118,6 +118,7 @@
     nonstandard_style,
     rust_2018_idioms,
     broken_intra_doc_links,
+    unsafe_code,
     unused,
     warnings
 )]

--- a/gateway/src/shard/emitter.rs
+++ b/gateway/src/shard/emitter.rs
@@ -125,7 +125,7 @@ impl Emitter {
         op: u8,
         seq: Option<u64>,
         event_type: Option<&str>,
-        json: &mut str,
+        json: &mut [u8],
     ) -> Result<(), EmitJsonError> {
         let flag = EventTypeFlags::try_from((op, event_type)).map_err(|(op, event_type)| {
             EmitJsonError {

--- a/gateway/src/shard/json.rs
+++ b/gateway/src/shard/json.rs
@@ -118,7 +118,7 @@ pub fn parse_gateway_event(
     gateway_deserializer
         .deserialize(&mut json_deserializer)
         .map_err(|source| {
-            tracing::debug!("invalid JSON: {}", json);
+            tracing::debug!("invalid JSON: {}", String::from_utf8_lossy(json));
 
             GatewayEventParsingError {
                 kind: GatewayEventParsingErrorType::Deserializing,

--- a/gateway/src/shard/json.rs
+++ b/gateway/src/shard/json.rs
@@ -65,19 +65,19 @@ pub fn parse_gateway_event(
     op: u8,
     sequence: Option<u64>,
     event_type: Option<&str>,
-    json: &mut str,
+    json: &mut [u8],
 ) -> Result<GatewayEvent, GatewayEventParsingError> {
     use serde::de::DeserializeSeed;
     use serde_json::Deserializer;
     use twilight_model::gateway::event::GatewayEventDeserializer;
 
     let gateway_deserializer = GatewayEventDeserializer::new(op, sequence, event_type);
-    let mut json_deserializer = Deserializer::from_str(json);
+    let mut json_deserializer = Deserializer::from_slice(json);
 
     gateway_deserializer
         .deserialize(&mut json_deserializer)
         .map_err(|source| {
-            tracing::debug!("invalid JSON: {}", json);
+            tracing::debug!("invalid JSON: {}", String::from_utf8_lossy(json));
 
             GatewayEventParsingError {
                 kind: GatewayEventParsingErrorType::Deserializing,
@@ -95,14 +95,13 @@ pub fn parse_gateway_event(
 ///
 /// Returns [`GatewayEventParsingError::Deserializing`] if the payload failed to
 /// deserialize.
-#[allow(unsafe_code)]
 #[cfg(feature = "simd-json")]
 #[allow(dead_code)]
 pub fn parse_gateway_event(
     op: u8,
     sequence: Option<u64>,
     event_type: Option<&str>,
-    json: &mut str,
+    json: &mut [u8],
 ) -> Result<GatewayEvent, GatewayEventParsingError> {
     use serde::de::DeserializeSeed;
     use simd_json::Deserializer;
@@ -110,14 +109,8 @@ pub fn parse_gateway_event(
 
     let gateway_deserializer = GatewayEventDeserializer::new(op, sequence, event_type);
 
-    // # Safety
-    //
-    // The SIMD deserializer may change the string in ways that aren't
-    // UTF-8 valid, but that's fine because it won't be used again.
-    let json_bytes = unsafe { json.as_bytes_mut() };
-
     let mut json_deserializer =
-        Deserializer::from_slice(json_bytes).map_err(|_| GatewayEventParsingError {
+        Deserializer::from_slice(json).map_err(|_| GatewayEventParsingError {
             kind: GatewayEventParsingErrorType::PayloadInvalid,
             source: None,
         })?;

--- a/gateway/src/shard/processor/compression/mod.rs
+++ b/gateway/src/shard/processor/compression/mod.rs
@@ -2,7 +2,6 @@
 mod inflater;
 
 use super::r#impl::ReceivingEventError;
-use std::str;
 
 #[cfg(feature = "compression")]
 use inflater::Inflater;
@@ -66,17 +65,6 @@ impl Compression {
 
         #[cfg(not(feature = "compression"))]
         self.inner.as_slice()
-    }
-
-    /// Mutable reference to the internal buffer slice as a mutable string slice.
-    ///
-    /// # Safety
-    ///
-    /// Ensuring that the internal buffer slice is UTF-8 valid is left to the
-    /// caller to determine.
-    pub unsafe fn buffer_str_mut(&mut self) -> &mut str {
-        // SAFETY: ensuring safety is left to the caller.
-        str::from_utf8_unchecked_mut(self.buffer_slice_mut())
     }
 
     /// Clear the inner buffer.

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -439,7 +439,7 @@ impl ShardProcessor {
                 } else if op == OpCode::Reconnect as u8 {
                     GatewayEvent::Reconnect
                 } else {
-                    json::parse_gateway_event(op, seq, event_type.as_deref(), json).map_err(
+                    json::parse_gateway_event(op, seq, event_type.as_deref(), buffer).map_err(
                         |source| ProcessError {
                             kind: ProcessErrorType::ParsingPayload,
                             source: Some(Box::new(source)),
@@ -494,12 +494,10 @@ impl ShardProcessor {
             (op, seq, event_type)
         };
 
-        // We already know from earlier that the payload is valid UTF-8, so we
-        // can skip having to re-validate here since it hasn't been mutated.
-        let json = unsafe { self.compression.buffer_str_mut() };
+        let buffer = self.compression.buffer_slice_mut();
 
         self.emitter
-            .json(op, Some(seq), event_type.as_deref(), json)
+            .json(op, Some(seq), event_type.as_deref(), buffer)
             .map_err(|source| {
                 let (kind, source) = source.into_parts();
 

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -88,6 +88,7 @@
     nonstandard_style,
     rust_2018_idioms,
     broken_intra_doc_links,
+    unsafe_code,
     unused,
     warnings
 )]

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -116,6 +116,7 @@
     nonstandard_style,
     rust_2018_idioms,
     broken_intra_doc_links,
+    unsafe_code,
     unused,
     warnings
 )]

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -43,6 +43,7 @@
     nonstandard_style,
     rust_2018_idioms,
     broken_intra_doc_links,
+    unsafe_code,
     unused,
     warnings
 )]

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -124,6 +124,7 @@
     clippy::missing_const_for_fn,
     missing_docs,
     rust_2018_idioms,
+    unsafe_code,
     unused,
     warnings
 )]


### PR DESCRIPTION
Remove unsafe code in the `gateway` crate. Its use of `unsafe` was to accommodate `simd-json`, but can be removed by instead continuously working with the mutable buffer rather than going from bytes -> str -> bytes again.

This also adds `#![deny(unsafe_code)]` to all crates that weren't already marked with it.