### PR TITLE
Fix two missed relative links

### DIFF
--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -592,8 +592,6 @@ impl Cluster {
     ///
     /// Returns a [`ClusterCommandErrorType::ShardNonexistent`] error type if
     /// the provided shard ID does not exist in the cluster.
-    ///
-    /// [`SessionInactiveError`]: struct.SessionInactiveError.html
     pub async fn send(&self, id: u64, message: Message) -> Result<(), ClusterSendError> {
         let shard = self.shard(id).ok_or(ClusterSendError {
             kind: ClusterSendErrorType::ShardNonexistent { id },

--- a/gateway/src/cluster/scheme.rs
+++ b/gateway/src/cluster/scheme.rs
@@ -164,7 +164,7 @@ impl Iterator for ShardSchemeIter {
 ///
 /// By default this is [`Auto`].
 ///
-/// [`Auto`]: #variant.Auto
+/// [`Auto`]: Self::Auto
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum ShardScheme {

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -72,7 +72,7 @@ pub struct Message {
     pub reference: Option<MessageReference>,
     /// The message associated with the [reference].
     ///
-    /// [reference]: #structfield.reference
+    /// [reference]: Self::reference
     #[serde(skip_serializing_if = "Option::is_none")]
     pub referenced_message: Option<Box<Message>>,
     /// Stickers within the message.


### PR DESCRIPTION
Fix two missed relative links by replacing them with intradoc links.