### PR TITLE
chore(model): Add `Command::version` field

### DIFF
--- a/http/src/request/application/command/mod.rs
+++ b/http/src/request/application/command/mod.rs
@@ -56,7 +56,7 @@ mod tests {
     use super::CommandBorrowed;
     use twilight_model::{
         application::command::{BaseCommandOptionData, Command, CommandOption, CommandType},
-        id::{ApplicationId, CommandId, GuildId},
+        id::{ApplicationId, CommandId, CommandVersionId, GuildId},
     };
 
     /// Test to convert a `Command` to a `CommandBorrowed`.
@@ -71,14 +71,15 @@ mod tests {
             default_permission: Some(true),
             description: "command description".to_owned(),
             guild_id: Some(GuildId::new(2).expect("non zero")),
+            id: Some(CommandId::new(3).expect("non zero")),
             kind: CommandType::ChatInput,
             name: "command name".to_owned(),
-            id: Some(CommandId::new(3).expect("non zero")),
             options: Vec::from([CommandOption::Boolean(BaseCommandOptionData {
                 description: "command description".to_owned(),
                 name: "command name".to_owned(),
                 required: true,
             })]),
+            version: CommandVersionId::new(1).expect("non zero"),
         };
 
         let _ = CommandBorrowed {

--- a/model/src/application/command/mod.rs
+++ b/model/src/application/command/mod.rs
@@ -13,7 +13,7 @@ pub use self::{
     },
 };
 
-use crate::id::{ApplicationId, CommandId, GuildId};
+use crate::id::{ApplicationId, CommandId, CommandVersionId, GuildId};
 use serde::{Deserialize, Serialize};
 
 /// Data sent to discord to create a command.
@@ -31,10 +31,6 @@ use serde::{Deserialize, Serialize};
 pub struct Command {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub application_id: Option<ApplicationId>,
-    /// Guild ID of the command, if not global.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub guild_id: Option<GuildId>,
-    pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_permission: Option<bool>,
     /// Description of the command.
@@ -44,10 +40,16 @@ pub struct Command {
     /// [`User`]: CommandType::User
     /// [`Message`]: CommandType::Message
     pub description: String,
+    /// Guild ID of the command, if not global.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guild_id: Option<GuildId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<CommandId>,
     #[serde(rename = "type")]
     pub kind: CommandType,
+    pub name: String,
     #[serde(default)]
     pub options: Vec<CommandOption>,
+    /// Autoincrementing version identifier.
+    pub version: CommandVersionId,
 }

--- a/model/src/application/command/option.rs
+++ b/model/src/application/command/option.rs
@@ -485,7 +485,7 @@ mod tests {
     };
     use crate::{
         channel::ChannelType,
-        id::{ApplicationId, CommandId, GuildId},
+        id::{ApplicationId, CommandId, CommandVersionId, GuildId},
     };
     use serde::{Deserialize, Serialize};
     use serde_test::Token;
@@ -539,12 +539,12 @@ mod tests {
     fn test_command_option_full() {
         let value = Command {
             application_id: Some(ApplicationId::new(100).expect("non zero")),
-            guild_id: Some(GuildId::new(300).expect("non zero")),
-            kind: CommandType::ChatInput,
-            name: "test command".into(),
             default_permission: Some(true),
             description: "this command is a test".into(),
+            guild_id: Some(GuildId::new(300).expect("non zero")),
             id: Some(CommandId::new(200).expect("non zero")),
+            kind: CommandType::ChatInput,
+            name: "test command".into(),
             options: vec![CommandOption::SubCommandGroup(OptionsCommandOptionData {
                 description: "sub group desc".into(),
                 name: "sub group name".into(),
@@ -614,6 +614,7 @@ mod tests {
                     ],
                 })],
             })],
+            version: CommandVersionId::new(1).expect("non zero"),
         };
 
         serde_test::assert_tokens(
@@ -621,7 +622,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Command",
-                    len: 8,
+                    len: 9,
                 },
                 Token::Str("application_id"),
                 Token::Some,
@@ -629,23 +630,23 @@ mod tests {
                     name: "ApplicationId",
                 },
                 Token::Str("100"),
-                Token::Str("guild_id"),
-                Token::Some,
-                Token::NewtypeStruct { name: "GuildId" },
-                Token::Str("300"),
-                Token::Str("name"),
-                Token::Str("test command"),
                 Token::Str("default_permission"),
                 Token::Some,
                 Token::Bool(true),
                 Token::Str("description"),
                 Token::Str("this command is a test"),
+                Token::Str("guild_id"),
+                Token::Some,
+                Token::NewtypeStruct { name: "GuildId" },
+                Token::Str("300"),
                 Token::Str("id"),
                 Token::Some,
                 Token::NewtypeStruct { name: "CommandId" },
                 Token::Str("200"),
                 Token::Str("type"),
                 Token::U8(1),
+                Token::Str("name"),
+                Token::Str("test command"),
                 Token::Str("options"),
                 Token::Seq { len: Some(1) },
                 Token::Struct {
@@ -827,6 +828,11 @@ mod tests {
                 Token::U8(2),
                 Token::StructEnd,
                 Token::SeqEnd,
+                Token::Str("version"),
+                Token::NewtypeStruct {
+                    name: "CommandVersionId",
+                },
+                Token::Str("1"),
                 Token::StructEnd,
             ],
         );

--- a/model/src/id.rs
+++ b/model/src/id.rs
@@ -309,6 +309,56 @@ impl From<NonZeroU64> for CommandId {
     }
 }
 
