### PR TITLE
chore: fix some spelling errors

### DIFF
--- a/embed-builder/src/field.rs
+++ b/embed-builder/src/field.rs
@@ -18,10 +18,10 @@ impl EmbedFieldBuilder {
     /// Create a new default embed field builder.
     ///
     /// Refer to [`EmbedBuilder::FIELD_NAME_LENGTH_LIMIT`] for the maximum
-    /// number of UTF-16 code poitns that can be in a field name.
+    /// number of UTF-16 code points that can be in a field name.
     ///
     /// Refer to [`EmbedBuilder::FIELD_VALUE_LENGTH_LIMIT`] for the maximum
-    /// number of UTF-16 code poitns that can be in a field value.
+    /// number of UTF-16 code points that can be in a field value.
     ///
     /// [`EmbedBuilder::FIELD_NAME_LENGTH_LIMIT`]: crate::EmbedBuilder::FIELD_NAME_LENGTH_LIMIT
     /// [`EmbedBuilder::FIELD_VALUE_LENGTH_LIMIT`]: crate::EmbedBuilder::FIELD_VALUE_LENGTH_LIMIT

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -438,7 +438,7 @@ impl ShardProcessor {
                     });
                 };
 
-            // We can do a few little optimisation tricks here. For the
+            // We can do a few little optimization tricks here. For the
             // "heartbeat ack" and "reconnect" opcodes we can construct
             // the gateway events without needing to go through a serde
             // context.

