### PR TITLE
Don't process model timestamp leap years twice

### DIFF
--- a/model/src/datetime/mod.rs
+++ b/model/src/datetime/mod.rs
@@ -140,7 +140,7 @@ impl Timestamp {
     ///
     /// [`TimestampParseErrorType::Format`]: error::TimestampParseErrorType::Format
     /// [`TimestampParseErrorType::Range`]: error::TimestampParseErrorType::Range
-    pub fn parse(datetime: &str) -> Result<Self, TimestampParseError> {
+    pub const fn parse(datetime: &str) -> Result<Self, TimestampParseError> {
         let micros = match parse_iso8601(datetime) {
             Ok(micros) => micros,
             Err(source) => return Err(source),


### PR DESCRIPTION
Our ISO8601 parser erroneously had a check for whether the year was a leap year and if the month was after February, increasing the day by 1 if so to account for February 29th. However, in another part of the parser, this is already handled by a call to `Month::running_total`, which takes the leap year into account. This caused dates like "2016-03-01T07:33:19.000000+00:00" to be a day later than they should have been.