### PR TITLE
Impl Copy for ShardScheme

### DIFF
--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -45,13 +45,13 @@ impl Config {
         &self.shard_config
     }
 
-    /// Return an immutable reference to the shard scheme used to start shards.
+    /// Return a copy of the shard scheme used to start shards.
     ///
     /// Refer to [`ClusterBuilder::shard_scheme`] for the default value.
     ///
     /// [`ClusterBuilder::shard_scheme`]: super::ClusterBuilder::shard_scheme
-    pub const fn shard_scheme(&self) -> &ShardScheme {
-        &self.shard_scheme
+    pub const fn shard_scheme(&self) -> ShardScheme {
+        self.shard_scheme
     }
 
     /// Return an immutable reference to the queue used for initiating shard

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -321,7 +321,7 @@ impl Cluster {
 
         let scheme = match config.shard_scheme() {
             ShardScheme::Auto => Self::retrieve_shard_count(&config.http_client).await?,
-            other => other.clone(),
+            other => other,
         };
 
         let iter = scheme.iter().expect("shard scheme is not auto");

--- a/gateway/src/cluster/scheme.rs
+++ b/gateway/src/cluster/scheme.rs
@@ -267,7 +267,7 @@ impl ShardScheme {
     /// In the case of the [`Auto`] variant the total is unknown.
     ///
     /// [`Auto`]: Self::Auto
-    pub fn to(self) -> Option<u64> {
+    pub const fn to(self) -> Option<u64> {
         match self {
             Self::Auto => None,
             Self::Bucket {


### PR DESCRIPTION
`ShardScheme` was missing Copy, this PR adds it. Targets next since `&ShardScheme` -> `ShardScheme` (cluster/`Config::shard_scheme`) could be a breaking change.