### PR TITLE
Chore/standardize bitflags

### DIFF
--- a/cache/in-memory/src/config.rs
+++ b/cache/in-memory/src/config.rs
@@ -95,23 +95,6 @@ mod tests {
     assert_fields!(Config: resource_types, message_cache_size);
 
     #[test]
-    #[allow(clippy::cognitive_complexity)]
-    fn test_resource_type_const_values() {
-        assert_eq!(1, ResourceType::CHANNEL.bits());
-        assert_eq!(1 << 1, ResourceType::EMOJI.bits());
-        assert_eq!(1 << 2, ResourceType::GUILD.bits());
-        assert_eq!(1 << 3, ResourceType::MEMBER.bits());
-        assert_eq!(1 << 4, ResourceType::MESSAGE.bits());
-        assert_eq!(1 << 5, ResourceType::PRESENCE.bits());
-        assert_eq!(1 << 6, ResourceType::REACTION.bits());
-        assert_eq!(1 << 7, ResourceType::ROLE.bits());
-        assert_eq!(1 << 8, ResourceType::USER_CURRENT.bits());
-        assert_eq!(1 << 9, ResourceType::USER.bits());
-        assert_eq!(1 << 10, ResourceType::VOICE_STATE.bits());
-        assert_eq!(1 << 11, ResourceType::STAGE_INSTANCE.bits());
-    }
-
-    #[test]
     fn test_defaults() {
         let conf = Config {
             resource_types: ResourceType::all(),

--- a/gateway/src/event.rs
+++ b/gateway/src/event.rs
@@ -4,7 +4,6 @@ use twilight_model::gateway::event::EventType;
 
 bitflags! {
     /// Bitflags representing all of the possible types of events.
-    #[non_exhaustive]
     pub struct EventTypeFlags: u64 {
         /// User has been banned from a guild.
         const BAN_ADD = 1;

--- a/model/src/channel/message/flags.rs
+++ b/model/src/channel/message/flags.rs
@@ -39,19 +39,3 @@ impl Serialize for MessageFlags {
         serializer.serialize_u64(self.bits())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::MessageFlags;
-    use serde_test::Token;
-
-    #[test]
-    fn test_variants() {
-        serde_test::assert_tokens(&MessageFlags::CROSSPOSTED, &[Token::U64(1)]);
-        serde_test::assert_tokens(&MessageFlags::IS_CROSSPOST, &[Token::U64(1 << 1)]);
-        serde_test::assert_tokens(&MessageFlags::SUPPRESS_EMBEDS, &[Token::U64(1 << 2)]);
-        serde_test::assert_tokens(&MessageFlags::SOURCE_MESSAGE_DELETED, &[Token::U64(1 << 3)]);
-        serde_test::assert_tokens(&MessageFlags::URGENT, &[Token::U64(1 << 4)]);
-        serde_test::assert_tokens(&MessageFlags::EPHEMERAL, &[Token::U64(1 << 6)]);
-    }
-}

--- a/model/src/gateway/intents.rs
+++ b/model/src/gateway/intents.rs
@@ -206,28 +206,3 @@ impl Serialize for Intents {
         serializer.serialize_u64(self.bits())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::Intents;
-    use serde_test::Token;
-
-    #[test]
-    fn test_variants() {
-        serde_test::assert_tokens(&Intents::GUILDS, &[Token::U64(1)]);
-        serde_test::assert_tokens(&Intents::GUILD_MEMBERS, &[Token::U64(1 << 1)]);
-        serde_test::assert_tokens(&Intents::GUILD_BANS, &[Token::U64(1 << 2)]);
-        serde_test::assert_tokens(&Intents::GUILD_EMOJIS, &[Token::U64(1 << 3)]);
-        serde_test::assert_tokens(&Intents::GUILD_INTEGRATIONS, &[Token::U64(1 << 4)]);
-        serde_test::assert_tokens(&Intents::GUILD_WEBHOOKS, &[Token::U64(1 << 5)]);
-        serde_test::assert_tokens(&Intents::GUILD_INVITES, &[Token::U64(1 << 6)]);
-        serde_test::assert_tokens(&Intents::GUILD_VOICE_STATES, &[Token::U64(1 << 7)]);
-        serde_test::assert_tokens(&Intents::GUILD_PRESENCES, &[Token::U64(1 << 8)]);
-        serde_test::assert_tokens(&Intents::GUILD_MESSAGES, &[Token::U64(1 << 9)]);
-        serde_test::assert_tokens(&Intents::GUILD_MESSAGE_REACTIONS, &[Token::U64(1 << 10)]);
-        serde_test::assert_tokens(&Intents::GUILD_MESSAGE_TYPING, &[Token::U64(1 << 11)]);
-        serde_test::assert_tokens(&Intents::DIRECT_MESSAGES, &[Token::U64(1 << 12)]);
-        serde_test::assert_tokens(&Intents::DIRECT_MESSAGE_REACTIONS, &[Token::U64(1 << 13)]);
-        serde_test::assert_tokens(&Intents::DIRECT_MESSAGE_TYPING, &[Token::U64(1 << 14)]);
-    }
-}

--- a/model/src/gateway/presence/activity_flags.rs
+++ b/model/src/gateway/presence/activity_flags.rs
@@ -29,19 +29,3 @@ impl Serialize for ActivityFlags {
         serializer.serialize_u64(self.bits())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::ActivityFlags;
-    use serde_test::Token;
-
-    #[test]
-    fn test_variants() {
-        serde_test::assert_tokens(&ActivityFlags::INSTANCE, &[Token::U64(1)]);
-        serde_test::assert_tokens(&ActivityFlags::JOIN, &[Token::U64(1 << 1)]);
-        serde_test::assert_tokens(&ActivityFlags::SPECTATE, &[Token::U64(1 << 2)]);
-        serde_test::assert_tokens(&ActivityFlags::JOIN_REQUEST, &[Token::U64(1 << 3)]);
-        serde_test::assert_tokens(&ActivityFlags::SYNC, &[Token::U64(1 << 4)]);
-        serde_test::assert_tokens(&ActivityFlags::PLAY, &[Token::U64(1 << 5)]);
-    }
-}

--- a/model/src/guild/permissions.rs
+++ b/model/src/guild/permissions.rs
@@ -85,39 +85,3 @@ impl Serialize for Permissions {
         serializer.serialize_str(&self.bits().to_string())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::Permissions;
-    use serde::{Deserialize, Serialize};
-    use serde_test::Token;
-    use static_assertions::{assert_impl_all, const_assert_eq};
-    use std::{fmt::Debug, hash::Hash};
-
-    assert_impl_all!(
-        Permissions: Copy,
-        Clone,
-        Debug,
-        Deserialize<'static>,
-        Eq,
-        Hash,
-        PartialEq,
-        Ord,
-        Send,
-        Serialize,
-        Sync
-    );
-    const_assert_eq!(0x0008_0000_0000, Permissions::CREATE_PUBLIC_THREADS.bits());
-    const_assert_eq!(0x0010_0000_0000, Permissions::CREATE_PRIVATE_THREADS.bits());
-    const_assert_eq!(
-        0x0040_0000_0000,
-        Permissions::SEND_MESSAGES_IN_THREADS.bits()
-    );
-
-    #[test]
-    fn test_permissions() {
-        let permissions = Permissions::DEAFEN_MEMBERS;
-
-        serde_test::assert_tokens(&permissions, &[Token::Str("8388608")]);
-    }
-}

--- a/model/src/guild/permissions.rs
+++ b/model/src/guild/permissions.rs
@@ -7,47 +7,47 @@ use std::fmt::{Formatter, Result as FmtResult};
 
 bitflags! {
     pub struct Permissions: u64 {
-        const CREATE_INVITE = 0x0000_0001;
-        const KICK_MEMBERS = 0x0000_0002;
-        const BAN_MEMBERS = 0x0000_0004;
-        const ADMINISTRATOR = 0x0000_0008;
-        const MANAGE_CHANNELS = 0x0000_0010;
-        const MANAGE_GUILD = 0x0000_0020;
-        const ADD_REACTIONS = 0x0000_0040;
-        const VIEW_AUDIT_LOG = 0x0000_0080;
-        const PRIORITY_SPEAKER = 0x0000_0100;
-        const STREAM = 0x0000_0200;
-        const VIEW_CHANNEL = 0x0000_0400;
-        const SEND_MESSAGES = 0x0000_0800;
-        const SEND_TTS_MESSAGES = 0x0000_1000;
-        const MANAGE_MESSAGES = 0x0000_2000;
-        const EMBED_LINKS = 0x0000_4000;
-        const ATTACH_FILES = 0x0000_8000;
-        const READ_MESSAGE_HISTORY = 0x0001_0000;
-        const MENTION_EVERYONE = 0x0002_0000;
-        const USE_EXTERNAL_EMOJIS = 0x0004_0000;
-        const VIEW_GUILD_INSIGHTS = 0x0008_0000;
-        const CONNECT = 0x0010_0000;
-        const SPEAK = 0x0020_0000;
-        const MUTE_MEMBERS = 0x0040_0000;
-        const DEAFEN_MEMBERS = 0x0080_0000;
-        const MOVE_MEMBERS = 0x0100_0000;
-        const USE_VAD = 0x0200_0000;
-        const CHANGE_NICKNAME = 0x0400_0000;
-        const MANAGE_NICKNAMES = 0x0800_0000;
-        const MANAGE_ROLES = 0x1000_0000;
-        const MANAGE_WEBHOOKS = 0x2000_0000;
-        const MANAGE_EMOJIS = 0x4000_0000;
-        const USE_SLASH_COMMANDS = 0x8000_0000;
-        const REQUEST_TO_SPEAK = 0x10000_0000;
+        const CREATE_INVITE = 1;
+        const KICK_MEMBERS = 1 << 1;
+        const BAN_MEMBERS = 1 << 2;
+        const ADMINISTRATOR = 1 << 3;
+        const MANAGE_CHANNELS = 1 << 4;
+        const MANAGE_GUILD = 1 << 5;
+        const ADD_REACTIONS = 1 << 6;
+        const VIEW_AUDIT_LOG = 1 << 7;
+        const PRIORITY_SPEAKER = 1 << 8;
+        const STREAM = 1 << 9;
+        const VIEW_CHANNEL = 1 << 10;
+        const SEND_MESSAGES = 1 << 11;
+        const SEND_TTS_MESSAGES = 1 << 12;
+        const MANAGE_MESSAGES = 1 << 13;
+        const EMBED_LINKS = 1 << 14;
+        const ATTACH_FILES = 1 << 15;
+        const READ_MESSAGE_HISTORY = 1 << 16;
+        const MENTION_EVERYONE = 1 << 17;
+        const USE_EXTERNAL_EMOJIS = 1 << 18;
+        const VIEW_GUILD_INSIGHTS = 1 << 19;
+        const CONNECT = 1 << 20;
+        const SPEAK = 1 << 21;
+        const MUTE_MEMBERS = 1 << 22;
+        const DEAFEN_MEMBERS = 1 << 23;
+        const MOVE_MEMBERS = 1 << 24;
+        const USE_VAD = 1 << 25;
+        const CHANGE_NICKNAME = 1 << 26;
+        const MANAGE_NICKNAMES = 1 << 27;
+        const MANAGE_ROLES = 1 << 28;
+        const MANAGE_WEBHOOKS = 1 << 29;
+        const MANAGE_EMOJIS = 1 << 30;
+        const USE_SLASH_COMMANDS = 1 << 31;
+        const REQUEST_TO_SPEAK = 1 << 32;
         /// Allows for deleting and archiving threads, and viewing all private threads.
-        const MANAGE_THREADS = 0x40000_0000;
+        const MANAGE_THREADS = 1 << 34;
         /// Allows for creating public threads.
-        const CREATE_PUBLIC_THREADS = 0x0008_0000_0000;
+        const CREATE_PUBLIC_THREADS = 1 << 35;
         /// Allows for creating private threads.
-        const CREATE_PRIVATE_THREADS = 0x0010_0000_0000;
+        const CREATE_PRIVATE_THREADS = 1 << 36;
         /// Allows for sending messages in threads.
-        const SEND_MESSAGES_IN_THREADS = 0x0040_0000_0000;
+        const SEND_MESSAGES_IN_THREADS = 1 << 38;
     }
 }
 

--- a/model/src/guild/system_channel_flags.rs
+++ b/model/src/guild/system_channel_flags.rs
@@ -26,25 +26,3 @@ impl Serialize for SystemChannelFlags {
         serializer.serialize_u64(self.bits())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::SystemChannelFlags;
-    use serde_test::Token;
-
-    #[test]
-    fn test_variants() {
-        serde_test::assert_tokens(
-            &SystemChannelFlags::SUPPRESS_JOIN_NOTIFICATIONS,
-            &[Token::U64(1)],
-        );
-        serde_test::assert_tokens(
-            &SystemChannelFlags::SUPPRESS_PREMIUM_SUBSCRIPTIONS,
-            &[Token::U64(1 << 1)],
-        );
-        serde_test::assert_tokens(
-            &SystemChannelFlags::SUPPRESS_GUILD_REMINDER_NOTIFICATIONS,
-            &[Token::U64(1 << 2)],
-        );
-    }
-}

--- a/model/src/oauth/current_application_info/flags.rs
+++ b/model/src/oauth/current_application_info/flags.rs
@@ -29,31 +29,3 @@ impl Serialize for ApplicationFlags {
         serializer.serialize_u64(self.bits())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::ApplicationFlags;
-    use serde_test::Token;
-
-    #[test]
-    fn test_variants() {
-        serde_test::assert_tokens(&ApplicationFlags::GATEWAY_PRESENCE, &[Token::U64(1 << 12)]);
-        serde_test::assert_tokens(
-            &ApplicationFlags::GATEWAY_PRESENCE_LIMITED,
-            &[Token::U64(1 << 13)],
-        );
-        serde_test::assert_tokens(
-            &ApplicationFlags::GATEWAY_GUILD_MEMBERS,
-            &[Token::U64(1 << 14)],
-        );
-        serde_test::assert_tokens(
-            &ApplicationFlags::GATEWAY_GUILD_MEMBERS_LIMITED,
-            &[Token::U64(1 << 15)],
-        );
-        serde_test::assert_tokens(
-            &ApplicationFlags::VERIFICATION_PENDING_GUILD_LIMIT,
-            &[Token::U64(1 << 16)],
-        );
-        serde_test::assert_tokens(&ApplicationFlags::EMBEDDED, &[Token::U64(1 << 17)]);
-    }
-}

--- a/model/src/user/flags.rs
+++ b/model/src/user/flags.rs
@@ -36,29 +36,3 @@ impl Serialize for UserFlags {
         serializer.serialize_u64(self.bits())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::UserFlags;
-    use serde_test::Token;
-
-    #[test]
-    fn test_variants() {
-        serde_test::assert_tokens(&UserFlags::DISCORD_EMPLOYEE, &[Token::U64(1)]);
-        serde_test::assert_tokens(&UserFlags::DISCORD_PARTNER, &[Token::U64(1 << 1)]);
-        serde_test::assert_tokens(&UserFlags::HYPESQUAD_EVENTS, &[Token::U64(1 << 2)]);
-        serde_test::assert_tokens(&UserFlags::BUG_HUNTER, &[Token::U64(1 << 3)]);
-        serde_test::assert_tokens(&UserFlags::HOUSE_BRAVERY, &[Token::U64(1 << 6)]);
-        serde_test::assert_tokens(&UserFlags::HOUSE_BRILLIANCE, &[Token::U64(1 << 7)]);
-        serde_test::assert_tokens(&UserFlags::HOUSE_BALANCE, &[Token::U64(1 << 8)]);
-        serde_test::assert_tokens(&UserFlags::EARLY_SUPPORTER, &[Token::U64(1 << 9)]);
-        serde_test::assert_tokens(&UserFlags::TEAM_USER, &[Token::U64(1 << 10)]);
-        serde_test::assert_tokens(&UserFlags::BUG_HUNTER_LEVEL_2, &[Token::U64(1 << 14)]);
-        serde_test::assert_tokens(&UserFlags::VERIFIED_BOT, &[Token::U64(1 << 16)]);
-        serde_test::assert_tokens(&UserFlags::VERIFIED_BOT_DEVELOPER, &[Token::U64(1 << 17)]);
-        serde_test::assert_tokens(
-            &UserFlags::DISCORD_CERTIFIED_MODERATOR,
-            &[Token::U64(1 << 18)],
-        );
-    }
-}


### PR DESCRIPTION
This standardizes the way bitflags are defined (bit shift & no `#[non_exhaustive]`).
I also removed some bitflag tests since they just restate the original definition and were not kept up to date anyway.