### PR TITLE
Add `EventTypeFlags` categories for `Intents`

### DIFF
--- a/gateway/src/event.rs
+++ b/gateway/src/event.rs
@@ -135,6 +135,32 @@ bitflags! {
 }
 
 impl EventTypeFlags {
+    /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGES`].
+    ///
+    /// [`Intents::DIRECT_MESSAGES`]: crate::Intents::DIRECT_MESSAGES
+    pub const DIRECT_MESSAGES: EventTypeFlags = EventTypeFlags::from_bits_truncate(
+        EventTypeFlags::MESSAGE_CREATE.bits()
+            | EventTypeFlags::MESSAGE_DELETE.bits()
+            | EventTypeFlags::MESSAGE_DELETE_BULK.bits()
+            | EventTypeFlags::MESSAGE_UPDATE.bits(),
+    );
+
+    /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGE_REACTIONS`].
+    ///
+    /// [`Intents::DIRECT_MESSAGE_REACTIONS`]: crate::Intents::DIRECT_MESSAGE_REACTIONS
+    pub const DIRECT_MESSAGE_REACTIONS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
+        EventTypeFlags::REACTION_ADD.bits()
+            | EventTypeFlags::REACTION_REMOVE.bits()
+            | EventTypeFlags::REACTION_REMOVE_ALL.bits()
+            | EventTypeFlags::REACTION_REMOVE_EMOJI.bits(),
+    );
+
+    /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGE_TYPING`].
+    ///
+    /// [`Intents::DIRECT_MESSAGE_TYPING`]: crate::Intents::DIRECT_MESSAGE_TYPING
+    pub const DIRECT_MESSAGE_TYPING: EventTypeFlags =
+        EventTypeFlags::from_bits_truncate(EventTypeFlags::TYPING_START.bits());
+
     /// All [`EventTypeFlags`] in [`Intents::GUILDS`].
     ///
     /// [`Intents::GUILDS`]: crate::Intents::GUILDS
@@ -149,15 +175,6 @@ impl EventTypeFlags {
             | EventTypeFlags::ROLE_CREATE.bits()
             | EventTypeFlags::ROLE_DELETE.bits()
             | EventTypeFlags::ROLE_UPDATE.bits(),
-    );
-
-    /// All [`EventTypeFlags`] in [`Intents::GUILD_MEMBERS`].
-    ///
-    /// [`Intents::GUILD_MEMBERS`]: crate::Intents::GUILD_MEMBERS
-    pub const GUILD_MEMBERS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
-        EventTypeFlags::MEMBER_ADD.bits()
-            | EventTypeFlags::MEMBER_REMOVE.bits()
-            | EventTypeFlags::MEMBER_UPDATE.bits(),
     );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_BANS`].
@@ -179,12 +196,6 @@ impl EventTypeFlags {
     pub const GUILD_INTEGRATIONS: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::GUILD_INTEGRATIONS_UPDATE.bits());
 
-    /// All [`EventTypeFlags`] in [`Intents::GUILD_WEBHOOKS`].
-    ///
-    /// [`Intents::GUILD_WEBHOOKS`]: crate::Intents::GUILD_WEBHOOKS
-    pub const GUILD_WEBHOOKS: EventTypeFlags =
-        EventTypeFlags::from_bits_truncate(EventTypeFlags::WEBHOOKS_UPDATE.bits());
-
     /// All [`EventTypeFlags`] in [`Intents::GUILD_INVITES`].
     ///
     /// [`Intents::GUILD_INVITES`]: crate::Intents::GUILD_INVITES
@@ -192,17 +203,14 @@ impl EventTypeFlags {
         EventTypeFlags::INVITE_CREATE.bits() | EventTypeFlags::INVITE_DELETE.bits(),
     );
 
-    /// All [`EventTypeFlags`] in [`Intents::GUILD_VOICE_STATES`].
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_MEMBERS`].
     ///
-    /// [`Intents::GUILD_VOICE_STATES`]: crate::Intents::GUILD_VOICE_STATES
-    pub const GUILD_VOICE_STATES: EventTypeFlags =
-        EventTypeFlags::from_bits_truncate(EventTypeFlags::VOICE_STATE_UPDATE.bits());
-
-    /// All [`EventTypeFlags`] in [`Intents::GUILD_PRESENCES`].
-    ///
-    /// [`Intents::GUILD_PRESENCES`]: crate::Intents::GUILD_PRESENCES
-    pub const GUILD_PRESENCES: EventTypeFlags =
-        EventTypeFlags::from_bits_truncate(EventTypeFlags::PRESENCE_UPDATE.bits());
+    /// [`Intents::GUILD_MEMBERS`]: crate::Intents::GUILD_MEMBERS
+    pub const GUILD_MEMBERS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
+        EventTypeFlags::MEMBER_ADD.bits()
+            | EventTypeFlags::MEMBER_REMOVE.bits()
+            | EventTypeFlags::MEMBER_UPDATE.bits(),
+    );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGES`].
     ///
