### PR TITLE
Add cache integration retrieval methods

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -413,16 +413,6 @@ impl InMemoryCache {
 
     /// Gets the set of integrations in a guild.
     ///
-    /// This requires the [`GUILD_INTEGRATIONS`] intent. The
-    /// [`ResourceType::INTEGRATION`] resource type must be enabled.
-    ///
-    /// [`GUILD_INTEGRATIONS`]: twilight_model::gateway::Intents::GUILD_INTEGRATIONS
-    pub fn guild_members(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
-        self.0.guild_members.get(&guild_id).map(|r| r.clone())
-    }
-
-    /// Gets the set of members in a guild.
-    ///
     /// This list may be incomplete if not all members have been cached.
     ///
     /// This is a O(m) operation, where m is the amount of members in the guild.
@@ -431,6 +421,16 @@ impl InMemoryCache {
     /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
     pub fn guild_integrations(&self, guild_id: GuildId) -> Option<HashSet<IntegrationId>> {
         self.0.guild_integrations.get(&guild_id).map(|r| r.clone())
+    }
+
+    /// Gets the set of members in a guild.
+    ///
+    /// This requires the [`GUILD_INTEGRATIONS`] intent. The
+    /// [`ResourceType::INTEGRATION`] resource type must be enabled.
+    ///
+    /// [`GUILD_INTEGRATIONS`]: twilight_model::gateway::Intents::GUILD_INTEGRATIONS
+    pub fn guild_members(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
+        self.0.guild_members.get(&guild_id).map(|r| r.clone())
     }
 
     /// Gets the set of presences in a guild.

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -411,6 +411,16 @@ impl InMemoryCache {
         self.0.guild_emojis.get(&guild_id).map(|r| r.clone())
     }
 
+    /// Gets the set of integrations in a guild.
+    ///
+    /// This requires the [`GUILD_INTEGRATIONS`] intent. The
+    /// [`ResourceType::INTEGRATION`] resource type must be enabled.
+    ///
+    /// [`GUILD_INTEGRATIONS`]: twilight_model::gateway::Intents::GUILD_INTEGRATIONS
+    pub fn guild_members(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
+        self.0.guild_members.get(&guild_id).map(|r| r.clone())
+    }
+
     /// Gets the set of members in a guild.
     ///
     /// This list may be incomplete if not all members have been cached.
@@ -419,8 +429,8 @@ impl InMemoryCache {
     /// This requires the [`GUILD_MEMBERS`] intent.
     ///
     /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
-    pub fn guild_members(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
-        self.0.guild_members.get(&guild_id).map(|r| r.clone())
+    pub fn guild_integrations(&self, guild_id: GuildId) -> Option<HashSet<IntegrationId>> {
+        self.0.guild_integrations.get(&guild_id).map(|r| r.clone())
     }
 
     /// Gets the set of presences in a guild.
@@ -456,6 +466,23 @@ impl InMemoryCache {
             .guild_stage_instances
             .get(&guild_id)
             .map(|r| r.value().clone())
+    }
+
+    /// Gets an integration by guild ID and integration ID.
+    ///
+    /// This is an O(1) operation. This requires the [`GUILD_INTEGRATIONS`]
+    /// intent. The [`ResourceType::INTEGRATION`] resource type must be enabled.
+    ///
+    /// [`GUILD_INTEGRATIONS`]: twilight_model::gateway::Intents::GUILD_INTEGRATIONS
+    pub fn integration(
+        &self,
+        guild_id: GuildId,
+        integration_id: IntegrationId,
+    ) -> Option<GuildIntegration> {
+        self.0
+            .integrations
+            .get(&(guild_id, integration_id))
+            .map(|r| r.data.clone())
     }
 
     /// Gets a member by guild ID and user ID.

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -413,22 +413,22 @@ impl InMemoryCache {
 
     /// Gets the set of integrations in a guild.
     ///
-    /// This list may be incomplete if not all members have been cached.
+    /// This requires the [`GUILD_INTEGRATIONS`] intent. The
+    /// [`ResourceType::INTEGRATION`] resource type must be enabled.
     ///
-    /// This is a O(m) operation, where m is the amount of members in the guild.
-    /// This requires the [`GUILD_MEMBERS`] intent.
-    ///
-    /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
+    /// [`GUILD_INTEGRATIONS`]: twilight_model::gateway::Intents::GUILD_INTEGRATIONS
     pub fn guild_integrations(&self, guild_id: GuildId) -> Option<HashSet<IntegrationId>> {
         self.0.guild_integrations.get(&guild_id).map(|r| r.clone())
     }
 
     /// Gets the set of members in a guild.
     ///
-    /// This requires the [`GUILD_INTEGRATIONS`] intent. The
-    /// [`ResourceType::INTEGRATION`] resource type must be enabled.
+    /// This list may be incomplete if not all members have been cached.
     ///
-    /// [`GUILD_INTEGRATIONS`]: twilight_model::gateway::Intents::GUILD_INTEGRATIONS
+    /// This is a O(m) operation, where m is the amount of members in the guild.
+    /// This requires the [`GUILD_MEMBERS`] intent.
+    ///
+    /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
     pub fn guild_members(&self, guild_id: GuildId) -> Option<HashSet<UserId>> {
         self.0.guild_members.get(&guild_id).map(|r| r.clone())
     }


### PR DESCRIPTION
Add methods for retrieving integrations by their guild and integration ID - exposed via the `InMemoryCache::integration` method - and for retrieving a list of a guild's integrations via the `InMemoryCache::guild_integrations` method.

Closes #1089.