### PR TITLE
refactor(model): improve `CommandDataOption` serde implementation

### DIFF
--- a/model/src/application/interaction/application_command/data/mod.rs
+++ b/model/src/application/interaction/application_command/data/mod.rs
@@ -130,9 +130,9 @@ struct CommandDataOptionEnvelope {
     name: String,
     #[serde(rename = "type")]
     kind: CommandOptionType,
-    value: Option<CommandOptionValueEnvelope>,
     #[serde(default)]
     options: Vec<CommandDataOption>,
+    value: Option<CommandOptionValueEnvelope>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/model/src/application/interaction/application_command/data/mod.rs
+++ b/model/src/application/interaction/application_command/data/mod.rs
@@ -7,11 +7,8 @@ use crate::{
     id::{ChannelId, CommandId, GenericId, RoleId, UserId},
 };
 use serde::{
-    de::{Error as DeError, Unexpected},
-    ser::SerializeStruct,
-    Deserialize, Deserializer, Serialize, Serializer,
+    de::Error as DeError, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::borrow::Cow;
 
 /// Data received when an [`ApplicationCommand`] interaction is executed.
 ///
@@ -43,164 +40,47 @@ pub struct CommandDataOption {
     pub value: CommandOptionValue,
 }
 
-/// Value of a [`CommandDataOption`].
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum CommandOptionValue {
-    String(String),
-    Integer(i64),
-    Boolean(bool),
-    User(UserId),
-    Channel(ChannelId),
-    Role(RoleId),
-    Mentionable(GenericId),
-    SubCommand(Vec<CommandDataOption>),
-    SubCommandGroup(Vec<CommandDataOption>),
-    Number(Number),
-}
-
-#[derive(Debug, Deserialize)]
-struct CommandDataOptionRaw<'a> {
-    name: String,
-    #[serde(rename = "type")]
-    kind: CommandOptionType,
-    value: Option<CommandOptionValueRaw<'a>>,
-    #[serde(default)]
-    options: Vec<CommandDataOption>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-enum CommandOptionValueRaw<'a> {
-    String(Cow<'a, str>),
-    Integer(i64),
-    Number(f64),
-    Boolean(bool),
-}
-
-impl Serialize for CommandDataOption {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let sub_command_is_empty = matches!(
-            &self.value,
-            CommandOptionValue::SubCommand(o)
-            | CommandOptionValue::SubCommandGroup(o)
-                if o.is_empty()
-        );
-
-        let len = if sub_command_is_empty { 2 } else { 3 };
-
-        let mut state = serializer.serialize_struct("CommandDataOptionRaw", len)?;
-
-        state.serialize_field("name", &self.name)?;
-
-        state.serialize_field("type", &self.value.kind())?;
-
-        match self.value {
-            CommandOptionValue::SubCommand(ref opts)
-            | CommandOptionValue::SubCommandGroup(ref opts) => {
-                if !sub_command_is_empty {
-                    state.serialize_field("options", &Some(opts))?
-                }
-            }
-            CommandOptionValue::String(ref value) => state
-                .serialize_field("value", &Some(CommandOptionValueRaw::String(value.into())))?,
-            CommandOptionValue::Integer(value) => {
-                state.serialize_field("value", &Some(CommandOptionValueRaw::Integer(value)))?
-            }
-            CommandOptionValue::Boolean(value) => {
-                state.serialize_field("value", &Some(CommandOptionValueRaw::Boolean(value)))?
-            }
-            CommandOptionValue::User(UserId(id))
-            | CommandOptionValue::Channel(ChannelId(id))
-            | CommandOptionValue::Role(RoleId(id))
-            | CommandOptionValue::Mentionable(GenericId(id)) => state.serialize_field(
-                "value",
-                &Some(CommandOptionValueRaw::String(id.to_string().into())),
-            )?,
-            CommandOptionValue::Number(value) => {
-                state.serialize_field("value", &Some(CommandOptionValueRaw::Number(value.0)))?
-            }
-        }
-        state.end()
-    }
-}
-
 impl<'de> Deserialize<'de> for CommandDataOption {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let raw = CommandDataOptionRaw::deserialize(deserializer)?;
-        let value =
-            if let Some(value) = raw.value {
-                match (raw.kind, value) {
-                    (CommandOptionType::String, CommandOptionValueRaw::String(s)) => {
-                        CommandOptionValue::String(s.into_owned())
-                    }
-                    (CommandOptionType::Integer, CommandOptionValueRaw::Integer(i)) => {
-                        CommandOptionValue::Integer(i)
-                    }
-                    (CommandOptionType::Boolean, CommandOptionValueRaw::Boolean(b)) => {
-                        CommandOptionValue::Boolean(b)
-                    }
-                    (CommandOptionType::User, CommandOptionValueRaw::String(s)) => {
-                        let id = UserId(s.parse().map_err(|_| {
-                            DeError::invalid_value(Unexpected::Str(&s), &"user ID")
-                        })?);
+        let raw = CommandDataOptionEnvelope::deserialize(deserializer)?;
 
-                        CommandOptionValue::User(id)
-                    }
-                    (CommandOptionType::Channel, CommandOptionValueRaw::String(s)) => {
-                        let id = ChannelId(s.parse().map_err(|_| {
-                            DeError::invalid_value(Unexpected::Str(&s), &"channel ID")
-                        })?);
+        let value = match (raw.kind, raw.value) {
+            (CommandOptionType::Boolean, Some(CommandOptionValueEnvelope::Boolean(b))) => {
+                CommandOptionValue::Boolean(b)
+            }
+            (CommandOptionType::Channel, Some(CommandOptionValueEnvelope::Id(i))) => {
+                CommandOptionValue::Channel(i.0.into())
+            }
+            (CommandOptionType::Integer, Some(CommandOptionValueEnvelope::Integer(i))) => {
+                CommandOptionValue::Integer(i)
+            }
+            (CommandOptionType::Mentionable, Some(CommandOptionValueEnvelope::Id(i))) => {
+                CommandOptionValue::Mentionable(i.0.into())
+            }
+            (CommandOptionType::Number, Some(CommandOptionValueEnvelope::Number(n))) => {
+                CommandOptionValue::Number(n)
+            }
+            (CommandOptionType::Role, Some(CommandOptionValueEnvelope::Id(i))) => {
+                CommandOptionValue::Role(i.0.into())
+            }
+            (CommandOptionType::String, Some(CommandOptionValueEnvelope::String(s))) => {
+                CommandOptionValue::String(s)
+            }
+            (CommandOptionType::SubCommand, _) => CommandOptionValue::SubCommand(raw.options),
+            (CommandOptionType::SubCommandGroup, _) => {
+                CommandOptionValue::SubCommandGroup(raw.options)
+            }
+            (CommandOptionType::User, Some(CommandOptionValueEnvelope::Id(i))) => {
+                CommandOptionValue::User(i.0.into())
+            }
+            (t, v) => {
+                return Err(DeError::custom(format!(
+                    "invalid value/type pair: value={:?} type={:?}",
+                    v, t
+                )));
+            }
+        };
 
-                        CommandOptionValue::Channel(id)
-                    }
-                    (CommandOptionType::Role, CommandOptionValueRaw::String(s)) => {
-                        let id = RoleId(s.parse().map_err(|_| {
-                            DeError::invalid_value(Unexpected::Str(&s), &"role ID")
-                        })?);
-
-                        CommandOptionValue::Role(id)
-                    }
-                    (CommandOptionType::Mentionable, CommandOptionValueRaw::String(s)) => {
-                        let id = GenericId(s.parse().map_err(|_| {
-                            DeError::invalid_value(Unexpected::Str(&s), &"snowflake ID")
-                        })?);
-
-                        CommandOptionValue::Mentionable(id)
-                    }
-                    (CommandOptionType::SubCommand | CommandOptionType::SubCommandGroup, _) => {
-                        return Err(DeError::custom(format!(
-                            "invalid option data: {:?} has value instead of options",
-                            raw.kind
-                        )));
-                    }
-                    (CommandOptionType::Number, CommandOptionValueRaw::String(s)) => {
-                        let value = s
-                            .parse::<f64>()
-                            .map_err(|_| DeError::invalid_value(Unexpected::Str(&s), &"number"))?;
-
-                        CommandOptionValue::Number(Number(value))
-                    }
-                    (kind, value) => {
-                        return Err(DeError::custom(format!(
-                            "invalid option value/type pair: value is {:?} but type is {:?}",
-                            value, kind,
-                        )));
-                    }
-                }
-            } else {
-                match raw.kind {
-                    CommandOptionType::SubCommand => CommandOptionValue::SubCommand(raw.options),
-                    CommandOptionType::SubCommandGroup => {
-                        CommandOptionValue::SubCommandGroup(raw.options)
-                    }
-                    kind => {
-                        return Err(DeError::custom(format!(
-                            "no `value` but type is {:?}",
-                            kind
-                        )))
-                    }
-                }
-            };
         Ok(CommandDataOption {
             name: raw.name,
             value,
@@ -208,19 +88,91 @@ impl<'de> Deserialize<'de> for CommandDataOption {
     }
 }
 
+impl Serialize for CommandDataOption {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let subcommand_is_empty = matches!(
+            &self.value,
+            CommandOptionValue::SubCommand(o)
+            | CommandOptionValue::SubCommandGroup(o)
+                if o.is_empty()
+        );
+
+        let len = 2 + !subcommand_is_empty as usize;
+
+        let mut state = serializer.serialize_struct("CommandDataOptionEnvelope", len)?;
+
+        state.serialize_field("name", &self.name)?;
+
+        state.serialize_field("type", &self.value.kind())?;
+
+        match &self.value {
+            CommandOptionValue::Boolean(b) => state.serialize_field("value", b)?,
+            CommandOptionValue::Channel(c) => state.serialize_field("value", c)?,
+            CommandOptionValue::Integer(i) => state.serialize_field("value", i)?,
+            CommandOptionValue::Mentionable(m) => state.serialize_field("value", m)?,
+            CommandOptionValue::Number(n) => state.serialize_field("value", n)?,
+            CommandOptionValue::Role(r) => state.serialize_field("value", r)?,
+            CommandOptionValue::String(s) => state.serialize_field("value", s)?,
+            CommandOptionValue::User(u) => state.serialize_field("value", u)?,
+            CommandOptionValue::SubCommand(s) | CommandOptionValue::SubCommandGroup(s) => {
+                if !subcommand_is_empty {
+                    state.serialize_field("options", s)?
+                }
+            }
+        }
+
+        state.end()
+    }
+}
+
+#[derive(Deserialize)]
+struct CommandDataOptionEnvelope {
+    name: String,
+    #[serde(rename = "type")]
+    kind: CommandOptionType,
+    value: Option<CommandOptionValueEnvelope>,
+    #[serde(default)]
+    options: Vec<CommandDataOption>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum CommandOptionValueEnvelope {
+    Boolean(bool),
+    Id(GenericId),
+    Integer(i64),
+    Number(Number),
+    String(String),
+}
+
+/// Value of a [`CommandDataOption`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CommandOptionValue {
+    Boolean(bool),
+    Channel(ChannelId),
+    Integer(i64),
+    Mentionable(GenericId),
+    Number(Number),
+    Role(RoleId),
+    String(String),
+    SubCommand(Vec<CommandDataOption>),
+    SubCommandGroup(Vec<CommandDataOption>),
+    User(UserId),
+}
+
 impl CommandOptionValue {
     pub const fn kind(&self) -> CommandOptionType {
         match self {
-            CommandOptionValue::String(_) => CommandOptionType::String,
-            CommandOptionValue::Integer(_) => CommandOptionType::Integer,
             CommandOptionValue::Boolean(_) => CommandOptionType::Boolean,
-            CommandOptionValue::User(_) => CommandOptionType::User,
             CommandOptionValue::Channel(_) => CommandOptionType::Channel,
-            CommandOptionValue::Role(_) => CommandOptionType::Role,
+            CommandOptionValue::Integer(_) => CommandOptionType::Integer,
             CommandOptionValue::Mentionable(_) => CommandOptionType::Mentionable,
+            CommandOptionValue::Number(_) => CommandOptionType::Number,
+            CommandOptionValue::Role(_) => CommandOptionType::Role,
+            CommandOptionValue::String(_) => CommandOptionType::String,
             CommandOptionValue::SubCommand(_) => CommandOptionType::SubCommand,
             CommandOptionValue::SubCommandGroup(_) => CommandOptionType::SubCommandGroup,
-            CommandOptionValue::Number(_) => CommandOptionType::Number,
+            CommandOptionValue::User(_) => CommandOptionType::User,
         }
     }
 }
@@ -264,7 +216,7 @@ mod tests {
                 Token::Str("options"),
                 Token::Seq { len: Some(1) },
                 Token::Struct {
-                    name: "CommandDataOptionRaw",
+                    name: "CommandDataOptionEnvelope",
                     len: 2,
                 },
                 Token::Str("name"),

--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -411,7 +411,7 @@ mod test {
                 Token::Str("options"),
                 Token::Seq { len: Some(1) },
                 Token::Struct {
-                    name: "CommandDataOptionRaw",
+                    name: "CommandDataOptionEnvelope",
                     len: 3,
                 },
                 Token::Str("name"),
@@ -419,7 +419,7 @@ mod test {
                 Token::Str("type"),
                 Token::U8(CommandOptionType::User as u8),
                 Token::Str("value"),
-                Token::Some,
+                Token::NewtypeStruct { name: "UserId" },
                 Token::Str("600"),
                 Token::StructEnd,
                 Token::SeqEnd,


### PR DESCRIPTION
The old implementation contained unnecessary code duplication and clones

~~depends on #1216~~