### PR TITLE
Link to crates' crates.io links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,12 @@ functionality. Please use the individual crates listed below instead!
 
 Twilight supports a MSRV of Rust 1.53+.
 
-We recommend that most users start out with these crates added to your
-`Cargo.toml`'s `[dependencies]` section:
+We recommend that most users start out with these crates:
 
-```toml
-twilight-cache-inmemory = "0.4"
-twilight-gateway = "0.4"
-twilight-http = "0.4"
-twilight-model = "0.4"
-```
+- [`twilight-cache-inmemory`][crates:cache-inmemory]
+- [`twilight-gateway`][crates:gateway]
+- [`twilight-http`][crates:http]
+- [`twilight-model`][crates:model]
 
 If you need any other functionality that Twilight provides, you can just add
 that dependency in.
@@ -216,6 +213,10 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [Lavalink]: https://github.com/freyacodes/Lavalink
 [`http`]: https://crates.io/crates/http
+[crates:cache-inmemory]: https://crates.io/crates/twilight-cache-inmemory
+[crates:gateway]: https://crates.io/crates/twilight-gateway
+[crates:http]: https://crates.io/crates/twilight-http
+[crates:model]: https://crates.io/crates/twilight-model
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -18,15 +18,12 @@
 //!
 //! Twilight supports a MSRV of Rust 1.53+.
 //!
-//! We recommend that most users start out with these crates added to your
-//! `Cargo.toml`'s `[dependencies]` section:
+//! We recommend that most users start out with these crates:
 //!
-//! ```toml
-//! twilight-cache-inmemory = "0.4"
-//! twilight-gateway = "0.4"
-//! twilight-http = "0.4"
-//! twilight-model = "0.4"
-//! ```
+//! - [`twilight-cache-inmemory`][crates:cache-inmemory]
+//! - [`twilight-gateway`][crates:gateway]
+//! - [`twilight-http`][crates:http]
+//! - [`twilight-model`][crates:model]
 //!
 //! If you need any other functionality that Twilight provides, you can just add
 //! that dependency in.
@@ -216,6 +213,10 @@
 //! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [Lavalink]: https://github.com/freyacodes/Lavalink
 //! [`http`]: https://crates.io/crates/http
+//! [crates:cache-inmemory]: https://crates.io/crates/twilight-cache-inmemory
+//! [crates:gateway]: https://crates.io/crates/twilight-gateway
+//! [crates:http]: https://crates.io/crates/twilight-http
+//! [crates:model]: https://crates.io/crates/twilight-model
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding


### PR DESCRIPTION
Instead of specifying a `Cargo.toml` `[dependencies]` section with crates and their versions just use a bullet list linking to their crates.io links.

Closes #1152.