@@ -230,31 +238,23 @@ impl EventTypeFlags {
     pub const GUILD_MESSAGE_TYPING: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::TYPING_START.bits());
 
-    /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGES`].
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_PRESENCES`].
     ///
-    /// [`Intents::DIRECT_MESSAGES`]: crate::Intents::DIRECT_MESSAGES
-    pub const DIRECT_MESSAGES: EventTypeFlags = EventTypeFlags::from_bits_truncate(
-        EventTypeFlags::MESSAGE_CREATE.bits()
-            | EventTypeFlags::MESSAGE_DELETE.bits()
-            | EventTypeFlags::MESSAGE_DELETE_BULK.bits()
-            | EventTypeFlags::MESSAGE_UPDATE.bits(),
-    );
+    /// [`Intents::GUILD_PRESENCES`]: crate::Intents::GUILD_PRESENCES
+    pub const GUILD_PRESENCES: EventTypeFlags =
+        EventTypeFlags::from_bits_truncate(EventTypeFlags::PRESENCE_UPDATE.bits());
 
-    /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGE_REACTIONS`].
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_VOICE_STATES`].
     ///
-    /// [`Intents::DIRECT_MESSAGE_REACTIONS`]: crate::Intents::DIRECT_MESSAGE_REACTIONS
-    pub const DIRECT_MESSAGE_REACTIONS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
-        EventTypeFlags::REACTION_ADD.bits()
-            | EventTypeFlags::REACTION_REMOVE.bits()
-            | EventTypeFlags::REACTION_REMOVE_ALL.bits()
-            | EventTypeFlags::REACTION_REMOVE_EMOJI.bits(),
-    );
+    /// [`Intents::GUILD_VOICE_STATES`]: crate::Intents::GUILD_VOICE_STATES
+    pub const GUILD_VOICE_STATES: EventTypeFlags =
+        EventTypeFlags::from_bits_truncate(EventTypeFlags::VOICE_STATE_UPDATE.bits());
 
-    /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGE_TYPING`].
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_WEBHOOKS`].
     ///
-    /// [`Intents::DIRECT_MESSAGE_TYPING`]: crate::Intents::DIRECT_MESSAGE_TYPING
-    pub const DIRECT_MESSAGE_TYPING: EventTypeFlags =
-        EventTypeFlags::from_bits_truncate(EventTypeFlags::TYPING_START.bits());
+    /// [`Intents::GUILD_WEBHOOKS`]: crate::Intents::GUILD_WEBHOOKS
+    pub const GUILD_WEBHOOKS: EventTypeFlags =
+        EventTypeFlags::from_bits_truncate(EventTypeFlags::WEBHOOKS_UPDATE.bits());
 }
 
 impl From<EventType> for EventTypeFlags {

--- a/gateway/src/event.rs
+++ b/gateway/src/event.rs
@@ -137,7 +137,7 @@ bitflags! {
 impl EventTypeFlags {
     /// All [`EventTypeFlags`] in [`Intents::GUILDS`].
     ///
-    /// [`Intents::GUILDS`]: twilight_gateway::Intents::GUILDS
+    /// [`Intents::GUILDS`]: crate::Intents::GUILDS
     pub const GUILDS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::CHANNEL_CREATE.bits()
             | EventTypeFlags::CHANNEL_DELETE.bits()
@@ -153,7 +153,7 @@ impl EventTypeFlags {
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MEMBERS`].
     ///
-    /// [`Intents::GUILD_MEMBERS`]: twilight_gateway::Intents::GUILD_MEMBERS
+    /// [`Intents::GUILD_MEMBERS`]: crate::Intents::GUILD_MEMBERS
     pub const GUILD_MEMBERS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::MEMBER_ADD.bits()
             | EventTypeFlags::MEMBER_REMOVE.bits()
@@ -162,51 +162,51 @@ impl EventTypeFlags {
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_BANS`].
     ///
-    /// [`Intents::GUILD_BANS`]: twilight_gateway::Intents::GUILD_BANS
+    /// [`Intents::GUILD_BANS`]: crate::Intents::GUILD_BANS
     pub const GUILD_BANS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::BAN_ADD.bits() | EventTypeFlags::BAN_REMOVE.bits(),
     );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_EMOJIS`].
     ///
-    /// [`Intents::GUILD_EMOJIS`]: twilight_gateway::Intents::GUILD_EMOJIS
+    /// [`Intents::GUILD_EMOJIS`]: crate::Intents::GUILD_EMOJIS
     pub const GUILD_EMOJIS: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::GUILD_EMOJIS_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_INTEGRATIONS`].
     ///
-    /// [`Intents::GUILD_INTEGRATIONS`]: twilight_gateway::Intents::GUILD_INTEGRATIONS
+    /// [`Intents::GUILD_INTEGRATIONS`]: crate::Intents::GUILD_INTEGRATIONS
     pub const GUILD_INTEGRATIONS: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::GUILD_INTEGRATIONS_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_WEBHOOKS`].
     ///
-    /// [`Intents::GUILD_WEBHOOKS`]: twilight_gateway::Intents::GUILD_WEBHOOKS
+    /// [`Intents::GUILD_WEBHOOKS`]: crate::Intents::GUILD_WEBHOOKS
     pub const GUILD_WEBHOOKS: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::WEBHOOKS_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_INVITES`].
     ///
