### PR TITLE
chore(ci): improve min-vers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,25 +48,26 @@ jobs:
         with:
           toolchain: nightly
           profile: minimal
-          override: true
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
 
       - name: Install cargo-hack
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-hack
 
-      - name: Check minimal versions
+      - name: Prepare minimal versions
         run: |
           # Ignore dev-deps
           cargo hack --remove-dev-deps --workspace
           # Ignore examples
           sed -i '/examples/d' Cargo.toml
           # Update Cargo.lock to minimal version dependencies.
-          cargo update -Z minimal-versions
-          cargo check --all-features
+          cargo +nightly update -Z minimal-versions
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Check minimal versions
+        run: cargo check --all-features
 
   rustfmt:
     name: Format


### PR DESCRIPTION
The previous implementation invalidated its cache every day (nightly) and it used the pre-minver `Cargo.lock` file as a cache key.