### PR TITLE
chore(util/builder): `CommandBuilder` remove unnecessary options

### DIFF
--- a/util/src/builder/command.rs
+++ b/util/src/builder/command.rs
@@ -32,7 +32,7 @@ use twilight_model::{
         CommandOption, CommandOptionChoice, CommandType, Number, OptionsCommandOptionData,
     },
     channel::ChannelType,
-    id::{ApplicationId, CommandId, GuildId},
+    id::GuildId,
 };
 
 /// Builder to create a [`Command`].
@@ -64,15 +64,6 @@ impl CommandBuilder {
         self.0
     }
 
-    /// Set the application ID of the command.
-    ///
-    /// Defaults to [`None`].
-    pub const fn application_id(mut self, application_id: ApplicationId) -> Self {
-        self.0.application_id = Some(application_id);
-
-        self
-    }
-
     /// Set the guild ID of the command.
     ///
     /// Defaults to [`None`].
@@ -87,15 +78,6 @@ impl CommandBuilder {
     /// Defaults to [`None`].
     pub const fn default_permission(mut self, default_permission: bool) -> Self {
         self.0.default_permission = Some(default_permission);
-
-        self
-    }
-
-    /// Set the ID of the command.
-    ///
-    /// Defaults to [`None`].
-    pub const fn id(mut self, id: CommandId) -> Self {
-        self.0.id = Some(id);
 
         self
     }
@@ -228,7 +210,7 @@ impl IntegerBuilder {
     /// Set the list of choices for an option.
     ///
     /// Accepts tuples of `(String, i64)` corresponding to the name and value.
-
+    ///
     /// Defaults to no choices.
     pub fn choices(mut self, choices: impl IntoIterator<Item = (String, i64)>) -> Self {
         self.0.choices = choices
@@ -509,11 +491,11 @@ impl SubCommandGroupBuilder {
         CommandOption::SubCommandGroup(self.0)
     }
 
-    /// Add a sub command option to the sub command group.
+    /// Set the list of sub commands to the group.
     ///
-    /// Defaults to an empty list.
-    pub fn option(mut self, option: SubCommandBuilder) -> Self {
-        self.0.options.push(option.into());
+    /// Defaults to no subcommands.
+    pub fn subcommands(mut self, subcommands: impl IntoIterator<Item = SubCommandBuilder>) -> Self {
+        self.0.options = subcommands.into_iter().map(Into::into).collect();
 
         self
     }
@@ -591,7 +573,7 @@ mod tests {
         )
         .option(
             SubCommandGroupBuilder::new("user".into(), "Get or edit permissions for a user".into())
-                .option(
+                .subcommands([
                     SubCommandBuilder::new("get".into(), "Get permissions for a user".into())
                         .option(
                             UserBuilder::new("user".into(), "The user to get".into())
@@ -603,8 +585,6 @@ mod tests {
                              will be returned"
                                 .into(),
                         )),
-                )
-                .option(
                     SubCommandBuilder::new("edit".into(), "Edit permissions for a user".into())
                         .option(
                             UserBuilder::new("user".into(), "The user to edit".into())
@@ -616,11 +596,11 @@ mod tests {
                              will be edited"
                                 .into(),
                         )),
-                ),
+                ]),
         )
         .option(
             SubCommandGroupBuilder::new("role".into(), "Get or edit permissions for a role".into())
-                .option(
+                .subcommands([
                     SubCommandBuilder::new("get".into(), "Get permissions for a role".into())
                         .option(
                             RoleBuilder::new("role".into(), "The role to get".into())
@@ -632,8 +612,6 @@ mod tests {
                              will be returned"
                                 .into(),
                         )),
-                )
-                .option(
                     SubCommandBuilder::new("edit".into(), "Edit permissions for a role".into())
                         .option(
                             RoleBuilder::new("role".into(), "The role to edit".into())
@@ -649,7 +627,7 @@ mod tests {
                             "position".into(),
                             "The position of the new role".into(),
                         )),
-                ),
+                ]),
         )
         .build();
 


### PR DESCRIPTION
These options are not meant to be sent to Discord so there's no need to customize them.

Also renames the `SubCommandGroupBuilder::options` method -> `subcommands` to better communicate that there's only one valid option.