-    /// [`Intents::GUILD_INVITES`]: twilight_gateway::Intents::GUILD_INVITES
+    /// [`Intents::GUILD_INVITES`]: crate::Intents::GUILD_INVITES
     pub const GUILD_INVITES: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::INVITE_CREATE.bits() | EventTypeFlags::INVITE_DELETE.bits(),
     );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_VOICE_STATES`].
     ///
-    /// [`Intents::GUILD_VOICE_STATES`]: twilight_gateway::Intents::GUILD_VOICE_STATES
+    /// [`Intents::GUILD_VOICE_STATES`]: crate::Intents::GUILD_VOICE_STATES
     pub const GUILD_VOICE_STATES: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::VOICE_STATE_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_PRESENCES`].
     ///
-    /// [`Intents::GUILD_PRESENCES`]: twilight_gateway::Intents::GUILD_PRESENCES
+    /// [`Intents::GUILD_PRESENCES`]: crate::Intents::GUILD_PRESENCES
     pub const GUILD_PRESENCES: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::PRESENCE_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGES`].
     ///
-    /// [`Intents::GUILD_MESSAGES`]: twilight_gateway::Intents::GUILD_MESSAGES
+    /// [`Intents::GUILD_MESSAGES`]: crate::Intents::GUILD_MESSAGES
     pub const GUILD_MESSAGES: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::MESSAGE_CREATE.bits()
             | EventTypeFlags::MESSAGE_DELETE.bits()
@@ -216,7 +216,7 @@ impl EventTypeFlags {
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGE_REACTIONS`].
     ///
-    /// [`Intents::GUILD_MESSAGE_REACTIONS`]: twilight_gateway::Intents::GUILD_MESSAGE_REACTIONS
+    /// [`Intents::GUILD_MESSAGE_REACTIONS`]: crate::Intents::GUILD_MESSAGE_REACTIONS
     pub const GUILD_MESSAGE_REACTIONS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::REACTION_ADD.bits()
             | EventTypeFlags::REACTION_REMOVE.bits()
@@ -226,13 +226,13 @@ impl EventTypeFlags {
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGE_TYPING`].
     ///
-    /// [`Intents::GUILD_MESSAGE_TYPING`]: twilight_gateway::Intents::GUILD_MESSAGE_TYPING
+    /// [`Intents::GUILD_MESSAGE_TYPING`]: crate::Intents::GUILD_MESSAGE_TYPING
     pub const GUILD_MESSAGE_TYPING: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::TYPING_START.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGES`].
     ///
-    /// [`Intents::DIRECT_MESSAGES`]: twilight_gateway::Intents::DIRECT_MESSAGES
+    /// [`Intents::DIRECT_MESSAGES`]: crate::Intents::DIRECT_MESSAGES
     pub const DIRECT_MESSAGES: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::MESSAGE_CREATE.bits()
             | EventTypeFlags::MESSAGE_DELETE.bits()
@@ -242,7 +242,7 @@ impl EventTypeFlags {
 
     /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGE_REACTIONS`].
     ///
-    /// [`Intents::DIRECT_MESSAGE_REACTIONS`]: twilight_gateway::Intents::DIRECT_MESSAGE_REACTIONS
+    /// [`Intents::DIRECT_MESSAGE_REACTIONS`]: crate::Intents::DIRECT_MESSAGE_REACTIONS
     pub const DIRECT_MESSAGE_REACTIONS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::REACTION_ADD.bits()
             | EventTypeFlags::REACTION_REMOVE.bits()
@@ -252,7 +252,7 @@ impl EventTypeFlags {
 
     /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGE_TYPING`].
     ///
-    /// [`Intents::DIRECT_MESSAGE_TYPING`]: twilight_gateway::Intents::DIRECT_MESSAGE_TYPING
+    /// [`Intents::DIRECT_MESSAGE_TYPING`]: crate::Intents::DIRECT_MESSAGE_TYPING
     pub const DIRECT_MESSAGE_TYPING: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::TYPING_START.bits());
 }