--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -231,7 +231,7 @@ is now written like this:
 
 ```rust
 client.create_message(ChannelId(1))
-    .content(&"some conntent")?
+    .content(&"some content")?
     .embeds(&[&Embed {}])?
     .exec()
     .await?
@@ -759,7 +759,7 @@ if the referenced message does not exist ([#708] - [@7596ff]).
 
 ### Enhancements
 
-Update `simd-json` to 0.4 ([#786] - [@Gekbpunkt]).
+Update `simd-json` to 0.4 ([#786] - [@Gelbpunkt]).
 
 The `futures-channel` dependency has been removed ([#785] - [@Gelbpunkt]).
 
@@ -972,7 +972,7 @@ a proxy, which can be configured with a manual `hyper` client.
 
 `error::UrlError`'s `UrlParsing` variant has been removed as it can no longer
 occur. `error::Error`'s `BuildingClient` has been removed as building clients
-can no longer fail. All Weqwest errors are now `hyper` errors.
+can no longer fail. All Reqwest errors are now `hyper` errors.
 
 A couple of re-exports have been removed. Use
 `twilight_model::user::CurrentUserGuild` instead of

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -1264,7 +1264,7 @@ impl Client {
     /// Get a list of users that reacted to a message with an `emoji`.
     ///
     /// This endpoint is limited to 100 users maximum, so if a message has more than 100 reactions,
-    /// requests must be chained until all reactions are retireved.
+    /// requests must be chained until all reactions are retrieved.
     pub const fn reactions<'a>(
         &'a self,
         channel_id: ChannelId,
@@ -2643,7 +2643,7 @@ impl Client {
     /// # Errors
     ///
     /// Returns an [`ErrorType::Unauthorized`] error type if the configured
-    /// token has become invalid due to expiration, revokation, etc.
+    /// token has become invalid due to expiration, revocation, etc.
     ///
     /// [`Response`]: super::response::Response
     pub fn request<T>(&self, request: Request) -> ResponseFuture<T> {

--- a/http/src/ratelimiting/mod.rs
+++ b/http/src/ratelimiting/mod.rs
@@ -96,7 +96,7 @@ impl Ratelimiter {
         path: Path,
         tx: Sender<Sender<Option<RatelimitHeaders>>>,
     ) -> (Arc<Bucket>, bool) {
-        // nb: not realisically point of contention
+        // nb: not realistically point of contention
         let mut buckets = self.buckets.lock().expect("ratelimit buckets poisoned");
 
         match buckets.entry(path.clone()) {

--- a/http/src/request/application/interaction/create_followup_message.rs
+++ b/http/src/request/application/interaction/create_followup_message.rs
@@ -228,7 +228,7 @@ impl<'a> CreateFollowupMessage<'a> {
         Ok(self)
     }
 
-    /// The content of the webook's message.
+    /// The content of the webhook's message.
     ///
     /// Up to 2000 UTF-16 codepoints.
     pub const fn content(mut self, content: &'a str) -> Self {

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -73,7 +73,7 @@ pub enum RoleFieldsErrorType {
 pub struct RoleFieldsBuilder(RoleFields);
 
 impl RoleFieldsBuilder {
-    /// The maximumn accepted color value.
+    /// The maximum accepted color value.
     ///
     /// This is used by [`color`].
     ///

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -75,7 +75,7 @@ struct UpdateCurrentUserFields<'a> {
 /// Update the current user.
 ///
 /// All parameters are optional. If the username is changed, it may cause the discriminator to be
-/// rnadomized.
+/// randomized.
 #[must_use = "requests must be configured and executed"]
 pub struct UpdateCurrentUser<'a> {
     fields: UpdateCurrentUserFields<'a>,

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -1,6 +1,6 @@
 /// Contains all of the input validation functions for requests.
 ///
-/// This is in a centralised place so that the validation parameters can be kept
+/// This is in a centralized place so that the validation parameters can be kept
 /// up-to-date more easily and because some of the checks are re-used across
 /// different modules.
 use super::{application::InteractionError, guild::sticker::StickerValidationError};

--- a/lavalink/src/http.rs
+++ b/lavalink/src/http.rs
@@ -93,7 +93,7 @@ pub struct LoadedTracks {
 pub struct FailingAddress {
     /// The IP address.
     pub address: String,
-    /// The time that the address started failing in unixtime.
+    /// The time that the address started failing in unix time.
     pub failing_timestamp: u64,
     /// The time that the address started failing as a timestamp.
     pub failing_time: String,

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -55,7 +55,7 @@ struct Hello {
 }
 
 /// A deserializer that deserializes into a `GatewayEvent` by cloning some bits
-/// of scanned information before the actual deserialisation.
+/// of scanned information before the actual deserialization.
 ///
 /// This is the owned version of [`GatewayEventDeserializer`].
 ///
@@ -121,7 +121,7 @@ impl GatewayEventDeserializerOwned {
 }
 
 /// A deserializer that deserializes into a `GatewayEvent` by borrowing some bits
-/// of scanned information before the actual deserialisation.
+/// of scanned information before the actual deserialization.
 ///
 /// This is the borrowed version of [`GatewayEventDeserializerOwned`].
 ///
@@ -149,7 +149,7 @@ impl<'a> GatewayEventDeserializer<'a> {
     }
 
     /// Create a gateway event deserializer with some information found by
-    /// scanning the JSON payload to deserialise.
+    /// scanning the JSON payload to deserialize.
     ///
     /// This will scan the payload for the opcode and, optionally, event type if
     /// provided. The opcode key ("op"), must be in the payload while the event

--- a/model/src/gateway/event/mod.rs
+++ b/model/src/gateway/event/mod.rs
@@ -43,7 +43,7 @@ pub enum Event {
     GatewayHello(u64),
     /// A shard's session was invalidated.
     ///
-    /// `true` if resumeable. If not, then the shard must do a full reconnect.
+    /// `true` if resumable. If not, then the shard must do a full reconnect.
     GatewayInvalidateSession(bool),
     /// The gateway is indicating to perform a reconnect.
     GatewayReconnect,

--- a/model/src/gateway/payload/incoming/member_chunk.rs
+++ b/model/src/gateway/payload/incoming/member_chunk.rs
@@ -104,9 +104,9 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
                         return Err(DeError::duplicate_field("members"));
                     }
 
-                    // Since the guild ID may not be deserialised yet we'll use
+                    // Since the guild ID may not be deserialized yet we'll use
                     // a temporary placeholder value and update it with the real
-                    // guild ID after all the fields have been deserialised.
+                    // guild ID after all the fields have been deserialized.
                     let deserializer =
                         MemberListDeserializer::new(GuildId::new(1).expect("non zero"));
 

--- a/model/src/gateway/payload/incoming/voice_state_update.rs
+++ b/model/src/gateway/payload/incoming/voice_state_update.rs
@@ -204,7 +204,7 @@ mod tests {
             request_to_speak_timestamp: Some(request_to_speak_timestamp),
         });
 
-        // Token stream here's `Member` has no `guild_id`, which deserialiser
+        // Token stream here's `Member` has no `guild_id`, which deserializer
         // must add.
         // Lack of "guild_id" in real "member" means that de+ser does not
         // reproduce original input (assert only `de`).

--- a/model/src/gateway/session_start_limit.rs
+++ b/model/src/gateway/session_start_limit.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-/// Current gateway session utilisation status.
+/// Current gateway session utilization status.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct SessionStartLimit {
     /// Maximum number of session that may be started concurrently.

--- a/model/src/voice/close_code.rs
+++ b/model/src/voice/close_code.rs
@@ -34,7 +34,7 @@ pub enum CloseCode {
     Disconnected = 4014,
     /// The voice server crashed.
     VoiceServerCrashed = 4015,
-    /// The encryption could not be recognised.
+    /// The encryption could not be recognized.
     UnknownEncryptionMode = 4016,
 }
 


### PR DESCRIPTION
Some errors were in exposed types, so I have not fixed them on the `main` branch, as that would be a breaking change.
