### PR TITLE
Model: Do not error if options is missing

### DIFF
--- a/model/src/application/command/option.rs
+++ b/model/src/application/command/option.rs
@@ -228,8 +228,7 @@ impl<'de> Visitor<'de> for OptionVisitor {
 
         Ok(match kind {
             CommandOptionType::SubCommand => {
-                let options = options
-                    .flatten().unwrap_or_default();
+                let options = options.flatten().unwrap_or_default();
 
                 CommandOption::SubCommand(OptionsCommandOptionData {
                     description,
@@ -239,8 +238,7 @@ impl<'de> Visitor<'de> for OptionVisitor {
                 })
             }
             CommandOptionType::SubCommandGroup => {
-                let options = options
-                    .flatten().unwrap_or_default();
+                let options = options.flatten().unwrap_or_default();
 
                 CommandOption::SubCommandGroup(OptionsCommandOptionData {
                     description,

--- a/model/src/application/command/option.rs
+++ b/model/src/application/command/option.rs
@@ -419,7 +419,7 @@ mod tests {
             required: false,
         });
 
-        serde_test::assert_tokens(
+        serde_test::assert_de_tokens(
             &value,
             &[
                 Token::Struct {
@@ -431,9 +431,7 @@ mod tests {
                 Token::Str("name"),
                 Token::Str("equestria"),
                 Token::Str("options"),
-                Token::Some,
-                Token::Seq { len: Some(0) },
-                Token::SeqEnd,
+                Token::None,
                 Token::Str("type"),
                 Token::U8(1),
                 Token::StructEnd,

--- a/model/src/application/command/option.rs
+++ b/model/src/application/command/option.rs
@@ -413,7 +413,7 @@ mod tests {
     #[test]
     fn test_issue_1150() {
         let value = CommandOption::SubCommand(OptionsCommandOptionData {
-            description: "ponyland".to_owned(),
+            description: "ponyville".to_owned(),
             name: "equestria".to_owned(),
             options: Vec::new(),
             required: false,
@@ -427,7 +427,7 @@ mod tests {
                     len: 4,
                 },
                 Token::Str("description"),
-                Token::Str("ponyland"),
+                Token::Str("ponyville"),
                 Token::Str("name"),
                 Token::Str("equestria"),
                 Token::Str("options"),

--- a/model/src/application/command/option.rs
+++ b/model/src/application/command/option.rs
@@ -229,8 +229,7 @@ impl<'de> Visitor<'de> for OptionVisitor {
         Ok(match kind {
             CommandOptionType::SubCommand => {
                 let options = options
-                    .flatten()
-                    .ok_or_else(|| DeError::missing_field("options"))?;
+                    .flatten().unwrap_or_default();
 
                 CommandOption::SubCommand(OptionsCommandOptionData {
                     description,
@@ -241,8 +240,7 @@ impl<'de> Visitor<'de> for OptionVisitor {
             }
             CommandOptionType::SubCommandGroup => {
                 let options = options
-                    .flatten()
-                    .ok_or_else(|| DeError::missing_field("options"))?;
+                    .flatten().unwrap_or_default();
 
                 CommandOption::SubCommandGroup(OptionsCommandOptionData {
                     description,
@@ -410,6 +408,17 @@ mod tests {
     };
     use crate::id::{ApplicationId, CommandId, GuildId};
     use serde_test::Token;
+
+    #[test]
+    fn pr_1112() {
+        let test_str = r#"
+{
+  "type": 1,
+  "description": "ponyland",
+  "name": "equestria"
+}"#;
+        serde_json::from_str::<CommandOption>(test_str).unwrap();
+    }
 
     #[test]
     #[allow(clippy::too_many_lines)]

--- a/model/src/application/command/option.rs
+++ b/model/src/application/command/option.rs
@@ -407,15 +407,38 @@ mod tests {
     use crate::id::{ApplicationId, CommandId, GuildId};
     use serde_test::Token;
 
+    /// Test that when a subcommand or subcommand group's `options` field is
+    /// missing during deserialization that the field is defaulted instead of
+    /// returning a missing field error.
     #[test]
-    fn pr_1112() {
-        let test_str = r#"
-{
-  "type": 1,
-  "description": "ponyland",
-  "name": "equestria"
-}"#;
-        serde_json::from_str::<CommandOption>(test_str).unwrap();
+    fn test_issue_1150() {
+        let value = CommandOption::SubCommand(OptionsCommandOptionData {
+            description: "ponyland".to_owned(),
+            name: "equestria".to_owned(),
+            options: Vec::new(),
+            required: false,
+        });
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "CommandOptionEnvelope",
+                    len: 4,
+                },
+                Token::Str("description"),
+                Token::Str("ponyland"),
+                Token::Str("name"),
+                Token::Str("equestria"),
+                Token::Str("options"),
+                Token::Some,
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
+                Token::Str("type"),
+                Token::U8(1),
+                Token::StructEnd,
+            ],
+        );
     }
 
     #[test]


### PR DESCRIPTION
This fixes that the deserializer for command options would erroneously
fail instead of setting missing options to default.