--- a/gateway/src/event.rs
+++ b/gateway/src/event.rs
@@ -134,6 +134,134 @@ bitflags! {
     }
 }
 
+impl EventTypeFlags {
+    /// All [`EventTypeFlags`] in [`Intents::GUILDS`].
+    ///
+    /// [`Intents::GUILDS`]: twilight-gateway::Intents::GUILDS
+    pub fn guilds() -> EventTypeFlags {
+        EventTypeFlags::CHANNEL_CREATE
+            | EventTypeFlags::CHANNEL_DELETE
+            | EventTypeFlags::CHANNEL_PINS_UPDATE
+            | EventTypeFlags::CHANNEL_UPDATE
+            | EventTypeFlags::GUILD_CREATE
+            | EventTypeFlags::GUILD_DELETE
+            | EventTypeFlags::GUILD_UPDATE
+            | EventTypeFlags::ROLE_CREATE
+            | EventTypeFlags::ROLE_DELETE
+            | EventTypeFlags::ROLE_UPDATE
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_MEMBERS`].
+    ///
+    /// [`Intents::GUILD_MEMBERS`]: twilight-gateway::Intents::GUILD_MEMBERS
+    pub fn guild_members() -> EventTypeFlags {
+        EventTypeFlags::MEMBER_ADD | EventTypeFlags::MEMBER_REMOVE | EventTypeFlags::MEMBER_UPDATE
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_BANS`].
+    ///
+    /// [`Intents::GUILD_BANS`]: twilight-gateway::Intents::GUILD_BANS
+    pub fn guild_bans() -> EventTypeFlags {
+        EventTypeFlags::BAN_ADD | EventTypeFlags::BAN_REMOVE
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_EMOJIS`].
+    ///
+    /// [`Intents::GUILD_EMOJIS`]: twilight-gateway::Intents::GUILD_EMOJIS
+    pub const fn guild_emojis() -> EventTypeFlags {
+        EventTypeFlags::GUILD_EMOJIS_UPDATE
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_INTEGRATIONS`].
+    ///
+    /// [`Intents::GUILD_INTEGRATIONS`]: twilight-gateway::Intents::GUILD_INTEGRATIONS
+    pub const fn guild_integrations() -> EventTypeFlags {
+        EventTypeFlags::GUILD_INTEGRATIONS_UPDATE
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_WEBHOOKS`].
+    ///
+    /// [`Intents::GUILD_WEBHOOKS`]: twilight-gateway::Intents::GUILD_WEBHOOKS
+    pub const fn guild_webhooks() -> EventTypeFlags {
+        EventTypeFlags::WEBHOOKS_UPDATE
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_INVITES`].
+    ///
+    /// [`Intents::GUILD_INVITES`]: twilight-gateway::Intents::GUILD_INVITES
+    pub fn guild_invites() -> EventTypeFlags {
+        EventTypeFlags::INVITE_CREATE | EventTypeFlags::INVITE_DELETE
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_VOICE_STATES`].
+    ///
+    /// [`Intents::GUILD_VOICE_STATES`]: twilight-gateway::Intents::GUILD_VOICE_STATES
+    pub const fn guild_voice_states() -> EventTypeFlags {
+        EventTypeFlags::VOICE_STATE_UPDATE
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_PRESENCES`].
+    ///
+    /// [`Intents::GUILD_PRESENCES`]: twilight-gateway::Intents::GUILD_PRESENCES
+    pub const fn guild_presences() -> EventTypeFlags {
+        EventTypeFlags::PRESENCE_UPDATE
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGES`].
+    ///
+    /// [`Intents::GUILD_MESSAGES`]: twilight-gateway::Intents::GUILD_MESSAGES
+    pub fn guild_messages() -> EventTypeFlags {
+        EventTypeFlags::MESSAGE_CREATE
+            | EventTypeFlags::MESSAGE_DELETE
+            | EventTypeFlags::MESSAGE_DELETE
+            | EventTypeFlags::MESSAGE_DELETE_BULK
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGE_REACTIONS`].
+    ///
+    /// [`Intents::GUILD_MESSAGE_REACTIONS`]: twilight-gateway::Intents::GUILD_MESSAGE_REACTIONS
+    pub fn guild_message_reactions() -> EventTypeFlags {
+        EventTypeFlags::REACTION_ADD
+            | EventTypeFlags::REACTION_REMOVE
+            | EventTypeFlags::REACTION_REMOVE_ALL
+            | EventTypeFlags::REACTION_REMOVE_EMOJI
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGE_TYPING`].
+    ///
+    /// [`Intents::GUILD_MESSAGE_TYPING`]: twilight-gateway::Intents::GUILD_MESSAGE_TYPING
+    pub const fn guild_message_typing() -> EventTypeFlags {
+        EventTypeFlags::TYPING_START
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGES`].
+    ///
+    /// [`Intents::DIRECT_MESSAGES`]: twilight-gateway::Intents::DIRECT_MESSAGES
+    pub fn direct_messages() -> EventTypeFlags {
+        EventTypeFlags::MESSAGE_CREATE
+            | EventTypeFlags::MESSAGE_DELETE
+            | EventTypeFlags::MESSAGE_DELETE_BULK
+            | EventTypeFlags::MESSAGE_UPDATE
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGE_REACTIONS`].
+    ///
+    /// [`Intents::DIRECT_MESSAGE_REACTIONS`]: twilight-gateway::Intents::DIRECT_MESSAGE_REACTIONS
+    pub fn direct_message_reactions() -> EventTypeFlags {
+        EventTypeFlags::REACTION_ADD
+            | EventTypeFlags::REACTION_REMOVE
+            | EventTypeFlags::REACTION_REMOVE_ALL
+            | EventTypeFlags::REACTION_REMOVE_EMOJI
+    }
+
+    /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGE_TYPING`].
+    ///
+    /// [`Intents::DIRECT_MESSAGE_TYPING`]: twilight-gateway::Intents::DIRECT_MESSAGE_TYPING
+    pub const fn direct_message_typing() -> EventTypeFlags {
+        EventTypeFlags::TYPING_START
+    }
+}
+
 impl From<EventType> for EventTypeFlags {
     fn from(event_type: EventType) -> Self {
         match event_type {

--- a/gateway/src/event.rs
+++ b/gateway/src/event.rs
@@ -137,7 +137,7 @@ bitflags! {
 impl EventTypeFlags {
     /// All [`EventTypeFlags`] in [`Intents::GUILDS`].
     ///
-    /// [`Intents::GUILDS`]: twilight-gateway::Intents::GUILDS
+    /// [`Intents::GUILDS`]: twilight_gateway::Intents::GUILDS
     pub const GUILDS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::CHANNEL_CREATE.bits()
             | EventTypeFlags::CHANNEL_DELETE.bits()
@@ -153,7 +153,7 @@ impl EventTypeFlags {
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MEMBERS`].
     ///
-    /// [`Intents::GUILD_MEMBERS`]: twilight-gateway::Intents::GUILD_MEMBERS
+    /// [`Intents::GUILD_MEMBERS`]: twilight_gateway::Intents::GUILD_MEMBERS
     pub const GUILD_MEMBERS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::MEMBER_ADD.bits()
             | EventTypeFlags::MEMBER_REMOVE.bits()
@@ -162,51 +162,51 @@ impl EventTypeFlags {
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_BANS`].
     ///
-    /// [`Intents::GUILD_BANS`]: twilight-gateway::Intents::GUILD_BANS
+    /// [`Intents::GUILD_BANS`]: twilight_gateway::Intents::GUILD_BANS
     pub const GUILD_BANS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::BAN_ADD.bits() | EventTypeFlags::BAN_REMOVE.bits(),
     );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_EMOJIS`].
     ///
-    /// [`Intents::GUILD_EMOJIS`]: twilight-gateway::Intents::GUILD_EMOJIS
+    /// [`Intents::GUILD_EMOJIS`]: twilight_gateway::Intents::GUILD_EMOJIS
     pub const GUILD_EMOJIS: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::GUILD_EMOJIS_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_INTEGRATIONS`].
     ///
-    /// [`Intents::GUILD_INTEGRATIONS`]: twilight-gateway::Intents::GUILD_INTEGRATIONS
+    /// [`Intents::GUILD_INTEGRATIONS`]: twilight_gateway::Intents::GUILD_INTEGRATIONS
     pub const GUILD_INTEGRATIONS: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::GUILD_INTEGRATIONS_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_WEBHOOKS`].
     ///
-    /// [`Intents::GUILD_WEBHOOKS`]: twilight-gateway::Intents::GUILD_WEBHOOKS
+    /// [`Intents::GUILD_WEBHOOKS`]: twilight_gateway::Intents::GUILD_WEBHOOKS
     pub const GUILD_WEBHOOKS: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::WEBHOOKS_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_INVITES`].
     ///
-    /// [`Intents::GUILD_INVITES`]: twilight-gateway::Intents::GUILD_INVITES
+    /// [`Intents::GUILD_INVITES`]: twilight_gateway::Intents::GUILD_INVITES
     pub const GUILD_INVITES: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::INVITE_CREATE.bits() | EventTypeFlags::INVITE_DELETE.bits(),
     );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_VOICE_STATES`].
     ///
-    /// [`Intents::GUILD_VOICE_STATES`]: twilight-gateway::Intents::GUILD_VOICE_STATES
+    /// [`Intents::GUILD_VOICE_STATES`]: twilight_gateway::Intents::GUILD_VOICE_STATES
     pub const GUILD_VOICE_STATES: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::VOICE_STATE_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_PRESENCES`].
     ///
