### PR TITLE
fix(model/application/command): remove `required` field from `OptionsCommandOptionData`

### DIFF
--- a/model/src/application/command/option.rs
+++ b/model/src/application/command/option.rs
@@ -47,7 +47,7 @@ impl CommandOption {
 
     pub const fn is_required(&self) -> bool {
         match self {
-            CommandOption::SubCommand(data) | CommandOption::SubCommandGroup(data) => data.required,
+            CommandOption::SubCommand(_) | CommandOption::SubCommandGroup(_) => false,
             CommandOption::String(data) | CommandOption::Integer(data) => data.required,
             CommandOption::Boolean(data)
             | CommandOption::User(data)
@@ -86,7 +86,7 @@ impl Serialize for CommandOption {
                 description: data.description.as_ref(),
                 name: data.name.as_ref(),
                 options: Some(data.options.as_ref()),
-                required: data.required,
+                required: false,
                 kind: self.kind(),
             },
             Self::String(data) | Self::Integer(data) => CommandOptionEnvelope {
@@ -236,7 +236,6 @@ impl<'de> Visitor<'de> for OptionVisitor {
                     description,
                     name,
                     options,
-                    required,
                 })
             }
             CommandOptionType::SubCommandGroup => {
@@ -248,7 +247,6 @@ impl<'de> Visitor<'de> for OptionVisitor {
                     description,
                     name,
                     options,
-                    required,
                 })
             }
             CommandOptionType::String => CommandOption::String(ChoiceCommandOptionData {
@@ -329,9 +327,6 @@ pub struct OptionsCommandOptionData {
     /// [`SubCommandGroup`]: CommandOptionType::SubCommandGroup
     #[serde(default)]
     pub options: Vec<CommandOption>,
-    /// Whether the option is required to be completed by a user.
-    #[serde(default)]
-    pub required: bool,
 }
 
 /// Data supplied to a [`CommandOption`] of type [`String`] or [`Integer`].
@@ -478,9 +473,7 @@ mod tests {
                             required: false,
                         }),
                     ],
-                    required: false,
                 })],
-                required: true,
             })],
         };
 
@@ -516,7 +509,7 @@ mod tests {
                 Token::Seq { len: Some(1) },
                 Token::Struct {
                     name: "CommandOptionEnvelope",
-                    len: 5,
+                    len: 4,
                 },
                 Token::Str("description"),
                 Token::Str("sub group desc"),
@@ -659,8 +652,6 @@ mod tests {
                 Token::U8(1),
                 Token::StructEnd,
                 Token::SeqEnd,
-                Token::Str("required"),
-                Token::Bool(true),
                 Token::Str("type"),
                 Token::U8(2),
                 Token::StructEnd,


### PR DESCRIPTION
If this set is set to `true` Discord will respond with an error (as reported in #1018).
Discord has now [documented](https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups) this too:
>Using subcommands or subcommand groups will make your base command unusable. You can't send the base `/permissions` command as a valid command if you also have `/permissions add | remove` as subcommands or subcommand groups.

I don't know if `is_required` returning `None` for `SubCommand | SubCommandGroup` is better than returning `false`

Closes #1018