### PR TITLE
feat: tarpaulin coverage action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Collect coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '--ignore-tests --workspace --all-features ${{ steps.excluded-examples.out }}'
+          args: '--ignore-tests --workspace ${{ steps.excluded-examples.out }}'
 
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,16 +114,15 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set excluded examples
-        run: |
-          exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
-
-      - name: Echo excluded examples (THIS IS A TEST)
-        run: echo "${exclude_examples[@]}"
+        id: excluded-examples
+        run: echo "::set-output name=out::$(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}')"
+        # run: |
+        #   exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
 
       - name: Collect coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '--workspace --all-features "${exclude_examples[@]}"'
+          args: '--ignore-tests --workspace --all-features ${{ steps.excluded-examples.out }}'
 
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,8 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           args: '--ignore-tests --workspace --all-features ${{ steps.excluded-examples.outputs.out }}'
+        env:
+          RUSTFLAGS: "-C target-cpu=haswell"
 
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Set excluded examples
         id: excluded-examples
-        run: echo "::set-output name=out::$(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}')"
+        run: echo "::set-output name=out::$(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' printf '--exclude {}')"
         # run: |
         #   exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,8 +107,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     # Don't wanna collect coverage if tests failed
-    # This commented out is temporary (don't merge until it's fixed)
-    # needs: test
+    needs: test
 
     steps:
       - name: Checkout sources
@@ -117,17 +116,14 @@ jobs:
       - name: Set excluded examples
         id: excluded-examples
         run: echo "::set-output name=out::$(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' printf '--exclude {} ')"
-        # run: |
-        #   exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
-
-      - name: Check exclusions
-        run: echo ${{ steps.excluded-examples.outputs.out }}
 
       - name: Collect coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
           args: '--ignore-tests --workspace --all-features ${{ steps.excluded-examples.outputs.out }}'
         env:
+          # Use `haswell` instead of `native` due to some GitHub Actions
+          # runners not supporting some `avx512` instructions.
           RUSTFLAGS: "-C target-cpu=haswell"
 
       - name: Upload coverage to codecov.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Set excluded examples
         id: excluded-examples
-        run: echo "::set-output name=out::$(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' printf '--exclude {}')"
+        run: echo "::set-output name=out::$(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' printf '--exclude {} ')"
         # run: |
         #   exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Set excluded examples
         id: excluded-examples
-        run: echo "::set-output name=out::$(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' printf '--exclude {} ')"
+        run: echo "::set-output name=out::$(grep -h '^name' examples/*/Cargo.toml | cut -d \" -f2 | xargs -I '{}' printf '--exclude {} ')"
 
       - name: Collect coverage
         uses: actions-rs/tarpaulin@v0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,12 +121,12 @@ jobs:
         #   exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
 
       - name: Check exclusions
-        run: echo ${{ steps.excluded-examples.out }}
+        run: echo ${{ steps.excluded-examples.outputs.out }}
 
       - name: Collect coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '--ignore-tests --workspace ${{ steps.excluded-examples.out }}'
+          args: '--ignore-tests --workspace ${{ steps.excluded-examples.outputs.out }}'
 
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Collect coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '--ignore-tests --workspace ${{ steps.excluded-examples.outputs.out }}'
+          args: '--ignore-tests --workspace --all-features ${{ steps.excluded-examples.outputs.out }}'
 
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,20 +107,23 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     # Don't wanna collect coverage if tests failed
-    needs: [test, test-features]
+    needs: test
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Set excluded examples/
+      - name: Set excluded examples
         run: |
           exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
 
       - name: Collect coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '-- "${exclude_examples[@]}"'
+          args: '-- --workspace --all-features "${exclude_examples[@]}"'
+
+      - name: Upload coverage to codecov.io
+        uses: codecov/codecov-action@v2
 
       - name: Upload coverage to GitHub
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,8 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     # Don't wanna collect coverage if tests failed
-    needs: test
+    # This commented out is temporary (don't merge until it's fixed)
+    # needs: test
 
     steps:
       - name: Checkout sources
@@ -118,6 +119,9 @@ jobs:
         run: echo "::set-output name=out::$(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}')"
         # run: |
         #   exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
+
+      - name: Check exclusions
+        run: echo ${{ steps.excluded-examples.out }}
 
       - name: Collect coverage
         uses: actions-rs/tarpaulin@v0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,11 @@ name: Test
 
 on: [push, pull_request]
 