-    /// [`Intents::GUILD_PRESENCES`]: twilight-gateway::Intents::GUILD_PRESENCES
+    /// [`Intents::GUILD_PRESENCES`]: twilight_gateway::Intents::GUILD_PRESENCES
     pub const GUILD_PRESENCES: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::PRESENCE_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGES`].
     ///
-    /// [`Intents::GUILD_MESSAGES`]: twilight-gateway::Intents::GUILD_MESSAGES
+    /// [`Intents::GUILD_MESSAGES`]: twilight_gateway::Intents::GUILD_MESSAGES
     pub const GUILD_MESSAGES: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::MESSAGE_CREATE.bits()
             | EventTypeFlags::MESSAGE_DELETE.bits()
@@ -216,7 +216,7 @@ impl EventTypeFlags {
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGE_REACTIONS`].
     ///
-    /// [`Intents::GUILD_MESSAGE_REACTIONS`]: twilight-gateway::Intents::GUILD_MESSAGE_REACTIONS
+    /// [`Intents::GUILD_MESSAGE_REACTIONS`]: twilight_gateway::Intents::GUILD_MESSAGE_REACTIONS
     pub const GUILD_MESSAGE_REACTIONS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::REACTION_ADD.bits()
             | EventTypeFlags::REACTION_REMOVE.bits()
