### PR TITLE
Allow `clippy::unnecessary_wraps` lint in gateway compression

### DIFF
--- a/gateway/src/shard/processor/compression/mod.rs
+++ b/gateway/src/shard/processor/compression/mod.rs
@@ -112,7 +112,10 @@ impl Compression {
     /// If compression is enabled then this returns a
     /// `ReceivingEventErrorType::Decompressing` error type if decompressing the
     /// message failed.
-    #[cfg_attr(not(feature = "compression"), allow(clippy::unused_self))]
+    #[cfg_attr(
+        not(feature = "compression"),
+        allow(clippy::unnecessary_wraps, clippy::unused_self)
+    )]
     pub fn message_mut(&mut self) -> Result<Option<&mut [u8]>, ReceivingEventError> {
         #[cfg(feature = "compression")]
         {


### PR DESCRIPTION
Allow the `clippy::unnecessary_wraps` lint in the `compression` gateway module when compression is disabled.