### PR TITLE
fix: remove lifetime from InMemoryCachePermissions

### DIFF
--- a/cache/in-memory/src/permission.rs
+++ b/cache/in-memory/src/permission.rs
@@ -252,7 +252,7 @@ impl<'a> InMemoryCachePermissions<'a> {
 
     /// Consume the statistics interface, returning the underlying cache
     /// reference.
-    pub const fn into_cache(self) -> &'a InMemoryCache {
+    pub const fn into_cache(self) -> InMemoryCache {
         self.0
     }
 


### PR DESCRIPTION
InMemoryCachePermissions::into_cache consumes the calculator, but still holds an unneeded lifetime