@@ -226,13 +226,13 @@ impl EventTypeFlags {
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGE_TYPING`].
     ///
-    /// [`Intents::GUILD_MESSAGE_TYPING`]: twilight-gateway::Intents::GUILD_MESSAGE_TYPING
+    /// [`Intents::GUILD_MESSAGE_TYPING`]: twilight_gateway::Intents::GUILD_MESSAGE_TYPING
     pub const GUILD_MESSAGE_TYPING: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::TYPING_START.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGES`].
     ///
-    /// [`Intents::DIRECT_MESSAGES`]: twilight-gateway::Intents::DIRECT_MESSAGES
+    /// [`Intents::DIRECT_MESSAGES`]: twilight_gateway::Intents::DIRECT_MESSAGES
     pub const DIRECT_MESSAGES: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::MESSAGE_CREATE.bits()
             | EventTypeFlags::MESSAGE_DELETE.bits()
@@ -242,7 +242,7 @@ impl EventTypeFlags {
 
     /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGE_REACTIONS`].
     ///
-    /// [`Intents::DIRECT_MESSAGE_REACTIONS`]: twilight-gateway::Intents::DIRECT_MESSAGE_REACTIONS
+    /// [`Intents::DIRECT_MESSAGE_REACTIONS`]: twilight_gateway::Intents::DIRECT_MESSAGE_REACTIONS
     pub const DIRECT_MESSAGE_REACTIONS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::REACTION_ADD.bits()
             | EventTypeFlags::REACTION_REMOVE.bits()
@@ -252,7 +252,7 @@ impl EventTypeFlags {
 
     /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGE_TYPING`].
     ///
-    /// [`Intents::DIRECT_MESSAGE_TYPING`]: twilight-gateway::Intents::DIRECT_MESSAGE_TYPING
+    /// [`Intents::DIRECT_MESSAGE_TYPING`]: twilight_gateway::Intents::DIRECT_MESSAGE_TYPING
     pub const DIRECT_MESSAGE_TYPING: EventTypeFlags =
         EventTypeFlags::from_bits_truncate(EventTypeFlags::TYPING_START.bits());
 }

