### PR TITLE
Rename `new_create_*_command` methods to `create_*_command`

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -8,12 +8,11 @@ use crate::{
     request::{
         application::{
             command::{
-                create_global_command::CreateGlobalChatInputCommand,
-                create_guild_command::CreateGuildChatInputCommand, CreateGlobalCommand,
-                CreateGuildCommand, DeleteGlobalCommand, DeleteGuildCommand, GetCommandPermissions,
-                GetGlobalCommand, GetGlobalCommands, GetGuildCommand, GetGuildCommandPermissions,
-                GetGuildCommands, SetCommandPermissions, SetGlobalCommands, SetGuildCommands,
-                UpdateCommandPermissions, UpdateGlobalCommand, UpdateGuildCommand,
+                CreateGlobalCommand, CreateGuildCommand, DeleteGlobalCommand, DeleteGuildCommand,
+                GetCommandPermissions, GetGlobalCommand, GetGlobalCommands, GetGuildCommand,
+                GetGuildCommandPermissions, GetGuildCommands, SetCommandPermissions,
+                SetGlobalCommands, SetGuildCommands, UpdateCommandPermissions, UpdateGlobalCommand,
+                UpdateGuildCommand,
             },
             interaction::{
                 CreateFollowupMessage, DeleteFollowupMessage, DeleteOriginalResponse,
@@ -2039,40 +2038,6 @@ impl Client {
         ))
     }
 
-    /// Create a new chat input command in a guild.
-    ///
-    /// The name must be between 1 and 32 characters in length. Creating a
-    /// guild command with the same name as an already-existing guild command in
-    /// the same guild will overwrite the old command. See [the discord docs]
-    /// for more information.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
-    /// error type if an application ID has not been configured via
-    /// [`Client::set_application_id`].
-    ///
-    /// Returns an [`InteractionErrorType::CommandNameValidationFailed`]
-    /// error type if the command name is not between 1 and 32 characters.
-    ///
-    /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
-    #[deprecated(
-        note = "use `new_create_guild_command`, which does not require a description",
-        since = "0.6.4"
-    )]
-    pub fn create_guild_command<'a>(
-        &'a self,
-        guild_id: GuildId,
-        name: &'a str,
-        description: &'a str,
-    ) -> Result<CreateGuildChatInputCommand<'a>, InteractionError> {
-        let application_id = self.application_id().ok_or(InteractionError {
-            kind: InteractionErrorType::ApplicationIdNotPresent,
-        })?;
-
-        CreateGuildCommand::new(self, application_id, guild_id, name)?.chat_input(description)
-    }
-
     /// Create a new command in a guild.
     ///
     /// The name must be between 1 and 32 characters in length. Creating a
@@ -2090,7 +2055,7 @@ impl Client {
     /// error type if the command name is not between 1 and 32 characters.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
-    pub fn new_create_guild_command<'a>(
+    pub fn create_guild_command<'a>(
         &'a self,
         guild_id: GuildId,
         name: &'a str,
@@ -2230,43 +2195,6 @@ impl Client {
         ))
     }
 
-    /// Create a new chat input global command.
-    ///
-    /// The name must be between 1 and 32 characters in length. The description
-    /// must be between 1 and 100 characters in length. Creating a command with
-    /// the same name as an already-existing global command will overwrite the
-    /// old command. See [the discord docs] for more information.
-    ///
-    /// # Errors
-    ///
-    /// Returns an [`InteractionErrorType::ApplicationIdNotPresent`]
-    /// error type if an application ID has not been configured via
-    /// [`Client::set_application_id`].
-    ///
-    /// Returns an [`InteractionErrorType::CommandNameValidationFailed`]
-    /// error type if the command name is not between 1 and 32 characters.
-    ///
-    /// Returns an [`InteractionErrorType::CommandDescriptionValidationFailed`]
-    /// error type if the command description is not between 1 and 100
-    /// characters.
-    ///
-    /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
-    #[deprecated(
-        note = "use `new_create_global_command`, which does not require a description",
-        since = "0.6.4"
-    )]
-    pub fn create_global_command<'a>(
-        &'a self,
-        name: &'a str,
-        description: &'a str,
-    ) -> Result<CreateGlobalChatInputCommand<'a>, InteractionError> {
-        let application_id = self.application_id().ok_or(InteractionError {
-            kind: InteractionErrorType::ApplicationIdNotPresent,
-        })?;
-
-        CreateGlobalCommand::new(self, application_id, name)?.chat_input(description)
-    }
-
     /// Create a new global command.
     ///
     /// The name must be between 1 and 32 characters in length. Creating a
@@ -2283,7 +2211,7 @@ impl Client {
     /// error type if the command name is not between 1 and 32 characters.
     ///
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
-    pub fn new_create_global_command<'a>(
+    pub fn create_global_command<'a>(
         &'a self,
         name: &'a str,
     ) -> Result<CreateGlobalCommand<'a>, InteractionError> {


### PR DESCRIPTION
Rename the `new_create_global_command` and `new_create_guild_command` methods to their proper counterparts.
