### PR TITLE
Fix HTTP response future returning error on non-success

### DIFF
--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -60,6 +60,7 @@ impl Display for Error {
             }
             ErrorType::RequestError => f.write_str("Parsing or sending the response failed"),
             ErrorType::RequestTimedOut => f.write_str("request timed out"),
+            #[allow(deprecated)]
             ErrorType::Response { error, status, .. } => {
                 f.write_str("Response error: status code ")?;
                 Display::fmt(status, f)?;
@@ -101,6 +102,7 @@ pub enum ErrorType {
     RequestCanceled,
     RequestError,
     RequestTimedOut,
+    #[deprecated(since = "0.6.2", note = "this variant is no longer used")]
     Response {
         body: Vec<u8>,
         error: ApiError,


### PR DESCRIPTION
Instead of returning a `twilight_http::error::Error` with an error type of `twilight_http::error::ErrorType::Response`, return a `Response`. Users can manually check the status code and then get the bytes or deserialize into a `twilight_http::api_error::ApiError`.

The `ErrorType::Response` variant is now deprecated.

BREAKING CHANGES: when a non-success status code occurs an error is no longer returned and instead a Response is.