+env:
+  # Use `haswell` instead of `native` due to some GitHub
+  # Actions runners not supporting some `avx512` instructions.
+  RUSTFLAGS: -C target-cpu=haswell
+
 jobs:
   test:
     name: Test
@@ -38,9 +43,6 @@ jobs:
           - package: http
             features: simd-json
             additional: --features rustls
-            # Use `haswell` instead of `native` due to some GitHub
-            # Actions runners not supporting some `avx512` instructions.
-            rustflags: "-C target-cpu=haswell"
           - package: gateway
             features: rustls
             additional: --features zlib-stock
@@ -50,7 +52,6 @@ jobs:
           - package: gateway
             features: simd-json
             additional: --features rustls,zlib-stock
-            rustflags: "-C target-cpu=native"
           - package: lavalink
             additional: --features http-support
 
@@ -70,8 +71,6 @@ jobs:
 
       - name: Test ${{ matrix.package }} feat. ${{ matrix.features }}
         working-directory: ${{ matrix.package }}
-        env:
-          RUSTFLAGS: ${{ matrix.rustflags }}
         run: |
           cargo test --no-default-features --features ${{ matrix.features }} ${{ matrix.additional }}
 
@@ -98,10 +97,6 @@ jobs:
         run: cat /proc/cpuinfo
 
       - run: cargo check --workspace --benches --examples --tests --all-features
-        env:
-          # Use `haswell` instead of `native` due to some GitHub Actions
-          # runners not supporting some `avx512` instructions.
-          RUSTFLAGS: "-C target-cpu=haswell"
 
   coverage:
     name: Coverage
@@ -120,11 +115,7 @@ jobs:
       - name: Collect coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '--ignore-tests --workspace --all-features ${{ steps.excluded-examples.outputs.out }}'
-        env:
-          # Use `haswell` instead of `native` due to some GitHub Actions
-          # runners not supporting some `avx512` instructions.
-          RUSTFLAGS: "-C target-cpu=haswell"
+          args: "--ignore-tests --workspace --all-features ${{ steps.excluded-examples.outputs.out }}"
 
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,3 +102,28 @@ jobs:
           # Use `haswell` instead of `native` due to some GitHub Actions
           # runners not supporting some `avx512` instructions.
           RUSTFLAGS: "-C target-cpu=haswell"
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    # Don't wanna collect coverage if tests failed
+    needs: [test, test-features]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Set excluded examples/
+        run: |
+          exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
+
+      - name: Collect coverage
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          args: '-- "${exclude_examples[@]}"'
+
+      - name: Upload coverage to GitHub
+        uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report
+          path: cobertura.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    # Don't wanna collect coverage if tests failed
+    # Don't collect coverage if tests failed
     needs: test
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,10 +117,13 @@ jobs:
         run: |
           exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
 
+      - name: Echo excluded examples (THIS IS A TEST)
+        run: echo "${exclude_examples[@]}"
+
       - name: Collect coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '-- --workspace --all-features "${exclude_examples[@]}"'
+          args: '--workspace --all-features "${exclude_examples[@]}"'
 
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # twilight
 
