### PR TITLE
refactor(cache/in-memory): separate user relations

### DIFF
--- a/cache/in-memory/src/event/message.rs
+++ b/cache/in-memory/src/event/message.rs
@@ -187,8 +187,8 @@ mod tests {
         cache.update(&MessageCreate(msg));
 
         {
-            let entry = cache.0.users.get(&UserId(3)).unwrap();
-            assert_eq!(entry.value().1.len(), 1);
+            let entry = cache.0.user_guilds.get(&UserId(3)).unwrap();
+            assert_eq!(entry.value().len(), 1);
         }
         assert_eq!(
             cache.member(GuildId(1), UserId(3)).unwrap().user_id,

--- a/cache/in-memory/src/event/mod.rs
+++ b/cache/in-memory/src/event/mod.rs
@@ -30,9 +30,13 @@ impl InMemoryCache {
 
     fn cache_user(&self, user: Cow<'_, User>, guild_id: Option<GuildId>) {
         match self.0.users.get_mut(&user.id) {
-            Some(mut u) if u.0 == *user => {
+            Some(u) if *u.value() == *user => {
                 if let Some(guild_id) = guild_id {
-                    u.1.insert(guild_id);
+                    self.0
+                        .user_guilds
+                        .entry(user.id)
+                        .or_default()
+                        .insert(guild_id);
                 }
 
                 return;
@@ -42,9 +46,13 @@ impl InMemoryCache {
         let user = user.into_owned();
 
         if let Some(guild_id) = guild_id {
+            let user_id = user.id;
+
+            self.0.users.insert(user.id, user);
+
             let mut guild_id_set = BTreeSet::new();
             guild_id_set.insert(guild_id);
-            self.0.users.insert(user.id, (user, guild_id_set));
+            self.0.user_guilds.insert(user_id, guild_id_set);
         }
     }
 

--- a/cache/in-memory/src/event/voice_state.rs
+++ b/cache/in-memory/src/event/voice_state.rs
@@ -323,8 +323,8 @@ mod tests {
 
         assert_eq!(cache.0.members.len(), 1);
         {
-            let entry = cache.0.users.get(&UserId(3)).unwrap();
-            assert_eq!(entry.value().1.len(), 1);
+            let entry = cache.0.user_guilds.get(&UserId(3)).unwrap();
+            assert_eq!(entry.value().len(), 1);
         }
         assert_eq!(
             cache.member(GuildId(2), UserId(3)).unwrap().user_id,

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -170,7 +170,8 @@ struct InMemoryCacheRef {
     roles: DashMap<RoleId, GuildItem<Role>>,
     stage_instances: DashMap<StageId, GuildItem<StageInstance>>,
     unavailable_guilds: DashSet<GuildId>,
-    users: DashMap<UserId, (User, BTreeSet<GuildId>)>,
+    users: DashMap<UserId, User>,
+    user_guilds: DashMap<UserId, BTreeSet<GuildId>>,
     /// Mapping of channels and the users currently connected.
     voice_state_channels: DashMap<ChannelId, HashSet<(GuildId, UserId)>>,
     /// Mapping of guilds and users currently connected to its voice channels.
@@ -528,7 +529,7 @@ impl InMemoryCache {
     ///
     /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
     pub fn user(&self, user_id: UserId) -> Option<User> {
-        self.0.users.get(&user_id).map(|r| r.0.clone())
+        self.0.users.get(&user_id).map(|r| r.value().clone())
     }
 
     /// Gets the voice states within a voice channel.


### PR DESCRIPTION
Separate the `users` cache field from being a tuple of the user and its guild relations to being in two separate fields, as is consistent with other resources.