### PR TITLE
feat: add Interaction#id to point to the underlying ID

### DIFF
--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -56,7 +56,7 @@ impl Interaction {
         match self {
             Self::Ping(ping) => ping.id,
             Self::ApplicationCommand(command) => command.id,
-            Self::MessageComponent(component) => component.id
+            Self::MessageComponent(component) => component.id,
         }
     }
 }


### PR DESCRIPTION
Adds the `Interaction#id()` method to point to the underlying ID, similar to `Channel#id()`;