### PR TITLE
Document that HTTP's `tracing` dependency is now optional

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -66,7 +66,7 @@ This is enabled by default.
 
 The `tracing` feature enables logging via the [`tracing`] crate.
 
-This is enabled by default.
+This is disabled by default.
 
 [`native-tls`]: https://crates.io/crates/native-tls
 [`hyper`]: https://crates.io/crates/hyper

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! The `tracing` feature enables logging via the [`tracing`] crate.
 //!
-//! This is enabled by default.
+//! This is disabled by default.
 //!
 //! [`native-tls`]: https://crates.io/crates/native-tls
 //! [`hyper`]: https://crates.io/crates/hyper


### PR DESCRIPTION
Update the documentation to state that the `tracing` dependency and feature are now optional.

This was changed by #910.

Closes #1124.