--- a/gateway/src/event.rs
+++ b/gateway/src/event.rs
@@ -138,128 +138,123 @@ impl EventTypeFlags {
     /// All [`EventTypeFlags`] in [`Intents::GUILDS`].
     ///
     /// [`Intents::GUILDS`]: twilight-gateway::Intents::GUILDS
-    pub fn guilds() -> EventTypeFlags {
-        EventTypeFlags::CHANNEL_CREATE
-            | EventTypeFlags::CHANNEL_DELETE
-            | EventTypeFlags::CHANNEL_PINS_UPDATE
-            | EventTypeFlags::CHANNEL_UPDATE
-            | EventTypeFlags::GUILD_CREATE
-            | EventTypeFlags::GUILD_DELETE
-            | EventTypeFlags::GUILD_UPDATE
-            | EventTypeFlags::ROLE_CREATE
-            | EventTypeFlags::ROLE_DELETE
-            | EventTypeFlags::ROLE_UPDATE
-    }
+    pub const GUILDS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
+        EventTypeFlags::CHANNEL_CREATE.bits()
+            | EventTypeFlags::CHANNEL_DELETE.bits()
+            | EventTypeFlags::CHANNEL_PINS_UPDATE.bits()
+            | EventTypeFlags::CHANNEL_UPDATE.bits()
+            | EventTypeFlags::GUILD_CREATE.bits()
+            | EventTypeFlags::GUILD_DELETE.bits()
+            | EventTypeFlags::GUILD_UPDATE.bits()
+            | EventTypeFlags::ROLE_CREATE.bits()
+            | EventTypeFlags::ROLE_DELETE.bits()
+            | EventTypeFlags::ROLE_UPDATE.bits(),
+    );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MEMBERS`].
     ///
     /// [`Intents::GUILD_MEMBERS`]: twilight-gateway::Intents::GUILD_MEMBERS
-    pub fn guild_members() -> EventTypeFlags {
-        EventTypeFlags::MEMBER_ADD | EventTypeFlags::MEMBER_REMOVE | EventTypeFlags::MEMBER_UPDATE
-    }
+    pub const GUILD_MEMBERS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
+        EventTypeFlags::MEMBER_ADD.bits()
+            | EventTypeFlags::MEMBER_REMOVE.bits()
+            | EventTypeFlags::MEMBER_UPDATE.bits(),
+    );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_BANS`].
     ///
     /// [`Intents::GUILD_BANS`]: twilight-gateway::Intents::GUILD_BANS
-    pub fn guild_bans() -> EventTypeFlags {
-        EventTypeFlags::BAN_ADD | EventTypeFlags::BAN_REMOVE
-    }
+    pub const GUILD_BANS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
+        EventTypeFlags::BAN_ADD.bits() | EventTypeFlags::BAN_REMOVE.bits(),
+    );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_EMOJIS`].
     ///
     /// [`Intents::GUILD_EMOJIS`]: twilight-gateway::Intents::GUILD_EMOJIS
-    pub const fn guild_emojis() -> EventTypeFlags {
-        EventTypeFlags::GUILD_EMOJIS_UPDATE
-    }
+    pub const GUILD_EMOJIS: EventTypeFlags =
+        EventTypeFlags::from_bits_truncate(EventTypeFlags::GUILD_EMOJIS_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_INTEGRATIONS`].
     ///
     /// [`Intents::GUILD_INTEGRATIONS`]: twilight-gateway::Intents::GUILD_INTEGRATIONS
-    pub const fn guild_integrations() -> EventTypeFlags {
-        EventTypeFlags::GUILD_INTEGRATIONS_UPDATE
-    }
+    pub const GUILD_INTEGRATIONS: EventTypeFlags =
+        EventTypeFlags::from_bits_truncate(EventTypeFlags::GUILD_INTEGRATIONS_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_WEBHOOKS`].
     ///
     /// [`Intents::GUILD_WEBHOOKS`]: twilight-gateway::Intents::GUILD_WEBHOOKS
-    pub const fn guild_webhooks() -> EventTypeFlags {
-        EventTypeFlags::WEBHOOKS_UPDATE
-    }
+    pub const GUILD_WEBHOOKS: EventTypeFlags =
+        EventTypeFlags::from_bits_truncate(EventTypeFlags::WEBHOOKS_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_INVITES`].
     ///
     /// [`Intents::GUILD_INVITES`]: twilight-gateway::Intents::GUILD_INVITES
-    pub fn guild_invites() -> EventTypeFlags {
-        EventTypeFlags::INVITE_CREATE | EventTypeFlags::INVITE_DELETE
-    }
+    pub const GUILD_INVITES: EventTypeFlags = EventTypeFlags::from_bits_truncate(
+        EventTypeFlags::INVITE_CREATE.bits() | EventTypeFlags::INVITE_DELETE.bits(),
+    );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_VOICE_STATES`].
     ///
     /// [`Intents::GUILD_VOICE_STATES`]: twilight-gateway::Intents::GUILD_VOICE_STATES
-    pub const fn guild_voice_states() -> EventTypeFlags {
-        EventTypeFlags::VOICE_STATE_UPDATE
-    }
+    pub const GUILD_VOICE_STATES: EventTypeFlags =
+        EventTypeFlags::from_bits_truncate(EventTypeFlags::VOICE_STATE_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_PRESENCES`].
     ///
     /// [`Intents::GUILD_PRESENCES`]: twilight-gateway::Intents::GUILD_PRESENCES
