### PR TITLE
fix(model): account for the `type` of `CommandDataOption` in deserialization

### DIFF
--- a/model/src/application/interaction/application_command/data/mod.rs
+++ b/model/src/application/interaction/application_command/data/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     id::{ChannelId, CommandId, GenericId, RoleId, UserId},
 };
 use serde::{
-    de::{Error as DeError, IgnoredAny, MapAccess, Visitor},
+    de::{Error as DeError, IgnoredAny, MapAccess, Unexpected, Visitor},
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
@@ -182,23 +182,22 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         if let ValueEnvelope::Boolean(b) = val {
                             CommandOptionValue::Boolean(b)
                         } else {
-                            return Err(DeError::custom(&format!(
-                                "expected boolean got {:?}",
-                                val
-                            )));
+                            return Err(DeError::invalid_type(
+                                Unexpected::Other(&format!("{:?}", val)),
+                                &"boolean",
+                            ));
                         }
                     }
                     CommandOptionType::Channel => {
                         let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
-                        match val {
-                            ValueEnvelope::Id(id) => CommandOptionValue::Channel(ChannelId(id.0)),
-                            other => {
-                                return Err(DeError::custom(&format!(
-                                    "expected id got {:?}",
-                                    other
-                                )));
-                            }
+                        if let ValueEnvelope::Id(id) = val {
+                            CommandOptionValue::Channel(ChannelId(id.0))
+                        } else {
+                            return Err(DeError::invalid_type(
+                                Unexpected::Other(&format!("{:?}", val)),
+                                &"channel id",
+                            ));
                         }
                     }
                     CommandOptionType::Integer => {
@@ -207,23 +206,22 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         if let ValueEnvelope::Integer(i) = val {
                             CommandOptionValue::Integer(i)
                         } else {
-                            return Err(DeError::custom(&format!(
-                                "expected integer got {:?}",
-                                val
-                            )));
+                            return Err(DeError::invalid_type(
+                                Unexpected::Other(&format!("{:?}", val)),
+                                &"integer",
+                            ));
                         }
                     }
                     CommandOptionType::Mentionable => {
                         let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
-                        match val {
-                            ValueEnvelope::Id(id) => CommandOptionValue::Mentionable(id),
-                            other => {
-                                return Err(DeError::custom(&format!(
-                                    "expected id got {:?}",
-                                    other
-                                )));
-                            }
+                        if let ValueEnvelope::Id(id) = val {
+                            CommandOptionValue::Mentionable(id)
+                        } else {
+                            return Err(DeError::invalid_type(
+                                Unexpected::Other(&format!("{:?}", val)),
+                                &"mentionable id",
+                            ));
                         }
                     }
                     CommandOptionType::Number => {
@@ -240,27 +238,27 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                                 CommandOptionValue::Number(Number(i as f64))
                             }
                             ValueEnvelope::Number(f) => CommandOptionValue::Number(Number(f)),
-                            _ => {
-                                return Err(DeError::custom(&format!(
-                                    "expected double got {:?}",
-                                    val
-                                )));
+                            other => {
+                                return Err(DeError::invalid_type(
+                                    Unexpected::Other(&format!("{:?}", other)),
+                                    &"number",
+                                ));
                             }
                         }
                     }
                     CommandOptionType::Role => {
                         let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
-                        match val {
-                            ValueEnvelope::Id(id) => CommandOptionValue::Role(RoleId(id.0)),
-                            other => {
-                                return Err(DeError::custom(&format!(
-                                    "expected id got {:?}",
-                                    other
-                                )));
-                            }
+                        if let ValueEnvelope::Id(id) = val {
+                            CommandOptionValue::Role(RoleId(id.0))
+                        } else {
+                            return Err(DeError::invalid_type(
+                                Unexpected::Other(&format!("{:?}", val)),
+                                &"role id",
+                            ));
                         }
                     }
+
                     CommandOptionType::String => {
                         let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
@@ -270,10 +268,10 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                                 CommandOptionValue::String(id.get().to_string())
                             }
                             other => {
-                                return Err(DeError::custom(&format!(
-                                    "expected string got {:?}",
-                                    other
-                                )));
+                                return Err(DeError::invalid_type(
+                                    Unexpected::Other(&format!("{:?}", other)),
+                                    &"string",
+                                ));
                             }
                         }
                     }
