### PR TITLE
Log response body parsing error body as text if UTF-8

### DIFF
--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -1,9 +1,9 @@
 use crate::{api_error::ApiError, json::JsonError, response::StatusCode};
 use hyper::{Body, Response};
-use std::str::from_utf8;
 use std::{
     error::Error as StdError,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
+    str,
 };
 
 #[derive(Debug)]
@@ -53,7 +53,7 @@ impl Display for Error {
             ErrorType::Json => f.write_str("Given value couldn't be serialized"),
             ErrorType::Parsing { body, .. } => {
                 f.write_str("Response body couldn't be deserialized: ")?;
-                if let Ok(body) = from_utf8(body) {
+                if let Ok(body) = str::from_utf8(body) {
                     f.write_str(body)
                 } else {
                     Debug::fmt(body, f)

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -1,10 +1,10 @@
 use crate::{api_error::ApiError, json::JsonError, response::StatusCode};
 use hyper::{Body, Response};
+use std::str::from_utf8;
 use std::{
     error::Error as StdError,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
 };
-use std::str::from_utf8;
 
 #[derive(Debug)]
 pub struct Error {
@@ -53,7 +53,7 @@ impl Display for Error {
             ErrorType::Json => f.write_str("Given value couldn't be serialized"),
             ErrorType::Parsing { body, .. } => {
                 f.write_str("Response body couldn't be deserialized: ")?;
-                if let Ok(body) = from_utf8(&body) {
+                if let Ok(body) = from_utf8(body) {
                     f.write_str(body)
                 } else {
                     Debug::fmt(body, f)

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -53,6 +53,7 @@ impl Display for Error {
             ErrorType::Json => f.write_str("Given value couldn't be serialized"),
             ErrorType::Parsing { body, .. } => {
                 f.write_str("Response body couldn't be deserialized: ")?;
+
                 if let Ok(body) = str::from_utf8(body) {
                     f.write_str(body)
                 } else {

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -4,6 +4,7 @@ use std::{
     error::Error as StdError,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
 };
+use std::str::from_utf8;
 
 #[derive(Debug)]
 pub struct Error {
@@ -52,8 +53,11 @@ impl Display for Error {
             ErrorType::Json => f.write_str("Given value couldn't be serialized"),
             ErrorType::Parsing { body, .. } => {
                 f.write_str("Response body couldn't be deserialized: ")?;
-
-                Debug::fmt(body, f)
+                if let Ok(body) = from_utf8(&body) {
+                    f.write_str(body)
+                } else {
+                    Debug::fmt(body, f)
+                }
             }
             ErrorType::RequestCanceled => {
                 f.write_str("Request was canceled either before or while being sent")


### PR DESCRIPTION
This makes an unknown body much easier to read in the errors if it's not compressed. For compressed bodies the current behavior is kept