### PR TITLE
Fix HTTP Set Command Permissions serialized body

### DIFF
--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -40,7 +40,7 @@ impl Serialize for OptionalCommandPermissions<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut seq = serializer.serialize_seq(Some(self.amount_present()))?;
 
-        for maybe_value in self.0 {
+        for maybe_value in &self.0 {
             if let Some(value) = maybe_value.as_ref() {
                 seq.serialize_element(value)?;
             } else {

--- a/http/src/request/application/set_command_permissions.rs
+++ b/http/src/request/application/set_command_permissions.rs
@@ -45,14 +45,12 @@ impl Serialize for OptionalCommandPermissions<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut seq = serializer.serialize_seq(Some(self.amount_present()))?;
 
-        for maybe_value in &self.0 {
-            if let Some(value) = maybe_value.as_ref() {
-                seq.serialize_element(value)?;
-            } else {
-                // If an element isn't present then any trailing elements aren't
-                // either.
-                break;
-            }
+        let mut iter = self.0.iter();
+
+        // If an element isn't present while we haven't reached the end of the
+        // iterator then any trailing elements aren't present either.
+        while let Some(Some(value)) = iter.next() {
+            seq.serialize_element(value)?;
         }
 
         seq.end()


### PR DESCRIPTION
Fix the serialized body of the `SetCommandPermissions` request builder. The request builder would serialize a command's permission as a single object, but Discord wants it in an array. Additionally, the request should support multiple permissions while we were only supporting one permission per command.

The functionality has been able to be fixed without causing a breaking change.