@@ -284,14 +282,13 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                     CommandOptionType::User => {
                         let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
-                        match val {
-                            ValueEnvelope::Id(id) => CommandOptionValue::User(UserId(id.0)),
-                            other => {
-                                return Err(DeError::custom(&format!(
-                                    "expected integer got {:?}",
-                                    other
-                                )));
-                            }
+                        if let ValueEnvelope::Id(id) = val {
+                            CommandOptionValue::User(UserId(id.0))
+                        } else {
+                            return Err(DeError::invalid_type(
+                                Unexpected::Other(&format!("{:?}", val)),
+                                &"user id",
+                            ));
                         }
                     }
                 };

--- a/model/src/application/interaction/application_command/data/mod.rs
+++ b/model/src/application/interaction/application_command/data/mod.rs
@@ -122,10 +122,10 @@ impl<'de> Deserialize<'de> for CommandDataOption {
             where
                 A: MapAccess<'de>,
             {
-                let mut name_opt: Option<String> = None;
-                let mut kind_opt: Option<CommandOptionType> = None;
-                let mut options: Vec<CommandDataOption> = Vec::new();
-                let mut value_opt: Option<ValueEnvelope> = None;
+                let mut name_opt = None;
+                let mut kind_opt = None;
+                let mut options = Vec::new();
+                let mut value_opt = None;
 
                 loop {
                     let key = match map.next_key() {

--- a/model/src/application/interaction/application_command/data/mod.rs
+++ b/model/src/application/interaction/application_command/data/mod.rs
@@ -245,11 +245,11 @@ impl<'de> Deserialize<'de> for CommandDataOption {
 
                         match val {
                             ValueEnvelope::Integer(i) => {
-                                // As json may sometime send floating
+                                // As json allows sending floating
                                 // points without the tailing decimals
-                                // it may be intepreted as a integer
+                                // it may be interpreted as a integer
                                 // but it is safe to cast as there can
-                                // not occour any loss.
+                                // not occur any loss.
                                 #[allow(clippy::cast_precision_loss)]
                                 CommandOptionValue::Number(Number(i as f64))
                             }

--- a/model/src/application/interaction/application_command/data/mod.rs
+++ b/model/src/application/interaction/application_command/data/mod.rs
@@ -82,10 +82,7 @@ impl Serialize for CommandDataOption {
 
 impl<'de> Deserialize<'de> for CommandDataOption {
     #[allow(clippy::too_many_lines)]
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Debug, Deserialize)]
         #[serde(field_identifier, rename_all = "snake_case")]
         enum Fields {
@@ -118,10 +115,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
             }
 
             #[allow(clippy::too_many_lines)]
-            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-            where
-                A: MapAccess<'de>,
-            {
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
                 let mut name_opt = None;
                 let mut kind_opt = None;
                 let mut options = Vec::new();

--- a/model/src/application/interaction/application_command/data/mod.rs
+++ b/model/src/application/interaction/application_command/data/mod.rs
@@ -105,6 +105,16 @@ impl<'de> Deserialize<'de> for CommandDataOption {
             String(String),
         }
 
+        fn make_unexpected(unexpected: &ValueEnvelope) -> Unexpected<'_> {
+            match unexpected {
+                ValueEnvelope::Boolean(b) => Unexpected::Bool(*b),
+                ValueEnvelope::Integer(i) => Unexpected::Signed(*i),
+                ValueEnvelope::Number(f) => Unexpected::Float(*f),
+                ValueEnvelope::Id(_id) => Unexpected::Other("ID"),
+                ValueEnvelope::String(s) => Unexpected::Str(&s),
+            }
+        }
+
         struct CommandDataOptionVisitor;
 
         impl<'de> Visitor<'de> for CommandDataOptionVisitor {
@@ -176,10 +186,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         if let ValueEnvelope::Boolean(b) = val {
                             CommandOptionValue::Boolean(b)
                         } else {
-                            return Err(DeError::invalid_type(
-                                Unexpected::Other(&format!("{:?}", val)),
-                                &"boolean",
-                            ));
+                            return Err(DeError::invalid_type(make_unexpected(&val), &"boolean"));
                         }
                     }
                     CommandOptionType::Channel => {
@@ -189,7 +196,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             CommandOptionValue::Channel(ChannelId(id.0))
                         } else {
                             return Err(DeError::invalid_type(
-                                Unexpected::Other(&format!("{:?}", val)),
+                                make_unexpected(&val),
                                 &"channel id",
                             ));
                         }
@@ -200,10 +207,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         if let ValueEnvelope::Integer(i) = val {
                             CommandOptionValue::Integer(i)
                         } else {
-                            return Err(DeError::invalid_type(
-                                Unexpected::Other(&format!("{:?}", val)),
-                                &"integer",
-                            ));
+                            return Err(DeError::invalid_type(make_unexpected(&val), &"integer"));
                         }
                     }
                     CommandOptionType::Mentionable => {
@@ -213,7 +217,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             CommandOptionValue::Mentionable(id)
                         } else {
                             return Err(DeError::invalid_type(
-                                Unexpected::Other(&format!("{:?}", val)),
+                                make_unexpected(&val),
                                 &"mentionable id",
                             ));
                         }
@@ -234,7 +238,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             ValueEnvelope::Number(f) => CommandOptionValue::Number(Number(f)),
                             other => {
                                 return Err(DeError::invalid_type(
-                                    Unexpected::Other(&format!("{:?}", other)),
+                                    make_unexpected(&other),
                                     &"number",
                                 ));
                             }
@@ -246,10 +250,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         if let ValueEnvelope::Id(id) = val {
                             CommandOptionValue::Role(RoleId(id.0))
                         } else {
-                            return Err(DeError::invalid_type(
-                                Unexpected::Other(&format!("{:?}", val)),
-                                &"role id",
-                            ));
+                            return Err(DeError::invalid_type(make_unexpected(&val), &"role id"));
                         }
                     }
 
@@ -263,7 +264,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             }
                             other => {
                                 return Err(DeError::invalid_type(
-                                    Unexpected::Other(&format!("{:?}", other)),
+                                    make_unexpected(&other),
                                     &"string",
                                 ));
                             }
@@ -279,10 +280,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         if let ValueEnvelope::Id(id) = val {
                             CommandOptionValue::User(UserId(id.0))
                         } else {
-                            return Err(DeError::invalid_type(
-                                Unexpected::Other(&format!("{:?}", val)),
-                                &"user id",
-                            ));
+                            return Err(DeError::invalid_type(make_unexpected(&val), &"user id"));
                         }
                     }
                 };

--- a/model/src/application/interaction/application_command/data/mod.rs
+++ b/model/src/application/interaction/application_command/data/mod.rs
@@ -111,7 +111,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                 ValueEnvelope::Integer(i) => Unexpected::Signed(*i),
                 ValueEnvelope::Number(f) => Unexpected::Float(*f),
                 ValueEnvelope::Id(_id) => Unexpected::Other("ID"),
-                ValueEnvelope::String(s) => Unexpected::Str(&s),
+                ValueEnvelope::String(s) => Unexpected::Str(s),
             }
         }
 

--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -411,7 +411,7 @@ mod test {
                 Token::Str("options"),
                 Token::Seq { len: Some(1) },
                 Token::Struct {
-                    name: "CommandDataOptionEnvelope",
+                    name: "CommandDataOption",
                     len: 3,
                 },
                 Token::Str("name"),


### PR DESCRIPTION
Because the json doubles sent by discord sometimes seems to be without
trailing decimals (eg `5.0` was sent as `5`) it would sometimes cause
the deserialzation to fail. This pr rewrites the deserialzation of
`CommandDataOption` to look at the type of the value when
deserialzation happens so it will convert `5` to a double iff the type
is a `Number`.