### PR TITLE
Add gateway `Command` marker trait

### DIFF
--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -524,7 +524,7 @@ impl Cluster {
     /// use twilight_gateway::{cluster::Cluster, Intents};
     /// use twilight_model::{
     ///     gateway::{
-    ///         payload::UpdatePresence,
+    ///         payload::outgoing::UpdatePresence,
     ///         presence::{Activity, ActivityType, MinimalActivity, Status},
     ///     },
     ///     id::GuildId,

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -1,7 +1,9 @@
 use super::{builder::ClusterBuilder, config::Config, event::Events, scheme::ShardScheme};
 use crate::{
     cluster::event::ShardEventsWithId,
-    shard::{raw_message::Message, Config as ShardConfig, Information, ResumeSession, Shard},
+    shard::{
+        raw_message::Message, Command, Config as ShardConfig, Information, ResumeSession, Shard,
+    },
     Intents,
 };
 use futures_util::{future, stream::SelectAll};
@@ -511,6 +513,50 @@ impl Cluster {
 
     /// Send a command to the specified shard.
     ///
+    /// # Examples
+    ///
+    /// Update the current user's presence on shard ID 2:
+    ///
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::env;
+    /// use twilight_gateway::{cluster::Cluster, Intents};
+    /// use twilight_model::{
+    ///     gateway::{
+    ///         payload::UpdatePresence,
+    ///         presence::{Activity, ActivityType, MinimalActivity, Status},
+    ///     },
+    ///     id::GuildId,
+    /// };
+    ///
+    /// let intents = Intents::GUILD_VOICE_STATES;
+    /// let token = env::var("DISCORD_TOKEN")?;
+    ///
+    /// let (cluster, _events) = Cluster::new(token, intents).await?;
+    ///
+    /// // Wait for shards to come up before sending a message to one of them.
+    /// cluster.up().await;
+    ///
+    /// // Update the user's presence to a custom activity with a name of
+    /// // "testing".
+    /// let activity = Activity::from(MinimalActivity {
+    ///     kind: ActivityType::Custom,
+    ///     name: "testing".to_owned(),
+    ///     url: None,
+    /// });
+    /// let request = UpdatePresence::new(
+    ///     Vec::from([activity]),
+    ///     false,
+    ///     None,
+    ///     Status::Online,
+    /// )?;
+    ///
+    /// // Send the request over the shard.
+    /// cluster.command(2, &request).await?;
+    /// # Ok(()) }
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns a [`ClusterCommandErrorType::Sending`] error type if the shard
@@ -518,11 +564,7 @@ impl Cluster {
     ///
     /// Returns a [`ClusterCommandErrorType::ShardNonexistent`] error type if
     /// the provided shard ID does not exist in the cluster.
-    pub async fn command(
-        &self,
-        id: u64,
-        value: &impl serde::Serialize,
-    ) -> Result<(), ClusterCommandError> {
+    pub async fn command(&self, id: u64, value: &impl Command) -> Result<(), ClusterCommandError> {
         let shard = self.shard(id).ok_or(ClusterCommandError {
             kind: ClusterCommandErrorType::ShardNonexistent { id },
             source: None,

--- a/gateway/src/shard/command.rs
+++ b/gateway/src/shard/command.rs
@@ -1,0 +1,61 @@
+//! Sealed Command trait to denote what can be provided to [`Shard::command`].
+//!
+//! [`Shard::command`]: super::Shard::command
+
+use twilight_model::gateway::payload::{
+    identify::Identify, resume::Resume, Heartbeat, RequestGuildMembers, UpdatePresence,
+    UpdateVoiceState,
+};
+
+mod private {
+    use serde::Serialize;
+    use twilight_model::gateway::payload::{
+        identify::Identify, resume::Resume, Heartbeat, RequestGuildMembers, UpdatePresence,
+        UpdateVoiceState,
+    };
+
+    pub trait Sealed: Serialize {}
+
+    impl Sealed for Heartbeat {}
+    impl Sealed for Identify {}
+    impl Sealed for RequestGuildMembers {}
+    impl Sealed for Resume {}
+    impl Sealed for UpdatePresence {}
+    impl Sealed for UpdateVoiceState {}
+}
+
+/// Trait marker to denote what can be provided to [`Shard::command`].
+///
+/// This trait exists to make it easier to determine what commands can be sent
+/// to the Discord Gateway API.
+///
+/// To send an arbitrary command to the Discord Gateway API then [`Shard::send`]
+/// may be used.
+///
+/// [`Shard::command`]: super::Shard::command
+/// [`Shard::send`]: super::Shard::send
+pub trait Command: private::Sealed {}
+
+impl Command for Heartbeat {}
+impl Command for Identify {}
+impl Command for RequestGuildMembers {}
+impl Command for Resume {}
+impl Command for UpdatePresence {}
+impl Command for UpdateVoiceState {}
+
+#[cfg(test)]
+mod tests {
+    use super::Command;
+    use static_assertions::assert_impl_all;
+    use twilight_model::gateway::payload::{
+        identify::Identify, resume::Resume, Heartbeat, RequestGuildMembers, UpdatePresence,
+        UpdateVoiceState,
+    };
+
+    assert_impl_all!(Heartbeat: Command);
+    assert_impl_all!(Identify: Command);
+    assert_impl_all!(RequestGuildMembers: Command);
+    assert_impl_all!(Resume: Command);
+    assert_impl_all!(UpdatePresence: Command);
+    assert_impl_all!(UpdateVoiceState: Command);
+}

--- a/gateway/src/shard/command.rs
+++ b/gateway/src/shard/command.rs
@@ -2,14 +2,14 @@
 //!
 //! [`Shard::command`]: super::Shard::command
 
-use twilight_model::gateway::payload::{
+use twilight_model::gateway::payload::outgoing::{
     identify::Identify, resume::Resume, Heartbeat, RequestGuildMembers, UpdatePresence,
     UpdateVoiceState,
 };
 
 mod private {
     use serde::Serialize;
-    use twilight_model::gateway::payload::{
+    use twilight_model::gateway::payload::outgoing::{
         identify::Identify, resume::Resume, Heartbeat, RequestGuildMembers, UpdatePresence,
         UpdateVoiceState,
     };
@@ -47,7 +47,7 @@ impl Command for UpdateVoiceState {}
 mod tests {
     use super::Command;
     use static_assertions::assert_impl_all;
-    use twilight_model::gateway::payload::{
+    use twilight_model::gateway::payload::outgoing::{
         identify::Identify, resume::Resume, Heartbeat, RequestGuildMembers, UpdatePresence,
         UpdateVoiceState,
     };

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -1,5 +1,6 @@
 use super::{
     builder::ShardBuilder,
+    command::Command,
     config::Config,
     emitter::Emitter,
     event::Events,
@@ -566,6 +567,36 @@ impl Shard {
 
     /// Send a command over the gateway.
     ///
+    /// # Examples
+    ///
+    /// Request members whose names start with "tw" in a guild:
+    ///
+    /// ```no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::env;
+    /// use twilight_gateway::{shard::Shard, Intents};
+    /// use twilight_model::{
+    ///     gateway::payload::RequestGuildMembers,
+    ///     id::GuildId,
+    /// };
+    ///
+    /// let intents = Intents::GUILD_VOICE_STATES;
+    /// let token = env::var("DISCORD_TOKEN")?;
+    ///
+    /// let (shard, _events) = Shard::new(token, intents);
+    /// shard.start().await?;
+    ///
+    /// // Query members whose names start with "tw" and limit the results to
+    /// // 10 members.
+    /// let request = RequestGuildMembers::builder(GuildId(1))
+    ///     .query("tw", Some(10));
+    ///
+    /// // Send the request over the shard.
+    /// shard.command(&request).await?;
+    /// # Ok(()) }
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns a [`CommandErrorType::Sending`] error type if the message could
@@ -577,7 +608,7 @@ impl Shard {
     ///
     /// Returns a [`CommandErrorType::SessionInactive`] error type if the shard
     /// has not been started.
-    pub async fn command(&self, value: &impl serde::Serialize) -> Result<(), CommandError> {
+    pub async fn command(&self, value: &impl Command) -> Result<(), CommandError> {
         let json = json::to_vec(value).map_err(|source| CommandError {
             source: Some(Box::new(source)),
             kind: CommandErrorType::Serializing,

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -577,7 +577,7 @@ impl Shard {
     /// use std::env;
     /// use twilight_gateway::{shard::Shard, Intents};
     /// use twilight_model::{
-    ///     gateway::payload::RequestGuildMembers,
+    ///     gateway::payload::outgoing::RequestGuildMembers,
     ///     id::GuildId,
     /// };
     ///
@@ -589,8 +589,9 @@ impl Shard {
     ///
     /// // Query members whose names start with "tw" and limit the results to
     /// // 10 members.
-    /// let request = RequestGuildMembers::builder(GuildId(1))
-    ///     .query("tw", Some(10));
+    /// let request =
+    ///     RequestGuildMembers::builder(GuildId::new(1).expect("non zero"))
+    ///         .query("tw", Some(10));
     ///
     /// // Send the request over the shard.
     /// shard.command(&request).await?;

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -23,6 +23,7 @@ pub mod raw_message;
 pub mod stage;
 
 mod builder;
+mod command;
 mod config;
 mod emitter;
 mod event;
@@ -34,6 +35,7 @@ pub use self::{
     builder::{
         LargeThresholdError, LargeThresholdErrorType, ShardBuilder, ShardIdError, ShardIdErrorType,
     },
+    command::Command,
     config::Config,
     event::Events,
     processor::heartbeat::Latency,

--- a/gateway/tests/test_shard_state_events.rs
+++ b/gateway/tests/test_shard_state_events.rs
@@ -1,7 +1,7 @@
 use futures::stream::StreamExt;
 use std::{env, error::Error};
 use twilight_gateway::{
-    shard::{Events, Shard},
+    shard::{raw_message::Message, Events, Shard},
     Event, Intents,
 };
 
@@ -26,7 +26,9 @@ async fn test_shard_event_emits() -> Result<(), Box<dyn Error>> {
         events.next().await.unwrap(),
         Event::GuildCreate(_)
     ));
-    shard.command(&"bad command").await?;
+    let bad_command = Message::Binary(b"bad command".to_vec());
+    shard.send(bad_command).await?;
+
     // Might have more guilds or something.
     while let Some(event) = events.next().await {
         if matches!(event, Event::ShardDisconnected(_)) {

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -14,6 +14,7 @@ use twilight_lavalink::{
 use twilight_model::{
     channel::Message,
     gateway::payload::{incoming::MessageCreate, outgoing::UpdateVoiceState},
+    id::ChannelId,
 };
 use twilight_standby::Standby;
 
@@ -112,7 +113,7 @@ async fn join(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
             new_msg.author.id == author_id
         })
         .await?;
-    let channel_id = msg.content.parse::<u64>()?;
+    let channel_id = ChannelId::new(msg.content.parse::<u64>()?).expect("non zero");
     let guild_id = msg.guild_id.expect("known to be present");
 
     state

--- a/lavalink/examples/basic-lavalink-bot/src/main.rs
+++ b/lavalink/examples/basic-lavalink-bot/src/main.rs
@@ -117,7 +117,12 @@ async fn join(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
 
     state
         .shard
-        .command(&UpdateVoiceState::new(guild_id, None, false, false))
+        .command(&UpdateVoiceState::new(
+            guild_id,
+            Some(channel_id),
+            false,
+            false,
+        ))
         .await?;
 
     state


### PR DESCRIPTION
Add a sealed `Command` marker trait for use with `Cluster::command` and `Shard::command`. These methods take anything that implements `serde::Serialize` but by instead using a marker trait we can limit what typed commands can be sent. If users want to send arbitrary messages `Cluster::send` and `Shard::send` are alternatives.

Closes #978.