### PR TITLE
fix(lavalink): reconfigure default features

### DIFF
--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -17,14 +17,16 @@ version = "0.7.1"
 [dependencies]
 dashmap = { default-features = false, version = "4.0" }
 futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }
-http = { default-features = false, optional = true, version = "0.2" }
+http = { default-features = false, version = "0.2" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
-percent-encoding = { default-features = false, optional = true, version = "2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["macros", "net", "rt", "sync", "time"], version = "1.0" }
 tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.14" }
 twilight-model = { default-features = false, path = "../model" }
+
+# Optional dependencies.
+percent-encoding = { default-features = false, optional = true, version = "2" }
 
 [dev-dependencies]
 serde_test = { default-features = false, version = "1" }
@@ -35,6 +37,6 @@ twilight-http = { default-features = false, features = ["rustls"], path = "../ht
 
 [features]
 default = ["http-support", "rustls"]
-http-support = ["http", "percent-encoding"]
+http-support = ["percent-encoding"]
 native = ["tokio-tungstenite/native-tls"]
 rustls = ["tokio-tungstenite/rustls-tls"]

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -126,7 +126,7 @@ pub mod model;
 pub mod node;
 pub mod player;
 
-#[cfg(feature = "http")]
+#[cfg(feature = "http-support")]
 pub mod http;
 
 pub use self::{client::Lavalink, node::Node, player::PlayerManager};


### PR DESCRIPTION
Promotes `http` to a required dependency. Changes the feature tag on the `http` module definition so that it is correctly enabled with its feature.

Fixes #1222.
