### PR TITLE
chore(gateway): shard resumption message info -> debug

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -953,7 +953,7 @@ impl ShardProcessor {
     /// connection.
     async fn resume(&mut self) {
         #[cfg(feature = "tracing")]
-        tracing::info!("resuming shard {:?}", self.config.shard());
+        tracing::debug!("resuming shard {:?}", self.config.shard());
 
         self.session.set_stage(Stage::Resuming);
         self.session.stop_heartbeater();


### PR DESCRIPTION
Shards resume themselves many times a day, this is intended and is not very interesting info for the user. The frequency is also a bit too high such that it can dominate logs.
Attached screenshot is ~48h from a simple bot I run, note that this is running just one shard.
![](https://cdn.discordapp.com/attachments/745811216579952680/880441898584637460/unknown.png)