### PR TITLE
Update get_current_user_guilds limit to 200

### DIFF
--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -58,7 +58,7 @@ impl Error for GetCurrentUserGuildsError {}
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum GetCurrentUserGuildsErrorType {
-    /// The maximum number of guilds to retrieve is 0 or more than 100.
+    /// The maximum number of guilds to retrieve is 0 or more than 200.
     LimitInvalid {
         /// Provided maximum number of guilds to retrieve.
         limit: u64,
@@ -130,12 +130,12 @@ impl<'a> GetCurrentUserGuilds<'a> {
 
     /// Set the maximum number of guilds to retrieve.
     ///
-    /// The minimum is 1 and the maximum is 100. Refer to [the discord docs] for more information.
+    /// The minimum is 1 and the maximum is 200. Refer to [the discord docs] for more information.
     ///
     /// # Errors
     ///
     /// Returns a [`GetCurrentUserGuildsErrorType::LimitInvalid`] error type if
-    /// the amount is greater than 100.
+    /// the amount is greater than 200.
     ///
     /// [the discord docs]: https://discordapp.com/developers/docs/resources/user#get-current-user-guilds-query-string-params
     pub fn limit(mut self, limit: u64) -> Result<Self, GetCurrentUserGuildsError> {

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -330,7 +330,7 @@ pub const fn get_channel_messages_limit(value: u64) -> bool {
 
 pub const fn get_current_user_guilds_limit(value: u64) -> bool {
     // <https://discordapp.com/developers/docs/resources/user#get-current-user-guilds-query-string-params>
-    value >= 1 && value <= 100
+    value >= 1 && value <= 200
 }
 
 pub const fn get_guild_members_limit(value: u64) -> bool {
@@ -716,10 +716,10 @@ mod tests {
     #[test]
     fn test_get_current_user_guilds_limit() {
         assert!(get_current_user_guilds_limit(1));
-        assert!(get_current_user_guilds_limit(100));
+        assert!(get_current_user_guilds_limit(200));
 
         assert!(!get_current_user_guilds_limit(0));
-        assert!(!get_current_user_guilds_limit(101));
+        assert!(!get_current_user_guilds_limit(201));
     }
 
     #[test]


### PR DESCRIPTION
The limit for the Get current user guilds request has been increased to 200 (https://github.com/discord/discord-api-docs/commit/daa13f60634396296092da02bb8acd8f3360e03b). This PR reflects this change on the Twilight API.