-    pub const fn guild_presences() -> EventTypeFlags {
-        EventTypeFlags::PRESENCE_UPDATE
-    }
+    pub const GUILD_PRESENCES: EventTypeFlags =
+        EventTypeFlags::from_bits_truncate(EventTypeFlags::PRESENCE_UPDATE.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGES`].
     ///
     /// [`Intents::GUILD_MESSAGES`]: twilight-gateway::Intents::GUILD_MESSAGES
-    pub fn guild_messages() -> EventTypeFlags {
-        EventTypeFlags::MESSAGE_CREATE
-            | EventTypeFlags::MESSAGE_DELETE
-            | EventTypeFlags::MESSAGE_DELETE
-            | EventTypeFlags::MESSAGE_DELETE_BULK
-    }
+    pub const GUILD_MESSAGES: EventTypeFlags = EventTypeFlags::from_bits_truncate(
+        EventTypeFlags::MESSAGE_CREATE.bits()
+            | EventTypeFlags::MESSAGE_DELETE.bits()
+            | EventTypeFlags::MESSAGE_DELETE.bits()
+            | EventTypeFlags::MESSAGE_DELETE_BULK.bits(),
+    );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGE_REACTIONS`].
     ///
     /// [`Intents::GUILD_MESSAGE_REACTIONS`]: twilight-gateway::Intents::GUILD_MESSAGE_REACTIONS
-    pub fn guild_message_reactions() -> EventTypeFlags {
-        EventTypeFlags::REACTION_ADD
-            | EventTypeFlags::REACTION_REMOVE
-            | EventTypeFlags::REACTION_REMOVE_ALL
-            | EventTypeFlags::REACTION_REMOVE_EMOJI
-    }
+    pub const GUILD_MESSAGE_REACTIONS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
+        EventTypeFlags::REACTION_ADD.bits()
+            | EventTypeFlags::REACTION_REMOVE.bits()
+            | EventTypeFlags::REACTION_REMOVE_ALL.bits()
+            | EventTypeFlags::REACTION_REMOVE_EMOJI.bits(),
+    );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGE_TYPING`].
     ///
     /// [`Intents::GUILD_MESSAGE_TYPING`]: twilight-gateway::Intents::GUILD_MESSAGE_TYPING
-    pub const fn guild_message_typing() -> EventTypeFlags {
-        EventTypeFlags::TYPING_START
-    }
+    pub const GUILD_MESSAGE_TYPING: EventTypeFlags =
+        EventTypeFlags::from_bits_truncate(EventTypeFlags::TYPING_START.bits());
 
     /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGES`].
     ///
     /// [`Intents::DIRECT_MESSAGES`]: twilight-gateway::Intents::DIRECT_MESSAGES
-    pub fn direct_messages() -> EventTypeFlags {
-        EventTypeFlags::MESSAGE_CREATE
-            | EventTypeFlags::MESSAGE_DELETE
-            | EventTypeFlags::MESSAGE_DELETE_BULK
-            | EventTypeFlags::MESSAGE_UPDATE
-    }
+    pub const DIRECT_MESSAGES: EventTypeFlags = EventTypeFlags::from_bits_truncate(
+        EventTypeFlags::MESSAGE_CREATE.bits()
+            | EventTypeFlags::MESSAGE_DELETE.bits()
+            | EventTypeFlags::MESSAGE_DELETE_BULK.bits()
+            | EventTypeFlags::MESSAGE_UPDATE.bits(),
+    );
 
     /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGE_REACTIONS`].
     ///
     /// [`Intents::DIRECT_MESSAGE_REACTIONS`]: twilight-gateway::Intents::DIRECT_MESSAGE_REACTIONS
-    pub fn direct_message_reactions() -> EventTypeFlags {
-        EventTypeFlags::REACTION_ADD
-            | EventTypeFlags::REACTION_REMOVE
-            | EventTypeFlags::REACTION_REMOVE_ALL
-            | EventTypeFlags::REACTION_REMOVE_EMOJI
-    }
+    pub const DIRECT_MESSAGE_REACTIONS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
+        EventTypeFlags::REACTION_ADD.bits()
+            | EventTypeFlags::REACTION_REMOVE.bits()
+            | EventTypeFlags::REACTION_REMOVE_ALL.bits()
+            | EventTypeFlags::REACTION_REMOVE_EMOJI.bits(),
+    );
 
     /// All [`EventTypeFlags`] in [`Intents::DIRECT_MESSAGE_TYPING`].
     ///
     /// [`Intents::DIRECT_MESSAGE_TYPING`]: twilight-gateway::Intents::DIRECT_MESSAGE_TYPING
-    pub const fn direct_message_typing() -> EventTypeFlags {
-        EventTypeFlags::TYPING_START
-    }
+    pub const DIRECT_MESSAGE_TYPING: EventTypeFlags =
+        EventTypeFlags::from_bits_truncate(EventTypeFlags::TYPING_START.bits());
 }
 
 impl From<EventType> for EventTypeFlags {


### PR DESCRIPTION
This adds associated functions to `EventTypeFlags` that return the `EventTypeFlags` for a given `Intent`. ~~This can not be const nor an associated const until [bitflags/bitflags/#217][bitflags-pr] lands.~~


[bitflags-pr]: https://github.com/bitflags/bitflags/pull/217