### PR TITLE
feat(http): add new error codes as of 2021-08-03

### DIFF
--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -64,6 +64,10 @@ pub enum ErrorCode {
     UnknownRedistributable,
     /// Unknown gift code
     UnknownGiftCode,
+    /// Unknown stream
+    UnknownStream,
+    /// Unknown premium server subscribe cooldown
+    UnknownPremiumServerSubscribeCooldown,
     /// Unknown guild template
     UnknownGuildTemplate,
     /// Unknown discoverable server category
@@ -82,6 +86,10 @@ pub enum ErrorCode {
     UnknownGuildMemberVerificationForm,
     /// Unknown Guild Welcome Screen
     UnknownGuildWelcomeScreen,
+    /// Unknown guild scheduled event
+    UnknownGuildScheduledEvent,
+    /// Unknown guild scheduled event user
+    UnknownGuildScheduledEventUser,
     /// Bots cannot use this endpoint
     BotsCannotUseEndpoint,
     /// Only bots can use this endpoint
@@ -221,6 +229,10 @@ pub enum ErrorCode {
     CommunityGuildRequired,
     /// Invalid sticker sent
     InvalidStickerSent,
+    /// This server is not available in your location
+    ServerNotAvailableLocation,
+    /// This server needs monetization enabled in order to perform this action
+    ServerNeedsMonetiazation,
     /// Two factor is required for this operation.
     TwoFactorRequired,
     /// No users with DiscordTag exist
@@ -269,6 +281,8 @@ impl ErrorCode {
             Self::UnknownStoreDirectoryLayout => 10033,
             Self::UnknownRedistributable => 10036,
             Self::UnknownGiftCode => 10038,
+            Self::UnknownStream => 10049,
+            Self::UnknownPremiumServerSubscribeCooldown => 10050,
             Self::UnknownGuildTemplate => 10057,
             Self::UnknownDiscoverableServerCategory => 10059,
             Self::UnknownSticker => 10060,
@@ -278,6 +292,8 @@ impl ErrorCode {
             Self::UnknownStageInstance => 10067,
             Self::UnknownGuildMemberVerificationForm => 10068,
             Self::UnknownGuildWelcomeScreen => 10069,
+            Self::UnknownGuildScheduledEvent => 10070,
+            Self::UnknownGuildScheduledEventUser => 10071,
             Self::BotsCannotUseEndpoint => 20001,
             Self::OnlyBotsCanUseEndpoint => 20002,
             Self::ExplicitContentSendingBlocked => 20009,
@@ -347,6 +363,8 @@ impl ErrorCode {
             Self::PaymentRequiredForGift => 50070,
             Self::CommunityGuildRequired => 50074,
             Self::InvalidStickerSent => 50081,
+            Self::ServerNotAvailableLocation => 50095,
+            Self::ServerNeedsMonetiazation => 50097,
             Self::TwoFactorRequired => 60003,
             Self::NoSuchUser => 80004,
             Self::ReactionBlocked => 90001,
@@ -389,6 +407,8 @@ impl From<u64> for ErrorCode {
             10033 => Self::UnknownStoreDirectoryLayout,
             10036 => Self::UnknownRedistributable,
             10038 => Self::UnknownGiftCode,
+            10049 => Self::UnknownStream,
+            10050 => Self::UnknownPremiumServerSubscribeCooldown,
             10057 => Self::UnknownGuildTemplate,
             10059 => Self::UnknownDiscoverableServerCategory,
             10060 => Self::UnknownSticker,
@@ -398,6 +418,8 @@ impl From<u64> for ErrorCode {
             10067 => Self::UnknownStageInstance,
             10068 => Self::UnknownGuildMemberVerificationForm,
             10069 => Self::UnknownGuildWelcomeScreen,
+            10070 => Self::UnknownGuildScheduledEvent,
+            10071 => Self::UnknownGuildScheduledEventUser,
             20001 => Self::BotsCannotUseEndpoint,
             20002 => Self::OnlyBotsCanUseEndpoint,
             20022 => Self::AnnouncementRateLimitReached,
@@ -466,6 +488,8 @@ impl From<u64> for ErrorCode {
             50054 => Self::CannotSelfRedeemGift,
             50070 => Self::PaymentRequiredForGift,
             50074 => Self::CommunityGuildRequired,
+            50095 => Self::ServerNotAvailableLocation,
+            50097 => Self::ServerNeedsMonetiazation,
             50081 => Self::InvalidStickerSent,
             60003 => Self::TwoFactorRequired,
             80004 => Self::NoSuchUser,
@@ -509,6 +533,8 @@ impl Display for ErrorCode {
             Self::UnknownStoreDirectoryLayout => f.write_str("Unknown store directory layout"),
             Self::UnknownRedistributable => f.write_str("Unknown redistributable"),
             Self::UnknownGiftCode => f.write_str("Unknown gift code"),
+            Self::UnknownStream => f.write_str("Unknown stream"),
+            Self::UnknownPremiumServerSubscribeCooldown => f.write_str("Unknown premium server subscribe cooldown"),
             Self::UnknownGuildTemplate => f.write_str("Unknown guild template"),
             Self::UnknownDiscoverableServerCategory => f.write_str("Unknown discoverable server category"),
             Self::UnknownSticker => f.write_str("Unknown sticker"),
@@ -518,6 +544,8 @@ impl Display for ErrorCode {
             Self::UnknownStageInstance => f.write_str("Unknown Stage Instance"),
             Self::UnknownGuildMemberVerificationForm => f.write_str("Unknown Guild Member Verification Form"),
             Self::UnknownGuildWelcomeScreen => f.write_str("Unknown Guild Welcome Screen"),
+            Self::UnknownGuildScheduledEvent => f.write_str("Unknown Guild Scheduled Event"),
+            Self::UnknownGuildScheduledEventUser => f.write_str("Unknown Guild Scheduled Event User"),
             Self::BotsCannotUseEndpoint => f.write_str("Bots cannot use this endpoint"),
             Self::OnlyBotsCanUseEndpoint => f.write_str("Only bots can use this endpoint"),
             Self::ExplicitContentSendingBlocked => f.write_str("Explicit content cannot be sent to the desired recipient(s)"),
@@ -587,6 +615,8 @@ impl Display for ErrorCode {
             Self::PaymentRequiredForGift => f.write_str("Payment source required to redeem gift"),
             Self::CommunityGuildRequired => f.write_str("Cannot delete a channel required for Community guilds"),
             Self::InvalidStickerSent => f.write_str("Invalid sticker sent"),
+            Self::ServerNotAvailableLocation => f.write_str("This server is not available in your location"),
+            Self::ServerNeedsMonetiazation => f.write_str("This server needs monetization enabled in order to perform this action"),
             Self::TwoFactorRequired => f.write_str("Two factor is required for this operation"),
             Self::NoSuchUser => f.write_str("No users with DiscordTag exist"),
             Self::ReactionBlocked => f.write_str("Reaction was blocked"),


### PR DESCRIPTION
Adds the following new error codes:


|-------|------------------------------------------------------------------------|
| 10049 | Unknown stream                                                         |
| 10050 | Unknown premium server subscribe cooldown                              |
| 10070 | Unknown Guild Scheduled Event                                          |
| 10071 | Unknown Guild Scheduled Event User                                     |
| 50095 | This server is not available in your location                          |
| 50097 | This server needs monetization enabled in order to perform this action |


closes #1091