### PR TITLE
gateway: Use tokio's OnceCell

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -21,10 +21,9 @@ twilight-gateway-queue = { default-features = false, path = "./queue" }
 twilight-http = { default-features = false, path = "../http" }
 twilight-model = { default-features = false, path = "../model" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
-once_cell = { default-features = false, features = ["std"], version = "1" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["net", "rt", "sync"], version = "1.0" }
+tokio = { default-features = false, features = ["net", "rt", "sync"], version = "1.5" }
 url = { default-features = false, version = "2" }
 
 # Optional

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -10,7 +10,6 @@ use super::{
 };
 use crate::Intents;
 use futures_util::stream::StreamExt;
-use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -18,7 +17,10 @@ use std::{
     fmt::{Display, Formatter, Result as FmtResult},
     sync::{atomic::Ordering, Arc, Mutex},
 };
-use tokio::{sync::watch::Receiver as WatchReceiver, task::JoinHandle};
+use tokio::{
+    sync::{watch::Receiver as WatchReceiver, OnceCell},
+    task::JoinHandle,
+};
 use tokio_tungstenite::tungstenite::protocol::{
     frame::coding::CloseCode, CloseFrame as TungsteniteCloseFrame,
 };


### PR DESCRIPTION
This exists in Tokio since 1.5 and makes it possible to eliminate a direct dependency on `once_cell`, but most use cases should still result in this being depended on indirectly through openssl and ring.