### PR TITLE
Revamp `Cluster`'s config

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -41,25 +41,8 @@ pub struct ClusterBuilder(ClusterConfig, ShardBuilder);
 impl ClusterBuilder {
     /// Create a new builder to construct and configure a cluster.
     pub fn new(token: impl Into<String>, intents: Intents) -> Self {
-        Self::_new(token.into(), intents)
-    }
-
-    fn _new(mut token: String, intents: Intents) -> Self {
-        if !token.starts_with("Bot ") {
-            token.insert_str(0, "Bot ");
-        }
-
-        let token = token.into_boxed_str();
-
-        let http_client = Client::new(token.to_string());
-
-        let shard_config =
-            ShardBuilder::new(token.clone(), intents).http_client(http_client.clone());
-
         Self(
             ClusterConfig {
-                http_client,
-                shard_config: shard_config.0,
                 shard_scheme: ShardScheme::Auto,
                 queue: Arc::new(LocalQueue::new()),
                 resume_sessions: HashMap::new(),
@@ -87,9 +70,7 @@ impl ClusterBuilder {
             }
         }
 
-        self.0.shard_config = (self.1).0;
-
-        Cluster::new_with_config(self.0).await
+        Cluster::new_with_config(self.0, self.1 .0).await
     }
 
     /// Set the event types to process.

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -1,50 +1,19 @@
 use super::scheme::ShardScheme;
-use crate::{
-    shard::{Config as ShardConfig, ResumeSession},
-    EventTypeFlags,
-};
+use crate::shard::ResumeSession;
 use std::{collections::HashMap, sync::Arc};
 use twilight_gateway_queue::Queue;
-use twilight_http::Client;
 
 /// Built configuration for a [`Cluster`].
 ///
 /// [`Cluster`]: crate::Cluster
 #[derive(Debug)]
 pub struct Config {
-    pub(super) http_client: Client,
-    pub(super) shard_config: ShardConfig,
     pub(super) shard_scheme: ShardScheme,
     pub(super) queue: Arc<dyn Queue>,
     pub(super) resume_sessions: HashMap<u64, ResumeSession>,
 }
 
 impl Config {
-    /// Copy of the event type flags.
-    pub const fn event_types(&self) -> EventTypeFlags {
-        self.shard_config.event_types()
-    }
-
-    /// Return an immutable reference to the `twilight_http` client used by the
-    /// cluster and shards to get the gateway information.
-    ///
-    /// Refer to [`ClusterBuilder::http_client`] for the default value.
-    ///
-    /// [`ClusterBuilder::http_client`]: super::ClusterBuilder::http_client
-    pub const fn http_client(&self) -> &Client {
-        &self.http_client
-    }
-
-    /// Return an immutable reference to the configuration used to create
-    /// shards.
-    ///
-    /// Refer to [`ShardBuilder`]'s methods for the default values.
-    ///
-    /// [`ShardBuilder`]: crate::shard::ShardBuilder#impl
-    pub const fn shard_config(&self) -> &ShardConfig {
-        &self.shard_config
-    }
-
     /// Return an immutable reference to the shard scheme used to start shards.
     ///
     /// Refer to [`ClusterBuilder::shard_scheme`] for the default value.


### PR DESCRIPTION
This PR removes some fields on `Cluster`'s Config that are included in all `Shard`s of the cluster. This saves some memory too since the cluster no longer contains a separate `HttpClient`.

`Cluster::config` could return a `(ClusterConfig, ShardConfig`) tuple or it could be left as is.