-[![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+[![codecov badge][]][codecov link] [[![discord badge][]][discord link] ![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 ![project logo][logo]
 
@@ -217,6 +217,8 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [crates:gateway]: https://crates.io/crates/twilight-gateway
 [crates:http]: https://crates.io/crates/twilight-http
 [crates:model]: https://crates.io/crates/twilight-model
+[codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+[codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # twilight
 
-[![codecov badge][]][codecov link] [[![discord badge][]][discord link] ![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+[![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 ![project logo][logo]
 

--- a/cache/in-memory/README.md
+++ b/cache/in-memory/README.md
@@ -2,7 +2,7 @@
 
 # twilight-cache-inmemory
 
-[![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+[![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 `twilight-cache-inmemory` is an in-process-memory cache for the
 [`twilight-rs`] ecosystem. It's responsible for processing events and
@@ -36,6 +36,8 @@ while let Some(event) = events.next().await {
 All first-party crates are licensed under [ISC][LICENSE.md]
 
 [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
+[codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+[codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -1,6 +1,6 @@
 //! # twilight-cache-inmemory
 //!
-//! [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//! [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! `twilight-cache-inmemory` is an in-process-memory cache for the
 //! [`twilight-rs`] ecosystem. It's responsible for processing events and
@@ -50,6 +50,8 @@
 //! All first-party crates are licensed under [ISC][LICENSE.md]
 //!
 //! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
+//! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+//! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding

--- a/command-parser/README.md
+++ b/command-parser/README.md
@@ -2,7 +2,7 @@
 
 # twilight-command-parser
 
-[![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+[![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 `twilight-command-parser` is a command parser for the [`twilight-rs`]
 ecosystem.
@@ -46,6 +46,8 @@ match parser.parse("!echo a message") {
 }
 ```
 
+[codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+[codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -1,6 +1,6 @@
 //! # twilight-command-parser
 //!
-//! [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//! [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! `twilight-command-parser` is a command parser for the [`twilight-rs`]
 //! ecosystem.
@@ -44,6 +44,8 @@
 //! }
 //! ```
 //!
+//! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+//! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/embed-builder/README.md
+++ b/embed-builder/README.md
@@ -2,7 +2,7 @@
 
 # twilight-embed-builder
 
-[![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+[![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 `twilight-embed-builder` is a set of builder for the [`twilight-rs`]
 ecosystem to create a message embed, useful when creating or updating
@@ -35,6 +35,8 @@ let embed = EmbedBuilder::new()
 ```
 
 [`twilight-rs`]: https://github.com/twilight-rs/twilight
+[codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+[codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/embed-builder/src/lib.rs
+++ b/embed-builder/src/lib.rs
@@ -1,6 +1,6 @@
 //! # twilight-embed-builder
 //!
-//! [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//! [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! `twilight-embed-builder` is a set of builder for the [`twilight-rs`]
 //! ecosystem to create a message embed, useful when creating or updating
@@ -37,6 +37,8 @@
 //! ```
 //!
 //! [`twilight-rs`]: https://github.com/twilight-rs/twilight
+//! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+//! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -2,7 +2,7 @@
 
 # twilight-gateway
 
-[![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+[![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 `twilight-gateway` is an implementation of Discord's sharding gateway sessions.
 This is responsible for receiving stateful events in real-time from Discord
@@ -114,6 +114,8 @@ This is disabled by default.
 [`tracing`]: https://crates.io/crates/tracing
 [`twilight-http`]: https://twilight-rs.github.io/twilight/twilight_http/index.html
 [`zlib-ng`]: https://github.com/zlib-ng/zlib-ng
+[codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+[codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -1,6 +1,6 @@
 //! # twilight-gateway
 //!
-//! [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//! [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! `twilight-gateway` is an implementation of Discord's sharding gateway sessions.
 //! This is responsible for receiving stateful events in real-time from Discord
@@ -112,6 +112,8 @@
 //! [`tracing`]: https://crates.io/crates/tracing
 //! [`twilight-http`]: https://twilight-rs.github.io/twilight/twilight_http/index.html
 //! [`zlib-ng`]: https://github.com/zlib-ng/zlib-ng
+//! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+//! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding

--- a/http/README.md
+++ b/http/README.md
@@ -2,7 +2,7 @@
 
 # twilight-http
 
-[![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+[![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 HTTP support for the twilight ecosystem.
 
@@ -86,6 +86,8 @@ This is disabled by default.
 [`serde_json`]: https://crates.io/crates/serde_json
 [`simd-json`]: https://crates.io/crates/simd-json
 [`tracing`]: https://crates.io/crates/tracing
+[codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+[codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -1,6 +1,6 @@
 //! # twilight-http
 //!
-//! [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//! [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! HTTP support for the twilight ecosystem.
 //!
@@ -84,6 +84,8 @@
 //! [`serde_json`]: https://crates.io/crates/serde_json
 //! [`simd-json`]: https://crates.io/crates/simd-json
 //! [`tracing`]: https://crates.io/crates/tracing
+//! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+//! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -2,7 +2,7 @@
 
 # twilight-lavalink
 
-[![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+[![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 `twilight-lavalink` is a client for [Lavalink] as part of the twilight
 ecosystem.
@@ -99,6 +99,8 @@ There is also an example of a basic bot located in the [root of the
 [`http`]: https://crates.io/crates/http
 [`rustls`]: https://crates.io/crates/rustls
 [client]: Lavalink
+[codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+[codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -1,6 +1,6 @@
 //! # twilight-lavalink
 //!
-//! [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//! [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! `twilight-lavalink` is a client for [Lavalink] as part of the twilight
 //! ecosystem.
@@ -97,6 +97,8 @@
 //! [`http`]: https://crates.io/crates/http
 //! [`rustls`]: https://crates.io/crates/rustls
 //! [client]: Lavalink
+//! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+//! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/mention/README.md
+++ b/mention/README.md
@@ -2,7 +2,7 @@
 
 # twilight-mention
 
-[![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+[![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 `twilight-mention` is a utility crate for the Discord [`twilight-rs`]
 ecosystem to mention its model types and parse those mentions.
@@ -23,6 +23,8 @@ let message = format!("Hey there, {}!", user_id.mention());
 ```
 
 [`twilight-rs`]: https://github.com/twilight-rs/twilight
+[codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+[codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/mention/src/lib.rs
+++ b/mention/src/lib.rs
@@ -1,6 +1,6 @@
 //! # twilight-mention
 //!
-//! [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//! [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! `twilight-mention` is a utility crate for the Discord [`twilight-rs`]
 //! ecosystem to mention its model types and parse those mentions.
@@ -21,6 +21,8 @@
 //! ```
 //!
 //! [`twilight-rs`]: https://github.com/twilight-rs/twilight
+//! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+//! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/model/README.md
+++ b/model/README.md
@@ -2,7 +2,7 @@
 
 # twilight-model
 
-[![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+[![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 See the [`twilight`] documentation for more information.
 
@@ -33,6 +33,8 @@ Some models have associated builders, which can be found in the
 [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [`twilight-util`]: https://docs.rs/twilight-util
 [`twilight`]: https://docs.rs/twilight
+[codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+[codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -1,6 +1,6 @@
 //! # twilight-model
 //!
-//! [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//! [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! See the [`twilight`] documentation for more information.
 //!
@@ -31,6 +31,8 @@
 //! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [`twilight-util`]: https://docs.rs/twilight-util
 //! [`twilight`]: https://docs.rs/twilight
+//! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+//! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/standby/README.md
+++ b/standby/README.md
@@ -2,7 +2,7 @@
 
 # twilight-standby
 
-[![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+[![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 Standby is a utility to wait for an event to happen based on a predicate
 check. For example, you may have a command that has a reaction menu of ✅
@@ -130,6 +130,8 @@ async fn react(
 For more examples, check out each of the methods on [`Standby`].
 
 [`tracing`]: https://crates.io/crates/tracing
+[codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+[codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -1,6 +1,6 @@
 //! # twilight-standby
 //!
-//! [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//! [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! Standby is a utility to wait for an event to happen based on a predicate
 //! check. For example, you may have a command that has a reaction menu of ✅
@@ -130,6 +130,8 @@
 //! For more examples, check out each of the methods on [`Standby`].
 //!
 //! [`tracing`]: https://crates.io/crates/tracing
+//! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+//! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -1,6 +1,6 @@
 //! # twilight
 //!
-//! [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//! [![codecov badge][]][codecov link] [[![discord badge][]][discord link] ![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! ![project logo][logo]
 //!
@@ -217,6 +217,8 @@
 //! [crates:gateway]: https://crates.io/crates/twilight-gateway
 //! [crates:http]: https://crates.io/crates/twilight-http
 //! [crates:model]: https://crates.io/crates/twilight-model
+//! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+//! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -1,6 +1,6 @@
 //! # twilight
 //!
-//! [![codecov badge][]][codecov link] [[![discord badge][]][discord link] ![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//! [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! ![project logo][logo]
 //!

--- a/util/README.md
+++ b/util/README.md
@@ -2,7 +2,7 @@
 
 # twilight-util
 
-[![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+[![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 `twilight-util` is a set of utility types and functions for the [`twilight-rs`] ecosystem to
 augment or enhance default functionality.
@@ -29,6 +29,8 @@ Allows the use of the `Snowflake` trait, which provides methods for the extracti
 structured information from [Discord snowflakes].
 
 [`twilight-rs`]: https://github.com/twilight-rs/twilight
+[codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+[codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,6 +1,6 @@
 //! # twilight-util
 //!
-//! [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
+//! [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
 //! `twilight-util` is a set of utility types and functions for the [`twilight-rs`] ecosystem to
 //! augment or enhance default functionality.
@@ -27,6 +27,8 @@
 //! structured information from [Discord snowflakes].
 //!
 //! [`twilight-rs`]: https://github.com/twilight-rs/twilight
+//! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
+//! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 //! [discord link]: https://discord.gg/7jj8n7D
 //! [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github


### PR DESCRIPTION
Code coverage action, right now just uploads coverage report to github with the upload-artifact action, and skips examples as well 