### PR TITLE
Support setting identify properties in gateway

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -11,7 +11,10 @@ use crate::{
 use std::{collections::HashMap, sync::Arc};
 use twilight_gateway_queue::{LocalQueue, Queue};
 use twilight_http::Client;
-use twilight_model::gateway::{payload::update_presence::UpdatePresencePayload, Intents};
+use twilight_model::gateway::{
+    payload::{identify::IdentifyProperties, update_presence::UpdatePresencePayload},
+    Intents,
+};
 
 /// Builder to configure and construct a [`Cluster`].
 ///
@@ -123,6 +126,40 @@ impl ClusterBuilder {
     /// Defaults to a new, default HTTP client is used.
     pub fn http_client(mut self, http_client: Client) -> Self {
         self.1 = self.1.http_client(http_client);
+
+        self
+    }
+
+    /// Set the properties for shards to identify with.
+    ///
+    /// This may be used if you want to set a different operating system.
+    ///
+    /// # Examples
+    ///
+    /// Set the identify properties for a shard:
+    ///
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::env::{self, consts::OS};
+    /// use twilight_gateway::{Intents, Cluster};
+    /// use twilight_model::gateway::payload::identify::IdentifyProperties;
+    ///
+    /// let token = env::var("DISCORD_TOKEN")?;
+    /// let properties = IdentifyProperties::new(
+    ///     "twilight.rs",
+    ///     "twilight.rs",
+    ///     OS,
+    ///     "",
+    ///     "",
+    /// );
+    ///
+    /// let builder = Cluster::builder(token, Intents::empty())
+    ///     .identify_properties(properties);
+    /// # Ok(()) }
+    /// ```
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn identify_properties(mut self, identify_properties: IdentifyProperties) -> Self {
+        self.1 = self.1.identify_properties(identify_properties);
 
         self
     }

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -137,7 +137,7 @@ impl ClusterBuilder {
     ///
     /// # Examples
     ///
-    /// Set the identify properties for a shard:
+    /// Set the identify properties for a cluster:
     ///
     /// ```no_run
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -132,7 +132,8 @@ impl ClusterBuilder {
 
     /// Set the properties for shards to identify with.
     ///
-    /// This may be used if you want to set a different operating system.
+    /// This may be used if you want to set a different operating system, for
+    /// example.
     ///
     /// # Examples
     ///

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -231,7 +231,8 @@ impl ShardBuilder {
 
     /// Set the properties to identify with.
     ///
-    /// This may be used if you want to set a different operating system.
+    /// This may be used if you want to set a different operating system, for
+    /// example.
     ///
     /// # Examples
     ///

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -7,7 +7,10 @@ use std::{
 };
 use twilight_gateway_queue::{LocalQueue, Queue};
 use twilight_http::Client as HttpClient;
-use twilight_model::gateway::{payload::update_presence::UpdatePresencePayload, Intents};
+use twilight_model::gateway::{
+    payload::{identify::IdentifyProperties, update_presence::UpdatePresencePayload},
+    Intents,
+};
 
 /// Large threshold configuration is invalid.
 ///
@@ -177,6 +180,7 @@ impl ShardBuilder {
             event_types: EventTypeFlags::default(),
             gateway_url: None,
             http_client: HttpClient::new(token.clone()),
+            identify_properties: None,
             intents,
             large_threshold: 250,
             presence: None,
@@ -221,6 +225,40 @@ impl ShardBuilder {
     #[allow(clippy::missing_const_for_fn)]
     pub fn http_client(mut self, http_client: HttpClient) -> Self {
         self.0.http_client = http_client;
+
+        self
+    }
+
+    /// Set the properties to identify with.
+    ///
+    /// This may be used if you want to set a different operating system.
+    ///
+    /// # Examples
+    ///
+    /// Set the identify properties for a shard:
+    ///
+    /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::env::{self, consts::OS};
+    /// use twilight_gateway::{Intents, Shard};
+    /// use twilight_model::gateway::payload::identify::IdentifyProperties;
+    ///
+    /// let token = env::var("DISCORD_TOKEN")?;
+    /// let properties = IdentifyProperties::new(
+    ///     "twilight.rs",
+    ///     "twilight.rs",
+    ///     OS,
+    ///     "",
+    ///     "",
+    /// );
+    ///
+    /// let builder = Shard::builder(token, Intents::empty())
+    ///     .identify_properties(properties);
+    /// # Ok(()) }
+    /// ```
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn identify_properties(mut self, identify_properties: IdentifyProperties) -> Self {
+        self.0.identify_properties = Some(identify_properties);
 
         self
     }

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -46,8 +46,8 @@ impl Config {
         &self.http_client
     }
 
-    /// Return an immutable reference to the identification properties to be used
-    /// by the shard.
+    /// Return an immutable reference to the identification properties the shard
+    /// will use.
     pub const fn identify_properties(&self) -> Option<&IdentifyProperties> {
         self.identify_properties.as_ref()
     }

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -2,7 +2,10 @@ use crate::EventTypeFlags;
 use std::sync::Arc;
 use twilight_gateway_queue::Queue;
 use twilight_http::Client;
-use twilight_model::gateway::{payload::update_presence::UpdatePresencePayload, Intents};
+use twilight_model::gateway::{
+    payload::{identify::IdentifyProperties, update_presence::UpdatePresencePayload},
+    Intents,
+};
 
 /// The configuration used by the shard to identify with the gateway and
 /// operate.
@@ -15,6 +18,7 @@ pub struct Config {
     pub(crate) event_types: EventTypeFlags,
     pub(crate) gateway_url: Option<Box<str>>,
     pub(crate) http_client: Client,
+    pub(super) identify_properties: Option<IdentifyProperties>,
     pub(super) intents: Intents,
     pub(super) large_threshold: u64,
     pub(super) presence: Option<UpdatePresencePayload>,
@@ -40,6 +44,12 @@ impl Config {
     /// by the shard.
     pub const fn http_client(&self) -> &Client {
         &self.http_client
+    }
+
+    /// Return an immutable reference to the identification properties to be used
+    /// by the shard.
+    pub const fn identify_properties(&self) -> Option<&IdentifyProperties> {
+        self.identify_properties.as_ref()
     }
 
     /// Return a copy of the intents that the gateway is using.


### PR DESCRIPTION
Support users setting the properties to send during identify via the new `ClusterBuilder::identify_properties` and `ShardBuilder::identify_properties` methods. When not set a default will be used.

Closes #1119.