### PR TITLE
Add `#[must_use]` to typed HTTP requests

### DIFF
--- a/http/src/request/application/create_followup_message.rs
+++ b/http/src/request/application/create_followup_message.rs
@@ -60,6 +60,7 @@ pub(crate) struct CreateFollowupMessageFields<'a> {
 /// [`content`]: Self::content
 /// [`embeds`]: Self::embeds
 /// [`files`]: Self::files
+#[must_use = "requests must be configured and executed"]
 pub struct CreateFollowupMessage<'a> {
     pub(crate) fields: CreateFollowupMessageFields<'a>,
     files: &'a [(&'a str, &'a [u8])],

--- a/http/src/request/application/create_global_command.rs
+++ b/http/src/request/application/create_global_command.rs
@@ -19,6 +19,7 @@ use twilight_model::{
 /// command. See [the discord docs] for more information.
 ///
 /// [the discord docs]: https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
+#[must_use = "requests must be configured and executed"]
 pub struct CreateGlobalCommand<'a> {
     application_id: ApplicationId,
     default_permission: Option<bool>,

--- a/http/src/request/application/create_guild_command.rs
+++ b/http/src/request/application/create_guild_command.rs
@@ -19,6 +19,7 @@ use twilight_model::{
 /// will overwrite the old command. See [the discord docs] for more information.
 ///
 /// [the discord docs]: https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command
+#[must_use = "requests must be configured and executed"]
 pub struct CreateGuildCommand<'a> {
     application_id: ApplicationId,
     default_permission: Option<bool>,

--- a/http/src/request/application/delete_followup_message.rs
+++ b/http/src/request/application/delete_followup_message.rs
@@ -23,6 +23,7 @@ use twilight_model::id::{ApplicationId, MessageId};
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteFollowupMessage<'a> {
     http: &'a Client,
     message_id: MessageId,

--- a/http/src/request/application/delete_global_command.rs
+++ b/http/src/request/application/delete_global_command.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::{ApplicationId, CommandId};
 
 /// Delete a global command, by ID.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteGlobalCommand<'a> {
     application_id: ApplicationId,
     command_id: CommandId,

--- a/http/src/request/application/delete_guild_command.rs
+++ b/http/src/request/application/delete_guild_command.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::{ApplicationId, CommandId, GuildId};
 
 /// Delete a command in a guild, by ID.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteGuildCommand<'a> {
     application_id: ApplicationId,
     command_id: CommandId,

--- a/http/src/request/application/delete_original_response.rs
+++ b/http/src/request/application/delete_original_response.rs
@@ -27,6 +27,7 @@ use twilight_model::id::ApplicationId;
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteOriginalResponse<'a> {
     application_id: ApplicationId,
     http: &'a Client,

--- a/http/src/request/application/get_command_permissions.rs
+++ b/http/src/request/application/get_command_permissions.rs
@@ -5,6 +5,7 @@ use twilight_model::{
 };
 
 /// Fetch command permissions for a command from the current application in a guild.
+#[must_use = "requests must be configured and executed"]
 pub struct GetCommandPermissions<'a> {
     application_id: ApplicationId,
     command_id: CommandId,

--- a/http/src/request/application/get_global_commands.rs
+++ b/http/src/request/application/get_global_commands.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::{application::command::Command, id::ApplicationId};
 
 /// Retrieve all global commands for an application.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGlobalCommands<'a> {
     application_id: ApplicationId,
     http: &'a Client,

--- a/http/src/request/application/get_guild_command_permissions.rs
+++ b/http/src/request/application/get_guild_command_permissions.rs
@@ -10,6 +10,7 @@ use twilight_model::{
 };
 
 /// Get command permissions for all commands from the current application in a guild.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildCommandPermissions<'a> {
     application_id: ApplicationId,
     guild_id: GuildId,

--- a/http/src/request/application/get_guild_commands.rs
+++ b/http/src/request/application/get_guild_commands.rs
@@ -10,6 +10,7 @@ use twilight_model::{
 };
 
 /// Fetch all commands for a guild, by ID.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildCommands<'a> {
     application_id: ApplicationId,
     guild_id: GuildId,

--- a/http/src/request/application/get_original_response.rs
+++ b/http/src/request/application/get_original_response.rs
@@ -22,6 +22,7 @@ use twilight_model::{channel::Message, id::ApplicationId};
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct GetOriginalResponse<'a> {
     application_id: ApplicationId,
     http: &'a Client,

--- a/http/src/request/application/interaction_callback.rs
+++ b/http/src/request/application/interaction_callback.rs
@@ -8,6 +8,7 @@ use crate::{
 use twilight_model::{application::callback::InteractionResponse, id::InteractionId};
 
 /// Respond to an interaction, by ID and token.
+#[must_use = "requests must be configured and executed"]
 pub struct InteractionCallback<'a> {
     interaction_id: InteractionId,
     interaction_token: &'a str,

--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -39,6 +39,7 @@ impl Serialize for PermissionListSerializer<'_> {
 /// This overwrites the command permissions so the full set of permissions
 /// have to be sent every time.
 #[derive(Debug)]
+#[must_use = "requests must be configured and executed"]
 pub struct SetCommandPermissions<'a> {
     application_id: ApplicationId,
     guild_id: GuildId,

--- a/http/src/request/application/set_global_commands.rs
+++ b/http/src/request/application/set_global_commands.rs
@@ -11,6 +11,7 @@ use twilight_model::{application::command::Command, id::ApplicationId};
 ///
 /// This method is idempotent: it can be used on every start, without being
 /// ratelimited if there aren't changes to the commands.
+#[must_use = "requests must be configured and executed"]
 pub struct SetGlobalCommands<'a> {
     commands: &'a [Command],
     application_id: ApplicationId,

--- a/http/src/request/application/set_guild_commands.rs
+++ b/http/src/request/application/set_guild_commands.rs
@@ -14,6 +14,7 @@ use twilight_model::{
 ///
 /// This method is idempotent: it can be used on every start, without being
 /// ratelimited if there aren't changes to the commands.
+#[must_use = "requests must be configured and executed"]
 pub struct SetGuildCommands<'a> {
     commands: &'a [Command],
     application_id: ApplicationId,

--- a/http/src/request/application/update_command_permissions.rs
+++ b/http/src/request/application/update_command_permissions.rs
@@ -25,6 +25,7 @@ struct UpdateCommandPermissionsFields<'a> {
 ///
 /// This overwrites the command permissions so the full set of permissions
 /// have to be sent every time.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateCommandPermissions<'a> {
     application_id: ApplicationId,
     command_id: CommandId,

--- a/http/src/request/application/update_followup_message.rs
+++ b/http/src/request/application/update_followup_message.rs
@@ -143,6 +143,7 @@ struct UpdateFollowupMessageFields<'a> {
 /// ```
 ///
 /// [`DeleteFollowupMessage`]: super::DeleteFollowupMessage
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateFollowupMessage<'a> {
     fields: UpdateFollowupMessageFields<'a>,
     files: &'a [(&'a str, &'a [u8])],

--- a/http/src/request/application/update_global_command.rs
+++ b/http/src/request/application/update_global_command.rs
@@ -27,6 +27,7 @@ struct UpdateGlobalCommandFields<'a> {
 /// information.
 ///
 /// [the discord docs]: https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateGlobalCommand<'a> {
     fields: UpdateGlobalCommandFields<'a>,
     command_id: CommandId,

--- a/http/src/request/application/update_guild_command.rs
+++ b/http/src/request/application/update_guild_command.rs
@@ -27,6 +27,7 @@ struct UpdateGuildCommandFields<'a> {
 /// information.
 ///
 /// [the discord docs]: https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateGuildCommand<'a> {
     fields: UpdateGuildCommandFields<'a>,
     application_id: ApplicationId,

--- a/http/src/request/application/update_original_response.rs
+++ b/http/src/request/application/update_original_response.rs
@@ -143,6 +143,7 @@ struct UpdateOriginalResponseFields<'a> {
 /// ```
 ///
 /// [`DeleteOriginalResponse`]: super::DeleteOriginalResponse
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateOriginalResponse<'a> {
     application_id: ApplicationId,
     fields: UpdateOriginalResponseFields<'a>,

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Create a new pin in a channel.
+#[must_use = "requests must be configured and executed"]
 pub struct CreatePin<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/create_typing_trigger.rs
+++ b/http/src/request/channel/create_typing_trigger.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::ChannelId;
 
 /// Fire a Typing Start event in the channel.
+#[must_use = "requests must be configured and executed"]
 pub struct CreateTypingTrigger<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::{channel::Channel, id::ChannelId};
 
 /// Delete a channel by ID.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteChannel<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/delete_channel_permission.rs
+++ b/http/src/request/channel/delete_channel_permission.rs
@@ -5,6 +5,7 @@ use twilight_model::id::{ChannelId, RoleId, UserId};
 /// Clear the permissions for a target ID in a channel.
 ///
 /// The target ID must be set with one of the associated methods.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteChannelPermission<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/delete_channel_permission_configured.rs
+++ b/http/src/request/channel/delete_channel_permission_configured.rs
@@ -9,6 +9,7 @@ use twilight_model::id::ChannelId;
 /// Clear the permissions for a target ID in a channel.
 ///
 /// The `target_id` is a `u64`, but it should point to a `RoleId` or a `UserId`.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteChannelPermissionConfigured<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Delete a pin in a channel, by ID.
+#[must_use = "requests must be configured and executed"]
 pub struct DeletePin<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/follow_news_channel.rs
+++ b/http/src/request/channel/follow_news_channel.rs
@@ -8,6 +8,7 @@ struct FollowNewsChannelFields {
 }
 
 /// Follow a news channel by [`ChannelId`]s.
+#[must_use = "requests must be configured and executed"]
 pub struct FollowNewsChannel<'a> {
     channel_id: ChannelId,
     fields: FollowNewsChannelFields,

--- a/http/src/request/channel/get_channel.rs
+++ b/http/src/request/channel/get_channel.rs
@@ -20,6 +20,7 @@ use twilight_model::{channel::Channel, id::ChannelId};
 /// let channel = client.channel(channel_id).exec().await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct GetChannel<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/get_pins.rs
+++ b/http/src/request/channel/get_pins.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::{channel::Message, id::ChannelId};
 
 /// Get the pins of a channel.
+#[must_use = "requests must be configured and executed"]
 pub struct GetPins<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -104,6 +104,7 @@ struct CreateInviteFields {
 /// ```
 ///
 /// [`CREATE_INVITE`]: twilight_model::guild::Permissions::CREATE_INVITE
+#[must_use = "requests must be configured and executed"]
 pub struct CreateInvite<'a> {
     channel_id: ChannelId,
     fields: CreateInviteFields,

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -12,6 +12,7 @@ use crate::{
 ///
 /// [`MANAGE_CHANNELS`]: twilight_model::guild::Permissions::MANAGE_CHANNELS
 /// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteInvite<'a> {
     code: &'a str,
     http: &'a Client,

--- a/http/src/request/channel/invite/get_channel_invites.rs
+++ b/http/src/request/channel/invite/get_channel_invites.rs
@@ -13,6 +13,7 @@ use twilight_model::{id::ChannelId, invite::Invite};
 ///
 /// [`MANAGE_CHANNELS`]: twilight_model::guild::Permissions::MANAGE_CHANNELS
 /// [`GuildChannel`]: twilight_model::channel::GuildChannel
+#[must_use = "requests must be configured and executed"]
 pub struct GetChannelInvites<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -31,6 +31,7 @@ struct GetInviteFields {
 ///
 /// [`with_counts`]: Self::with_counts
 /// [`with_expiration`]: Self::with_expiration
+#[must_use = "requests must be configured and executed"]
 pub struct GetInvite<'a> {
     code: &'a str,
     fields: GetInviteFields,

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -132,6 +132,7 @@ pub(crate) struct CreateMessageFields<'a> {
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct CreateMessage<'a> {
     channel_id: ChannelId,
     pub(crate) fields: CreateMessageFields<'a>,

--- a/http/src/request/channel/message/crosspost_message.rs
+++ b/http/src/request/channel/message/crosspost_message.rs
@@ -5,6 +5,7 @@ use twilight_model::{
 };
 
 /// Crosspost a message by [`ChannelId`] and [`MessageId`].
+#[must_use = "requests must be configured and executed"]
 pub struct CrosspostMessage<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Delete a message by [`ChannelId`] and [`MessageId`].
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteMessage<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -20,6 +20,7 @@ struct DeleteMessagesFields<'a> {
 /// [the discord docs] for more information.
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/channel#bulk-delete-messages
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteMessages<'a> {
     channel_id: ChannelId,
     fields: DeleteMessagesFields<'a>,

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -102,6 +102,7 @@ struct GetChannelMessagesFields {
 /// [`before`]: Self::before
 /// [`GetChannelMessagesConfigured`]: super::GetChannelMessagesConfigured
 /// [`limit`]: Self::limit
+#[must_use = "requests must be configured and executed"]
 pub struct GetChannelMessages<'a> {
     channel_id: ChannelId,
     fields: GetChannelMessagesFields,

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -76,6 +76,7 @@ struct GetChannelMessagesConfiguredFields {
 // nb: after, around, and before are mutually exclusive, so we use this
 // "configured" request to utilize the type system to prevent these from being
 // set in combination.
+#[must_use = "requests must be configured and executed"]
 pub struct GetChannelMessagesConfigured<'a> {
     after: Option<MessageId>,
     around: Option<MessageId>,

--- a/http/src/request/channel/message/get_message.rs
+++ b/http/src/request/channel/message/get_message.rs
@@ -5,6 +5,7 @@ use twilight_model::{
 };
 
 /// Get a message by [`ChannelId`] and [`MessageId`].
+#[must_use = "requests must be configured and executed"]
 pub struct GetMessage<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -146,6 +146,7 @@ struct UpdateMessageFields<'a> {
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateMessage<'a> {
     channel_id: ChannelId,
     fields: UpdateMessageFields<'a>,

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -32,6 +32,7 @@ use twilight_model::id::{ChannelId, MessageId};
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct CreateReaction<'a> {
     channel_id: ChannelId,
     emoji: &'a RequestReactionType<'a>,

--- a/http/src/request/channel/reaction/delete_all_reaction.rs
+++ b/http/src/request/channel/reaction/delete_all_reaction.rs
@@ -8,6 +8,7 @@ use crate::{
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Remove all reactions of a specified emoji from a message.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteAllReaction<'a> {
     channel_id: ChannelId,
     emoji: &'a RequestReactionType<'a>,

--- a/http/src/request/channel/reaction/delete_all_reactions.rs
+++ b/http/src/request/channel/reaction/delete_all_reactions.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::{ChannelId, MessageId};
 
 /// Delete all reactions by all users on a message.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteAllReactions<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/reaction/delete_reaction.rs
+++ b/http/src/request/channel/reaction/delete_reaction.rs
@@ -16,6 +16,7 @@ pub(crate) enum TargetUser {
 }
 
 /// Delete one reaction by a user on a message.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteReaction<'a> {
     channel_id: ChannelId,
     emoji: &'a RequestReactionType<'a>,

--- a/http/src/request/channel/reaction/get_reactions.rs
+++ b/http/src/request/channel/reaction/get_reactions.rs
@@ -71,6 +71,7 @@ struct GetReactionsFields {
 ///
 /// This endpoint is limited to 100 users maximum, so if a message has more than 100 reactions,
 /// requests must be chained until all reactions are retireved.
+#[must_use = "requests must be configured and executed"]
 pub struct GetReactions<'a> {
     channel_id: ChannelId,
     emoji: &'a RequestReactionType<'a>,

--- a/http/src/request/channel/stage/create_stage_instance.rs
+++ b/http/src/request/channel/stage/create_stage_instance.rs
@@ -76,6 +76,7 @@ struct CreateStageInstanceFields<'a> {
 /// Create a new stage instance associated with a stage channel.
 ///
 /// Requires the user to be a moderator of the stage channel.
+#[must_use = "requests must be configured and executed"]
 pub struct CreateStageInstance<'a> {
     fields: CreateStageInstanceFields<'a>,
     http: &'a Client,

--- a/http/src/request/channel/stage/delete_stage_instance.rs
+++ b/http/src/request/channel/stage/delete_stage_instance.rs
@@ -9,6 +9,7 @@ use twilight_model::id::ChannelId;
 /// Delete the stage instance of a stage channel.
 ///
 /// Requires the user to be a moderator of the stage channel.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteStageInstance<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/stage/get_stage_instance.rs
+++ b/http/src/request/channel/stage/get_stage_instance.rs
@@ -2,6 +2,7 @@ use crate::{client::Client, request::Request, response::ResponseFuture, routing:
 use twilight_model::{channel::StageInstance, id::ChannelId};
 
 /// Gets the stage instance associated with a stage channel, if it exists.
+#[must_use = "requests must be configured and executed"]
 pub struct GetStageInstance<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/stage/update_stage_instance.rs
+++ b/http/src/request/channel/stage/update_stage_instance.rs
@@ -76,6 +76,7 @@ struct UpdateStageInstanceFields<'a> {
 /// Update fields of an existing stage instance.
 ///
 /// Requires the user to be a moderator of the stage channel.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateStageInstance<'a> {
     channel_id: ChannelId,
     fields: UpdateStageInstanceFields<'a>,

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -102,6 +102,7 @@ struct UpdateChannelFields<'a> {
 ///
 /// All fields are optional. The minimum length of the name is 1 UTF-16 character
 /// and the maximum is 100 UTF-16 characters.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateChannel<'a> {
     channel_id: ChannelId,
     fields: UpdateChannelFields<'a>,

--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -32,6 +32,7 @@ use twilight_model::{
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateChannelPermission<'a> {
     allow: Permissions,
     channel_id: ChannelId,

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -21,6 +21,7 @@ struct UpdateChannelPermissionConfiguredFields {
 }
 
 /// Created when either `member` or `role` is called on a `DeleteChannelPermission` struct.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateChannelPermissionConfigured<'a> {
     channel_id: ChannelId,
     fields: UpdateChannelPermissionConfiguredFields,

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -33,6 +33,7 @@ struct CreateWebhookFields<'a> {
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct CreateWebhook<'a> {
     channel_id: ChannelId,
     fields: CreateWebhookFields<'a>,

--- a/http/src/request/channel/webhook/delete_webhook.rs
+++ b/http/src/request/channel/webhook/delete_webhook.rs
@@ -11,6 +11,7 @@ struct DeleteWebhookParams<'a> {
 }
 
 /// Delete a webhook by its ID.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteWebhook<'a> {
     fields: DeleteWebhookParams<'a>,
     http: &'a Client,

--- a/http/src/request/channel/webhook/delete_webhook_message.rs
+++ b/http/src/request/channel/webhook/delete_webhook_message.rs
@@ -26,6 +26,7 @@ use twilight_model::id::{MessageId, WebhookId};
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteWebhookMessage<'a> {
     http: &'a Client,
     message_id: MessageId,

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -56,6 +56,7 @@ pub(crate) struct ExecuteWebhookFields<'a> {
 /// [`content`]: Self::content
 /// [`embeds`]: Self::embeds
 /// [`files`]: Self::files
+#[must_use = "requests must be configured and executed"]
 pub struct ExecuteWebhook<'a> {
     pub(crate) fields: ExecuteWebhookFields<'a>,
     files: &'a [(&'a str, &'a [u8])],

--- a/http/src/request/channel/webhook/execute_webhook_and_wait.rs
+++ b/http/src/request/channel/webhook/execute_webhook_and_wait.rs
@@ -32,6 +32,7 @@ use twilight_model::channel::Message;
 /// [`content`]: Self::content
 /// [`embeds`]: Self::embeds
 /// [`file`]: Self::file
+#[must_use = "requests must be configured and executed"]
 pub struct ExecuteWebhookAndWait<'a> {
     inner: ExecuteWebhook<'a>,
 }

--- a/http/src/request/channel/webhook/get_channel_webhooks.rs
+++ b/http/src/request/channel/webhook/get_channel_webhooks.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::{channel::Webhook, id::ChannelId};
 
 /// Get all the webhooks of a channel.
+#[must_use = "requests must be configured and executed"]
 pub struct GetChannelWebhooks<'a> {
     channel_id: ChannelId,
     http: &'a Client,

--- a/http/src/request/channel/webhook/get_webhook.rs
+++ b/http/src/request/channel/webhook/get_webhook.rs
@@ -6,6 +6,7 @@ struct GetWebhookFields<'a> {
 }
 
 /// Get a webhook by ID.
+#[must_use = "requests must be configured and executed"]
 pub struct GetWebhook<'a> {
     fields: GetWebhookFields<'a>,
     http: &'a Client,

--- a/http/src/request/channel/webhook/get_webhook_message.rs
+++ b/http/src/request/channel/webhook/get_webhook_message.rs
@@ -8,6 +8,7 @@ use twilight_model::{
 ///
 /// [`WebhookId`]: twilight_model::id::WebhookId
 /// [`MessageId`]: twilight_model::id::MessageId
+#[must_use = "requests must be configured and executed"]
 pub struct GetWebhookMessage<'a> {
     http: &'a Client,
     message_id: MessageId,

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -21,6 +21,7 @@ struct UpdateWebhookFields<'a> {
 }
 
 /// Update a webhook by ID.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateWebhook<'a> {
     fields: UpdateWebhookFields<'a>,
     http: &'a Client,

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -140,6 +140,7 @@ struct UpdateWebhookMessageFields<'a> {
 /// ```
 ///
 /// [`DeleteWebhookMessage`]: super::DeleteWebhookMessage
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateWebhookMessage<'a> {
     fields: UpdateWebhookMessageFields<'a>,
     files: &'a [(&'a str, &'a [u8])],

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -16,6 +16,7 @@ struct UpdateWebhookWithTokenFields<'a> {
 }
 
 /// Update a webhook, with a token, by ID.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateWebhookWithToken<'a> {
     fields: UpdateWebhookWithTokenFields<'a>,
     http: &'a Client,

--- a/http/src/request/get_gateway.rs
+++ b/http/src/request/get_gateway.rs
@@ -40,6 +40,7 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 /// println!("Recommended shards to use: {}", info.shards);
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct GetGateway<'a> {
     http: &'a Client,
 }

--- a/http/src/request/get_gateway_authed.rs
+++ b/http/src/request/get_gateway_authed.rs
@@ -5,6 +5,7 @@ use twilight_model::gateway::connection_info::BotConnectionInfo;
 ///
 /// Returns additional information: the recommended number of shards to use, and information on
 /// the current session start limit.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGatewayAuthed<'a> {
     http: &'a Client,
 }

--- a/http/src/request/get_user_application.rs
+++ b/http/src/request/get_user_application.rs
@@ -1,6 +1,7 @@
 use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::oauth::CurrentApplicationInfo;
 
+#[must_use = "requests must be configured and executed"]
 pub struct GetUserApplicationInfo<'a> {
     http: &'a Client,
 }

--- a/http/src/request/get_voice_regions.rs
+++ b/http/src/request/get_voice_regions.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::voice::VoiceRegion;
 
 /// Get a list of voice regions that can be used when creating a guild.
+#[must_use = "requests must be configured and executed"]
 pub struct GetVoiceRegions<'a> {
     http: &'a Client,
 }

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -87,6 +87,7 @@ struct CreateBanFields<'a> {
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct CreateBan<'a> {
     fields: CreateBanFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -26,6 +26,7 @@ use twilight_model::id::{GuildId, UserId};
 /// client.delete_ban(guild_id, user_id).exec().await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteBan<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/ban/get_ban.rs
+++ b/http/src/request/guild/ban/get_ban.rs
@@ -7,6 +7,7 @@ use twilight_model::{
 /// Get information about a ban of a guild.
 ///
 /// Includes the user banned and the reason.
+#[must_use = "requests must be configured and executed"]
 pub struct GetBan<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/ban/get_bans.rs
+++ b/http/src/request/guild/ban/get_bans.rs
@@ -25,6 +25,7 @@ use twilight_model::{guild::Ban, id::GuildId};
 /// let bans = client.bans(guild_id).exec().await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct GetBans<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -214,6 +214,7 @@ pub struct VoiceFields {
 ///
 /// The minimum length of the name is 2 UTF-16 characters and the maximum is 100 UTF-16 characters.
 /// This endpoint can only be used by bots in less than 10 guilds.
+#[must_use = "requests must be configured and executed"]
 pub struct CreateGuild<'a> {
     fields: CreateGuildFields,
     http: &'a Client,

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -103,6 +103,7 @@ struct CreateGuildChannelFields<'a> {
 ///
 /// All fields are optional except for name. The minimum length of the name is 1
 /// UTF-16 characters and the maximum is 100 UTF-16 characters.
+#[must_use = "requests must be configured and executed"]
 pub struct CreateGuildChannel<'a> {
     fields: CreateGuildChannelFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -76,6 +76,7 @@ struct CreateGuildPruneFields<'a> {
 /// Refer to [the discord docs] for more information.
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#begin-guild-prune
+#[must_use = "requests must be configured and executed"]
 pub struct CreateGuildPrune<'a> {
     fields: CreateGuildPruneFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/delete_guild.rs
+++ b/http/src/request/guild/delete_guild.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::GuildId;
 
 /// Delete a guild permanently. The user must be the owner.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteGuild<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -25,6 +25,7 @@ struct CreateEmojiFields<'a> {
 /// for more information about image data.
 ///
 /// [the discord docs]: https://discord.com/developers/docs/reference#image-data
+#[must_use = "requests must be configured and executed"]
 pub struct CreateEmoji<'a> {
     fields: CreateEmojiFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::{EmojiId, GuildId};
 
 /// Delete an emoji in a guild, by id.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteEmoji<'a> {
     emoji_id: EmojiId,
     guild_id: GuildId,

--- a/http/src/request/guild/emoji/get_emoji.rs
+++ b/http/src/request/guild/emoji/get_emoji.rs
@@ -24,6 +24,7 @@ use twilight_model::{
 /// client.emoji(guild_id, emoji_id).exec().await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct GetEmoji<'a> {
     emoji_id: EmojiId,
     guild_id: GuildId,

--- a/http/src/request/guild/emoji/get_emojis.rs
+++ b/http/src/request/guild/emoji/get_emojis.rs
@@ -25,6 +25,7 @@ use twilight_model::{guild::Emoji, id::GuildId};
 /// client.emojis(guild_id).exec().await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct GetEmojis<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -19,6 +19,7 @@ struct UpdateEmojiFields<'a> {
 }
 
 /// Update an emoji in a guild, by id.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateEmoji<'a> {
     emoji_id: EmojiId,
     fields: UpdateEmojiFields<'a>,

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -96,6 +96,7 @@ struct GetAuditLogFields {
 /// }
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct GetAuditLog<'a> {
     fields: GetAuditLogFields,
     guild_id: GuildId,

--- a/http/src/request/guild/get_guild.rs
+++ b/http/src/request/guild/get_guild.rs
@@ -6,6 +6,7 @@ struct GetGuildFields {
 }
 
 /// Get information about a guild.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuild<'a> {
     fields: GetGuildFields,
     guild_id: GuildId,

--- a/http/src/request/guild/get_guild_channels.rs
+++ b/http/src/request/guild/get_guild_channels.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::{channel::GuildChannel, id::GuildId};
 
 /// Get the channels in a guild.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildChannels<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/get_guild_invites.rs
+++ b/http/src/request/guild/get_guild_invites.rs
@@ -11,6 +11,7 @@ use twilight_model::{id::GuildId, invite::Invite};
 /// Requires the [`MANAGE_GUILD`] permission.
 ///
 /// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildInvites<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/get_guild_preview.rs
+++ b/http/src/request/guild/get_guild_preview.rs
@@ -4,6 +4,7 @@ use twilight_model::{guild::GuildPreview, id::GuildId};
 /// For public guilds, get the guild preview.
 ///
 /// This works even if the user is not in the guild.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildPreview<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -71,6 +71,7 @@ struct GetGuildPruneCountFields<'a> {
 }
 
 /// Get the counts of guild members to be pruned.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildPruneCount<'a> {
     fields: GetGuildPruneCountFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/get_guild_vanity_url.rs
+++ b/http/src/request/guild/get_guild_vanity_url.rs
@@ -2,6 +2,7 @@ use crate::{client::Client, request::Request, response::ResponseFuture, routing:
 use twilight_model::{guild::VanityUrl, id::GuildId};
 
 /// Get a guild's vanity url, if there is one.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildVanityUrl<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/get_guild_voice_regions.rs
+++ b/http/src/request/guild/get_guild_voice_regions.rs
@@ -9,6 +9,7 @@ use twilight_model::{id::GuildId, voice::VoiceRegion};
 /// Get voice region data for the guild.
 ///
 /// Can return VIP servers if the guild is VIP-enabled.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildVoiceRegions<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/get_guild_webhooks.rs
+++ b/http/src/request/guild/get_guild_webhooks.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::{channel::Webhook, id::GuildId};
 
 /// Get the webhooks of a guild.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildWebhooks<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/get_guild_welcome_screen.rs
+++ b/http/src/request/guild/get_guild_welcome_screen.rs
@@ -2,6 +2,7 @@ use crate::{client::Client, request::Request, response::ResponseFuture, routing:
 use twilight_model::{id::GuildId, invite::WelcomeScreen};
 
 /// Get the guild's welcome screen.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildWelcomeScreen<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/get_guild_widget.rs
+++ b/http/src/request/guild/get_guild_widget.rs
@@ -6,6 +6,7 @@ use twilight_model::{guild::GuildWidget, id::GuildId};
 /// Refer to [the discord docs] for more information.
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#get-guild-widget
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildWidget<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::{GuildId, IntegrationId};
 
 /// Delete an integration for a guild, by the integration's id.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteGuildIntegration<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/integration/get_guild_integrations.rs
+++ b/http/src/request/guild/integration/get_guild_integrations.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::{guild::GuildIntegration, id::GuildId};
 
 /// Get the guild's integrations.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildIntegrations<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/member/add_guild_member.rs
+++ b/http/src/request/guild/member/add_guild_member.rs
@@ -77,6 +77,7 @@ struct AddGuildMemberFields<'a> {
     pub roles: Option<&'a [RoleId]>,
 }
 
+#[must_use = "requests must be configured and executed"]
 pub struct AddGuildMember<'a> {
     fields: AddGuildMemberFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -30,6 +30,7 @@ use twilight_model::id::{GuildId, RoleId, UserId};
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct AddRoleToMember<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -91,6 +91,7 @@ struct GetGuildMembersFields {
 /// let members = client.guild_members(guild_id).after(user_id).exec().await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildMembers<'a> {
     fields: GetGuildMembersFields,
     guild_id: GuildId,

--- a/http/src/request/guild/member/get_member.rs
+++ b/http/src/request/guild/member/get_member.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::{GuildId, UserId};
 
 /// Get a member of a guild, by id.
+#[must_use = "requests must be configured and executed"]
 pub struct GetMember<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::{GuildId, UserId};
 
 /// Kick a member from a guild, by their id.
+#[must_use = "requests must be configured and executed"]
 pub struct RemoveMember<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/member/remove_role_from_member.rs
+++ b/http/src/request/guild/member/remove_role_from_member.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::{GuildId, RoleId, UserId};
 
 /// Remove a role from a member in a guild, by id.
+#[must_use = "requests must be configured and executed"]
 pub struct RemoveRoleFromMember<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -98,6 +98,7 @@ struct SearchGuildMembersFields<'a> {
 /// limit is invalid.
 ///
 /// [`GUILD_MEMBERS`]: twilight_model::gateway::Intents#GUILD_MEMBERS
+#[must_use = "requests must be configured and executed"]
 pub struct SearchGuildMembers<'a> {
     fields: SearchGuildMembersFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -84,6 +84,7 @@ struct UpdateGuildMemberFields<'a> {
 /// All fields are optional. Refer to [the discord docs] for more information.
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild-member
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateGuildMember<'a> {
     fields: UpdateGuildMemberFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -44,6 +44,7 @@ struct CreateRoleFields<'a> {
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct CreateRole<'a> {
     fields: CreateRoleFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::{GuildId, RoleId};
 
 /// Delete a role in a guild, by id.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteRole<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/role/get_guild_roles.rs
+++ b/http/src/request/guild/role/get_guild_roles.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::{guild::Role, id::GuildId};
 
 /// Get the roles of a guild.
+#[must_use = "requests must be configured and executed"]
 pub struct GetGuildRoles<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -25,6 +25,7 @@ struct UpdateRoleFields<'a> {
 }
 
 /// Update a role by guild id and its id.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateRole<'a> {
     fields: UpdateRoleFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/role/update_role_positions.rs
+++ b/http/src/request/guild/role/update_role_positions.rs
@@ -12,6 +12,7 @@ use twilight_model::{
 /// Modify the position of the roles.
 ///
 /// The minimum amount of roles to modify, is a swap between two roles.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateRolePositions<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/update_current_user_nick.rs
+++ b/http/src/request/guild/update_current_user_nick.rs
@@ -13,6 +13,7 @@ struct UpdateCurrentUserNickFields<'a> {
 }
 
 /// Changes the user's nickname in a guild.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateCurrentUserNick<'a> {
     fields: UpdateCurrentUserNickFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -106,6 +106,7 @@ struct UpdateGuildFields<'a> {
 /// All endpoints are optional. Refer to [the discord docs] for more information.
 ///
 /// [the discord docs]: https://discord.com/developers/docs/resources/guild#modify-guild
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateGuild<'a> {
     fields: UpdateGuildFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/update_guild_channel_positions.rs
+++ b/http/src/request/guild/update_guild_channel_positions.rs
@@ -35,6 +35,7 @@ impl From<(ChannelId, u64)> for Position {
 ///
 /// This function accepts an `Iterator` of `(ChannelId, u64)`. It also accepts
 /// an `Iterator` of `Position`, which has extra fields.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateGuildChannelPositions<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/guild/update_guild_welcome_screen.rs
+++ b/http/src/request/guild/update_guild_welcome_screen.rs
@@ -25,6 +25,7 @@ struct UpdateGuildWelcomeScreenFields<'a> {
 /// Requires the [`MANAGE_GUILD`] permission.
 ///
 /// [`MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateGuildWelcomeScreen<'a> {
     fields: UpdateGuildWelcomeScreenFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/update_guild_widget.rs
+++ b/http/src/request/guild/update_guild_widget.rs
@@ -19,6 +19,7 @@ struct UpdateGuildWidgetFields {
 }
 
 /// Modify the guild widget.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateGuildWidget<'a> {
     fields: UpdateGuildWidgetFields,
     guild_id: GuildId,

--- a/http/src/request/guild/user/update_current_user_voice_state.rs
+++ b/http/src/request/guild/user/update_current_user_voice_state.rs
@@ -17,6 +17,7 @@ struct UpdateCurrentUserVoiceStateFields<'a> {
 }
 
 /// Update the current user's voice state.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateCurrentUserVoiceState<'a> {
     fields: UpdateCurrentUserVoiceStateFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/guild/user/update_user_voice_state.rs
+++ b/http/src/request/guild/user/update_user_voice_state.rs
@@ -15,6 +15,7 @@ struct UpdateUserVoiceStateFields {
 }
 
 /// Update another user's voice state.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateUserVoiceState<'a> {
     fields: UpdateUserVoiceStateFields,
     guild_id: GuildId,

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -77,6 +77,7 @@ struct CreateGuildFromTemplateFields<'a> {
 ///
 /// Returns a [`CreateGuildFromTemplateErrorType::NameInvalid`] error type if
 /// the name is invalid.
+#[must_use = "requests must be configured and executed"]
 pub struct CreateGuildFromTemplate<'a> {
     fields: CreateGuildFromTemplateFields<'a>,
     http: &'a Client,

--- a/http/src/request/template/create_template.rs
+++ b/http/src/request/template/create_template.rs
@@ -83,6 +83,7 @@ struct CreateTemplateFields<'a> {
 ///
 /// Returns a [`CreateTemplateErrorType::NameInvalid`] error type if the name is
 /// invalid.
+#[must_use = "requests must be configured and executed"]
 pub struct CreateTemplate<'a> {
     fields: CreateTemplateFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/template/delete_template.rs
+++ b/http/src/request/template/delete_template.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::GuildId;
 
 /// Delete a template by ID and code.
+#[must_use = "requests must be configured and executed"]
 pub struct DeleteTemplate<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/template/get_template.rs
+++ b/http/src/request/template/get_template.rs
@@ -2,6 +2,7 @@ use crate::{client::Client, request::Request, response::ResponseFuture, routing:
 use twilight_model::template::Template;
 
 /// Get a template by its code.
+#[must_use = "requests must be configured and executed"]
 pub struct GetTemplate<'a> {
     http: &'a Client,
     template_code: &'a str,

--- a/http/src/request/template/get_templates.rs
+++ b/http/src/request/template/get_templates.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::{id::GuildId, template::Template};
 
 /// Get a list of templates in a guild, by ID.
+#[must_use = "requests must be configured and executed"]
 pub struct GetTemplates<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/template/sync_template.rs
+++ b/http/src/request/template/sync_template.rs
@@ -2,6 +2,7 @@ use crate::{client::Client, request::Request, response::ResponseFuture, routing:
 use twilight_model::{id::GuildId, template::Template};
 
 /// Sync a template to the current state of the guild, by ID and code.
+#[must_use = "requests must be configured and executed"]
 pub struct SyncTemplate<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/template/update_template.rs
+++ b/http/src/request/template/update_template.rs
@@ -75,6 +75,7 @@ struct UpdateTemplateFields<'a> {
 }
 
 /// Update the template's metadata, by ID and code.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateTemplate<'a> {
     fields: UpdateTemplateFields<'a>,
     guild_id: GuildId,

--- a/http/src/request/user/create_private_channel.rs
+++ b/http/src/request/user/create_private_channel.rs
@@ -10,6 +10,7 @@ struct CreatePrivateChannelFields {
 /// Create a group DM.
 ///
 /// This endpoint is limited to 10 active group DMs.
+#[must_use = "requests must be configured and executed"]
 pub struct CreatePrivateChannel<'a> {
     fields: CreatePrivateChannelFields,
     http: &'a Client,

--- a/http/src/request/user/get_current_user.rs
+++ b/http/src/request/user/get_current_user.rs
@@ -2,6 +2,7 @@ use crate::{client::Client, request::Request, response::ResponseFuture, routing:
 use twilight_model::user::CurrentUser;
 
 /// Get information about the current user.
+#[must_use = "requests must be configured and executed"]
 pub struct GetCurrentUser<'a> {
     http: &'a Client,
 }

--- a/http/src/request/user/get_current_user_connections.rs
+++ b/http/src/request/user/get_current_user_connections.rs
@@ -9,6 +9,7 @@ use twilight_model::user::Connection;
 /// Get the current user's connections.
 ///
 /// Requires the `connections` `OAuth2` scope.
+#[must_use = "requests must be configured and executed"]
 pub struct GetCurrentUserConnections<'a> {
     http: &'a Client,
 }

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -91,6 +91,7 @@ struct GetCurrentUserGuildsFields {
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[must_use = "requests must be configured and executed"]
 pub struct GetCurrentUserGuilds<'a> {
     fields: GetCurrentUserGuildsFields,
     http: &'a Client,

--- a/http/src/request/user/get_user.rs
+++ b/http/src/request/user/get_user.rs
@@ -2,6 +2,7 @@ use crate::{client::Client, request::Request, response::ResponseFuture, routing:
 use twilight_model::{id::UserId, user::User};
 
 /// Get a user's information by id.
+#[must_use = "requests must be configured and executed"]
 pub struct GetUser<'a> {
     http: &'a Client,
     user_id: UserId,

--- a/http/src/request/user/leave_guild.rs
+++ b/http/src/request/user/leave_guild.rs
@@ -7,6 +7,7 @@ use crate::{
 use twilight_model::id::GuildId;
 
 /// Leave a guild by id.
+#[must_use = "requests must be configured and executed"]
 pub struct LeaveGuild<'a> {
     guild_id: GuildId,
     http: &'a Client,

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -76,6 +76,7 @@ struct UpdateCurrentUserFields<'a> {
 ///
 /// All parameters are optional. If the username is changed, it may cause the discriminator to be
 /// rnadomized.
+#[must_use = "requests must be configured and executed"]
 pub struct UpdateCurrentUser<'a> {
     fields: UpdateCurrentUserFields<'a>,
     http: &'a Client,


### PR DESCRIPTION
Add the `#[must_use]` attribute to all typed HTTP requests. The message reads `#[must_use = "requests must be configured and executed"]`.

Closes #1062.