### PR TITLE
chore: link to command builder where applicable

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -2214,11 +2214,17 @@ impl Client {
     /// This method is idempotent: it can be used on every start, without being
     /// ratelimited if there aren't changes to the commands.
     ///
+    /// The [`Command`] struct has an [associated builder] in the
+    /// [`twilight-util`] crate.
+    ///
     /// # Errors
     ///
     /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
     /// error type if an application ID has not been configured via
     /// [`Client::set_application_id`].
+    ///
+    /// [`twilight-util`]: https://api.twilight.rs/twilight_util/index.html
+    /// [associated builder]: https://api.twilight.rs/twilight_util/builder/command/struct.CommandBuilder.html
     pub fn set_guild_commands<'a>(
         &'a self,
         guild_id: GuildId,
@@ -2379,11 +2385,17 @@ impl Client {
     /// This method is idempotent: it can be used on every start, without being
     /// ratelimited if there aren't changes to the commands.
     ///
+    /// The [`Command`] struct has an [associated builder] in the
+    /// [`twilight-util`] crate.
+    ///
     /// # Errors
     ///
     /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
     /// error type if an application ID has not been configured via
     /// [`Client::set_application_id`].
+    ///
+    /// [`twilight-util`]: https://api.twilight.rs/twilight_util/index.html
+    /// [associated builder]: https://api.twilight.rs/twilight_util/builder/command/struct.CommandBuilder.html
     pub fn set_global_commands<'a>(
         &'a self,
         commands: &'a [Command],

--- a/http/src/request/application/command/set_global_commands.rs
+++ b/http/src/request/application/command/set_global_commands.rs
@@ -11,6 +11,12 @@ use twilight_model::{application::command::Command, id::ApplicationId};
 ///
 /// This method is idempotent: it can be used on every start, without being
 /// ratelimited if there aren't changes to the commands.
+///
+/// The [`Command`] struct has an [associated builder] in the
+/// [`twilight-util`] crate.
+///
+/// [`twilight-util`]: https://api.twilight.rs/twilight_util/index.html
+/// [associated builder]: https://api.twilight.rs/twilight_util/builder/command/struct.CommandBuilder.html
 #[must_use = "requests must be configured and executed"]
 pub struct SetGlobalCommands<'a> {
     commands: &'a [Command],

--- a/http/src/request/application/command/set_guild_commands.rs
+++ b/http/src/request/application/command/set_guild_commands.rs
@@ -14,6 +14,12 @@ use twilight_model::{
 ///
 /// This method is idempotent: it can be used on every start, without being
 /// ratelimited if there aren't changes to the commands.
+///
+/// The [`Command`] struct has an [associated builder] in the
+/// [`twilight-util`] crate.
+///
+/// [`twilight-util`]: https://api.twilight.rs/twilight_util/index.html
+/// [associated builder]: https://api.twilight.rs/twilight_util/builder/command/struct.CommandBuilder.html
 #[must_use = "requests must be configured and executed"]
 pub struct SetGuildCommands<'a> {
     commands: &'a [Command],

--- a/model/README.md
+++ b/model/README.md
@@ -23,11 +23,15 @@ and returned by the gateway API. `guild` contains types owned by the Guild
 resource category. These types may be directly returned by, built on top of,
 or extended by other crates.
 
+Some models have associated builders, which can be found in the
+[`twilight-util`] crate.
+
 ## License
 
 [ISC][LICENSE.md]
 
 [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
+[`twilight-util`]: https://docs.rs/twilight-util
 [`twilight`]: https://docs.rs/twilight
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D

--- a/model/src/application/command/mod.rs
+++ b/model/src/application/command/mod.rs
@@ -22,6 +22,10 @@ use serde::{Deserialize, Serialize};
 /// Command names must be lower case, matching the Regex `^[\w-]{1,32}$`. Refer
 /// to [the discord docs] for more information.
 ///
+/// This struct has an [associated builder] in the [`twilight-util`] crate.
+///
+/// [`twilight-util`]: https://api.twilight.rs/twilight_util/index.html
+/// [associated builder]: https://api.twilight.rs/twilight_util/builder/command/struct.CommandBuilder.html
 /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#applicationcommand
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Command {

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -21,11 +21,15 @@
 //! resource category. These types may be directly returned by, built on top of,
 //! or extended by other crates.
 //!
+//! Some models have associated builders, which can be found in the
+//! [`twilight-util`] crate.
+//!
 //! ## License
 //!
 //! [ISC][LICENSE.md]
 //!
 //! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
+//! [`twilight-util`]: https://docs.rs/twilight-util
 //! [`twilight`]: https://docs.rs/twilight
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D

--- a/util/src/builder/command.rs
+++ b/util/src/builder/command.rs
@@ -1,4 +1,30 @@
 //! Create a [`Command`] with a builder.
+//!
+//! # Examples
+//!
+//! ```
+//! use twilight_model::application::command::CommandType;
+//! use twilight_util::builder::command::{BooleanBuilder, CommandBuilder, StringBuilder};
+//!
+//! CommandBuilder::new(
+//!     "blep".into(),
+//!     "Send a random adorable animal photo".into(),
+//!     CommandType::ChatInput,
+//! )
+//! .option(
+//!     StringBuilder::new("animal".into(), "The type of animal".into())
+//!         .required(true)
+//!         .choices([
+//!             ("Dog".into(), "animal_dog".into()),
+//!             ("Cat".into(), "animal_cat".into()),
+//!             ("Penguin".into(), "animal_penguin".into()),
+//!         ]),
+//! )
+//! .option(BooleanBuilder::new(
+//!     "only_smol".into(),
+//!     "Whether to show only baby animals".into(),
+//! ));
+//! ```
 
 use twilight_model::{
     application::command::{
@@ -9,31 +35,6 @@ use twilight_model::{
 };
 
 /// Builder to create a [`Command`].
-///
-/// # Examples
-/// ```
-/// use twilight_model::application::command::CommandType;
-/// use twilight_util::builder::command::{BooleanBuilder, CommandBuilder, StringBuilder};
-///
-/// CommandBuilder::new(
-///     "blep".into(),
-///     "Send a random adorable animal photo".into(),
-///     CommandType::ChatInput,
-/// )
-/// .option(
-///     StringBuilder::new("animal".into(), "The type of animal".into())
-///         .required(true)
-///         .choices([
-///             ("Dog".into(), "animal_dog".into()),
-///             ("Cat".into(), "animal_cat".into()),
-///             ("Penguin".into(), "animal_penguin".into()),
-///         ]),
-/// )
-/// .option(BooleanBuilder::new(
-///     "only_smol".into(),
-///     "Whether to show only baby animals".into(),
-/// ));
-/// ```
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug)]
 #[must_use = "must be built into a command"]


### PR DESCRIPTION
Links to the `CommandBuilder` where it may be useful.`api.twilight.rs`
links were used since the builder isn't released yet.

Additionally, moves the `CommandBuilder` example to module-level.
