### PR TITLE
Make `Ready::shard` required

### DIFF
--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -172,7 +172,7 @@ impl Lavalink {
 
         let guild_id = match event {
             Event::Ready(e) => {
-                let shard_id = e.shard.map_or(0, |[id, _]| id);
+                let shard_id = e.shard[0];
 
                 self.clear_shard_states(shard_id);
 

--- a/model/src/gateway/payload/incoming/ready.rs
+++ b/model/src/gateway/payload/incoming/ready.rs
@@ -6,8 +6,14 @@ pub struct Ready {
     pub application: PartialApplication,
     pub guilds: Vec<UnavailableGuild>,
     pub session_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub shard: Option<[u64; 2]>,
+    /// Two-element array where the first element is the 0-indexed ID of the
+    /// current shard and the 1-indexed total number of shards used by the
+    /// session.
+    ///
+    /// For example, if you have 5 shards and create a session with shard 3 then
+    /// it is the second-to-last shard in the set. This array value would be
+    /// `[3, 5]`.
+    pub shard: [u64; 2],
     pub user: CurrentUser,
     #[serde(rename = "v")]
     pub version: u64,
@@ -45,7 +51,7 @@ mod tests {
             },
             guilds,
             session_id: "foo".to_owned(),
-            shard: Some([4, 7]),
+            shard: [4, 7],
             user: CurrentUser {
                 accent_color: None,
                 avatar: None,
@@ -111,7 +117,6 @@ mod tests {
                 Token::Str("session_id"),
                 Token::Str("foo"),
                 Token::Str("shard"),
-                Token::Some,
                 Token::Tuple { len: 2 },
                 Token::U64(4),
                 Token::U64(7),

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -372,11 +372,7 @@ impl Standby {
     /// let standby = Standby::new();
     ///
     /// let ready = standby.wait_for_event(|event: &Event| {
-    ///     if let Event::Ready(ready) = event {
-    ///         ready.shard.map(|[id, _]| id == 5).unwrap_or(false)
-    ///     } else {
-    ///         false
-    ///     }
+    ///     matches!(event, Event::Ready(ready) if ready.shard[0] == 5)
     /// }).await?;
     /// # Ok(()) }
     /// ```
@@ -425,11 +421,7 @@ impl Standby {
     /// let standby = Standby::new();
     ///
     /// let mut events = standby.wait_for_event_stream(|event: &Event| {
-    ///     if let Event::Ready(ready) = event {
-    ///         ready.shard.map(|[id, _]| id == 5).unwrap_or(false)
-    ///     } else {
-    ///         false
-    ///     }
+    ///     matches!(event, Event::Ready(ready) if ready.shard[0] == 5)
     /// });
     ///
     /// while let Some(event) = events.next().await {
@@ -1083,7 +1075,7 @@ mod tests {
             },
             guilds: Vec::new(),
             session_id: String::new(),
-            shard: Some([5, 7]),
+            shard: [5, 7],
             user: CurrentUser {
                 accent_color: None,
                 avatar: None,
@@ -1105,10 +1097,9 @@ mod tests {
         let event = Event::Ready(Box::new(ready));
 
         let standby = Standby::new();
-        let wait = standby.wait_for_event(|event: &Event| match event {
-            Event::Ready(ready) => ready.shard.map(|[id, _]| id == 5).unwrap_or(false),
-            _ => false,
-        });
+        let wait = standby.wait_for_event(
+            |event: &Event| matches!(event, Event::Ready(ready) if ready.shard[0] == 5),
+        );
         assert!(!standby.events.is_empty());
         standby.process(&event);
 


### PR DESCRIPTION
Change the `twilight_model::gateway::payload::incoming::Ready::shard` field from being an `Option<[u64; 2]>` to being just a `[u64; 2]`; this field is always present and does not need to be wrapped in an `Option`.

The field has, additionally, been documented.