### PR TITLE
fix(http)!: interaction followups have no `thread_id`

### DIFF
--- a/http/src/request/application/interaction/delete_followup_message.rs
+++ b/http/src/request/application/interaction/delete_followup_message.rs
@@ -4,7 +4,7 @@ use crate::{
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
-use twilight_model::id::{ApplicationId, ChannelId, MessageId};
+use twilight_model::id::{ApplicationId, MessageId};
 
 /// Delete a followup message created from a interaction.
 ///
@@ -27,7 +27,6 @@ use twilight_model::id::{ApplicationId, ChannelId, MessageId};
 pub struct DeleteFollowupMessage<'a> {
     http: &'a Client,
     message_id: MessageId,
-    thread_id: Option<ChannelId>,
     token: &'a str,
     application_id: ApplicationId,
 }
@@ -42,24 +41,15 @@ impl<'a> DeleteFollowupMessage<'a> {
         Self {
             http,
             message_id,
-            thread_id: None,
             token,
             application_id,
         }
     }
 
-    /// Delete in a thread belonging to the channel instead of the channel
-    /// itself.
-    pub fn thread_id(mut self, thread_id: ChannelId) -> Self {
-        self.thread_id.replace(thread_id);
-
-        self
-    }
-
     fn request(self) -> Request {
         Request::from_route(&Route::DeleteWebhookMessage {
             message_id: self.message_id.get(),
-            thread_id: self.thread_id.map(ChannelId::get),
+            thread_id: None,
             token: self.token,
             webhook_id: self.application_id.get(),
         })

--- a/http/src/request/application/interaction/get_followup_message.rs
+++ b/http/src/request/application/interaction/get_followup_message.rs
@@ -1,7 +1,7 @@
 use crate::{client::Client, request::Request, response::ResponseFuture, routing::Route};
 use twilight_model::{
     channel::Message,
-    id::{ApplicationId, ChannelId, MessageId},
+    id::{ApplicationId, MessageId},
 };
 
 /// Get a followup message of an interaction.
@@ -30,7 +30,6 @@ pub struct GetFollowupMessage<'a> {
     application_id: ApplicationId,
     http: &'a Client,
     message_id: MessageId,
-    thread_id: Option<ChannelId>,
     interaction_token: &'a str,
 }
 
@@ -45,24 +44,15 @@ impl<'a> GetFollowupMessage<'a> {
             application_id,
             http,
             message_id,
-            thread_id: None,
             interaction_token,
         }
-    }
-
-    /// Get a message in a thread belonging to the channel instead of the
-    /// channel itself.
-    pub fn thread_id(mut self, thread_id: ChannelId) -> Self {
-        self.thread_id.replace(thread_id);
-
-        self
     }
 
     fn request(&self) -> Request {
         Request::from_route(&Route::GetFollowupMessage {
             application_id: self.application_id.get(),
             interaction_token: self.interaction_token,
-            thread_id: self.thread_id.map(ChannelId::get),
+            thread_id: None,
             message_id: self.message_id.get(),
         })
     }
@@ -81,7 +71,7 @@ mod tests {
     use crate::{client::Client, request::Request, routing::Route};
     use static_assertions::assert_impl_all;
     use std::error::Error;
-    use twilight_model::id::{ApplicationId, ChannelId, MessageId};
+    use twilight_model::id::{ApplicationId, MessageId};
 
     assert_impl_all!(GetFollowupMessage<'_>: Send, Sync);
 
@@ -111,41 +101,6 @@ mod tests {
         assert!(expected.body().is_none());
         assert_eq!(expected.path(), actual.path());
         assert_eq!(expected.ratelimit_path(), actual.ratelimit_path());
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_request_with_thread_id() -> Result<(), Box<dyn Error>> {
-        const TOKEN: &str = "token";
-
-        fn application_id() -> ApplicationId {
-            ApplicationId::new(1).expect("non zero")
-        }
-
-        fn message_id() -> MessageId {
-            MessageId::new(2).expect("non zero")
-        }
-
-        let client = Client::new("token".to_owned());
-        client.set_application_id(application_id());
-
-        let actual = client
-            .followup_message(TOKEN, message_id())?
-            .thread_id(ChannelId::new(3).expect("non zero"))
-            .request();
-
-        let expected = Request::from_route(&Route::GetFollowupMessage {
-            application_id: application_id().get(),
-            interaction_token: TOKEN,
-            thread_id: Some(3),
-            message_id: message_id().get(),
-        });
-
-        assert!(expected.body().is_none());
-        assert_eq!(expected.path(), actual.path());
-        assert_eq!(expected.ratelimit_path(), actual.ratelimit_path());
-        assert_eq!("webhooks/1/token/messages/2?thread_id=3", expected.path());
 
         Ok(())
     }

--- a/http/src/request/application/interaction/update_followup_message.rs
+++ b/http/src/request/application/interaction/update_followup_message.rs
@@ -20,7 +20,7 @@ use std::{
 use twilight_model::{
     application::component::Component,
     channel::{embed::Embed, message::AllowedMentions, Attachment},
-    id::{ApplicationId, ChannelId, MessageId},
+    id::{ApplicationId, MessageId},
 };
 
 /// A followup message can not be updated as configured.
@@ -178,7 +178,6 @@ pub struct UpdateFollowupMessage<'a> {
     fields: UpdateFollowupMessageFields<'a>,
     http: &'a Client,
     message_id: MessageId,
-    thread_id: Option<ChannelId>,
     token: &'a str,
 }
 
@@ -204,7 +203,6 @@ impl<'a> UpdateFollowupMessage<'a> {
             attachments: Cow::Borrowed(&[]),
             http,
             message_id,
-            thread_id: None,
             token,
             application_id,
         }
@@ -408,20 +406,12 @@ impl<'a> UpdateFollowupMessage<'a> {
         self
     }
 
-    /// Update in a thread belonging to the channel instead of the channel
-    /// itself.
-    pub fn thread_id(mut self, thread_id: ChannelId) -> Self {
-        self.thread_id.replace(thread_id);
-
-        self
-    }
-
     // `self` needs to be consumed and the client returned due to parameters
     // being consumed in request construction.
     fn request(&mut self) -> Result<Request, HttpError> {
         let mut request = Request::builder(&Route::UpdateWebhookMessage {
             message_id: self.message_id.get(),
-            thread_id: self.thread_id.map(ChannelId::get),
+            thread_id: None,
             token: self.token,
             webhook_id: self.application_id.get(),
         });


### PR DESCRIPTION
This is breaking, however the previous commit has not been released.

Hotfix followup to #1286.
