### PR TITLE
Update tokio-tungstenite to 0.15

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -20,7 +20,7 @@ futures-util = { default-features = false, features = ["std"], version = "0.3" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.5" }
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.14" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.15" }
 twilight-gateway-queue = { default-features = false, path = "queue" }
 twilight-http = { default-features = false, path = "../http" }
 twilight-model = { default-features = false, path = "../model" }

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -23,7 +23,7 @@ percent-encoding = { default-features = false, optional = true, version = "2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["macros", "net", "rt", "sync", "time"], version = "1.0" }
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.14" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.15" }
 twilight-model = { default-features = false, path = "../model" }
 
 [dev-dependencies]


### PR DESCRIPTION
This is a revive of #1028 as the parts for #1058 are yet to be published to crates.io.