### PR TITLE
fix(cache): use normal partialeq impl

### DIFF
--- a/cache/in-memory/src/event/member.rs
+++ b/cache/in-memory/src/event/member.rs
@@ -59,7 +59,7 @@ impl InMemoryCache {
         let id = (guild_id, user_id);
 
         if let Some(m) = self.members.get(&id) {
-            if *m == member {
+            if &*m == member {
                 return;
             }
         }
@@ -92,7 +92,7 @@ impl InMemoryCache {
         let id = (guild_id, member.id);
 
         let (avatar, deaf, mute) = match self.members.get(&id) {
-            Some(m) if *m == member => return,
+            Some(m) if &*m == member => return,
             Some(m) => (m.avatar().map(ToString::to_string), m.deaf(), m.mute()),
             None => (None, None, None),
         };

--- a/cache/in-memory/src/model/member.rs
+++ b/cache/in-memory/src/model/member.rs
@@ -102,8 +102,8 @@ impl PartialEq<Member> for CachedMember {
     }
 }
 
-impl PartialEq<&PartialMember> for CachedMember {
-    fn eq(&self, other: &&PartialMember) -> bool {
+impl PartialEq<PartialMember> for CachedMember {
+    fn eq(&self, other: &PartialMember) -> bool {
         (
             self.deaf,
             self.joined_at,
@@ -122,19 +122,15 @@ impl PartialEq<&PartialMember> for CachedMember {
     }
 }
 
-impl PartialEq<&InteractionMember> for CachedMember {
-    fn eq(&self, other: &&InteractionMember) -> bool {
-        (
-            self.joined_at,
-            self.nick.as_deref(),
-            self.premium_since,
-            &self.roles,
-        ) == (
-            other.joined_at,
-            other.nick.as_deref(),
-            other.premium_since,
-            &other.roles,
-        )
+impl PartialEq<InteractionMember> for CachedMember {
+    fn eq(&self, other: &InteractionMember) -> bool {
+        (self.joined_at, &self.nick, self.premium_since, &self.roles)
+            == (
+                other.joined_at,
+                &other.nick,
+                other.premium_since,
+                &other.roles,
+            )
     }
 }
 
@@ -234,6 +230,6 @@ mod tests {
             user: None,
         };
 
-        assert_eq!(cached_member(), &member);
+        assert_eq!(cached_member(), member);
     }
 }


### PR DESCRIPTION
`PartialEq` should be implemented for the Owned variants.

Split out of #1278