### PR TITLE
chore(gh-actions): check minver deps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,11 @@ name: Lint
 
 on: [push, pull_request]
 
+env:
+  # Use `haswell` instead of `native` due to some GitHub
+  # Actions runners not supporting some `avx512` instructions.
+  RUSTFLAGS: -C target-cpu=haswell
+
 jobs:
   clippy:
     name: Clippy
@@ -16,13 +21,52 @@ jobs:
 
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
-        env:
-          # Use `haswell` instead of `native` due to some GitHub Actions
-          # runners not supporting some `avx512` instructions.
-          RUSTFLAGS: "-C target-cpu=haswell"
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --workspace --benches --examples --tests --all-features
+
+  codespell:
+    name: Spelling
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Run Codespell
+        uses: codespell-project/actions-codespell@master
+
+  min-vers:
+    name: Minimal crate versions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Install cargo-hack
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-hack
+
+      - name: Check minimal versions
+        run: |
+          # Ignore dev-deps
+          cargo hack --remove-dev-deps --workspace
+          # Ignore examples
+          sed -i '/examples/d' Cargo.toml
+          # Update Cargo.lock to minimal version dependencies.
+          cargo update -Z minimal-versions
+          cargo check --all-features
 
   rustfmt:
     name: Format
@@ -34,13 +78,3 @@ jobs:
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
-
-  codespell:
-    name: Spelling
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Run Codespell
-        uses: codespell-project/actions-codespell@master

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -16,9 +16,9 @@ version = "0.7.1"
 
 [dependencies]
 bitflags = { default-features = false, version = "1" }
-serde = { default-features = false, features = ["derive", "std"], version = "1.0.4" }
+serde = { default-features = false, features = ["derive", "std"], version = "1.0.103" }
 serde-value = { default-features = false, version = "0.7" }
-serde_repr = { default-features = false, version = "0.1" }
+serde_repr = { default-features = false, version = "0.1.5" }
 tracing = { default-features = false, version = "0.1" }
 
 [dev-dependencies]


### PR DESCRIPTION
Will catch if newer features are unintentionally used without a dependency bump. Note that `model`'s minimal versions bubble up to all its dependents.

Inspired by Tokio's CI.