### PR TITLE
Deserialize thread member by injecting the guild id

### DIFF
--- a/model/src/channel/thread/member.rs
+++ b/model/src/channel/thread/member.rs
@@ -1,9 +1,4 @@
-use crate::{
-    datetime::Timestamp,
-    gateway::presence::Presence,
-    guild::Member,
-    id::{ChannelId, UserId},
-};
+use crate::{datetime::Timestamp, gateway::presence::{Presence, PresenceIntermediary}, guild::{member::MemberIntermediary, Member}, id::{ChannelId, GuildId, UserId}};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -19,6 +14,39 @@ pub struct ThreadMember {
     pub presence: Option<Presence>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_id: Option<UserId>,
+}
+
+/// Version of [`ThreadMember`], but without a guild ID in the
+/// [`Self::member`] field.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+pub struct ThreadMemberIntermediary {
+    // Values currently unknown and undocumented.
+    pub flags: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<ChannelId>,
+    pub join_timestamp: Timestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub member: Option<MemberIntermediary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presence: Option<PresenceIntermediary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<UserId>,
+}
+
+impl ThreadMemberIntermediary {
+    /// Inject a guild ID into a thread member intermediary
+    pub fn into_thread_member(self, guild_id: GuildId) -> ThreadMember {
+        let member = self.member.map(|m| m.into_member(guild_id));
+        let presence = self.presence.map(|p| p.into_presence(guild_id));
+        ThreadMember {
+            flags: self.flags,
+            id: self.id,
+            join_timestamp: self.join_timestamp,
+            member,
+            presence,
+            user_id: self.user_id,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/model/src/channel/thread/member.rs
+++ b/model/src/channel/thread/member.rs
@@ -1,4 +1,9 @@
-use crate::{datetime::Timestamp, gateway::presence::{Presence, PresenceIntermediary}, guild::{member::MemberIntermediary, Member}, id::{ChannelId, GuildId, UserId}};
+use crate::{
+    datetime::Timestamp,
+    gateway::presence::{Presence, PresenceIntermediary},
+    guild::{member::MemberIntermediary, Member},
+    id::{ChannelId, GuildId, UserId},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]

--- a/model/src/channel/thread/mod.rs
+++ b/model/src/channel/thread/mod.rs
@@ -10,3 +10,5 @@ pub use self::{
     auto_archive_duration::AutoArchiveDuration, listing::ThreadsListing, member::ThreadMember,
     metadata::ThreadMetadata, news::NewsThread, private::PrivateThread, public::PublicThread,
 };
+
+pub(crate) use self::member::ThreadMemberIntermediary;

--- a/model/src/gateway/payload/incoming/thread_members_update.rs
+++ b/model/src/gateway/payload/incoming/thread_members_update.rs
@@ -102,10 +102,13 @@ mod tests {
 
     #[test]
     fn test_thread_members_update() {
+        const JOIN_TIMESTAMP: &str = "2015-04-26T06:26:56.936000+00:00";
+        const PREMIUM_SINCE: &str = "2021-03-16T14:29:19.046000+00:00";
+
         let joined_at =
-            Timestamp::from_str("2015-04-26T06:26:56.936000+00:00").expect("timestamp error");
+            Timestamp::from_str(&JOIN_TIMESTAMP).expect("timestamp error");
         let premium_since =
-            Timestamp::from_str("2021-03-16T14:29:19.046000+00:00").expect("timestamp error");
+            Timestamp::from_str(&PREMIUM_SINCE).expect("timestamp error");
 
         let member = Member {
             avatar: Some("guild avatar".to_owned()),
@@ -172,8 +175,6 @@ mod tests {
             },
         };
 
-        const JOIN_TIMESTAMP: &str = "2015-04-26T06:26:56.936000+00:00";
-
         let join_timestamp = Timestamp::from_str(JOIN_TIMESTAMP).expect("timestamp error");
 
         let value = ThreadMembersUpdate {
@@ -228,7 +229,7 @@ mod tests {
                 Token::Str("1"),
                 Token::Str("joined_at"),
                 Token::Some,
-                Token::Str("2015-04-26T06:26:56.936000+00:00"),
+                Token::Str(JOIN_TIMESTAMP),
                 Token::Str("mute"),
                 Token::Bool(true),
                 Token::Str("nick"),
@@ -238,7 +239,7 @@ mod tests {
                 Token::Bool(false),
                 Token::Str("premium_since"),
                 Token::Some,
-                Token::Str("2021-03-16T14:29:19.046000+00:00"),
+                Token::Str(PREMIUM_SINCE),
                 Token::Str("roles"),
                 Token::Seq { len: Some(0) },
                 Token::SeqEnd,

--- a/model/src/gateway/payload/incoming/thread_members_update.rs
+++ b/model/src/gateway/payload/incoming/thread_members_update.rs
@@ -1,10 +1,15 @@
+use std::fmt::{Formatter, Result as FmtResult};
+
 use crate::{
-    channel::thread::ThreadMember,
+    channel::thread::{ThreadMember, ThreadMemberIntermediary},
     id::{ChannelId, GuildId, UserId},
 };
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::{value::MapAccessDeserializer, MapAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 pub struct ThreadMembersUpdate {
     /// List of thread members.
     ///
@@ -19,4 +24,59 @@ pub struct ThreadMembersUpdate {
     pub member_count: u8,
     #[serde(default)]
     pub removed_member_ids: Vec<UserId>,
+}
+
+impl<'de> Deserialize<'de> for ThreadMembersUpdate {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_map(ThreadMembersUpdateVisitor)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+struct ThreadMembersUpdateIntermediary {
+    /// ThreadMembers without the guild ID.
+    #[serde(default)]
+    pub added_members: Vec<ThreadMemberIntermediary>,
+    pub guild_id: GuildId,
+    pub id: ChannelId,
+    /// Max value of 50.
+    pub member_count: u8,
+    #[serde(default)]
+    pub removed_member_ids: Vec<UserId>,
+}
+
+impl ThreadMembersUpdateIntermediary {
+    fn into_thread_members_update(self) -> ThreadMembersUpdate {
+        let guild_id = self.guild_id;
+        let added_members = self
+            .added_members
+            .into_iter()
+            .map(|tm| tm.into_thread_member(guild_id))
+            .collect();
+
+        ThreadMembersUpdate {
+            added_members,
+            guild_id,
+            id: self.id,
+            member_count: self.member_count,
+            removed_member_ids: self.removed_member_ids,
+        }
+    }
+}
+
+struct ThreadMembersUpdateVisitor;
+
+impl<'de> Visitor<'de> for ThreadMembersUpdateVisitor {
+    type Value = ThreadMembersUpdate;
+
+    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str("struct ThreadMembersUpdate")
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+        let deser = MapAccessDeserializer::new(map);
+        let update = ThreadMembersUpdateIntermediary::deserialize(deser)?;
+
+        Ok(update.into_thread_members_update())
+    }
 }

--- a/model/src/gateway/payload/incoming/thread_members_update.rs
+++ b/model/src/gateway/payload/incoming/thread_members_update.rs
@@ -106,10 +106,8 @@ mod tests {
         const JOIN_TIMESTAMP: &str = "2015-04-26T06:26:56.936000+00:00";
         const PREMIUM_SINCE: &str = "2021-03-16T14:29:19.046000+00:00";
 
-        let joined_at =
-            Timestamp::from_str(JOIN_TIMESTAMP).expect("timestamp error");
-        let premium_since =
-            Timestamp::from_str(PREMIUM_SINCE).expect("timestamp error");
+        let joined_at = Timestamp::from_str(JOIN_TIMESTAMP).expect("timestamp error");
+        let premium_since = Timestamp::from_str(PREMIUM_SINCE).expect("timestamp error");
 
         let member = Member {
             avatar: Some("guild avatar".to_owned()),

--- a/model/src/gateway/payload/incoming/thread_members_update.rs
+++ b/model/src/gateway/payload/incoming/thread_members_update.rs
@@ -100,15 +100,16 @@ mod tests {
 
     use super::ThreadMembersUpdate;
 
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn test_thread_members_update() {
         const JOIN_TIMESTAMP: &str = "2015-04-26T06:26:56.936000+00:00";
         const PREMIUM_SINCE: &str = "2021-03-16T14:29:19.046000+00:00";
 
         let joined_at =
-            Timestamp::from_str(&JOIN_TIMESTAMP).expect("timestamp error");
+            Timestamp::from_str(JOIN_TIMESTAMP).expect("timestamp error");
         let premium_since =
-            Timestamp::from_str(&PREMIUM_SINCE).expect("timestamp error");
+            Timestamp::from_str(PREMIUM_SINCE).expect("timestamp error");
 
         let member = Member {
             avatar: Some("guild avatar".to_owned()),

--- a/model/src/gateway/payload/incoming/thread_members_update.rs
+++ b/model/src/gateway/payload/incoming/thread_members_update.rs
@@ -1,5 +1,3 @@
-use std::fmt::{Formatter, Result as FmtResult};
-
 use crate::{
     channel::thread::{ThreadMember, ThreadMemberIntermediary},
     id::{ChannelId, GuildId, UserId},
@@ -8,6 +6,7 @@ use serde::{
     de::{value::MapAccessDeserializer, MapAccess, Visitor},
     Deserialize, Deserializer, Serialize,
 };
+use std::fmt::{Formatter, Result as FmtResult};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 pub struct ThreadMembersUpdate {

--- a/model/src/gateway/payload/incoming/thread_members_update.rs
+++ b/model/src/gateway/payload/incoming/thread_members_update.rs
@@ -84,17 +84,28 @@ impl<'de> Visitor<'de> for ThreadMembersUpdateVisitor {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
-    
+
     use serde_test::Token;
 
-    use crate::{channel::thread::ThreadMember, datetime::Timestamp, gateway::presence::{Activity, ActivityEmoji, ActivityType, ClientStatus, Presence, Status, UserOrId}, guild::Member, id::{ChannelId, GuildId, UserId}, user::User};
+    use crate::{
+        channel::thread::ThreadMember,
+        datetime::Timestamp,
+        gateway::presence::{
+            Activity, ActivityEmoji, ActivityType, ClientStatus, Presence, Status, UserOrId,
+        },
+        guild::Member,
+        id::{ChannelId, GuildId, UserId},
+        user::User,
+    };
 
     use super::ThreadMembersUpdate;
 
     #[test]
     fn test_thread_members_update() {
-        let joined_at = Timestamp::from_str("2015-04-26T06:26:56.936000+00:00").expect("timestamp error");
-        let premium_since = Timestamp::from_str("2021-03-16T14:29:19.046000+00:00").expect("timestamp error");
+        let joined_at =
+            Timestamp::from_str("2015-04-26T06:26:56.936000+00:00").expect("timestamp error");
+        let premium_since =
+            Timestamp::from_str("2021-03-16T14:29:19.046000+00:00").expect("timestamp error");
 
         let member = Member {
             avatar: Some("guild avatar".to_owned()),
@@ -162,9 +173,9 @@ mod tests {
         };
 
         const JOIN_TIMESTAMP: &str = "2015-04-26T06:26:56.936000+00:00";
-        
+
         let join_timestamp = Timestamp::from_str(JOIN_TIMESTAMP).expect("timestamp error");
-        
+
         let value = ThreadMembersUpdate {
             added_members: vec![ThreadMember {
                 flags: 1,
@@ -172,7 +183,7 @@ mod tests {
                 join_timestamp,
                 member: Some(member),
                 presence: Some(presence),
-                user_id: Some(UserId::new(3).expect("non zero"))
+                user_id: Some(UserId::new(3).expect("non zero")),
             }],
             guild_id: GuildId::new(2).expect("non zero"),
             id: ChannelId::new(4).expect("non zero"),
@@ -189,7 +200,10 @@ mod tests {
                 },
                 Token::Str("added_members"),
                 Token::Seq { len: Some(1) },
-                Token::Struct { name: "ThreadMemberIntermediary", len: 6 },
+                Token::Struct {
+                    name: "ThreadMemberIntermediary",
+                    len: 6,
+                },
                 Token::Str("flags"),
                 Token::U64(1),
                 Token::Str("id"),
@@ -330,6 +344,7 @@ mod tests {
                 Token::Seq { len: Some(0) },
                 Token::SeqEnd,
                 Token::StructEnd,
-            ]);
+            ],
+        );
     }
 }

--- a/model/src/gateway/payload/incoming/thread_members_update.rs
+++ b/model/src/gateway/payload/incoming/thread_members_update.rs
@@ -83,10 +83,7 @@ impl<'de> Visitor<'de> for ThreadMembersUpdateVisitor {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use serde_test::Token;
-
+    use super::ThreadMembersUpdate;
     use crate::{
         channel::thread::ThreadMember,
         datetime::Timestamp,
@@ -97,8 +94,8 @@ mod tests {
         id::{ChannelId, GuildId, UserId},
         user::User,
     };
-
-    use super::ThreadMembersUpdate;
+    use serde_test::Token;
+    use std::str::FromStr;
 
     #[allow(clippy::too_many_lines)]
     #[test]

--- a/model/src/gateway/payload/incoming/thread_members_update.rs
+++ b/model/src/gateway/payload/incoming/thread_members_update.rs
@@ -80,3 +80,256 @@ impl<'de> Visitor<'de> for ThreadMembersUpdateVisitor {
         Ok(update.into_thread_members_update())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    
+    use serde_test::Token;
+
+    use crate::{channel::thread::ThreadMember, datetime::Timestamp, gateway::presence::{Activity, ActivityEmoji, ActivityType, ClientStatus, Presence, Status, UserOrId}, guild::Member, id::{ChannelId, GuildId, UserId}, user::User};
+
+    use super::ThreadMembersUpdate;
+
+    #[test]
+    fn test_thread_members_update() {
+        let joined_at = Timestamp::from_str("2015-04-26T06:26:56.936000+00:00").expect("timestamp error");
+        let premium_since = Timestamp::from_str("2021-03-16T14:29:19.046000+00:00").expect("timestamp error");
+
+        let member = Member {
+            avatar: Some("guild avatar".to_owned()),
+            deaf: false,
+            guild_id: GuildId::new(2).expect("non zero"),
+            joined_at: Some(joined_at),
+            mute: true,
+            nick: Some("twilight".to_owned()),
+            pending: false,
+            premium_since: Some(premium_since),
+            roles: Vec::new(),
+            user: User {
+                accent_color: None,
+                avatar: None,
+                banner: None,
+                bot: false,
+                discriminator: 1,
+                email: None,
+                flags: None,
+                id: UserId::new(3).expect("non zero"),
+                locale: None,
+                mfa_enabled: None,
+                name: "twilight".to_owned(),
+                premium_type: None,
+                public_flags: None,
+                system: None,
+                verified: None,
+            },
+        };
+
+        let activity = Activity {
+            application_id: None,
+            assets: None,
+            buttons: Vec::new(),
+            created_at: Some(1_571_048_061_237),
+            details: None,
+            flags: None,
+            id: Some("aaaaaaaaaaaaaaaa".to_owned()),
+            instance: None,
+            kind: ActivityType::Custom,
+            name: "foo".to_owned(),
+            emoji: Some(ActivityEmoji {
+                name: "Test".to_string(),
+                id: None,
+                animated: None,
+            }),
+            party: None,
+            secrets: None,
+            state: None,
+            timestamps: None,
+            url: None,
+        };
+        let presence = Presence {
+            activities: vec![activity],
+            client_status: ClientStatus {
+                desktop: Some(Status::Online),
+                mobile: None,
+                web: None,
+            },
+            guild_id: GuildId::new(2).expect("non zero"),
+            status: Status::Online,
+            user: UserOrId::UserId {
+                id: UserId::new(3).expect("non zero"),
+            },
+        };
+
+        const JOIN_TIMESTAMP: &str = "2015-04-26T06:26:56.936000+00:00";
+        
+        let join_timestamp = Timestamp::from_str(JOIN_TIMESTAMP).expect("timestamp error");
+        
+        let value = ThreadMembersUpdate {
+            added_members: vec![ThreadMember {
+                flags: 1,
+                id: Some(ChannelId::new(123).expect("non zero")),
+                join_timestamp,
+                member: Some(member),
+                presence: Some(presence),
+                user_id: Some(UserId::new(3).expect("non zero"))
+            }],
+            guild_id: GuildId::new(2).expect("non zero"),
+            id: ChannelId::new(4).expect("non zero"),
+            member_count: 8,
+            removed_member_ids: vec![],
+        };
+
+        serde_test::assert_de_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "ThreadMemberUpdate",
+                    len: 6,
+                },
+                Token::Str("added_members"),
+                Token::Seq { len: Some(1) },
+                Token::Struct { name: "ThreadMemberIntermediary", len: 6 },
+                Token::Str("flags"),
+                Token::U64(1),
+                Token::Str("id"),
+                Token::Some,
+                Token::NewtypeStruct { name: "ChannelId" },
+                Token::Str("123"),
+                Token::Str("join_timestamp"),
+                Token::Str(JOIN_TIMESTAMP),
+                Token::Str("member"),
+                Token::Some,
+                Token::Struct {
+                    name: "MemberIntermediary",
+                    len: 10,
+                },
+                Token::Str("avatar"),
+                Token::Some,
+                Token::Str("guild avatar"),
+                Token::Str("deaf"),
+                Token::Bool(false),
+                Token::Str("guild_id"),
+                Token::NewtypeStruct { name: "GuildId" },
+                Token::Str("1"),
+                Token::Str("joined_at"),
+                Token::Some,
+                Token::Str("2015-04-26T06:26:56.936000+00:00"),
+                Token::Str("mute"),
+                Token::Bool(true),
+                Token::Str("nick"),
+                Token::Some,
+                Token::Str("twilight"),
+                Token::Str("pending"),
+                Token::Bool(false),
+                Token::Str("premium_since"),
+                Token::Some,
+                Token::Str("2021-03-16T14:29:19.046000+00:00"),
+                Token::Str("roles"),
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
+                Token::Str("user"),
+                Token::Struct {
+                    name: "User",
+                    len: 7,
+                },
+                Token::Str("accent_color"),
+                Token::None,
+                Token::Str("avatar"),
+                Token::None,
+                Token::Str("banner"),
+                Token::None,
+                Token::Str("bot"),
+                Token::Bool(false),
+                Token::Str("discriminator"),
+                Token::Str("0001"),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "UserId" },
+                Token::Str("3"),
+                Token::Str("username"),
+                Token::Str("twilight"),
+                Token::StructEnd,
+                Token::StructEnd,
+                Token::Str("presence"),
+                Token::Some,
+                Token::Struct {
+                    name: "PresenceIntermediary",
+                    len: 5,
+                },
+                Token::Str("activities"),
+                Token::Seq { len: Some(1) },
+                Token::Struct {
+                    name: "Activity",
+                    len: 5,
+                },
+                Token::Str("created_at"),
+                Token::Some,
+                Token::U64(1_571_048_061_237),
+                Token::Str("emoji"),
+                Token::Some,
+                Token::Struct {
+                    name: "ActivityEmoji",
+                    len: 1,
+                },
+                Token::Str("name"),
+                Token::Str("Test"),
+                Token::StructEnd,
+                Token::Str("id"),
+                Token::Some,
+                Token::Str("aaaaaaaaaaaaaaaa"),
+                Token::Str("type"),
+                Token::U8(4),
+                Token::Str("name"),
+                Token::Str("foo"),
+                Token::StructEnd,
+                Token::SeqEnd,
+                Token::Str("client_status"),
+                Token::Struct {
+                    name: "ClientStatus",
+                    len: 1,
+                },
+                Token::Str("desktop"),
+                Token::Some,
+                Token::Enum { name: "Status" },
+                Token::Str("online"),
+                Token::Unit,
+                Token::StructEnd,
+                Token::Str("guild_id"),
+                Token::Some,
+                Token::NewtypeStruct { name: "GuildId" },
+                Token::Str("2"),
+                Token::Str("status"),
+                Token::Enum { name: "Status" },
+                Token::Str("online"),
+                Token::Unit,
+                Token::Str("user"),
+                Token::Struct {
+                    name: "UserOrId",
+                    len: 1,
+                },
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "UserId" },
+                Token::Str("3"),
+                Token::StructEnd,
+                Token::StructEnd,
+                Token::Str("user_id"),
+                Token::Some,
+                Token::NewtypeStruct { name: "UserId" },
+                Token::Str("3"),
+                Token::StructEnd,
+                Token::SeqEnd,
+                Token::Str("guild_id"),
+                Token::NewtypeStruct { name: "GuildId" },
+                Token::Str("2"),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "ChannelId" },
+                Token::Str("4"),
+                Token::Str("member_count"),
+                Token::U8(8),
+                Token::Str("removed_member_ids"),
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
+                Token::StructEnd,
+            ]);
+    }
+}

--- a/model/src/gateway/presence/mod.rs
+++ b/model/src/gateway/presence/mod.rs
@@ -70,6 +70,19 @@ pub struct PresenceIntermediary {
     pub user: UserOrId,
 }
 
+impl PresenceIntermediary {
+    /// Inject guild ID into presence if not already present.
+    pub fn into_presence(self, guild_id: GuildId) -> Presence {
+        Presence {
+            activities: self.activities,
+            client_status: self.client_status,
+            guild_id: self.guild_id.unwrap_or(guild_id),
+            status: self.status,
+            user: self.user,
+        }
+    }
+}
+
 struct PresenceVisitor(GuildId);
 
 impl<'de> Visitor<'de> for PresenceVisitor {

--- a/model/src/guild/member.rs
+++ b/model/src/guild/member.rs
@@ -55,6 +55,24 @@ pub struct MemberIntermediary {
     pub user: User,
 }
 
+impl MemberIntermediary {
+    /// Inject a guild ID into a MemberIntermediary.
+    pub fn into_member(self, guild_id: GuildId) -> Member {
+        Member {
+            avatar: self.avatar,
+            deaf: self.deaf,
+            guild_id,
+            joined_at: self.joined_at,
+            mute: self.mute,
+            nick: self.nick,
+            pending: self.pending,
+            premium_since: self.premium_since,
+            roles: self.roles,
+            user: self.user,
+        }
+    }
+}
+
 /// Deserialize a member when the payload doesn't have the guild ID but
 /// you already know the guild ID.
 ///

--- a/model/src/guild/member.rs
+++ b/model/src/guild/member.rs
@@ -56,7 +56,8 @@ pub struct MemberIntermediary {
 }
 
 impl MemberIntermediary {
-    /// Inject a guild ID into a MemberIntermediary.
+    /// Inject a guild ID to create a [`Member`].
+    #[allow(clippy::missing_const_for_fn)] // false positive
     pub fn into_member(self, guild_id: GuildId) -> Member {
         Member {
             avatar: self.avatar,


### PR DESCRIPTION
This injects the guild ID into the fields member and presence for
THREAD_MEMBERS_UPDATE.

Closes #1262