### PR TITLE
fix(model): actually re-export `Number`

### DIFF
--- a/model/src/application/command/mod.rs
+++ b/model/src/application/command/mod.rs
@@ -9,7 +9,7 @@ pub use self::{
     command_type::CommandType,
     option::{
         BaseCommandOptionData, ChoiceCommandOptionData, CommandOption, CommandOptionChoice,
-        CommandOptionType, OptionsCommandOptionData,
+        CommandOptionType, Number, OptionsCommandOptionData,
     },
 };
 


### PR DESCRIPTION
I missed this when reviewing #1053, so this is technically part of it.