### PR TITLE
fix(http-ratelimiting): Webhook token is major parameter

### DIFF
--- a/http-ratelimiting/src/request.rs
+++ b/http-ratelimiting/src/request.rs
@@ -255,10 +255,12 @@ pub enum Path {
     UsersIdGuildsId,
     /// Operating on the voice regions available to the current user.
     VoiceRegions,
-    /// Operating on a message created by a webhook.
-    WebhooksIdTokenMessagesId(u64),
-    /// Operating on a webhook.
+    /// Operating on a webhook as a bot.
     WebhooksId(u64),
+    /// Operating on a webhook as a webhook.
+    WebhooksIdToken(u64, Box<str>),
+    /// Operating on a message created by a webhook.
+    WebhooksIdTokenMessagesId(u64, Box<str>),
 }
 
 impl FromStr for Path {
@@ -402,8 +404,13 @@ impl FromStr for Path {
             ["users", _, "guilds"] => UsersIdGuilds,
             ["users", _, "guilds", _] => UsersIdGuildsId,
             ["voice", "regions"] => VoiceRegions,
-            ["webhooks", id] | ["webhooks", id, _] => WebhooksId(parse_id(id)?),
-            ["webhooks", id, _, "messages", _] => WebhooksIdTokenMessagesId(parse_id(id)?),
+            ["webhooks", id] => WebhooksId(parse_id(id)?),
+            ["webhooks", id, token] => {
+                WebhooksIdToken(parse_id(id)?, (*token).to_string().into_boxed_str())
+            }
+            ["webhooks", id, token, "messages", _] => {
+                WebhooksIdTokenMessagesId(parse_id(id)?, (*token).to_string().into_boxed_str())
+            }
             _ => {
                 return Err(PathParseError {
                     kind: PathParseErrorType::NoMatch,

--- a/http/src/routing/route.rs
+++ b/http/src/routing/route.rs
@@ -1292,12 +1292,29 @@ impl<'a> Route<'a> {
             | Self::UpdateGuildIntegration { guild_id, .. } => {
                 Path::GuildsIdIntegrationsId(*guild_id)
             }
-            Self::DeleteInteractionOriginal { application_id, .. }
-            | Self::GetFollowupMessage { application_id, .. }
-            | Self::GetInteractionOriginal { application_id, .. }
-            | Self::UpdateInteractionOriginal { application_id, .. } => {
-                Path::WebhooksIdTokenMessagesId(*application_id)
+            Self::DeleteInteractionOriginal {
+                application_id,
+                interaction_token,
+                ..
             }
+            | Self::GetFollowupMessage {
+                application_id,
+                interaction_token,
+                ..
+            }
+            | Self::GetInteractionOriginal {
+                application_id,
+                interaction_token,
+                ..
+            }
+            | Self::UpdateInteractionOriginal {
+                application_id,
+                interaction_token,
+                ..
+            } => Path::WebhooksIdToken(
+                *application_id,
+                (*interaction_token).to_string().into_boxed_str(),
+            ),
             Self::DeleteInvite { .. }
             | Self::GetInvite { .. }
             | Self::GetInviteWithExpiration { .. } => Path::InvitesCode,
@@ -1335,13 +1352,35 @@ impl<'a> Route<'a> {
                 *guild_id,
                 (*template_code).to_string().into_boxed_str(),
             ),
-            Self::DeleteWebhookMessage { webhook_id, .. }
-            | Self::GetWebhookMessage { webhook_id, .. }
-            | Self::UpdateWebhookMessage { webhook_id, .. } => {
-                Path::WebhooksIdTokenMessagesId(*webhook_id)
+            Self::DeleteWebhookMessage {
+                webhook_id, token, ..
             }
+            | Self::GetWebhookMessage {
+                webhook_id, token, ..
+            }
+            | Self::UpdateWebhookMessage {
+                webhook_id, token, ..
+            } => {
+                Path::WebhooksIdTokenMessagesId(*webhook_id, (*token).to_string().into_boxed_str())
+            }
+            Self::DeleteWebhook {
+                webhook_id,
+                token: Some(token),
+                ..
+            }
+            | Self::ExecuteWebhook {
+                webhook_id, token, ..
+            }
+            | Self::GetWebhook {
+                webhook_id,
+                token: Some(token),
+                ..
+            }
+            | Self::UpdateWebhook {
+                webhook_id,
+                token: Some(token),
+            } => Path::WebhooksIdToken(*webhook_id, (*token).to_string().into_boxed_str()),
             Self::DeleteWebhook { webhook_id, .. }
-            | Self::ExecuteWebhook { webhook_id, .. }
             | Self::GetWebhook { webhook_id, .. }
             | Self::UpdateWebhook { webhook_id, .. } => (Path::WebhooksId(*webhook_id)),
             Self::FollowNewsChannel { channel_id } => Path::ChannelsIdFollowers(*channel_id),

--- a/http/src/routing/route.rs
+++ b/http/src/routing/route.rs
@@ -1311,7 +1311,7 @@ impl<'a> Route<'a> {
                 application_id,
                 interaction_token,
                 ..
-            } => Path::WebhooksIdToken(
+            } => Path::WebhooksIdTokenMessagesId(
                 *application_id,
                 (*interaction_token).to_string().into_boxed_str(),
             ),


### PR DESCRIPTION
This should fix a lot of issues when responding to lots of interactions, because currently they're being handled as the same bucket when they actually aren't.

I'm not 100% sure about the documentation for the Path variants, it feels kind of weird to describe the difference as "as a bot" and "as a webhook", but I think this should accurately reflect Discord's docs.

PR made against next because of the ratelimiting changes in next making porting from main to next a little hard.

Fixes #840 