### PR TITLE
Add breakage policy

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -6,6 +6,12 @@
 
 HTTP support for the twilight ecosystem.
 
+## SemVer
+
+Library functionality unrelated to the Discord API is subject to standard
+SemVer rules. However, any functionality that relies on the Discord API may
+break in a minor release if it can not be avoided.
+
 ## Features
 
 ### Deserialization

--- a/http/README.md
+++ b/http/README.md
@@ -9,8 +9,8 @@ HTTP support for the twilight ecosystem.
 ## Semantic Versioning
 
 Library functionality unrelated to the Discord API is subject to standard
-SemVer rules. However, any functionality that relies on the Discord API may
-break in a minor release if it can not be avoided.
+Semantic Versioning rules. However, any functionality that relies on the
+Discord API may break in a minor release if it can not be avoided.
 
 ## Features
 

--- a/http/README.md
+++ b/http/README.md
@@ -6,7 +6,7 @@
 
 HTTP support for the twilight ecosystem.
 
-## SemVer
+## Semantic Versioning
 
 Library functionality unrelated to the Discord API is subject to standard
 SemVer rules. However, any functionality that relies on the Discord API may

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -4,6 +4,12 @@
 //!
 //! HTTP support for the twilight ecosystem.
 //!
+//! ## SemVer
+//!
+//! Library functionality unrelated to the Discord API is subject to standard
+//! SemVer rules. However, any functionality that relies on the Discord API may
+//! break in a minor release if it can not be avoided.
+//!
 //! ## Features
 //!
 //! ### Deserialization

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -7,8 +7,8 @@
 //! ## Semantic Versioning
 //!
 //! Library functionality unrelated to the Discord API is subject to standard
-//! SemVer rules. However, any functionality that relies on the Discord API may
-//! break in a minor release if it can not be avoided.
+//! Semantic Versioning rules. However, any functionality that relies on the
+//! Discord API may break in a minor release if it can not be avoided.
 //!
 //! ## Features
 //!

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! HTTP support for the twilight ecosystem.
 //!
-//! ## SemVer
+//! ## Semantic Versioning
 //!
 //! Library functionality unrelated to the Discord API is subject to standard
 //! SemVer rules. However, any functionality that relies on the Discord API may

--- a/model/README.md
+++ b/model/README.md
@@ -23,6 +23,12 @@ and returned by the gateway API. `guild` contains types owned by the Guild
 resource category. These types may be directly returned by, built on top of,
 or extended by other crates.
 
+## SemVer
+
+Library functionality unrelated to the Discord API is subject to standard
+SemVer rules. However, any functionality that relies on the Discord API may
+break in a minor release if it can not be avoided.
+
 ## License
 
 [ISC][LICENSE.md]

--- a/model/README.md
+++ b/model/README.md
@@ -26,8 +26,8 @@ or extended by other crates.
 ## Semantic Versioning
 
 Library functionality unrelated to the Discord API is subject to standard
-SemVer rules. However, any functionality that relies on the Discord API may
-break in a minor release if it can not be avoided.
+Semantic Versioning rules. However, any functionality that relies on the
+Discord API may break in a minor release if it can not be avoided.
 
 ## License
 

--- a/model/README.md
+++ b/model/README.md
@@ -23,7 +23,7 @@ and returned by the gateway API. `guild` contains types owned by the Guild
 resource category. These types may be directly returned by, built on top of,
 or extended by other crates.
 
-## SemVer
+## Semantic Versioning
 
 Library functionality unrelated to the Discord API is subject to standard
 SemVer rules. However, any functionality that relies on the Discord API may

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -21,6 +21,12 @@
 //! resource category. These types may be directly returned by, built on top of,
 //! or extended by other crates.
 //!
+//! ## SemVer
+//!
+//! Library functionality unrelated to the Discord API is subject to standard
+//! SemVer rules. However, any functionality that relies on the Discord API may
+//! break in a minor release if it can not be avoided.
+//!
 //! ## License
 //!
 //! [ISC][LICENSE.md]

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -21,7 +21,7 @@
 //! resource category. These types may be directly returned by, built on top of,
 //! or extended by other crates.
 //!
-//! ## SemVer
+//! ## Semantic Versioning
 //!
 //! Library functionality unrelated to the Discord API is subject to standard
 //! SemVer rules. However, any functionality that relies on the Discord API may

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -24,8 +24,8 @@
 //! ## Semantic Versioning
 //!
 //! Library functionality unrelated to the Discord API is subject to standard
-//! SemVer rules. However, any functionality that relies on the Discord API may
-//! break in a minor release if it can not be avoided.
+//! Semantic Versioning rules. However, any functionality that relies on the
+//! Discord API may break in a minor release if it can not be avoided.
 //!
 //! ## License
 //!


### PR DESCRIPTION
When 1.0 rolls around, we will need to have a policy like this to prevent reaching version 100 due to the Discord API breaking its spec often. I'm adding this now so that my minor changes to how interactions work (in #1107) don't cause us to hit 0.7 already.

Feedback is appreciated.
