### PR TITLE
chore(http/validate): new select option limits

### DIFF
--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -1179,10 +1179,10 @@ mod tests {
     const_assert_eq!(25, ComponentValidationError::SELECT_MINIMUM_VALUES_LIMIT);
     const_assert_eq!(25, ComponentValidationError::SELECT_OPTION_COUNT);
     const_assert_eq!(
-        50,
+        100,
         ComponentValidationError::SELECT_OPTION_DESCRIPTION_LENGTH
     );
-    const_assert_eq!(25, ComponentValidationError::SELECT_OPTION_LABEL_LENGTH);
+    const_assert_eq!(100, ComponentValidationError::SELECT_OPTION_LABEL_LENGTH);
     const_assert_eq!(100, ComponentValidationError::SELECT_OPTION_VALUE_LENGTH);
     const_assert_eq!(100, ComponentValidationError::SELECT_PLACEHOLDER_LENGTH);
     const_assert_eq!(256, EmbedValidationError::AUTHOR_NAME_LENGTH);

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -111,7 +111,7 @@ impl ComponentValidationError {
     /// [Discord Docs/Select Menu Option][1].
     ///
     /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
-    pub const SELECT_OPTION_DESCRIPTION_LENGTH: usize = 50;
+    pub const SELECT_OPTION_DESCRIPTION_LENGTH: usize = 100;
 
     /// Maximum length of a [`SelectMenuOption::label`] in codepoints.
     ///
@@ -120,7 +120,7 @@ impl ComponentValidationError {
     ///
     /// [`SelectMenuOption::label`]: twilight_model::application::component::select_menu::SelectMenuOption::label
     /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
-    pub const SELECT_OPTION_LABEL_LENGTH: usize = 25;
+    pub const SELECT_OPTION_LABEL_LENGTH: usize = 100;
 
     /// Maximum length of a [`SelectMenuOption::value`] in codepoints.
     ///


### PR DESCRIPTION
Update HTTP validation to take into account the new Select Menu Option limits. Label and descriptions lengths have been increased from 25 to 100.

API docs: <https://github.com/discord/discord-api-docs/commit/02870dd7ccc9bed981f540e693ee7991c1f418c4>