### PR TITLE
fix(http): add missing `?` to get public archived threads route

### DIFF
--- a/http/src/routing/route_display.rs
+++ b/http/src/routing/route_display.rs
@@ -940,7 +940,7 @@ impl Display for RouteDisplay<'_> {
             } => {
                 f.write_str("channels/")?;
                 Display::fmt(channel_id, f)?;
-                f.write_str("/threads/archived/public")?;
+                f.write_str("/threads/archived/public?")?;
 
                 if let Some(before) = before {
                     f.write_str("before=")?;
@@ -1118,5 +1118,19 @@ mod tests {
         };
 
         assert_eq!("applications/1/commands/2", route.display().to_string());
+    }
+
+    #[test]
+    fn test_get_public_archived_threads() {
+        let route = Route::GetPublicArchivedThreads {
+            channel_id: 1,
+            before: Some("2021-01-01T00:00:00Z"),
+            limit: None,
+        };
+
+        assert_eq!(
+            "channels/1/threads/archived/public?before=2021-01-01T00:00:00Z",
+            route.display().to_string()
+        );
     }
 }


### PR DESCRIPTION
This PR adds a `?` after the route `/threads/archived/public` so using the `before` or `limit` parameters work instead of getting a 404.