### PR TITLE
Gateway: Reuse tls connectors between shards

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -20,7 +20,7 @@ futures-util = { default-features = false, features = ["std"], version = "0.3" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.5" }
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.16" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.16.1" }
 twilight-gateway-queue = { default-features = false, path = "../gateway-queue" }
 twilight-http = { default-features = false, path = "../http" }
 twilight-model = { default-features = false, path = "../model" }
@@ -37,6 +37,13 @@ metrics = { default-features = false, features = ["std"], optional = true, versi
 simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.4" }
 tracing = { default-features = false, features = ["std", "attributes"], optional = true, version = "0.1" }
 
+# TLS libraries
+# They need to track what is used in tokio-tungstenite
+native-tls = { default-features = false, features = [], optional = true, version = "0.2.8" }
+rustls-tls = { default-features = false, features = [], optional = true, package = "rustls", version = "0.20" }
+rustls-native-certs = {default-features = false, features = [], optional = true, version = "0.6.1" }
+webpki-roots = {default-features = false, features = [], optional = true, version = "0.22" }
+
 [dev-dependencies]
 futures = { default-features = false, version = "0.3" }
 static_assertions = { default-features = false, version = "1" }
@@ -49,10 +56,10 @@ proc-macro-hack = { default-features = false, version = "0.5.7" }
 [features]
 default = ["compression", "rustls", "tracing", "flate2/zlib"]
 compression = ["flate2"]
-native = ["twilight-http/native", "twilight-gateway-queue/native", "tokio-tungstenite/native-tls"]
-rustls = ["rustls-native-roots"]
-rustls-native-roots = ["twilight-http/rustls-native-roots", "twilight-gateway-queue/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]
-rustls-webpki-roots = ["twilight-http/rustls-webpki-roots", "twilight-gateway-queue/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
+native = ["native-tls", "twilight-http/native", "twilight-gateway-queue/native", "tokio-tungstenite/native-tls"]
+rustls = ["rustls-tls", "rustls-native-roots"]
+rustls-native-roots = ["rustls-native-certs", "twilight-http/rustls-native-roots", "twilight-gateway-queue/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]
+rustls-webpki-roots = ["webpki-roots", "twilight-http/rustls-webpki-roots", "twilight-gateway-queue/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
 zlib-simd = ["compression", "flate2/zlib-ng-compat"]
 # if the `zlib` feature is enabled anywhere in the dependency tree it will
 # always use stock zlib instead of zlib-ng.

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -38,7 +38,7 @@ simd-json = { default-features = false, features = ["serde_impl", "swar-number-p
 tracing = { default-features = false, features = ["std", "attributes"], optional = true, version = "0.1" }
 
 # TLS libraries
-# They need to track what is used in tokio-tungstenite
+# They are needed to track what is used in tokio-tungstenite
 native-tls = { default-features = false, features = [], optional = true, version = "0.2.8" }
 rustls-tls = { default-features = false, features = [], optional = true, package = "rustls", version = "0.20" }
 rustls-native-certs = {default-features = false, features = [], optional = true, version = "0.6.1" }
@@ -57,9 +57,9 @@ proc-macro-hack = { default-features = false, version = "0.5.7" }
 default = ["compression", "rustls", "tracing", "flate2/zlib"]
 compression = ["flate2"]
 native = ["native-tls", "twilight-http/native", "twilight-gateway-queue/native", "tokio-tungstenite/native-tls"]
-rustls = ["rustls-tls", "rustls-native-roots"]
-rustls-native-roots = ["rustls-native-certs", "twilight-http/rustls-native-roots", "twilight-gateway-queue/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]
-rustls-webpki-roots = ["webpki-roots", "twilight-http/rustls-webpki-roots", "twilight-gateway-queue/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
+rustls = ["rustls-native-roots"]
+rustls-native-roots = ["rustls-tls", "rustls-native-certs", "twilight-http/rustls-native-roots", "twilight-gateway-queue/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]
+rustls-webpki-roots = ["rustls-tls", "webpki-roots", "twilight-http/rustls-webpki-roots", "twilight-gateway-queue/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
 zlib-simd = ["compression", "flate2/zlib-ng-compat"]
 # if the `zlib` feature is enabled anywhere in the dependency tree it will
 # always use stock zlib instead of zlib-ng.

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -39,10 +39,10 @@ tracing = { default-features = false, features = ["std", "attributes"], optional
 
 # TLS libraries
 # They are needed to track what is used in tokio-tungstenite
-native-tls = { default-features = false, features = [], optional = true, version = "0.2.8" }
-rustls-tls = { default-features = false, features = [], optional = true, package = "rustls", version = "0.20" }
-rustls-native-certs = {default-features = false, features = [], optional = true, version = "0.6.1" }
-webpki-roots = {default-features = false, features = [], optional = true, version = "0.22" }
+native-tls = { default-features = false, optional = true, version = "0.2.8" }
+rustls-tls = { default-features = false, optional = true, package = "rustls", version = "0.20" }
+rustls-native-certs = {default-features = false, optional = true, version = "0.6" }
+webpki-roots = {default-features = false, optional = true, version = "0.22" }
 
 [dev-dependencies]
 futures = { default-features = false, version = "0.3" }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -41,8 +41,8 @@ tracing = { default-features = false, features = ["std", "attributes"], optional
 # They are needed to track what is used in tokio-tungstenite
 native-tls = { default-features = false, optional = true, version = "0.2.8" }
 rustls-tls = { default-features = false, optional = true, package = "rustls", version = "0.20" }
-rustls-native-certs = {default-features = false, optional = true, version = "0.6" }
-webpki-roots = {default-features = false, optional = true, version = "0.22" }
+rustls-native-certs = { default-features = false, optional = true, version = "0.6" }
+webpki-roots = { default-features = false, optional = true, version = "0.22" }
 
 [dev-dependencies]
 futures = { default-features = false, version = "0.3" }

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -1,6 +1,12 @@
-use super::{ClusterStartErrorType, config::Config as ClusterConfig, event::Events, r#impl::{Cluster, ClusterStartError}, scheme::ShardScheme};
+use super::{
+    config::Config as ClusterConfig,
+    event::Events,
+    r#impl::{Cluster, ClusterStartError},
+    scheme::ShardScheme,
+    ClusterStartErrorType,
+};
 use crate::{
-    shard::{LargeThresholdError, ResumeSession, ShardBuilder, tls::TlsContainer},
+    shard::{tls::TlsContainer, LargeThresholdError, ResumeSession, ShardBuilder},
     EventTypeFlags,
 };
 use std::{collections::HashMap, sync::Arc};
@@ -64,7 +70,7 @@ impl ClusterBuilder {
         })?;
 
         (self.1).0.tls = Some(tls);
-        
+
         if (self.1).0.gateway_url.is_none() {
             let maybe_response = (self.1).0.http_client.gateway().authed().exec().await;
 

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -1,11 +1,6 @@
-use super::{
-    config::Config as ClusterConfig,
-    event::Events,
-    r#impl::{Cluster, ClusterStartError},
-    scheme::ShardScheme,
-};
+use super::{ClusterStartErrorType, config::Config as ClusterConfig, event::Events, r#impl::{Cluster, ClusterStartError}, scheme::ShardScheme};
 use crate::{
-    shard::{LargeThresholdError, ResumeSession, ShardBuilder},
+    shard::{LargeThresholdError, ResumeSession, ShardBuilder, tls::TlsContainer},
     EventTypeFlags,
 };
 use std::{collections::HashMap, sync::Arc};
@@ -63,6 +58,13 @@ impl ClusterBuilder {
     ///
     /// [`ClusterStartErrorType::RetrievingGatewayInfo`]: super::ClusterStartErrorType::RetrievingGatewayInfo
     pub async fn build(mut self) -> Result<(Cluster, Events), ClusterStartError> {
+        let tls = TlsContainer::new().map_err(|err| ClusterStartError {
+            kind: ClusterStartErrorType::Tls,
+            source: Some(Box::new(err)),
+        })?;
+
+        (self.1).0.tls = Some(tls);
+        
         if (self.1).0.gateway_url.is_none() {
             let maybe_response = (self.1).0.http_client.gateway().authed().exec().await;
 

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -18,8 +18,8 @@ use twilight_http::Client as HttpClient;
 /// Sending a command to a shard failed.
 #[derive(Debug)]
 pub struct ClusterCommandError {
-    kind: ClusterCommandErrorType,
-    source: Option<Box<dyn Error + Send + Sync>>,
+    pub(super) kind: ClusterCommandErrorType,
+    pub(super) source: Option<Box<dyn Error + Send + Sync>>,
 }
 
 impl ClusterCommandError {
@@ -150,8 +150,8 @@ pub enum ClusterSendErrorType {
 /// Starting a cluster failed.
 #[derive(Debug)]
 pub struct ClusterStartError {
-    kind: ClusterStartErrorType,
-    source: Option<Box<dyn Error + Send + Sync>>,
+    pub(super) kind: ClusterStartErrorType,
+    pub(super) source: Option<Box<dyn Error + Send + Sync>>,
 }
 
 impl ClusterStartError {
@@ -180,6 +180,9 @@ impl Display for ClusterStartError {
             ClusterStartErrorType::RetrievingGatewayInfo { .. } => {
                 f.write_str("getting the bot's gateway info failed")
             }
+            ClusterStartErrorType::Tls => {
+                f.write_str("creating the TLS connector resulted in a error")
+            }
         }
     }
 }
@@ -204,6 +207,8 @@ pub enum ClusterStartErrorType {
     ///
     /// [automatic sharding]: ShardScheme::Auto
     RetrievingGatewayInfo,
+    /// Creating the TLS connector resulted in a error.
+    Tls,
 }
 
 /// A manager for multiple shards.

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -189,6 +189,7 @@ impl ShardBuilder {
             token: token.into_boxed_str(),
             session_id: None,
             sequence: None,
+            tls: None,
         })
     }
 

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -1,4 +1,4 @@
-use crate::EventTypeFlags;
+use crate::{EventTypeFlags, shard::tls::TlsContainer};
 use std::sync::Arc;
 use twilight_gateway_queue::Queue;
 use twilight_http::Client;
@@ -27,6 +27,7 @@ pub struct Config {
     pub(super) token: Box<str>,
     pub(crate) session_id: Option<Box<str>>,
     pub(crate) sequence: Option<u64>,
+    pub(crate) tls: Option<TlsContainer>,
 }
 
 impl Config {

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -1,4 +1,4 @@
-use crate::{EventTypeFlags, shard::tls::TlsContainer};
+use crate::{shard::tls::TlsContainer, EventTypeFlags};
 use std::sync::Arc;
 use twilight_gateway_queue::Queue;
 use twilight_http::Client;

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -30,6 +30,7 @@ mod event;
 mod r#impl;
 mod json;
 mod processor;
+pub(crate) mod tls;
 
 pub use self::{
     builder::{

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -10,7 +10,7 @@ use super::{
     session::{Session, SessionSendError, SessionSendErrorType},
     socket_forwarder::SocketForwarder,
 };
-use crate::event::EventTypeFlags;
+use crate::{event::EventTypeFlags, shard::tls::TlsContainer};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -314,7 +314,7 @@ impl ShardProcessor {
             gateway: url.clone(),
             shard_id: config.shard()[0],
         }));
-        let stream = Self::connect(&url).await?;
+        let stream = Self::connect(&url, config.tls.as_ref()).await?;
         let (forwarder, rx, tx) = SocketForwarder::new(stream);
         tokio::spawn(async move {
             forwarder.run().await;
@@ -842,7 +842,8 @@ impl ShardProcessor {
         Ok(())
     }
 
-    async fn connect(url: &str) -> Result<ShardStream, ConnectingError> {
+    async fn connect(url: &str, tls: Option<&TlsContainer>) -> Result<ShardStream, ConnectingError> {
+        #[allow(rust_2021_incompatible_closure_captures)]
         let url = Url::parse(url).map_err(|source| ConnectingError {
             kind: ConnectingErrorType::ParsingUrl {
                 url: url.to_owned(),
@@ -862,7 +863,7 @@ impl ShardProcessor {
             max_send_queue: None,
         };
 
-        let (stream, _) = tokio_tungstenite::connect_async_with_config(url, Some(config))
+        let (stream, _) = tokio_tungstenite::connect_async_tls_with_config(url, Some(config), tls.map(|t| t.connector()))
             .await
             .map_err(|source| ConnectingError {
                 kind: ConnectingErrorType::Establishing,
@@ -927,7 +928,7 @@ impl ShardProcessor {
                 shard_id: self.config.shard()[0],
             }));
 
-            let stream = match Self::connect(&self.url).await {
+            let stream = match Self::connect(&self.url, self.config.tls.as_ref()).await {
                 Ok(s) => s,
                 Err(_source) => {
                     #[cfg(feature = "tracing")]
@@ -996,7 +997,7 @@ impl ShardProcessor {
             shard_id: self.config.shard()[0],
         }));
 
-        let stream = Self::connect(&self.url).await?;
+        let stream = Self::connect(&self.url, self.config.tls.as_ref()).await?;
 
         self.set_session(stream, Stage::Resuming);
 

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -846,7 +846,6 @@ impl ShardProcessor {
         url: &str,
         tls: Option<&TlsContainer>,
     ) -> Result<ShardStream, ConnectingError> {
-        #[allow(rust_2021_incompatible_closure_captures)]
         let url = Url::parse(url).map_err(|source| ConnectingError {
             kind: ConnectingErrorType::ParsingUrl {
                 url: url.to_owned(),

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -842,7 +842,10 @@ impl ShardProcessor {
         Ok(())
     }
 
-    async fn connect(url: &str, tls: Option<&TlsContainer>) -> Result<ShardStream, ConnectingError> {
+    async fn connect(
+        url: &str,
+        tls: Option<&TlsContainer>,
+    ) -> Result<ShardStream, ConnectingError> {
         #[allow(rust_2021_incompatible_closure_captures)]
         let url = Url::parse(url).map_err(|source| ConnectingError {
             kind: ConnectingErrorType::ParsingUrl {
@@ -863,12 +866,16 @@ impl ShardProcessor {
             max_send_queue: None,
         };
 
-        let (stream, _) = tokio_tungstenite::connect_async_tls_with_config(url, Some(config), tls.map(|t| t.connector()))
-            .await
-            .map_err(|source| ConnectingError {
-                kind: ConnectingErrorType::Establishing,
-                source: Some(Box::new(source)),
-            })?;
+        let (stream, _) = tokio_tungstenite::connect_async_tls_with_config(
+            url,
+            Some(config),
+            tls.map(TlsContainer::connector),
+        )
+        .await
+        .map_err(|source| ConnectingError {
+            kind: ConnectingErrorType::Establishing,
+            source: Some(Box::new(source)),
+        })?;
 
         #[cfg(feature = "tracing")]
         tracing::debug!("Shook hands with remote");

--- a/gateway/src/shard/tls.rs
+++ b/gateway/src/shard/tls.rs
@@ -109,37 +109,33 @@ impl TlsContainer {
     #[cfg(feature = "rustls")]
     pub fn new() -> Result<Self, TlsError> {
         let mut roots = rustls_tls::RootCertStore::empty();
-        
+
         #[cfg(feature = "rustls-native-roots")]
         {
-            let certs = rustls_native_certs::load_native_certs()
-                .map_err(|err| TlsError {
-                    kind: TlsErrorType::NativeCerts,
-                    source: Some(Box::new(err)),
-                })?;
+            let certs = rustls_native_certs::load_native_certs().map_err(|err| TlsError {
+                kind: TlsErrorType::NativeCerts,
+                source: Some(Box::new(err)),
+            })?;
 
             for cert in certs {
-                roots.add(&rustls_tls::Certificate(cert.0)).map_err(|err| TlsError {
-                    kind: TlsErrorType::NativeCerts,
-                    source: Some(Box::new(err)),
-                })?;
+                roots
+                    .add(&rustls_tls::Certificate(cert.0))
+                    .map_err(|err| TlsError {
+                        kind: TlsErrorType::NativeCerts,
+                        source: Some(Box::new(err)),
+                    })?;
             }
         }
 
         #[cfg(feature = "rustls-webpki-roots")]
         {
-            roots.add_server_trust_anchors(
-                webpki_roots::TLS_SERVER_ROOTS
-                    .0
-                    .iter()
-                    .map(|ta| {
-                        OwnedTrustAnchor::from_subject_spki_name_constraints(
-                            ta.subject,
-                            ta.spki,
-                            ta.name_constraints,
-                        )
-                    }),
-            );
+            roots.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+                OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    ta.subject,
+                    ta.spki,
+                    ta.name_constraints,
+                )
+            }));
         };
 
         let config = ClientConfig::builder()

--- a/gateway/src/shard/tls.rs
+++ b/gateway/src/shard/tls.rs
@@ -1,0 +1,165 @@
+//! TLS manager to reuse connections between shards.
+
+#[cfg(feature = "rustls")]
+use std::sync::Arc;
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+
+#[cfg(all(feature = "native", not(feature = "rustls")))]
+use native_tls::TlsConnector as NativeTlsConnector;
+#[cfg(feature = "rustls")]
+use rustls_tls::ClientConfig;
+#[cfg(all(feature = "rustls", feature = "rustls-webpki-roots"))]
+use rustls_tls::OwnedTrustAnchor;
+use tokio_tungstenite::Connector;
+
+#[cfg(all(feature = "native", not(feature = "rustls")))]
+pub type TlsConnector = NativeTlsConnector;
+#[cfg(feature = "rustls")]
+pub type TlsConnector = Arc<ClientConfig>;
+
+#[derive(Debug)]
+pub struct TlsError {
+    kind: TlsErrorType,
+    source: Option<Box<dyn Error + Send + Sync>>,
+}
+
+#[allow(dead_code)]
+impl TlsError {
+    /// Immutable reference to the type of error that occurred.
+    #[must_use = "retrieving the type has no effect if left unused"]
+    pub const fn kind(&self) -> &TlsErrorType {
+        &self.kind
+    }
+
+    /// Consume the error, returning the source error if there is any.
+    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
+    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
+        self.source
+    }
+
+    /// Consume the error, returning the owned error type and the source error.
+    #[must_use = "consuming the error into its parts has no effect if left unused"]
+    pub fn into_parts(self) -> (TlsErrorType, Option<Box<dyn Error + Send + Sync>>) {
+        (self.kind, self.source)
+    }
+}
+
+impl Display for TlsError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match &self.kind {
+            #[cfg(all(feature = "native", not(feature = "rustls")))]
+            TlsErrorType::NativeTls => {
+                f.write_str("construction of the nativetls connector failed")
+            }
+            #[cfg(feature = "rustls-native-roots")]
+            TlsErrorType::NativeCerts => f.write_str("could not load native certificates"),
+        }
+    }
+}
+
+impl Error for TlsError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|source| &**source as &(dyn Error + 'static))
+    }
+}
+
+/// Type of [`ClusterCommandError`] that occurred.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum TlsErrorType {
+    /// Construction of the nativetls connector failed.
+    #[cfg(all(feature = "native", not(feature = "rustls")))]
+    NativeTls,
+    /// Could not load native certificates.
+    #[cfg(feature = "rustls-native-roots")]
+    NativeCerts,
+}
+
+#[derive(Clone)]
+#[cfg_attr(all(feature = "native", not(feature = "rustls")), derive(Debug))]
+pub struct TlsContainer {
+    tls: TlsConnector,
+}
+
+#[cfg(feature = "rustls")]
+impl std::fmt::Debug for TlsContainer {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.debug_struct("TlsContainer").finish()
+    }
+}
+
+impl TlsContainer {
+    #[cfg(all(feature = "native", not(feature = "rustls")))]
+    pub fn new() -> Result<Self, TlsError> {
+        let native_connector = TlsConnector::new().map_err(|err| TlsError {
+            kind: TlsErrorType::NativeTls,
+            source: Some(Box::new(err)),
+        })?;
+
+        Ok(TlsContainer {
+            tls: native_connector,
+        })
+    }
+
+    #[cfg(feature = "rustls")]
+    pub fn new() -> Result<Self, TlsError> {
+        let mut roots = rustls_tls::RootCertStore::empty();
+        
+        #[cfg(feature = "rustls-native-roots")]
+        {
+            let certs = rustls_native_certs::load_native_certs()
+                .map_err(|err| TlsError {
+                    kind: TlsErrorType::NativeCerts,
+                    source: Some(Box::new(err)),
+                })?;
+
+            for cert in certs {
+                roots.add(&rustls_tls::Certificate(cert.0)).map_err(|err| TlsError {
+                    kind: TlsErrorType::NativeCerts,
+                    source: Some(Box::new(err)),
+                })?;
+            }
+        }
+
+        #[cfg(feature = "rustls-webpki-roots")]
+        {
+            roots.add_server_trust_anchors(
+                webpki_roots::TLS_SERVER_ROOTS
+                    .0
+                    .iter()
+                    .map(|ta| {
+                        OwnedTrustAnchor::from_subject_spki_name_constraints(
+                            ta.subject,
+                            ta.spki,
+                            ta.name_constraints,
+                        )
+                    }),
+            );
+        };
+
+        let config = ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+
+        Ok(TlsContainer {
+            tls: Arc::new(config),
+        })
+    }
+
+    pub fn connector(&self) -> Connector {
+        #[cfg(all(feature = "native", not(feature = "rustls")))]
+        return Connector::NativeTls(self.tls.clone());
+
+        #[cfg(feature = "rustls")]
+        return Connector::Rustls(Arc::clone(&self.tls));
+    }
+}
+
+#[cfg(test)]
+static_assertions::assert_impl_all!(TlsContainer: std::fmt::Debug, Clone, Send, Sync);


### PR DESCRIPTION
This saves a lot of memory when `native-tls` is used and a moderate
amount when `rustls` is used.

![image](https://user-images.githubusercontent.com/3659684/126563728-08593c73-61d5-4bcd-93b2-bd841a4764bf.png)

This pr depends on #1276.