### PR TITLE
ci: deploy dev docs to netlify

### DIFF
--- a/netlify.sh
+++ b/netlify.sh
@@ -1,0 +1,10 @@
+# Install nightly toolchain
+rustup toolchain install nightly
+
+# Build crates without examples
+exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
+cargo doc --workspace --no-deps --features=permission-calculator "${exclude_examples[@]}"
+cargo doc -p twilight-util --no-deps --all-features
+
+# Prepare docs for publish
+echo '<meta http-equiv="refresh" content="0;url=twilight/index.html">' > target/doc/index.html

--- a/netlify.sh
+++ b/netlify.sh
@@ -1,6 +1,9 @@
 # Install nightly toolchain
 rustup toolchain install nightly
 
+# Configure rustdoc environment
+export RUSTDOCFLAGS="--cfg docsrs -D broken_intra_doc_links"
+
 # Build crates without examples
 exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
 cargo +nightly doc --workspace --no-deps --features=permission-calculator "${exclude_examples[@]}"

--- a/netlify.sh
+++ b/netlify.sh
@@ -3,8 +3,8 @@ rustup toolchain install nightly
 
 # Build crates without examples
 exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
-cargo doc --workspace --no-deps --features=permission-calculator "${exclude_examples[@]}"
-cargo doc -p twilight-util --no-deps --all-features
+cargo +nightly doc --workspace --no-deps --features=permission-calculator "${exclude_examples[@]}"
+cargo +nightly doc -p twilight-util --no-deps --all-features
 
 # Prepare docs for publish
 echo '<meta http-equiv="refresh" content="0;url=twilight/index.html">' > target/doc/index.html

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+publish = "target/doc/"
+command = "./netlify.sh"


### PR DESCRIPTION
This PR adds instructions that tells Netlify how to build our documentation for the purposes of previewing it.