### PR TITLE
Add back HTTP raw request builder

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -2179,7 +2179,7 @@ impl Client {
     /// token has become invalid due to expiration, revokation, etc.
     ///
     /// [`Response`]: super::response::Response
-    pub fn request<T>(&self, request: Request<'_>) -> ResponseFuture<T> {
+    pub fn request<T>(&self, request: Request) -> ResponseFuture<T> {
         match self.try_request::<T>(request) {
             Ok(future) => future,
             Err(source) => ResponseFuture::error(source),
@@ -2187,7 +2187,7 @@ impl Client {
     }
 
     #[allow(clippy::too_many_lines)]
-    fn try_request<T>(&self, request: Request<'_>) -> Result<ResponseFuture<T>, Error> {
+    fn try_request<T>(&self, request: Request) -> Result<ResponseFuture<T>, Error> {
         if self.state.token_invalid.load(Ordering::Relaxed) {
             return Err(Error {
                 kind: ErrorType::Unauthorized,
@@ -2199,25 +2199,21 @@ impl Client {
             body,
             form,
             headers: req_headers,
-            route,
+            method,
+            path,
+            ratelimit_path,
             use_authorization_token,
         } = request;
 
         let protocol = if self.state.use_http { "http" } else { "https" };
         let host = self.state.proxy.as_deref().unwrap_or("discord.com");
 
-        let url = format!(
-            "{}://{}/api/v{}/{}",
-            protocol,
-            host,
-            API_VERSION,
-            route.display()
-        );
+        let url = format!("{}://{}/api/v{}/{}", protocol, host, API_VERSION, path);
         #[cfg(feature = "tracing")]
         tracing::debug!("URL: {:?}", url);
 
         let mut builder = hyper::Request::builder()
-            .method(route.method().into_hyper())
+            .method(method.into_hyper())
             .uri(&url);
 
         if use_authorization_token {
@@ -2276,8 +2272,6 @@ impl Client {
             }
         }
 
-        let method = route.method();
-
         let req = if let Some(form) = form {
             let form_bytes = form.build();
             if let Some(headers) = builder.headers_mut() {
@@ -2317,7 +2311,7 @@ impl Client {
         // due to move semantics in both cases.
         #[allow(clippy::option_if_let_else)]
         if let Some(ratelimiter) = self.state.ratelimiter.as_ref() {
-            let rx = ratelimiter.ticket(route.path());
+            let rx = ratelimiter.ticket(ratelimit_path);
 
             Ok(ResponseFuture::ratelimit(
                 None,

--- a/http/src/request/application/create_followup_message.rs
+++ b/http/src/request/application/create_followup_message.rs
@@ -220,8 +220,8 @@ impl<'a> CreateFollowupMessage<'a> {
 
     // `self` needs to be consumed and the client returned due to parameters
     // being consumed in request construction.
-    fn request(&self) -> Result<Request<'a>, Error> {
-        let mut request = Request::builder(Route::ExecuteWebhook {
+    fn request(&self) -> Result<Request, Error> {
+        let mut request = Request::builder(&Route::ExecuteWebhook {
             token: self.token,
             wait: None,
             webhook_id: self.application_id.0,

--- a/http/src/request/application/create_global_command.rs
+++ b/http/src/request/application/create_global_command.rs
@@ -101,8 +101,8 @@ impl<'a> CreateGlobalCommand<'a> {
         self
     }
 
-    fn request(&self) -> Result<Request<'a>, HttpError> {
-        Request::builder(Route::CreateGlobalCommand {
+    fn request(&self) -> Result<Request, HttpError> {
+        Request::builder(&Route::CreateGlobalCommand {
             application_id: self.application_id.0,
         })
         .json(&CommandBorrowed {

--- a/http/src/request/application/create_guild_command.rs
+++ b/http/src/request/application/create_guild_command.rs
@@ -105,8 +105,8 @@ impl<'a> CreateGuildCommand<'a> {
         Ok(self)
     }
 
-    fn request(&self) -> Result<Request<'a>, HttpError> {
-        Request::builder(Route::CreateGuildCommand {
+    fn request(&self) -> Result<Request, HttpError> {
+        Request::builder(&Route::CreateGuildCommand {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,
         })

--- a/http/src/request/application/delete_followup_message.rs
+++ b/http/src/request/application/delete_followup_message.rs
@@ -45,8 +45,8 @@ impl<'a> DeleteFollowupMessage<'a> {
         }
     }
 
-    const fn request(self) -> Request<'a> {
-        Request::from_route(Route::DeleteWebhookMessage {
+    fn request(self) -> Request {
+        Request::from_route(&Route::DeleteWebhookMessage {
             message_id: self.message_id.0,
             token: self.token,
             webhook_id: self.application_id.0,
@@ -74,12 +74,12 @@ mod tests {
         let builder = DeleteFollowupMessage::new(&client, ApplicationId(1), "token", MessageId(2));
         let actual = builder.request();
 
-        let expected = Request::from_route(Route::DeleteWebhookMessage {
+        let expected = Request::from_route(&Route::DeleteWebhookMessage {
             message_id: 2,
             token: "token",
             webhook_id: 1,
         });
 
-        assert_eq!(expected.route, actual.route);
+        assert_eq!(expected.path, actual.path);
     }
 }

--- a/http/src/request/application/delete_global_command.rs
+++ b/http/src/request/application/delete_global_command.rs
@@ -30,7 +30,7 @@ impl<'a> DeleteGlobalCommand<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = Request::from_route(Route::DeleteGlobalCommand {
+        let request = Request::from_route(&Route::DeleteGlobalCommand {
             application_id: self.application_id.0,
             command_id: self.command_id.0,
         });

--- a/http/src/request/application/delete_guild_command.rs
+++ b/http/src/request/application/delete_guild_command.rs
@@ -30,7 +30,7 @@ impl<'a> DeleteGuildCommand<'a> {
     }
 
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = Request::from_route(Route::DeleteGuildCommand {
+        let request = Request::from_route(&Route::DeleteGuildCommand {
             application_id: self.application_id.0,
             command_id: self.command_id.0,
             guild_id: self.guild_id.0,

--- a/http/src/request/application/delete_original_response.rs
+++ b/http/src/request/application/delete_original_response.rs
@@ -50,7 +50,7 @@ impl<'a> DeleteOriginalResponse<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = Request::from_route(Route::DeleteInteractionOriginal {
+        let request = Request::from_route(&Route::DeleteInteractionOriginal {
             application_id: self.application_id.0,
             interaction_token: self.token,
         });

--- a/http/src/request/application/get_command_permissions.rs
+++ b/http/src/request/application/get_command_permissions.rs
@@ -31,7 +31,7 @@ impl<'a> GetCommandPermissions<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<GuildCommandPermissions> {
-        let request = Request::from_route(Route::GetCommandPermissions {
+        let request = Request::from_route(&Route::GetCommandPermissions {
             application_id: self.application_id.0,
             command_id: self.command_id.0,
             guild_id: self.guild_id.0,

--- a/http/src/request/application/get_global_commands.rs
+++ b/http/src/request/application/get_global_commands.rs
@@ -24,7 +24,7 @@ impl<'a> GetGlobalCommands<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Command>> {
-        let request = Request::from_route(Route::GetGlobalCommands {
+        let request = Request::from_route(&Route::GetGlobalCommands {
             application_id: self.application_id.0,
         });
 

--- a/http/src/request/application/get_guild_command_permissions.rs
+++ b/http/src/request/application/get_guild_command_permissions.rs
@@ -33,7 +33,7 @@ impl<'a> GetGuildCommandPermissions<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<GuildCommandPermissions>> {
-        let request = Request::from_route(Route::GetGuildCommandPermissions {
+        let request = Request::from_route(&Route::GetGuildCommandPermissions {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/application/get_guild_commands.rs
+++ b/http/src/request/application/get_guild_commands.rs
@@ -33,7 +33,7 @@ impl<'a> GetGuildCommands<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Command>> {
-        let request = Request::from_route(Route::GetGuildCommands {
+        let request = Request::from_route(&Route::GetGuildCommands {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/application/get_original_response.rs
+++ b/http/src/request/application/get_original_response.rs
@@ -45,7 +45,7 @@ impl<'a> GetOriginalResponse<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Message> {
-        let request = Request::from_route(Route::GetInteractionOriginal {
+        let request = Request::from_route(&Route::GetInteractionOriginal {
             application_id: self.application_id.0,
             interaction_token: self.token,
         });

--- a/http/src/request/application/interaction_callback.rs
+++ b/http/src/request/application/interaction_callback.rs
@@ -32,8 +32,8 @@ impl<'a> InteractionCallback<'a> {
 
     // `self` needs to be consumed and the client returned due to parameters
     // being consumed in request construction.
-    fn request(&self) -> Result<Request<'a>, Error> {
-        let request = Request::builder(Route::InteractionCallback {
+    fn request(&self) -> Result<Request, Error> {
+        let request = Request::builder(&Route::InteractionCallback {
             interaction_id: self.interaction_id.0,
             interaction_token: self.interaction_token,
         })

--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -91,8 +91,8 @@ impl<'a> SetCommandPermissions<'a> {
         })
     }
 
-    fn request(&self) -> Result<Request<'a>, Error> {
-        Request::builder(Route::SetCommandPermissions {
+    fn request(&self) -> Result<Request, Error> {
+        Request::builder(&Route::SetCommandPermissions {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,
         })

--- a/http/src/request/application/set_global_commands.rs
+++ b/http/src/request/application/set_global_commands.rs
@@ -30,8 +30,8 @@ impl<'a> SetGlobalCommands<'a> {
         }
     }
 
-    fn request(&self) -> Result<Request<'a>, Error> {
-        Request::builder(Route::SetGlobalCommands {
+    fn request(&self) -> Result<Request, Error> {
+        Request::builder(&Route::SetGlobalCommands {
             application_id: self.application_id.0,
         })
         .json(&self.commands)

--- a/http/src/request/application/set_guild_commands.rs
+++ b/http/src/request/application/set_guild_commands.rs
@@ -36,8 +36,8 @@ impl<'a> SetGuildCommands<'a> {
         }
     }
 
-    fn request(&self) -> Result<Request<'a>, Error> {
-        Request::builder(Route::SetGuildCommands {
+    fn request(&self) -> Result<Request, Error> {
+        Request::builder(&Route::SetGuildCommands {
             application_id: self.application_id.0,
             guild_id: self.guild_id.0,
         })

--- a/http/src/request/application/update_command_permissions.rs
+++ b/http/src/request/application/update_command_permissions.rs
@@ -56,8 +56,8 @@ impl<'a> UpdateCommandPermissions<'a> {
         })
     }
 
-    fn request(&self) -> Result<Request<'a>, Error> {
-        Request::builder(Route::UpdateCommandPermissions {
+    fn request(&self) -> Result<Request, Error> {
+        Request::builder(&Route::UpdateCommandPermissions {
             application_id: self.application_id.0,
             command_id: self.command_id.0,
             guild_id: self.guild_id.0,

--- a/http/src/request/application/update_followup_message.rs
+++ b/http/src/request/application/update_followup_message.rs
@@ -324,8 +324,8 @@ impl<'a> UpdateFollowupMessage<'a> {
 
     // `self` needs to be consumed and the client returned due to parameters
     // being consumed in request construction.
-    fn request(&mut self) -> Result<Request<'a>, HttpError> {
-        let mut request = Request::builder(Route::UpdateWebhookMessage {
+    fn request(&mut self) -> Result<Request, HttpError> {
+        let mut request = Request::builder(&Route::UpdateWebhookMessage {
             message_id: self.message_id.0,
             token: self.token,
             webhook_id: self.application_id.0,

--- a/http/src/request/application/update_global_command.rs
+++ b/http/src/request/application/update_global_command.rs
@@ -73,8 +73,8 @@ impl<'a> UpdateGlobalCommand<'a> {
         self
     }
 
-    fn request(&self) -> Result<Request<'a>, Error> {
-        Request::builder(Route::UpdateGlobalCommand {
+    fn request(&self) -> Result<Request, Error> {
+        Request::builder(&Route::UpdateGlobalCommand {
             application_id: self.application_id.0,
             command_id: self.command_id.0,
         })

--- a/http/src/request/application/update_guild_command.rs
+++ b/http/src/request/application/update_guild_command.rs
@@ -76,8 +76,8 @@ impl<'a> UpdateGuildCommand<'a> {
         self
     }
 
-    fn request(&self) -> Result<Request<'a>, Error> {
-        Request::builder(Route::UpdateGuildCommand {
+    fn request(&self) -> Result<Request, Error> {
+        Request::builder(&Route::UpdateGuildCommand {
             application_id: self.application_id.0,
             command_id: self.command_id.0,
             guild_id: self.guild_id.0,

--- a/http/src/request/application/update_original_response.rs
+++ b/http/src/request/application/update_original_response.rs
@@ -325,8 +325,8 @@ impl<'a> UpdateOriginalResponse<'a> {
 
     // `self` needs to be consumed and the client returned due to parameters
     // being consumed in request construction.
-    fn request(&mut self) -> Result<Request<'a>, HttpError> {
-        let mut request = Request::builder(Route::UpdateInteractionOriginal {
+    fn request(&mut self) -> Result<Request, HttpError> {
+        let mut request = Request::builder(&Route::UpdateInteractionOriginal {
             application_id: self.application_id.0,
             interaction_token: self.token,
         });

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -32,7 +32,7 @@ impl<'a> CreatePin<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::PinMessage {
+        let mut request = Request::builder(&Route::PinMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });

--- a/http/src/request/channel/create_typing_trigger.rs
+++ b/http/src/request/channel/create_typing_trigger.rs
@@ -21,7 +21,7 @@ impl<'a> CreateTypingTrigger<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = Request::from_route(Route::CreateTypingTrigger {
+        let request = Request::from_route(&Route::CreateTypingTrigger {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -26,7 +26,7 @@ impl<'a> DeleteChannel<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Channel> {
-        let mut request = Request::builder(Route::DeleteChannel {
+        let mut request = Request::builder(&Route::DeleteChannel {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/delete_channel_permission_configured.rs
+++ b/http/src/request/channel/delete_channel_permission_configured.rs
@@ -30,7 +30,7 @@ impl<'a> DeleteChannelPermissionConfigured<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::DeletePermissionOverwrite {
+        let mut request = Request::builder(&Route::DeletePermissionOverwrite {
             channel_id: self.channel_id.0,
             target_id: self.target_id,
         });

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -32,7 +32,7 @@ impl<'a> DeletePin<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::UnpinMessage {
+        let mut request = Request::builder(&Route::UnpinMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });

--- a/http/src/request/channel/follow_news_channel.rs
+++ b/http/src/request/channel/follow_news_channel.rs
@@ -31,7 +31,7 @@ impl<'a> FollowNewsChannel<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<FollowedChannel> {
-        let mut request = Request::builder(Route::FollowNewsChannel {
+        let mut request = Request::builder(&Route::FollowNewsChannel {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/get_channel.rs
+++ b/http/src/request/channel/get_channel.rs
@@ -34,7 +34,7 @@ impl<'a> GetChannel<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Channel> {
-        let request = Request::from_route(Route::GetChannel {
+        let request = Request::from_route(&Route::GetChannel {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/get_pins.rs
+++ b/http/src/request/channel/get_pins.rs
@@ -21,7 +21,7 @@ impl<'a> GetPins<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Message>> {
-        let request = Request::from_route(Route::GetPins {
+        let request = Request::from_route(&Route::GetPins {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -257,7 +257,7 @@ impl<'a> CreateInvite<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Invite> {
-        let mut request = Request::builder(Route::CreateInvite {
+        let mut request = Request::builder(&Route::CreateInvite {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -31,7 +31,7 @@ impl<'a> DeleteInvite<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::DeleteInvite { code: self.code });
+        let mut request = Request::builder(&Route::DeleteInvite { code: self.code });
 
         if let Some(reason) = self.reason {
             let header = match request::audit_header(reason) {

--- a/http/src/request/channel/invite/get_channel_invites.rs
+++ b/http/src/request/channel/invite/get_channel_invites.rs
@@ -27,7 +27,7 @@ impl<'a> GetChannelInvites<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Invite>> {
-        let request = Request::from_route(Route::GetChannelInvites {
+        let request = Request::from_route(&Route::GetChannelInvites {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -67,7 +67,7 @@ impl<'a> GetInvite<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Invite> {
-        let request = Request::from_route(Route::GetInviteWithExpiration {
+        let request = Request::from_route(&Route::GetInviteWithExpiration {
             code: self.code,
             with_counts: self.fields.with_counts,
             with_expiration: self.fields.with_expiration,

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -296,7 +296,7 @@ impl<'a> CreateMessage<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Message> {
-        let mut request = Request::builder(Route::CreateMessage {
+        let mut request = Request::builder(&Route::CreateMessage {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/message/crosspost_message.rs
+++ b/http/src/request/channel/message/crosspost_message.rs
@@ -28,7 +28,7 @@ impl<'a> CrosspostMessage<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Message> {
-        let request = Request::from_route(Route::CrosspostMessage {
+        let request = Request::from_route(&Route::CrosspostMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -32,7 +32,7 @@ impl<'a> DeleteMessage<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::DeleteMessage {
+        let mut request = Request::builder(&Route::DeleteMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -45,7 +45,7 @@ impl<'a> DeleteMessages<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::DeleteMessages {
+        let mut request = Request::builder(&Route::DeleteMessages {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -174,7 +174,7 @@ impl<'a> GetChannelMessages<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Message>> {
-        let request = Request::from_route(Route::GetMessages {
+        let request = Request::from_route(&Route::GetMessages {
             after: None,
             around: None,
             before: None,

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -128,7 +128,7 @@ impl<'a> GetChannelMessagesConfigured<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Message>> {
-        let request = Request::from_route(Route::GetMessages {
+        let request = Request::from_route(&Route::GetMessages {
             after: self.after.map(|x| x.0),
             around: self.around.map(|x| x.0),
             before: self.before.map(|x| x.0),

--- a/http/src/request/channel/message/get_message.rs
+++ b/http/src/request/channel/message/get_message.rs
@@ -28,7 +28,7 @@ impl<'a> GetMessage<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Message> {
-        let request = Request::from_route(Route::GetMessage {
+        let request = Request::from_route(&Route::GetMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -274,7 +274,7 @@ impl<'a> UpdateMessage<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Message> {
-        let mut request = Request::builder(Route::UpdateMessage {
+        let mut request = Request::builder(&Route::UpdateMessage {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -54,8 +54,8 @@ impl<'a> CreateReaction<'a> {
         }
     }
 
-    const fn request(&self) -> Request<'a> {
-        Request::from_route(Route::CreateReaction {
+    fn request(&self) -> Request {
+        Request::from_route(&Route::CreateReaction {
             channel_id: self.channel_id.0,
             emoji: self.emoji,
             message_id: self.message_id.0,
@@ -91,12 +91,12 @@ mod tests {
         let builder = CreateReaction::new(&client, ChannelId(123), MessageId(456), &emoji);
         let actual = builder.request();
 
-        let expected = Request::from_route(Route::CreateReaction {
+        let expected = Request::from_route(&Route::CreateReaction {
             channel_id: 123,
             emoji: &RequestReactionType::Unicode { name: "🌃" },
             message_id: 456,
         });
 
-        assert_eq!(actual.route, expected.route);
+        assert_eq!(actual.path, expected.path);
     }
 }

--- a/http/src/request/channel/reaction/delete_all_reaction.rs
+++ b/http/src/request/channel/reaction/delete_all_reaction.rs
@@ -34,7 +34,7 @@ impl<'a> DeleteAllReaction<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = Request::from_route(Route::DeleteMessageSpecificReaction {
+        let request = Request::from_route(&Route::DeleteMessageSpecificReaction {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
             emoji: self.emoji,

--- a/http/src/request/channel/reaction/delete_all_reactions.rs
+++ b/http/src/request/channel/reaction/delete_all_reactions.rs
@@ -30,7 +30,7 @@ impl<'a> DeleteAllReactions<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = Request::from_route(Route::DeleteMessageReactions {
+        let request = Request::from_route(&Route::DeleteMessageReactions {
             channel_id: self.channel_id.0,
             message_id: self.message_id.0,
         });

--- a/http/src/request/channel/reaction/delete_reaction.rs
+++ b/http/src/request/channel/reaction/delete_reaction.rs
@@ -59,6 +59,6 @@ impl<'a> DeleteReaction<'a> {
             },
         };
 
-        self.http.request(Request::from_route(route))
+        self.http.request(Request::from_route(&route))
     }
 }

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -130,7 +130,7 @@ impl<'a> GetReactions<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<User>> {
-        let request = Request::from_route(Route::GetReactionUsers {
+        let request = Request::from_route(&Route::GetReactionUsers {
             after: self.fields.after.map(|x| x.0),
             channel_id: self.channel_id.0,
             emoji: self.emoji,

--- a/http/src/request/channel/stage/create_stage_instance.rs
+++ b/http/src/request/channel/stage/create_stage_instance.rs
@@ -115,7 +115,7 @@ impl<'a> CreateStageInstance<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::CreateStageInstance);
+        let mut request = Request::builder(&Route::CreateStageInstance);
 
         request = match request.json(&self.fields) {
             Ok(request) => request,

--- a/http/src/request/channel/stage/delete_stage_instance.rs
+++ b/http/src/request/channel/stage/delete_stage_instance.rs
@@ -23,7 +23,7 @@ impl<'a> DeleteStageInstance<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = Request::from_route(Route::DeleteStageInstance {
+        let request = Request::from_route(&Route::DeleteStageInstance {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/stage/get_stage_instance.rs
+++ b/http/src/request/channel/stage/get_stage_instance.rs
@@ -16,7 +16,7 @@ impl<'a> GetStageInstance<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<StageInstance> {
-        let request = Request::from_route(Route::GetStageInstance {
+        let request = Request::from_route(&Route::GetStageInstance {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -119,7 +119,7 @@ impl<'a> UpdateStageInstance<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::UpdateStageInstance {
+        let mut request = Request::builder(&Route::UpdateStageInstance {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -56,6 +56,7 @@ impl Display for UpdateChannelError {
 
 impl Error for UpdateChannelError {}
 
+#[allow(clippy::pub_enum_variant_names)]
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum UpdateChannelErrorType {
@@ -275,8 +276,8 @@ impl<'a> UpdateChannel<'a> {
         self
     }
 
-    fn request(&self) -> Result<Request<'a>, HttpError> {
-        let mut request = Request::builder(Route::UpdateChannel {
+    fn request(&self) -> Result<Request, HttpError> {
+        let mut request = Request::builder(&Route::UpdateChannel {
             channel_id: self.channel_id.0,
         })
         .json(&self.fields)?;

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -59,8 +59,8 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
         }
     }
 
-    fn request(&self) -> Result<Request<'a>, Error> {
-        let mut request = Request::builder(Route::UpdatePermissionOverwrite {
+    fn request(&self) -> Result<Request, Error> {
+        let mut request = Request::builder(&Route::UpdatePermissionOverwrite {
             channel_id: self.channel_id.0,
             target_id: self.target_id,
         })
@@ -124,9 +124,9 @@ mod tests {
             channel_id: 1,
             target_id: 2,
         };
-        let expected = Request::builder(route).body(body).build();
+        let expected = Request::builder(&route).body(body).build();
 
         assert_eq!(expected.body, actual.body);
-        assert_eq!(expected.route, actual.route);
+        assert_eq!(expected.path, actual.path);
     }
 }

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -67,7 +67,7 @@ impl<'a> CreateWebhook<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Webhook> {
-        let mut request = Request::builder(Route::CreateWebhook {
+        let mut request = Request::builder(&Route::CreateWebhook {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/webhook/delete_webhook.rs
+++ b/http/src/request/channel/webhook/delete_webhook.rs
@@ -39,7 +39,7 @@ impl<'a> DeleteWebhook<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::DeleteWebhook {
+        let mut request = Request::builder(&Route::DeleteWebhook {
             webhook_id: self.id.0,
             token: self.fields.token,
         });

--- a/http/src/request/channel/webhook/delete_webhook_message.rs
+++ b/http/src/request/channel/webhook/delete_webhook_message.rs
@@ -52,8 +52,8 @@ impl<'a> DeleteWebhookMessage<'a> {
 
     // `self` needs to be consumed and the client returned due to parameters
     // being consumed in request construction.
-    fn request(&self) -> Result<Request<'a>, Error> {
-        let mut request = Request::builder(Route::DeleteWebhookMessage {
+    fn request(&self) -> Result<Request, Error> {
+        let mut request = Request::builder(&Route::DeleteWebhookMessage {
             message_id: self.message_id.0,
             token: self.token,
             webhook_id: self.webhook_id.0,
@@ -98,13 +98,13 @@ mod tests {
         let builder = DeleteWebhookMessage::new(&client, WebhookId(1), "token", MessageId(2));
         let actual = builder.request().expect("failed to create request");
 
-        let expected = Request::from_route(Route::DeleteWebhookMessage {
+        let expected = Request::from_route(&Route::DeleteWebhookMessage {
             message_id: 2,
             token: "token",
             webhook_id: 1,
         });
 
         assert_eq!(expected.body, actual.body);
-        assert_eq!(expected.route, actual.route);
+        assert_eq!(expected.path, actual.path);
     }
 }

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -207,8 +207,8 @@ impl<'a> ExecuteWebhook<'a> {
 
     // `self` needs to be consumed and the client returned due to parameters
     // being consumed in request construction.
-    pub(super) fn request(&self, wait: bool) -> Result<Request<'a>, Error> {
-        let mut request = Request::builder(Route::ExecuteWebhook {
+    pub(super) fn request(&self, wait: bool) -> Result<Request, Error> {
+        let mut request = Request::builder(&Route::ExecuteWebhook {
             token: self.token,
             wait: Some(wait),
             webhook_id: self.webhook_id.0,

--- a/http/src/request/channel/webhook/get_channel_webhooks.rs
+++ b/http/src/request/channel/webhook/get_channel_webhooks.rs
@@ -21,7 +21,7 @@ impl<'a> GetChannelWebhooks<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Webhook>> {
-        let request = Request::from_route(Route::GetChannelWebhooks {
+        let request = Request::from_route(&Route::GetChannelWebhooks {
             channel_id: self.channel_id.0,
         });
 

--- a/http/src/request/channel/webhook/get_webhook.rs
+++ b/http/src/request/channel/webhook/get_webhook.rs
@@ -35,7 +35,7 @@ impl<'a> GetWebhook<'a> {
     pub fn exec(self) -> ResponseFuture<Webhook> {
         let use_webhook_token = self.fields.token.is_some();
 
-        let mut request = Request::builder(Route::GetWebhook {
+        let mut request = Request::builder(&Route::GetWebhook {
             token: self.fields.token,
             webhook_id: self.id.0,
         });

--- a/http/src/request/channel/webhook/get_webhook_message.rs
+++ b/http/src/request/channel/webhook/get_webhook_message.rs
@@ -34,7 +34,7 @@ impl<'a> GetWebhookMessage<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Message> {
-        let request = Request::builder(Route::GetWebhookMessage {
+        let request = Request::builder(&Route::GetWebhookMessage {
             message_id: self.message_id.0,
             token: self.token,
             webhook_id: self.webhook_id.0,

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -74,7 +74,7 @@ impl<'a> UpdateWebhook<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Webhook> {
-        let mut request = Request::builder(Route::UpdateWebhook {
+        let mut request = Request::builder(&Route::UpdateWebhook {
             token: None,
             webhook_id: self.webhook_id.0,
         });

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -322,8 +322,8 @@ impl<'a> UpdateWebhookMessage<'a> {
 
     // `self` needs to be consumed and the client returned due to parameters
     // being consumed in request construction.
-    fn request(&mut self) -> Result<Request<'a>, HttpError> {
-        let mut request = Request::builder(Route::UpdateWebhookMessage {
+    fn request(&mut self) -> Result<Request, HttpError> {
+        let mut request = Request::builder(&Route::UpdateWebhookMessage {
             message_id: self.message_id.0,
             token: self.token,
             webhook_id: self.webhook_id.0,
@@ -415,12 +415,12 @@ mod tests {
             token: "token",
             webhook_id: 1,
         };
-        let expected = Request::builder(route)
+        let expected = Request::builder(&route)
             .json(&body)
             .expect("failed to serialize body")
             .build();
 
         assert_eq!(expected.body, actual.body);
-        assert_eq!(expected.route, actual.route);
+        assert_eq!(expected.path, actual.path);
     }
 }

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -60,7 +60,7 @@ impl<'a> UpdateWebhookWithToken<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Webhook> {
-        let mut request = Request::builder(Route::UpdateWebhook {
+        let mut request = Request::builder(&Route::UpdateWebhook {
             token: Some(self.token),
             webhook_id: self.webhook_id.0,
         })

--- a/http/src/request/get_gateway.rs
+++ b/http/src/request/get_gateway.rs
@@ -61,7 +61,7 @@ impl<'a> GetGateway<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ConnectionInfo> {
-        let request = Request::from_route(Route::GetGateway);
+        let request = Request::from_route(&Route::GetGateway);
 
         self.http.request(request)
     }

--- a/http/src/request/get_gateway_authed.rs
+++ b/http/src/request/get_gateway_authed.rs
@@ -18,7 +18,7 @@ impl<'a> GetGatewayAuthed<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<BotConnectionInfo> {
-        let request = Request::from_route(Route::GetGatewayBot);
+        let request = Request::from_route(&Route::GetGatewayBot);
 
         self.http.request(request)
     }

--- a/http/src/request/get_user_application.rs
+++ b/http/src/request/get_user_application.rs
@@ -14,7 +14,7 @@ impl<'a> GetUserApplicationInfo<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<CurrentApplicationInfo> {
-        let request = Request::from_route(Route::GetCurrentUserApplicationInfo);
+        let request = Request::from_route(&Route::GetCurrentUserApplicationInfo);
 
         self.http.request(request)
     }

--- a/http/src/request/get_voice_regions.rs
+++ b/http/src/request/get_voice_regions.rs
@@ -20,7 +20,7 @@ impl<'a> GetVoiceRegions<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<VoiceRegion>> {
-        let request = Request::from_route(Route::GetVoiceRegions);
+        let request = Request::from_route(&Route::GetVoiceRegions);
 
         self.http.request(request)
     }

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -131,7 +131,7 @@ impl<'a> CreateBan<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = Request::from_route(Route::CreateBan {
+        let request = Request::from_route(&Route::CreateBan {
             delete_message_days: self.fields.delete_message_days,
             guild_id: self.guild_id.0,
             reason: self.fields.reason,

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -47,7 +47,7 @@ impl<'a> DeleteBan<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::DeleteBan {
+        let mut request = Request::builder(&Route::DeleteBan {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
         });

--- a/http/src/request/guild/ban/get_ban.rs
+++ b/http/src/request/guild/ban/get_ban.rs
@@ -26,7 +26,7 @@ impl<'a> GetBan<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Ban> {
-        let request = Request::from_route(Route::GetBan {
+        let request = Request::from_route(&Route::GetBan {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
         });

--- a/http/src/request/guild/ban/get_bans.rs
+++ b/http/src/request/guild/ban/get_bans.rs
@@ -39,7 +39,7 @@ impl<'a> GetBans<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Ban>> {
-        let request = Request::from_route(Route::GetBans {
+        let request = Request::from_route(&Route::GetBans {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -449,7 +449,7 @@ impl<'a> CreateGuild<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<PartialGuild> {
-        let mut request = Request::builder(Route::CreateGuild);
+        let mut request = Request::builder(&Route::CreateGuild);
 
         request = match request.json(&self.fields) {
             Ok(request) => request,

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -47,6 +47,7 @@ impl CreateGuildChannelError {
 }
 
 /// Type of [`CreateGuildChannelError`] that occurred.
+#[allow(clippy::pub_enum_variant_names)]
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum CreateGuildChannelErrorType {
@@ -254,7 +255,7 @@ impl<'a> CreateGuildChannel<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<GuildChannel> {
-        let mut request = Request::builder(Route::CreateChannel {
+        let mut request = Request::builder(&Route::CreateChannel {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -135,7 +135,7 @@ impl<'a> CreateGuildPrune<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<GuildPrune> {
-        let mut request = Request::builder(Route::CreateGuildPrune {
+        let mut request = Request::builder(&Route::CreateGuildPrune {
             compute_prune_count: self.fields.compute_prune_count,
             days: self.fields.days,
             guild_id: self.guild_id.0,

--- a/http/src/request/guild/delete_guild.rs
+++ b/http/src/request/guild/delete_guild.rs
@@ -21,7 +21,7 @@ impl<'a> DeleteGuild<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = Request::from_route(Route::DeleteGuild {
+        let request = Request::from_route(&Route::DeleteGuild {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -66,7 +66,7 @@ impl<'a> CreateEmoji<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Emoji> {
-        let mut request = Request::builder(Route::CreateEmoji {
+        let mut request = Request::builder(&Route::CreateEmoji {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -28,7 +28,7 @@ impl<'a> DeleteEmoji<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::DeleteEmoji {
+        let mut request = Request::builder(&Route::DeleteEmoji {
             emoji_id: self.emoji_id.0,
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/emoji/get_emoji.rs
+++ b/http/src/request/guild/emoji/get_emoji.rs
@@ -43,7 +43,7 @@ impl<'a> GetEmoji<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Emoji> {
-        let request = Request::from_route(Route::GetEmoji {
+        let request = Request::from_route(&Route::GetEmoji {
             emoji_id: self.emoji_id.0,
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/emoji/get_emojis.rs
+++ b/http/src/request/guild/emoji/get_emojis.rs
@@ -39,7 +39,7 @@ impl<'a> GetEmojis<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Emoji>> {
-        let request = Request::from_route(Route::GetEmojis {
+        let request = Request::from_route(&Route::GetEmojis {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -59,7 +59,7 @@ impl<'a> UpdateEmoji<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Emoji> {
-        let mut request = Request::builder(Route::UpdateEmoji {
+        let mut request = Request::builder(&Route::UpdateEmoji {
             emoji_id: self.emoji_id.0,
             guild_id: self.guild_id.0,
         });

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -163,7 +163,7 @@ impl<'a> GetAuditLog<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<AuditLog> {
-        let request = Request::from_route(Route::GetAuditLogs {
+        let request = Request::from_route(&Route::GetAuditLogs {
             action_type: self.fields.action_type.map(|x| x as u64),
             before: self.fields.before,
             guild_id: self.guild_id.0,

--- a/http/src/request/guild/get_guild.rs
+++ b/http/src/request/guild/get_guild.rs
@@ -33,7 +33,7 @@ impl<'a> GetGuild<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Guild> {
-        let request = Request::from_route(Route::GetGuild {
+        let request = Request::from_route(&Route::GetGuild {
             guild_id: self.guild_id.0,
             with_counts: self.fields.with_counts,
         });

--- a/http/src/request/guild/get_guild_channels.rs
+++ b/http/src/request/guild/get_guild_channels.rs
@@ -21,7 +21,7 @@ impl<'a> GetGuildChannels<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<GuildChannel>> {
-        let request = Request::from_route(Route::GetChannels {
+        let request = Request::from_route(&Route::GetChannels {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/get_guild_invites.rs
+++ b/http/src/request/guild/get_guild_invites.rs
@@ -25,7 +25,7 @@ impl<'a> GetGuildInvites<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Invite>> {
-        let request = Request::from_route(Route::GetGuildInvites {
+        let request = Request::from_route(&Route::GetGuildInvites {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/get_guild_preview.rs
+++ b/http/src/request/guild/get_guild_preview.rs
@@ -18,7 +18,7 @@ impl<'a> GetGuildPreview<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<GuildPreview> {
-        let request = Request::from_route(Route::GetGuildPreview {
+        let request = Request::from_route(&Route::GetGuildPreview {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -121,7 +121,7 @@ impl<'a> GetGuildPruneCount<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<GuildPrune> {
-        let request = Request::from_route(Route::GetGuildPruneCount {
+        let request = Request::from_route(&Route::GetGuildPruneCount {
             days: self.fields.days,
             guild_id: self.guild_id.0,
             include_roles: self.fields.include_roles,

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -16,7 +16,7 @@ impl<'a> GetGuildVanityUrl<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<VanityUrl> {
-        let request = Request::from_route(Route::GetGuildVanityUrl {
+        let request = Request::from_route(&Route::GetGuildVanityUrl {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/get_guild_voice_regions.rs
+++ b/http/src/request/guild/get_guild_voice_regions.rs
@@ -23,7 +23,7 @@ impl<'a> GetGuildVoiceRegions<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<VoiceRegion>> {
-        let request = Request::from_route(Route::GetGuildVoiceRegions {
+        let request = Request::from_route(&Route::GetGuildVoiceRegions {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/get_guild_webhooks.rs
+++ b/http/src/request/guild/get_guild_webhooks.rs
@@ -21,7 +21,7 @@ impl<'a> GetGuildWebhooks<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Webhook>> {
-        let request = Request::from_route(Route::GetGuildWebhooks {
+        let request = Request::from_route(&Route::GetGuildWebhooks {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/get_guild_welcome_screen.rs
+++ b/http/src/request/guild/get_guild_welcome_screen.rs
@@ -16,7 +16,7 @@ impl<'a> GetGuildWelcomeScreen<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<WelcomeScreen> {
-        let request = Request::from_route(Route::GetGuildWelcomeScreen {
+        let request = Request::from_route(&Route::GetGuildWelcomeScreen {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/get_guild_widget.rs
+++ b/http/src/request/guild/get_guild_widget.rs
@@ -20,7 +20,7 @@ impl<'a> GetGuildWidget<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<GuildWidget> {
-        let request = Request::from_route(Route::GetGuildWidget {
+        let request = Request::from_route(&Route::GetGuildWidget {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -32,7 +32,7 @@ impl<'a> DeleteGuildIntegration<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::DeleteGuildIntegration {
+        let mut request = Request::builder(&Route::DeleteGuildIntegration {
             guild_id: self.guild_id.0,
             integration_id: self.integration_id.0,
         });

--- a/http/src/request/guild/integration/get_guild_integrations.rs
+++ b/http/src/request/guild/integration/get_guild_integrations.rs
@@ -21,7 +21,7 @@ impl<'a> GetGuildIntegrations<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<GuildIntegration>> {
-        let request = Request::from_route(Route::GetGuildIntegrations {
+        let request = Request::from_route(&Route::GetGuildIntegrations {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/member/add_guild_member.rs
+++ b/http/src/request/guild/member/add_guild_member.rs
@@ -158,7 +158,7 @@ impl<'a> AddGuildMember<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<PartialMember> {
-        let mut request = Request::builder(Route::AddGuildMember {
+        let mut request = Request::builder(&Route::AddGuildMember {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
         });

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -58,7 +58,7 @@ impl<'a> AddRoleToMember<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::AddMemberRole {
+        let mut request = Request::builder(&Route::AddMemberRole {
             guild_id: self.guild_id.0,
             role_id: self.role_id.0,
             user_id: self.user_id.0,

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -148,7 +148,7 @@ impl<'a> GetGuildMembers<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<MemberListBody> {
-        let request = Request::from_route(Route::GetGuildMembers {
+        let request = Request::from_route(&Route::GetGuildMembers {
             after: self.fields.after.map(|x| x.0),
             guild_id: self.guild_id.0,
             limit: self.fields.limit,

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -26,7 +26,7 @@ impl<'a> GetMember<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<MemberBody> {
-        let request = Request::from_route(Route::GetMember {
+        let request = Request::from_route(&Route::GetMember {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
         });

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -28,7 +28,7 @@ impl<'a> RemoveMember<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::RemoveMember {
+        let mut request = Request::builder(&Route::RemoveMember {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
         });

--- a/http/src/request/guild/member/remove_role_from_member.rs
+++ b/http/src/request/guild/member/remove_role_from_member.rs
@@ -35,7 +35,7 @@ impl<'a> RemoveRoleFromMember<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::RemoveMemberRole {
+        let mut request = Request::builder(&Route::RemoveMemberRole {
             guild_id: self.guild_id.0,
             role_id: self.role_id.0,
             user_id: self.user_id.0,

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -139,7 +139,7 @@ impl<'a> SearchGuildMembers<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<MemberListBody> {
-        let request = Request::from_route(Route::SearchGuildMembers {
+        let request = Request::from_route(&Route::SearchGuildMembers {
             guild_id: self.guild_id.0,
             limit: self.fields.limit,
             query: self.fields.query,

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -159,8 +159,8 @@ impl<'a> UpdateGuildMember<'a> {
         self
     }
 
-    fn request(&self) -> Result<Request<'a>, HttpError> {
-        let mut request = Request::builder(Route::UpdateMember {
+    fn request(&self) -> Result<Request, HttpError> {
+        let mut request = Request::builder(&Route::UpdateMember {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
         })
@@ -230,10 +230,10 @@ mod tests {
             guild_id: GUILD_ID.0,
             user_id: USER_ID.0,
         };
-        let expected = Request::builder(route).json(&body)?.build();
+        let expected = Request::builder(&route).json(&body)?.build();
 
         assert_eq!(actual.body, expected.body);
-        assert_eq!(actual.route, expected.route);
+        assert_eq!(actual.path, expected.path);
 
         Ok(())
     }
@@ -255,7 +255,7 @@ mod tests {
             guild_id: GUILD_ID.0,
             user_id: USER_ID.0,
         };
-        let expected = Request::builder(route).json(&body)?.build();
+        let expected = Request::builder(&route).json(&body)?.build();
 
         assert_eq!(actual.body, expected.body);
 
@@ -279,7 +279,7 @@ mod tests {
             guild_id: GUILD_ID.0,
             user_id: USER_ID.0,
         };
-        let expected = Request::builder(route).json(&body)?.build();
+        let expected = Request::builder(&route).json(&body)?.build();
 
         assert_eq!(actual.body, expected.body);
 

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -108,7 +108,7 @@ impl<'a> CreateRole<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Role> {
-        let mut request = Request::builder(Route::CreateRole {
+        let mut request = Request::builder(&Route::CreateRole {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -28,7 +28,7 @@ impl<'a> DeleteRole<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::DeleteRole {
+        let mut request = Request::builder(&Route::DeleteRole {
             guild_id: self.guild_id.0,
             role_id: self.role_id.0,
         });

--- a/http/src/request/guild/role/get_guild_roles.rs
+++ b/http/src/request/guild/role/get_guild_roles.rs
@@ -21,7 +21,7 @@ impl<'a> GetGuildRoles<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Role>> {
-        let request = Request::from_route(Route::GetGuildRoles {
+        let request = Request::from_route(&Route::GetGuildRoles {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -89,7 +89,7 @@ impl<'a> UpdateRole<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Role> {
-        let mut request = Request::builder(Route::UpdateRole {
+        let mut request = Request::builder(&Route::UpdateRole {
             guild_id: self.guild_id.0,
             role_id: self.role_id.0,
         });

--- a/http/src/request/guild/role/update_role_positions.rs
+++ b/http/src/request/guild/role/update_role_positions.rs
@@ -35,7 +35,7 @@ impl<'a> UpdateRolePositions<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Role>> {
-        let mut request = Request::builder(Route::UpdateRolePositions {
+        let mut request = Request::builder(&Route::UpdateRolePositions {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/update_current_user_nick.rs
+++ b/http/src/request/guild/update_current_user_nick.rs
@@ -32,7 +32,7 @@ impl<'a> UpdateCurrentUserNick<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::UpdateNickname {
+        let mut request = Request::builder(&Route::UpdateNickname {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -324,7 +324,7 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<PartialGuild> {
-        let mut request = Request::builder(Route::UpdateGuild {
+        let mut request = Request::builder(&Route::UpdateGuild {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/update_guild_channel_positions.rs
+++ b/http/src/request/guild/update_guild_channel_positions.rs
@@ -58,7 +58,7 @@ impl<'a> UpdateGuildChannelPositions<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::UpdateGuildChannels {
+        let mut request = Request::builder(&Route::UpdateGuildChannels {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/update_guild_welcome_screen.rs
+++ b/http/src/request/guild/update_guild_welcome_screen.rs
@@ -69,7 +69,7 @@ impl<'a> UpdateGuildWelcomeScreen<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<WelcomeScreen> {
-        let mut request = Request::builder(Route::UpdateGuildWelcomeScreen {
+        let mut request = Request::builder(&Route::UpdateGuildWelcomeScreen {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/update_guild_widget.rs
+++ b/http/src/request/guild/update_guild_widget.rs
@@ -55,7 +55,7 @@ impl<'a> UpdateGuildWidget<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<GuildWidget> {
-        let mut request = Request::builder(Route::UpdateGuildWidget {
+        let mut request = Request::builder(&Route::UpdateGuildWidget {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/user/update_current_user_voice_state.rs
+++ b/http/src/request/guild/user/update_current_user_voice_state.rs
@@ -71,7 +71,7 @@ impl<'a> UpdateCurrentUserVoiceState<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::UpdateCurrentUserVoiceState {
+        let mut request = Request::builder(&Route::UpdateCurrentUserVoiceState {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/guild/user/update_user_voice_state.rs
+++ b/http/src/request/guild/user/update_user_voice_state.rs
@@ -62,7 +62,7 @@ impl<'a> UpdateUserVoiceState<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let mut request = Request::builder(Route::UpdateUserVoiceState {
+        let mut request = Request::builder(&Route::UpdateUserVoiceState {
             guild_id: self.guild_id.0,
             user_id: self.user_id.0,
         });

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -119,7 +119,7 @@ impl<'a> CreateGuildFromTemplate<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Guild> {
-        let mut request = Request::builder(Route::CreateGuildFromTemplate {
+        let mut request = Request::builder(&Route::CreateGuildFromTemplate {
             template_code: self.template_code,
         });
 

--- a/http/src/request/template/create_template.rs
+++ b/http/src/request/template/create_template.rs
@@ -135,7 +135,7 @@ impl<'a> CreateTemplate<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Template> {
-        let mut request = Request::builder(Route::CreateTemplate {
+        let mut request = Request::builder(&Route::CreateTemplate {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/template/delete_template.rs
+++ b/http/src/request/template/delete_template.rs
@@ -26,7 +26,7 @@ impl<'a> DeleteTemplate<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = Request::from_route(Route::DeleteTemplate {
+        let request = Request::from_route(&Route::DeleteTemplate {
             guild_id: self.guild_id.0,
             template_code: self.template_code,
         });

--- a/http/src/request/template/get_template.rs
+++ b/http/src/request/template/get_template.rs
@@ -19,7 +19,7 @@ impl<'a> GetTemplate<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Template> {
-        let request = Request::from_route(Route::GetTemplate {
+        let request = Request::from_route(&Route::GetTemplate {
             template_code: self.template_code,
         });
 

--- a/http/src/request/template/get_templates.rs
+++ b/http/src/request/template/get_templates.rs
@@ -21,7 +21,7 @@ impl<'a> GetTemplates<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Template>> {
-        let request = Request::from_route(Route::GetTemplates {
+        let request = Request::from_route(&Route::GetTemplates {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/template/sync_template.rs
+++ b/http/src/request/template/sync_template.rs
@@ -21,7 +21,7 @@ impl<'a> SyncTemplate<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Template> {
-        let request = Request::from_route(Route::SyncTemplate {
+        let request = Request::from_route(&Route::SyncTemplate {
             guild_id: self.guild_id.0,
             template_code: self.template_code,
         });

--- a/http/src/request/template/update_template.rs
+++ b/http/src/request/template/update_template.rs
@@ -139,7 +139,7 @@ impl<'a> UpdateTemplate<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Template> {
-        let mut request = Request::builder(Route::UpdateTemplate {
+        let mut request = Request::builder(&Route::UpdateTemplate {
             guild_id: self.guild_id.0,
             template_code: self.template_code,
         });

--- a/http/src/request/user/create_private_channel.rs
+++ b/http/src/request/user/create_private_channel.rs
@@ -23,7 +23,7 @@ impl<'a> CreatePrivateChannel<'a> {
         }
     }
     pub fn exec(self) -> ResponseFuture<PrivateChannel> {
-        let request = Request::builder(Route::CreatePrivateChannel);
+        let request = Request::builder(&Route::CreatePrivateChannel);
 
         let request = match request.json(&self.fields) {
             Ok(request) => request,

--- a/http/src/request/user/get_current_user.rs
+++ b/http/src/request/user/get_current_user.rs
@@ -15,7 +15,7 @@ impl<'a> GetCurrentUser<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<CurrentUser> {
-        let request = Request::from_route(Route::GetCurrentUser);
+        let request = Request::from_route(&Route::GetCurrentUser);
 
         self.http.request(request)
     }

--- a/http/src/request/user/get_current_user_connections.rs
+++ b/http/src/request/user/get_current_user_connections.rs
@@ -22,7 +22,7 @@ impl<'a> GetCurrentUserConnections<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Connection>> {
-        let request = Request::from_route(Route::GetUserConnections);
+        let request = Request::from_route(&Route::GetUserConnections);
 
         self.http.request(request)
     }

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -148,7 +148,7 @@ impl<'a> GetCurrentUserGuilds<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<CurrentUserGuild>> {
-        let request = Request::from_route(Route::GetGuilds {
+        let request = Request::from_route(&Route::GetGuilds {
             after: self.fields.after.map(|x| x.0),
             before: self.fields.before.map(|x| x.0),
             limit: self.fields.limit,

--- a/http/src/request/user/get_user.rs
+++ b/http/src/request/user/get_user.rs
@@ -16,7 +16,7 @@ impl<'a> GetUser<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<User> {
-        let request = Request::from_route(Route::GetUser {
+        let request = Request::from_route(&Route::GetUser {
             user_id: self.user_id.0,
         });
 

--- a/http/src/request/user/leave_guild.rs
+++ b/http/src/request/user/leave_guild.rs
@@ -21,7 +21,7 @@ impl<'a> LeaveGuild<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = Request::from_route(Route::LeaveGuild {
+        let request = Request::from_route(&Route::LeaveGuild {
             guild_id: self.guild_id.0,
         });
 

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -129,7 +129,7 @@ impl<'a> UpdateCurrentUser<'a> {
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<User> {
-        let mut request = Request::builder(Route::UpdateCurrentUser);
+        let mut request = Request::builder(&Route::UpdateCurrentUser);
 
         request = match request.json(&self.fields) {
             Ok(request) => request,


### PR DESCRIPTION
`request::RequestBuilder::raw` was accidentally removed for 0.6; this adds it back in, hiding the existing fields behind methods due to the type of one of the public fields being inaccurate in the first place. This is considered a hotfix.

BREAKING CHANGES: `request::Request` fields are now private and behind getters, `request::RequestBuilder` and `request::Request` initialization methods now take route references.