### PR TITLE
Applications should use application flags

### DIFF
--- a/model/src/gateway/payload/ready.rs
+++ b/model/src/gateway/payload/ready.rs
@@ -19,8 +19,8 @@ mod tests {
     use crate::{
         guild::UnavailableGuild,
         id::{ApplicationId, GuildId, UserId},
-        oauth::PartialApplication,
-        user::{CurrentUser, UserFlags},
+        oauth::{current_application_info::ApplicationFlags, PartialApplication},
+        user::CurrentUser,
     };
     use serde_test::Token;
 
@@ -40,7 +40,7 @@ mod tests {
 
         let ready = Ready {
             application: PartialApplication {
-                flags: UserFlags::empty(),
+                flags: ApplicationFlags::empty(),
                 id: ApplicationId(100),
             },
             guilds,

--- a/model/src/oauth/partial_application.rs
+++ b/model/src/oauth/partial_application.rs
@@ -1,8 +1,8 @@
-use crate::{id::ApplicationId, user::UserFlags};
+use crate::{id::ApplicationId, oauth::current_application_info::ApplicationFlags};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PartialApplication {
-    pub flags: UserFlags,
+    pub flags: ApplicationFlags,
     pub id: ApplicationId,
 }

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -883,8 +883,8 @@ mod tests {
             payload::{MessageCreate, ReactionAdd, Ready, RoleDelete},
         },
         id::{ApplicationId, ChannelId, GuildId, MessageId, RoleId, UserId},
-        oauth::PartialApplication,
-        user::{CurrentUser, User, UserFlags},
+        oauth::{current_application_info::ApplicationFlags, PartialApplication},
+        user::{CurrentUser, User},
     };
 
     assert_impl_all!(Standby: Clone, Debug, Default, Send, Sync);
@@ -1013,7 +1013,7 @@ mod tests {
     async fn test_wait_for_event() {
         let ready = Ready {
             application: PartialApplication {
-                flags: UserFlags::empty(),
+                flags: ApplicationFlags::empty(),
                 id: ApplicationId(0),
             },
             guilds: Vec::new(),


### PR DESCRIPTION
This shows up in the ready payload in the example on the site:

```
Event: Ready(Ready { application: PartialApplication { flags: DISCORD_CERTIFIED_MODERATOR, id: ApplicationId(....) }, guilds: [], session_id: "....", shard: Some([0, 1]), user: CurrentUser { avatar: ...., bot: true, discriminator: "....", email: None, flags: Some((empty)), id: UserId(....), locale: None, mfa_enabled: true, name: "....", premium_type: None, public_flags: None, verified: Some(true) }, version: 8 })
```

Evidently bots can't be certified moderators.