+/// Unique version ID of a command.
+#[allow(clippy::unsafe_derive_deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct CommandVersionId(#[serde(with = "string")] pub NonZeroU64);
+
+impl CommandVersionId {
+    /// Create a non-zero command version ID without checking the value.
+    ///
+    /// Equivalent to [`NonZeroU64::new_unchecked`].
+    ///
+    /// # Safety
+    ///
+    /// The value must not be zero.
+    #[allow(unsafe_code)]
+    pub const unsafe fn new_unchecked(n: u64) -> Self {
+        Self(NonZeroU64::new_unchecked(n))
+    }
+
+    /// Create a non-zero command version ID if the given value is not zero.
+    ///
+    /// Equivalent to [`NonZeroU64::new`].
+    pub const fn new(n: u64) -> Option<Self> {
+        #[allow(clippy::option_if_let_else)]
+        if let Some(n) = NonZeroU64::new(n) {
+            Some(Self(n))
+        } else {
+            None
+        }
+    }
+
+    /// Return the inner primitive value.
+    ///
+    /// Equivalent to [`NonZeroU64::get`].
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl Display for CommandVersionId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl From<NonZeroU64> for CommandVersionId {
+    fn from(id: NonZeroU64) -> Self {
+        CommandVersionId(id)
+    }
+}
+
 /// Unique ID of an emoji.
 #[allow(clippy::unsafe_derive_deserialize)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -812,8 +862,9 @@ impl From<NonZeroU64> for WebhookId {
 #[cfg(test)]
 mod tests {
     use super::{
-        ApplicationId, AttachmentId, AuditLogEntryId, ChannelId, CommandId, EmojiId, GenericId,
-        GuildId, IntegrationId, InteractionId, MessageId, RoleId, StageId, UserId, WebhookId,
+        ApplicationId, AttachmentId, AuditLogEntryId, ChannelId, CommandId, CommandVersionId,
+        EmojiId, GenericId, GuildId, IntegrationId, InteractionId, MessageId, RoleId, StageId,
+        UserId, WebhookId,
     };
     use serde_test::Token;
 
@@ -899,6 +950,24 @@ mod tests {
             &CommandId::new(114_941_315_417_899_012).expect("non zero"),
             &[
                 Token::NewtypeStruct { name: "CommandId" },
+                Token::U64(114_941_315_417_899_012),
+            ],
+        );
+        serde_test::assert_tokens(
+            &CommandVersionId::new(114_941_315_417_899_012).expect("non zero"),
+            &[
+                Token::NewtypeStruct {
+                    name: "CommandVersionId",
+                },
+                Token::Str("114941315417899012"),
+            ],
+        );
+        serde_test::assert_de_tokens(
+            &CommandVersionId::new(114_941_315_417_899_012).expect("non zero"),
+            &[
+                Token::NewtypeStruct {
+                    name: "CommandVersionId",
+                },
                 Token::U64(114_941_315_417_899_012),
             ],
         );

--- a/util/src/builder/command.rs
+++ b/util/src/builder/command.rs
@@ -32,7 +32,7 @@ use twilight_model::{
         CommandOption, CommandOptionChoice, CommandType, Number, OptionsCommandOptionData,
     },
     channel::ChannelType,
-    id::{ApplicationId, CommandId, GuildId},
+    id::{ApplicationId, CommandId, CommandVersionId, GuildId},
 };
 
 /// Builder to create a [`Command`].
@@ -44,7 +44,7 @@ pub struct CommandBuilder(Command);
 impl CommandBuilder {
     /// Create a new default [`Command`] builder.
     #[must_use = "builders have no effect if unused"]
-    pub const fn new(name: String, description: String, kind: CommandType) -> Self {
+    pub fn new(name: String, description: String, kind: CommandType) -> Self {
         Self(Command {
             application_id: None,
             default_permission: None,
@@ -54,6 +54,7 @@ impl CommandBuilder {
             kind,
             name,
             options: Vec::new(),
+            version: CommandVersionId::new(1).expect("non zero"),
         })
     }
 
@@ -661,15 +662,15 @@ mod tests {
             default_permission: None,
             description: String::from("Get or edit permissions for a user or a role"),
             id: None,
-            options: vec![
+            options: Vec::from([
                 CommandOption::SubCommandGroup(OptionsCommandOptionData {
                     description: String::from("Get or edit permissions for a user"),
                     name: String::from("user"),
-                    options: vec![
+                    options: Vec::from([
                         CommandOption::SubCommand(OptionsCommandOptionData {
                             description: String::from("Get permissions for a user"),
                             name: String::from("get"),
-                            options: vec![
+                            options: Vec::from([
                                 CommandOption::User(BaseCommandOptionData {
                                     description: String::from("The user to get"),
                                     name: String::from("user"),
@@ -684,12 +685,12 @@ mod tests {
                                     name: String::from("channel"),
                                     required: false,
                                 }),
-                            ],
+                            ]),
                         }),
                         CommandOption::SubCommand(OptionsCommandOptionData {
                             description: String::from("Edit permissions for a user"),
                             name: String::from("edit"),
-                            options: vec![
+                            options: Vec::from([
                                 CommandOption::User(BaseCommandOptionData {
                                     description: String::from("The user to edit"),
                                     name: String::from("user"),
@@ -704,18 +705,18 @@ mod tests {
                                     name: String::from("channel"),
                                     required: false,
                                 }),
-                            ],
+                            ]),
                         }),
-                    ],
+                    ]),
                 }),
                 CommandOption::SubCommandGroup(OptionsCommandOptionData {
                     description: String::from("Get or edit permissions for a role"),
                     name: String::from("role"),
-                    options: vec![
+                    options: Vec::from([
                         CommandOption::SubCommand(OptionsCommandOptionData {
                             description: String::from("Get permissions for a role"),
                             name: String::from("get"),
-                            options: vec![
+                            options: Vec::from([
                                 CommandOption::Role(BaseCommandOptionData {
                                     description: String::from("The role to get"),
                                     name: String::from("role"),
@@ -730,12 +731,12 @@ mod tests {
                                     name: String::from("channel"),
                                     required: false,
                                 }),
-                            ],
+                            ]),
                         }),
                         CommandOption::SubCommand(OptionsCommandOptionData {
                             description: String::from("Edit permissions for a role"),
                             name: String::from("edit"),
-                            options: vec![
+                            options: Vec::from([
                                 CommandOption::Role(BaseCommandOptionData {
                                     description: String::from("The role to edit"),
                                     name: String::from("role"),
@@ -756,11 +757,12 @@ mod tests {
                                     name: String::from("position"),
                                     required: false,
                                 }),
-                            ],
+                            ]),
                         }),
-                    ],
+                    ]),
                 }),
-            ],
+            ]),
+            version: CommandVersionId::new(1).expect("non zero"),
         };
 
         assert_eq!(command, command_manual);


### PR DESCRIPTION
Also adds a `CommandVersionId` identifier.

Closes #1172