### PR TITLE
fix(http): readd and deprecate prelude

### DIFF
--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -5,6 +5,12 @@ pub mod sticker;
 pub mod template;
 pub mod user;
 
+#[deprecated(
+    note = "this will be removed in a future major version",
+    since = "0.7.2"
+)]
+pub mod prelude;
+
 mod audit_reason;
 mod base;
 mod get_gateway;

--- a/http/src/request/prelude.rs
+++ b/http/src/request/prelude.rs
@@ -1,0 +1,13 @@
+pub use super::{
+    audit_reason::{AuditLogReason, AuditLogReasonError},
+    channel::{invite::*, message::*, reaction::*, stage::*, webhook::*, *},
+    get_gateway::GetGateway,
+    get_gateway_authed::GetGatewayAuthed,
+    get_voice_regions::GetVoiceRegions,
+    guild::{ban::*, emoji::*, integration::*, member::*, role::*, user::*, *},
+    template::{
+        create_guild_from_template::CreateGuildFromTemplateError,
+        create_template::CreateTemplateError, *,
+    },
+    user::*,
+};


### PR DESCRIPTION
#1257 accidentally caused a breaking change. This reverts it to the extent where it is no longer breaking.
