### PR TITLE
remove `vip` field from `VoiceRegion`

### DIFF
--- a/model/src/voice/voice_region.rs
+++ b/model/src/voice/voice_region.rs
@@ -10,7 +10,7 @@ pub struct VoiceRegion {
     pub optimal: bool,
     #[deprecated(
         since = "0.6.5",
-        ntoe = "the `vip` field has been removed from the Voice Region object on Discord's side."
+        note = "the `vip` field has been removed from the Voice Region object on Discord's side."
     )]
     #[serde(default)]
     pub vip: bool,

--- a/model/src/voice/voice_region.rs
+++ b/model/src/voice/voice_region.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use serde::{Deserialize, Serialize};
 
 #[allow(clippy::struct_excessive_bools)]
@@ -29,7 +31,6 @@ mod tests {
             id: "region".to_owned(),
             name: "Region".to_owned(),
             optimal: false,
-            #[allow(deprecated)]
             vip: false,
         };
 

--- a/model/src/voice/voice_region.rs
+++ b/model/src/voice/voice_region.rs
@@ -9,8 +9,8 @@ pub struct VoiceRegion {
     pub name: String,
     pub optimal: bool,
     #[deprecated(
-        since = "0.6.5", 
-        reason = "the `vip` field has been removed from the Voice Region object on Discord's side."
+        since = "0.6.5",
+        ntoe = "the `vip` field has been removed from the Voice Region object on Discord's side."
     )]
     #[serde(default)]
     pub vip: bool,

--- a/model/src/voice/voice_region.rs
+++ b/model/src/voice/voice_region.rs
@@ -29,6 +29,7 @@ mod tests {
             id: "region".to_owned(),
             name: "Region".to_owned(),
             optimal: false,
+            #[allow(deprecated)]
             vip: false,
         };
 

--- a/model/src/voice/voice_region.rs
+++ b/model/src/voice/voice_region.rs
@@ -8,6 +8,7 @@ pub struct VoiceRegion {
     pub id: String,
     pub name: String,
     pub optimal: bool,
+    pub vip: bool,
 }
 
 #[cfg(test)]
@@ -23,6 +24,9 @@ mod tests {
             id: "region".to_owned(),
             name: "Region".to_owned(),
             optimal: false,
+            #[deprecated(since = "0.6.5", reason = "the `vip` field has been removed from the Voice Region object on Discord's side.")]
+            #[serde(default)]
+            vip: false,
         };
 
         serde_test::assert_tokens(
@@ -41,6 +45,8 @@ mod tests {
                 Token::Str("name"),
                 Token::Str("Region"),
                 Token::Str("optimal"),
+                Token::Bool(false),
+                Token::Str("vip"),
                 Token::Bool(false),
                 Token::StructEnd,
             ],

--- a/model/src/voice/voice_region.rs
+++ b/model/src/voice/voice_region.rs
@@ -9,8 +9,8 @@ pub struct VoiceRegion {
     pub name: String,
     pub optimal: bool,
     #[deprecated(
-        since = "0.6.5",
-        note = "the `vip` field has been removed from the Voice Region object on Discord's side."
+        note = "the `vip` field has been removed from the Voice Region object on Discord's side.",
+        since = "0.6.5"
     )]
     #[serde(default)]
     pub vip: bool,

--- a/model/src/voice/voice_region.rs
+++ b/model/src/voice/voice_region.rs
@@ -8,7 +8,6 @@ pub struct VoiceRegion {
     pub id: String,
     pub name: String,
     pub optimal: bool,
-    pub vip: bool,
 }
 
 #[cfg(test)]
@@ -24,7 +23,6 @@ mod tests {
             id: "region".to_owned(),
             name: "Region".to_owned(),
             optimal: false,
-            vip: false,
         };
 
         serde_test::assert_tokens(
@@ -43,8 +41,6 @@ mod tests {
                 Token::Str("name"),
                 Token::Str("Region"),
                 Token::Str("optimal"),
-                Token::Bool(false),
-                Token::Str("vip"),
                 Token::Bool(false),
                 Token::StructEnd,
             ],

--- a/model/src/voice/voice_region.rs
+++ b/model/src/voice/voice_region.rs
@@ -8,6 +8,11 @@ pub struct VoiceRegion {
     pub id: String,
     pub name: String,
     pub optimal: bool,
+    #[deprecated(
+        since = "0.6.5", 
+        reason = "the `vip` field has been removed from the Voice Region object on Discord's side."
+    )]
+    #[serde(default)]
     pub vip: bool,
 }
 
@@ -24,8 +29,6 @@ mod tests {
             id: "region".to_owned(),
             name: "Region".to_owned(),
             optimal: false,
-            #[deprecated(since = "0.6.5", reason = "the `vip` field has been removed from the Voice Region object on Discord's side.")]
-            #[serde(default)]
             vip: false,
         };
 


### PR DESCRIPTION
This Pull Request is to fix a breaking change from Discord, that the `vip` field is now removed (the documentation has yet to reflect the change).