### PR TITLE
http: Support trust-dns

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.7.2"
 hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
 hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.23" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
-hyper-trust-dns = { default-features = false, optional = true, version = "0.3" }
+hyper-trust-dns = { default-features = false, optional = true, version = "0.3.1" }
 percent-encoding = { default-features = false, version = "2" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -18,6 +18,7 @@ version = "0.7.2"
 hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
 hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.23" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
+hyper-trust-dns = { default-features = false, optional = true, version = "0.3" }
 percent-encoding = { default-features = false, version = "2" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1" }
@@ -38,6 +39,7 @@ native = ["hyper-tls"]
 rustls = ["rustls-native-roots"]
 rustls-native-roots = ["hyper-rustls/native-tokio"]
 rustls-webpki-roots = ["hyper-rustls/webpki-tokio"]
+trust-dns = ["hyper-trust-dns"]
 
 [dev-dependencies]
 criterion = { default-features = false, version = "0.3" }

--- a/http/README.md
+++ b/http/README.md
@@ -79,6 +79,12 @@ The `tracing` feature enables logging via the [`tracing`] crate.
 
 This is disabled by default.
 
+### Trust-DNS
+
+The `trust-dns` enables [`hyper-trust-dns`], which replaces the default
+`GaiResolver` in [`hyper`]. [`hyper-trust-dns`] instead provides a fully
+async DNS resolver on the application level.
+
 [`brotli`]: https://github.com/dropbox/rust-brotli
 [`native-tls`]: https://crates.io/crates/native-tls
 [`hyper`]: https://crates.io/crates/hyper
@@ -86,6 +92,7 @@ This is disabled by default.
 [`serde_json`]: https://crates.io/crates/serde_json
 [`simd-json`]: https://crates.io/crates/simd-json
 [`tracing`]: https://crates.io/crates/tracing
+[`hyper-trust-dns`]: https://crates.io/crates/hyper-trust-dns
 [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
 [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -32,13 +32,18 @@ impl ClientBuilder {
 
     /// Build the [`Client`].
     pub fn build(self) -> Client {
+        #[cfg(not(feature = "trust-dns"))]
+        let http_connector = hyper::client::HttpConnector::new();
+        #[cfg(feature = "trust-dns")]
+        let http_connector = hyper_trust_dns::new_trust_dns_http_connector();
+
         #[cfg(feature = "rustls-native-roots")]
         let connector = hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()
             .https_or_http()
             .enable_http1()
             .enable_http2()
-            .build();
+            .wrap_connector(http_connector);
 
         #[cfg(all(feature = "rustls-webpki-roots", not(feature = "rustls-native-roots")))]
         let connector = hyper_rustls::HttpsConnectorBuilder::new()
@@ -46,7 +51,7 @@ impl ClientBuilder {
             .https_or_http()
             .enable_http1()
             .enable_http2()
-            .build();
+            .wrap_connector(http_connector);
 
         #[cfg(all(
             feature = "hyper-tls",

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -58,7 +58,7 @@ impl ClientBuilder {
             not(feature = "rustls-native-roots"),
             not(feature = "rustls-webpki-roots")
         ))]
-        let connector = hyper_tls::HttpsConnector::new();
+        let connector = hyper_tls::HttpsConnector::new_with_connector(http_connector);
 
         let http = hyper::client::Builder::default().build(connector);
 

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -88,7 +88,7 @@ use crate::{
     API_VERSION,
 };
 use hyper::{
-    client::{Client as HyperClient, HttpConnector},
+    client::Client as HyperClient,
     header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
     Body,
 };
@@ -122,6 +122,11 @@ use twilight_model::{
 type HttpsConnector<T> = hyper_rustls::HttpsConnector<T>;
 #[cfg(all(feature = "hyper-tls", not(feature = "hyper-rustls")))]
 type HttpsConnector<T> = hyper_tls::HttpsConnector<T>;
+
+#[cfg(feature = "trust-dns")]
+type HttpConnector = hyper_trust_dns::TrustDnsHttpConnector;
+#[cfg(not(feature = "trust-dns"))]
+type HttpConnector = hyper::client::HttpConnector;
 
 /// Twilight's http client.
 ///

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -77,6 +77,12 @@
 //!
 //! This is disabled by default.
 //!
+//! ### Trust-DNS
+//!
+//! The `trust-dns` enables [`hyper-trust-dns`], which replaces the default
+//! `GaiResolver` in [`hyper`]. [`hyper-trust-dns`] instead provides a fully
+//! async DNS resolver on the application level.
+//!
 //! [`brotli`]: https://github.com/dropbox/rust-brotli
 //! [`native-tls`]: https://crates.io/crates/native-tls
 //! [`hyper`]: https://crates.io/crates/hyper
@@ -84,6 +90,7 @@
 //! [`serde_json`]: https://crates.io/crates/serde_json
 //! [`simd-json`]: https://crates.io/crates/simd-json
 //! [`tracing`]: https://crates.io/crates/tracing
+//! [`hyper-trust-dns`]: https://crates.io/crates/hyper-trust-dns
 //! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
 //! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge


### PR DESCRIPTION
This adds back [trust-dns](https://docs.rs/trust-dns-resolver/latest/trust_dns_resolver/) support to twilight-http. It used to be possible to use this via reqwest's trust-dns feature flag and was no longer possible after the switch to hyper.

trust-dns is desirable because it replaces the default [GaiResolver](https://docs.rs/hyper/latest/hyper/client/connect/dns/struct.GaiResolver.html) in hyper, which uses a blocking getaddrinfo call and runs that in a tokio threadpool. trust-dns instead provides a fully async DNS resolver on application level.

trust-dns also provides advanced features like DNS-over-HTTPS, DNS-over-TLS and DNSSEC, which can be enabled by adding e.g. this to Cargo.toml: `hyper-trust-dns = { version = "0.3", default-features = false, features = ["dns-over-rustls", "dnssec-ring"] }`

The crate that is used to do this is a very thin wrapper around trust-dns, it is a [100 LOC](https://github.com/Gelbpunkt/hyper-trust-dns/blob/main/src/lib.rs) wrapper to implement `Service<Name>` for trust-dns' TokioAsyncResolver. The maintainance effort is therefore pretty low and porting to newer versions of the dependencies is very straightforward.