### PR TITLE
Cache model field getters

### DIFF
--- a/cache/in-memory/src/event/guild.rs
+++ b/cache/in-memory/src/event/guild.rs
@@ -92,8 +92,8 @@ impl InMemoryCache {
             widget_enabled: guild.widget_enabled,
         };
 
-        self.0.unavailable_guilds.remove(&guild.id);
-        self.0.guilds.insert(guild.id, guild);
+        self.0.unavailable_guilds.remove(&guild.id());
+        self.0.guilds.insert(guild.id(), guild);
     }
 }
 

--- a/cache/in-memory/src/event/member.rs
+++ b/cache/in-memory/src/event/member.rs
@@ -93,7 +93,7 @@ impl InMemoryCache {
 
         let (deaf, mute) = match self.0.members.get(&id) {
             Some(m) if *m == member => return,
-            Some(m) => (m.deaf, m.mute),
+            Some(m) => (m.deaf(), m.mute()),
             None => (None, None),
         };
 
@@ -194,8 +194,8 @@ impl UpdateCache for MemberUpdate {
             None => return,
         };
 
-        member.deaf = self.deaf.or(member.deaf);
-        member.mute = self.mute.or(member.mute);
+        member.deaf = self.deaf.or_else(|| member.deaf());
+        member.mute = self.mute.or_else(|| member.mute());
         member.nick = self.nick.clone();
         member.roles = self.roles.clone();
         member.joined_at.replace(self.joined_at.clone());

--- a/cache/in-memory/src/event/message.rs
+++ b/cache/in-memory/src/event/message.rs
@@ -40,7 +40,7 @@ impl UpdateCache for MessageDelete {
 
         let mut channel = cache.0.messages.entry(self.channel_id).or_default();
 
-        if let Some(idx) = channel.iter().position(|msg| msg.id == self.id) {
+        if let Some(idx) = channel.iter().position(|msg| msg.id() == self.id) {
             channel.remove(idx);
         }
     }
@@ -55,7 +55,7 @@ impl UpdateCache for MessageDeleteBulk {
         let mut channel = cache.0.messages.entry(self.channel_id).or_default();
 
         for id in &self.ids {
-            if let Some(idx) = channel.iter().position(|msg| &msg.id == id) {
+            if let Some(idx) = channel.iter().position(|msg| &msg.id() == id) {
                 channel.remove(idx);
             }
         }
@@ -70,7 +70,7 @@ impl UpdateCache for MessageUpdate {
 
         let mut channel = cache.0.messages.entry(self.channel_id).or_default();
 
-        if let Some(mut message) = channel.iter_mut().find(|msg| msg.id == self.id) {
+        if let Some(mut message) = channel.iter_mut().find(|msg| msg.id() == self.id) {
             if let Some(attachments) = &self.attachments {
                 message.attachments = attachments.clone();
             }

--- a/cache/in-memory/src/event/presence.rs
+++ b/cache/in-memory/src/event/presence.rs
@@ -25,7 +25,7 @@ impl InMemoryCache {
     fn cache_presence(&self, guild_id: GuildId, presence: CachedPresence) {
         self.0
             .presences
-            .insert((guild_id, presence.user_id), presence);
+            .insert((guild_id, presence.user_id()), presence);
     }
 }
 

--- a/cache/in-memory/src/event/reaction.rs
+++ b/cache/in-memory/src/event/reaction.rs
@@ -12,7 +12,7 @@ impl UpdateCache for ReactionAdd {
 
         let mut channel = cache.0.messages.entry(self.0.channel_id).or_default();
 
-        let message = match channel.iter_mut().find(|msg| msg.id == self.0.message_id) {
+        let message = match channel.iter_mut().find(|msg| msg.id() == self.0.message_id) {
             Some(message) => message,
             None => return,
         };
@@ -54,7 +54,7 @@ impl UpdateCache for ReactionRemove {
 
         let mut channel = cache.0.messages.entry(self.0.channel_id).or_default();
 
-        let message = match channel.iter_mut().find(|msg| msg.id == self.0.message_id) {
+        let message = match channel.iter_mut().find(|msg| msg.id() == self.0.message_id) {
             Some(message) => message,
             None => return,
         };
@@ -89,7 +89,7 @@ impl UpdateCache for ReactionRemoveAll {
 
         let mut channel = cache.0.messages.entry(self.channel_id).or_default();
 
-        let message = match channel.iter_mut().find(|msg| msg.id == self.message_id) {
+        let message = match channel.iter_mut().find(|msg| msg.id() == self.message_id) {
             Some(message) => message,
             None => return,
         };
@@ -106,7 +106,7 @@ impl UpdateCache for ReactionRemoveEmoji {
 
         let mut channel = cache.0.messages.entry(self.channel_id).or_default();
 
-        let message = match channel.iter_mut().find(|msg| msg.id == self.message_id) {
+        let message = match channel.iter_mut().find(|msg| msg.id() == self.message_id) {
             Some(message) => message,
             None => return,
         };

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -477,7 +477,7 @@ impl InMemoryCache {
     pub fn message(&self, channel_id: ChannelId, message_id: MessageId) -> Option<CachedMessage> {
         let channel = self.0.messages.get(&channel_id)?;
 
-        channel.iter().find(|msg| msg.id == message_id).cloned()
+        channel.iter().find(|msg| msg.id() == message_id).cloned()
     }
 
     /// Gets a presence by, optionally, guild ID, and user ID.

--- a/cache/in-memory/src/model/emoji.rs
+++ b/cache/in-memory/src/model/emoji.rs
@@ -9,24 +9,58 @@ use twilight_model::{
 /// [`Emoji`]: twilight_model::guild::Emoji
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedEmoji {
-    /// ID of the Emoji.
-    pub id: EmojiId,
+    pub(crate) animated: bool,
+    pub(crate) available: bool,
+    pub(crate) id: EmojiId,
+    pub(crate) managed: bool,
+    pub(crate) name: String,
+    pub(crate) require_colons: bool,
+    pub(crate) roles: Vec<RoleId>,
+    pub(crate) user_id: Option<UserId>,
+}
+
+impl CachedEmoji {
     /// Whether the emoji is animated.
-    pub animated: bool,
-    /// Name of the Emoji.
-    pub name: String,
-    /// Whether the emoji is managed.
-    pub managed: bool,
-    /// Whether the emoji must be wrapped in colons.
-    pub require_colons: bool,
-    /// List of roles allowed to use this emoji.
-    pub roles: Vec<RoleId>,
-    /// ID of the user who created the emoji.
-    pub user_id: Option<UserId>,
+    pub const fn available(&self) -> bool {
+        self.available
+    }
+
     /// Whether this emoji can be used.
     ///
     /// May be false due to loss of Server Boosts.
-    pub available: bool,
+    pub const fn animated(&self) -> bool {
+        self.animated
+    }
+
+    /// ID of the Emoji.
+    pub const fn id(&self) -> EmojiId {
+        self.id
+    }
+
+    /// Whether the emoji is managed.
+    pub const fn managed(&self) -> bool {
+        self.managed
+    }
+
+    /// Name of the Emoji.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Whether the emoji must be wrapped in colons.
+    pub const fn require_colons(&self) -> bool {
+        self.require_colons
+    }
+
+    /// List of roles allowed to use this emoji.
+    pub fn roles(&self) -> &[RoleId] {
+        &self.roles
+    }
+
+    /// ID of the user who created the emoji.
+    pub const fn user_id(&self) -> Option<UserId> {
+        self.user_id
+    }
 }
 
 impl PartialEq<Emoji> for CachedEmoji {

--- a/cache/in-memory/src/model/guild.rs
+++ b/cache/in-memory/src/model/guild.rs
@@ -1,3 +1,5 @@
+use std::slice::Iter;
+
 use serde::Serialize;
 use twilight_model::{
     guild::{
@@ -12,94 +14,246 @@ use twilight_model::{
 /// [`Guild`]: twilight_model::guild::Guild
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedGuild {
-    /// ID of the guild.
-    pub id: GuildId,
+    pub(crate) afk_channel_id: Option<ChannelId>,
+    pub(crate) afk_timeout: u64,
+    pub(crate) application_id: Option<ApplicationId>,
+    pub(crate) banner: Option<String>,
+    pub(crate) default_message_notifications: DefaultMessageNotificationLevel,
+    pub(crate) description: Option<String>,
+    pub(crate) discovery_splash: Option<String>,
+    pub(crate) explicit_content_filter: ExplicitContentFilter,
+    pub(crate) features: Vec<String>,
+    pub(crate) icon: Option<String>,
+    pub(crate) id: GuildId,
+    pub(crate) joined_at: Option<String>,
+    pub(crate) large: bool,
+    pub(crate) max_members: Option<u64>,
+    pub(crate) max_presences: Option<u64>,
+    pub(crate) member_count: Option<u64>,
+    pub(crate) mfa_level: MfaLevel,
+    pub(crate) name: String,
+    pub(crate) nsfw_level: NSFWLevel,
+    pub(crate) owner_id: UserId,
+    pub(crate) owner: Option<bool>,
+    pub(crate) permissions: Option<Permissions>,
+    pub(crate) preferred_locale: String,
+    pub(crate) premium_subscription_count: Option<u64>,
+    pub(crate) premium_tier: PremiumTier,
+    pub(crate) rules_channel_id: Option<ChannelId>,
+    pub(crate) splash: Option<String>,
+    pub(crate) system_channel_id: Option<ChannelId>,
+    pub(crate) system_channel_flags: SystemChannelFlags,
+    pub(crate) unavailable: bool,
+    pub(crate) vanity_url_code: Option<String>,
+    pub(crate) verification_level: VerificationLevel,
+    pub(crate) widget_channel_id: Option<ChannelId>,
+    pub(crate) widget_enabled: Option<bool>,
+}
+
+impl CachedGuild {
     /// ID of the AFK channel.
-    pub afk_channel_id: Option<ChannelId>,
+    pub const fn afk_channel_id(&self) -> Option<ChannelId> {
+        self.afk_channel_id
+    }
+
     /// AFK timeout in seconds.
-    pub afk_timeout: u64,
+    pub const fn afk_timeout(&self) -> u64 {
+        self.afk_timeout
+    }
+
     /// For bot created guilds, the ID of the creating application.
-    pub application_id: Option<ApplicationId>,
+    pub const fn application_id(&self) -> Option<ApplicationId> {
+        self.application_id
+    }
+
     /// Banner hash.
     ///
     /// See [Discord Docs/Image Formatting].
     ///
     /// [Discord Docs/Image Formatting]: https://discord.com/developers/docs/reference#image-formatting
-    pub banner: Option<String>,
+    pub fn banner(&self) -> Option<&str> {
+        self.banner.as_deref()
+    }
+
     /// Default message notification level.
-    pub default_message_notifications: DefaultMessageNotificationLevel,
+    pub const fn default_message_notifications(&self) -> DefaultMessageNotificationLevel {
+        self.default_message_notifications
+    }
+
     /// For Community guilds, the description.
-    pub description: Option<String>,
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
     /// For discoverable guilds, the discovery splash hash.
     ///
     /// See [Discord Docs/Image Formatting].
     ///
     /// [Discord Docs/Image Formatting]: https://discord.com/developers/docs/reference#image-formatting
-    pub discovery_splash: Option<String>,
+    pub fn discovery_splash(&self) -> Option<&str> {
+        self.discovery_splash.as_deref()
+    }
+
     /// Explicit content filter level.
-    pub explicit_content_filter: ExplicitContentFilter,
+    pub const fn explicit_content_filter(&self) -> ExplicitContentFilter {
+        self.explicit_content_filter
+    }
+
     /// Enabled [guild features].
     ///
     /// [guild features]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
-    pub features: Vec<String>,
+    pub fn features(&self) -> Features<'_> {
+        Features {
+            inner: self.features.iter(),
+        }
+    }
+
     /// Icon hash.
     ///
     /// See [Discord Docs/Image Formatting].
     ///
     /// [Discord Docs/Image Formatting]: https://discord.com/developers/docs/reference#image-formatting
-    pub icon: Option<String>,
+    pub fn icon(&self) -> Option<&str> {
+        self.icon.as_deref()
+    }
+
+    /// ID of the guild.
+    pub const fn id(&self) -> GuildId {
+        self.id
+    }
+
     /// ISO 8601 timestamp of the user's join date.
-    pub joined_at: Option<String>,
+    pub fn joined_at(&self) -> Option<&str> {
+        self.joined_at.as_deref()
+    }
+
     /// Whether this guild is "large".
-    pub large: bool,
+    pub const fn large(&self) -> bool {
+        self.large
+    }
+
     /// Maximum members.
-    pub max_members: Option<u64>,
+    pub const fn max_members(&self) -> Option<u64> {
+        self.max_members
+    }
+
     /// Maximum presences.
-    pub max_presences: Option<u64>,
+    pub const fn max_presences(&self) -> Option<u64> {
+        self.max_presences
+    }
+
     /// Total number of members in the guild.
-    pub member_count: Option<u64>,
+    pub const fn member_count(&self) -> Option<u64> {
+        self.member_count
+    }
+
     /// Required MFA level.
-    pub mfa_level: MfaLevel,
+    pub const fn mfa_level(&self) -> MfaLevel {
+        self.mfa_level
+    }
+
     /// Name of the guild.
-    pub name: String,
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     /// NSFW level.
-    pub nsfw_level: NSFWLevel,
+    pub const fn nsfw_level(&self) -> NSFWLevel {
+        self.nsfw_level
+    }
+
     /// Whether the current user is the owner of the guild.
-    pub owner: Option<bool>,
+    pub const fn owner(&self) -> Option<bool> {
+        self.owner
+    }
+
     /// ID of the guild's owner.
-    pub owner_id: UserId,
+    pub const fn owner_id(&self) -> UserId {
+        self.owner_id
+    }
+
     /// Total permissions for the current user in the guild, excluding overwrites.
-    pub permissions: Option<Permissions>,
+    pub const fn permissions(&self) -> Option<Permissions> {
+        self.permissions
+    }
+
     /// Preferred locale for Community guilds.
     ///
     /// Used in server discovery and notices from Discord. Defaults to "en-US".
-    pub preferred_locale: String,
+    pub fn preferred_locale(&self) -> &str {
+        &self.preferred_locale
+    }
+
     /// Number of boosts this guild currently has.
-    pub premium_subscription_count: Option<u64>,
+    pub const fn premium_subscription_count(&self) -> Option<u64> {
+        self.premium_subscription_count
+    }
+
     /// Server boost level.
-    pub premium_tier: PremiumTier,
+    pub const fn premium_tier(&self) -> PremiumTier {
+        self.premium_tier
+    }
+
     /// For Community guilds, the ID of the rules channel.
-    pub rules_channel_id: Option<ChannelId>,
+    pub const fn rules_channel_id(&self) -> Option<ChannelId> {
+        self.rules_channel_id
+    }
+
     /// Splash hash.
     ///
     /// See [Discord Docs/Image Formatting].
     ///
     /// [Discord Docs/Image Formatting]: https://discord.com/developers/docs/reference#image-formatting
-    pub splash: Option<String>,
+    pub fn splash(&self) -> Option<&str> {
+        self.splash.as_deref()
+    }
+
     /// ID of the channel where notices are posted.
     ///
     /// Example notices include welcome messages and boost events.
-    pub system_channel_id: Option<ChannelId>,
+    pub const fn system_channel_id(&self) -> Option<ChannelId> {
+        self.system_channel_id
+    }
+
     /// System channel flags.
-    pub system_channel_flags: SystemChannelFlags,
+    pub const fn system_channel_flags(&self) -> SystemChannelFlags {
+        self.system_channel_flags
+    }
+
     /// Whether the guild is unavailable due to an outage.
-    pub unavailable: bool,
+    pub const fn unavailable(&self) -> bool {
+        self.unavailable
+    }
+
     /// Vanity URL code.
-    pub verification_level: VerificationLevel,
-    /// ID of the channel that a widget generates an invite to.
-    pub vanity_url_code: Option<String>,
+    pub fn vanity_url_code(&self) -> Option<&str> {
+        self.vanity_url_code.as_deref()
+    }
+
     /// Required verification level.
-    pub widget_channel_id: Option<ChannelId>,
+    pub const fn verification_level(&self) -> VerificationLevel {
+        self.verification_level
+    }
+
+    /// ID of the channel that a widget generates an invite to.
+    pub const fn widget_channel_id(&self) -> Option<ChannelId> {
+        self.widget_channel_id
+    }
+
     /// Whether the widget is enabled.
-    pub widget_enabled: Option<bool>,
+    pub const fn widget_enabled(&self) -> Option<bool> {
+        self.widget_enabled
+    }
+}
+
+pub struct Features<'a> {
+    inner: Iter<'a, String>,
+}
+
+impl<'a> Iterator for Features<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(AsRef::as_ref)
+    }
 }

--- a/cache/in-memory/src/model/member.rs
+++ b/cache/in-memory/src/model/member.rs
@@ -10,24 +10,63 @@ use twilight_model::{
 /// [`Member`]: twilight_model::guild::Member
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedMember {
+    pub(crate) deaf: Option<bool>,
+    pub(crate) guild_id: GuildId,
+    pub(crate) joined_at: Option<String>,
+    pub(crate) mute: Option<bool>,
+    pub(crate) nick: Option<String>,
+    pub(crate) pending: bool,
+    pub(crate) premium_since: Option<String>,
+    pub(crate) roles: Vec<RoleId>,
+    pub(crate) user_id: UserId,
+}
+
+impl CachedMember {
     /// Whether the member is deafened in a voice channel.
-    pub deaf: Option<bool>,
+    pub const fn deaf(&self) -> Option<bool> {
+        self.deaf
+    }
+
     /// ID of the guild this member is a part of.
-    pub guild_id: GuildId,
+    pub const fn guild_id(&self) -> GuildId {
+        self.guild_id
+    }
+
     /// ISO 8601 timestamp of this member's join date.
-    pub joined_at: Option<String>,
+    pub fn joined_at(&self) -> Option<&str> {
+        self.joined_at.as_deref()
+    }
+
     /// Whether the member is muted in a voice channel.
-    pub mute: Option<bool>,
+    pub const fn mute(&self) -> Option<bool> {
+        self.mute
+    }
+
     /// Nickname of the member.
-    pub nick: Option<String>,
-    /// Whether the member has not yet passed the guild's Membership Screening requirements.
-    pub pending: bool,
+    pub fn nick(&self) -> Option<&str> {
+        self.nick.as_deref()
+    }
+
+    /// Whether the member has not yet passed the guild's Membership Screening
+    /// requirements.
+    pub const fn pending(&self) -> bool {
+        self.pending
+    }
+
     /// ISO 8601 timestamp of the date the member boosted the guild.
-    pub premium_since: Option<String>,
+    pub fn premium_since(&self) -> Option<&str> {
+        self.premium_since.as_deref()
+    }
+
     /// List of role IDs this member has.
-    pub roles: Vec<RoleId>,
+    pub fn roles(&self) -> &[RoleId] {
+        &self.roles
+    }
+
     /// ID of the user relating to the member.
-    pub user_id: UserId,
+    pub const fn user_id(&self) -> UserId {
+        self.user_id
+    }
 }
 
 impl PartialEq<Member> for CachedMember {

--- a/cache/in-memory/src/model/message.rs
+++ b/cache/in-memory/src/model/message.rs
@@ -17,56 +17,154 @@ use twilight_model::{
 /// [`Message`]: twilight_model::channel::Message
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedMessage {
-    /// ID of the message.
-    pub id: MessageId,
+    activity: Option<MessageActivity>,
+    application: Option<MessageApplication>,
+    pub(crate) attachments: Vec<Attachment>,
+    author: UserId,
+    channel_id: ChannelId,
+    pub(crate) content: String,
+    pub(crate) edited_timestamp: Option<String>,
+    pub(crate) embeds: Vec<Embed>,
+    flags: Option<MessageFlags>,
+    guild_id: Option<GuildId>,
+    id: MessageId,
+    kind: MessageType,
+    member: Option<PartialMember>,
+    mention_channels: Vec<ChannelMention>,
+    pub(crate) mention_everyone: bool,
+    pub(crate) mention_roles: Vec<RoleId>,
+    pub(crate) mentions: Vec<UserId>,
+    pub(crate) pinned: bool,
+    pub(crate) reactions: Vec<MessageReaction>,
+    reference: Option<MessageReference>,
+    sticker_items: Vec<MessageSticker>,
+    pub(crate) timestamp: String,
+    pub(crate) tts: bool,
+    webhook_id: Option<WebhookId>,
+}
+
+impl CachedMessage {
     /// For rich presence chat embeds, the activity object.
-    pub activity: Option<MessageActivity>,
+    pub const fn activity(&self) -> Option<&MessageActivity> {
+        self.activity.as_ref()
+    }
+
     /// For interaction responses, the ID of the interaction's application.
-    pub application: Option<MessageApplication>,
+    pub const fn application(&self) -> Option<&MessageApplication> {
+        self.application.as_ref()
+    }
+
     /// Attached files.
-    pub attachments: Vec<Attachment>,
+    pub fn attachments(&self) -> &[Attachment] {
+        &self.attachments
+    }
+
     /// ID of the message author.
     ///
     /// If the author is a webhook, this is its ID.
-    pub author: UserId,
+    pub const fn author(&self) -> UserId {
+        self.author
+    }
+
     /// ID of the channel the message was sent in.
-    pub channel_id: ChannelId,
+    pub const fn channel_id(&self) -> ChannelId {
+        self.channel_id
+    }
+
     /// Content of the message.
-    pub content: String,
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
     /// ISO 8601 timestamp of the date the message was last edited.
-    pub edited_timestamp: Option<String>,
+    pub fn edited_timestamp(&self) -> Option<&str> {
+        self.edited_timestamp.as_deref()
+    }
+
     /// Embeds attached to the message.
-    pub embeds: Vec<Embed>,
+    pub fn embeds(&self) -> &[Embed] {
+        &self.embeds
+    }
+
     /// Message flags.
-    pub flags: Option<MessageFlags>,
+    pub const fn flags(&self) -> Option<MessageFlags> {
+        self.flags
+    }
+
     /// ID of the guild the message was sent in, if there is one.
-    pub guild_id: Option<GuildId>,
+    pub const fn guild_id(&self) -> Option<GuildId> {
+        self.guild_id
+    }
+
+    /// ID of the message.
+    pub const fn id(&self) -> MessageId {
+        self.id
+    }
+
     /// Type of the message.
-    pub kind: MessageType,
+    pub const fn kind(&self) -> MessageType {
+        self.kind
+    }
+
     /// Member data for the author, if there is any.
-    pub member: Option<PartialMember>,
+    pub const fn member(&self) -> Option<&PartialMember> {
+        self.member.as_ref()
+    }
+
     /// Channels mentioned in the content.
-    pub mention_channels: Vec<ChannelMention>,
+    pub fn mention_channels(&self) -> &[ChannelMention] {
+        &self.mention_channels
+    }
+
     /// Whether or not '@everyone' or '@here' is mentioned in the content.
-    pub mention_everyone: bool,
+    pub const fn mention_everyone(&self) -> bool {
+        self.mention_everyone
+    }
+
     /// Roles mentioned in the content.
-    pub mention_roles: Vec<RoleId>,
+    pub fn mention_roles(&self) -> &[RoleId] {
+        &self.mention_roles
+    }
+
     /// Users mentioned in the content.
-    pub mentions: Vec<UserId>,
+    pub fn mentions(&self) -> &[UserId] {
+        &self.mentions
+    }
+
     /// Whether or not the message is pinned.
-    pub pinned: bool,
+    pub const fn pinned(&self) -> bool {
+        self.pinned
+    }
+
     /// Reactions to the message.
-    pub reactions: Vec<MessageReaction>,
+    pub fn reactions(&self) -> &[MessageReaction] {
+        &self.reactions
+    }
+
     /// Message reference.
-    pub reference: Option<MessageReference>,
+    pub const fn reference(&self) -> Option<&MessageReference> {
+        self.reference.as_ref()
+    }
+
     /// Stickers within the message.
-    pub sticker_items: Vec<MessageSticker>,
+    pub fn sticker_items(&self) -> &[MessageSticker] {
+        &self.sticker_items
+    }
+
     /// ISO 8601 timestamp of the date the message was sent.
-    pub timestamp: String,
+    pub fn timestamp(&self) -> &str {
+        &self.timestamp
+    }
+
     /// Whether the message is text-to-speech.
-    pub tts: bool,
+    pub const fn tts(&self) -> bool {
+        self.tts
+    }
+
     /// For messages sent by webhooks, the webhook ID.
-    pub webhook_id: Option<WebhookId>,
+    pub const fn webhook_id(&self) -> Option<WebhookId> {
+        self.webhook_id
+    }
 }
 
 impl From<Message> for CachedMessage {

--- a/cache/in-memory/src/model/presence.rs
+++ b/cache/in-memory/src/model/presence.rs
@@ -9,16 +9,38 @@ use twilight_model::{
 /// [`Presence`]: twilight_model::gateway::presence::Presence
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedPresence {
+    pub(crate) activities: Vec<Activity>,
+    pub(crate) client_status: ClientStatus,
+    pub(crate) guild_id: GuildId,
+    pub(crate) status: Status,
+    pub(crate) user_id: UserId,
+}
+
+impl CachedPresence {
     /// Current activities.
-    pub activities: Vec<Activity>,
+    pub fn activities(&self) -> &[Activity] {
+        &self.activities
+    }
+
     /// Platform-dependent status.
-    pub client_status: ClientStatus,
+    pub const fn client_status(&self) -> &ClientStatus {
+        &self.client_status
+    }
+
     /// ID of the guild.
-    pub guild_id: GuildId,
+    pub const fn guild_id(&self) -> GuildId {
+        self.guild_id
+    }
+
     /// Status of the user.
-    pub status: Status,
+    pub const fn status(&self) -> Status {
+        self.status
+    }
+
     /// ID of the user.
-    pub user_id: UserId,
+    pub const fn user_id(&self) -> UserId {
+        self.user_id
+    }
 }
 
 impl PartialEq<Presence> for CachedPresence {

--- a/cache/in-memory/src/model/voice_state.rs
+++ b/cache/in-memory/src/model/voice_state.rs
@@ -9,28 +9,74 @@ use twilight_model::{
 /// [`VoiceState`]: twilight_model::voice::VoiceState
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedVoiceState {
+    channel_id: Option<ChannelId>,
+    deaf: bool,
+    guild_id: Option<GuildId>,
+    mute: bool,
+    self_deaf: bool,
+    self_mute: bool,
+    self_stream: bool,
+    session_id: String,
+    suppress: bool,
+    token: Option<String>,
+    user_id: UserId,
+}
+
+impl CachedVoiceState {
     /// ID of the channel that this user is connected to.
-    pub channel_id: Option<ChannelId>,
+    pub const fn channel_id(&self) -> Option<ChannelId> {
+        self.channel_id
+    }
+
     /// Whether the user is deafened.
-    pub deaf: bool,
+    pub const fn deaf(&self) -> bool {
+        self.deaf
+    }
+
     /// ID of the guild that this user is connected in, if there is one.
-    pub guild_id: Option<GuildId>,
+    pub const fn guild_id(&self) -> Option<GuildId> {
+        self.guild_id
+    }
+
     /// Whether the user is muted.
-    pub mute: bool,
+    pub const fn mute(&self) -> bool {
+        self.mute
+    }
+
     /// Whether the user has deafened themself.
-    pub self_deaf: bool,
+    pub const fn self_deaf(&self) -> bool {
+        self.self_deaf
+    }
+
     /// Whether the user has muted themself.
-    pub self_mute: bool,
+    pub const fn self_mute(&self) -> bool {
+        self.self_mute
+    }
+
     /// Whether the user is streaming via "Go Live".
-    pub self_stream: bool,
+    pub const fn self_stream(&self) -> bool {
+        self.self_stream
+    }
+
     /// Session ID.
-    pub session_id: String,
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
     /// Whether this user is muted by the current user.
-    pub suppress: bool,
+    pub const fn suppress(&self) -> bool {
+        self.suppress
+    }
+
     /// Voice connection token.
-    pub token: Option<String>,
+    pub fn token(&self) -> Option<&str> {
+        self.token.as_deref()
+    }
+
     /// ID of the user.
-    pub user_id: UserId,
+    pub const fn user_id(&self) -> UserId {
+        self.user_id
+    }
 }
 
 impl PartialEq<VoiceState> for CachedVoiceState {


### PR DESCRIPTION
Instead of exposing the fields of models directly, expose them behind getters. This will allow us to add new fields without causing a breaking change.