### PR TITLE
Fix a variety of clippy lints

### DIFF
--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -184,9 +184,8 @@ mod tests {
     #[test]
     fn double_command() {
         let parser = simple_config();
-        if parser.parse("!echoecho").is_some() {
-            panic!("Double match!");
-        }
+
+        assert!(parser.parse("!echoecho").is_none(), "double match");
     }
 
     #[test]

--- a/examples/lavalink-basic-bot/src/main.rs
+++ b/examples/lavalink-basic-bot/src/main.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
                 continue;
             }
 
-            match msg.content.splitn(2, ' ').next() {
+            match msg.content.split_once(' ').map(|x| x.0) {
                 Some("!join") => spawn(join(msg.0, Arc::clone(&state))),
                 Some("!leave") => spawn(leave(msg.0, Arc::clone(&state))),
                 Some("!pause") => spawn(pause(msg.0, Arc::clone(&state))),

--- a/gateway-queue/src/day_limiter.rs
+++ b/gateway-queue/src/day_limiter.rs
@@ -90,6 +90,9 @@ impl DayLimiter {
         })))
     }
 
+    // `clippy::needless_return` lint doesn't work on an item scope, so it needs
+    // to be applied on the function scope.
+    #[cfg_attr(not(feature = "tracing"), allow(clippy::needless_return))]
     pub async fn get(&self) {
         let mut lock = self.0.lock().await;
         if lock.current < lock.total {

--- a/gateway-queue/src/large_bot_queue.rs
+++ b/gateway-queue/src/large_bot_queue.rs
@@ -70,9 +70,9 @@ impl LargeBotQueue {
 async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
     const DUR: Duration = Duration::from_secs(6);
     while let Some(req) = rx.recv().await {
-        if let Err(err) = req.send(()) {
+        if let Err(_source) = req.send(()) {
             #[cfg(feature = "tracing")]
-            tracing::warn!("skipping, send failed with: {:?}", err);
+            tracing::warn!("skipping, send failed with: {:?}", _source);
         }
         sleep(DUR).await;
     }
@@ -89,9 +89,9 @@ impl Queue for LargeBotQueue {
 
         Box::pin(async move {
             self.limiter.get().await;
-            if let Err(err) = self.buckets[bucket].clone().send(tx) {
+            if let Err(_source) = self.buckets[bucket].clone().send(tx) {
                 #[cfg(feature = "tracing")]
-                tracing::warn!("skipping, send failed with: {:?}", err);
+                tracing::warn!("skipping, send failed with: {:?}", _source);
                 return;
             }
 

--- a/gateway-queue/src/lib.rs
+++ b/gateway-queue/src/lib.rs
@@ -124,9 +124,9 @@ impl LocalQueue {
 async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
     const DUR: Duration = Duration::from_secs(6);
     while let Some(req) = rx.recv().await {
-        if let Err(err) = req.send(()) {
+        if let Err(_source) = req.send(()) {
             #[cfg(feature = "tracing")]
-            tracing::warn!("skipping, send failed: {:?}", err);
+            tracing::warn!("skipping, send failed: {:?}", _source);
         }
         sleep(DUR).await;
     }
@@ -136,18 +136,18 @@ impl Queue for LocalQueue {
     /// Request to be able to identify with the gateway. This will place this
     /// request behind all other requests, and the returned future will resolve
     /// once the request has been completed.
-    fn request(&'_ self, [id, total]: [u64; 2]) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+    fn request(&'_ self, [_id, _total]: [u64; 2]) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
             let (tx, rx) = oneshot::channel();
 
-            if let Err(err) = self.0.clone().send(tx) {
+            if let Err(_source) = self.0.clone().send(tx) {
                 #[cfg(feature = "tracing")]
-                tracing::warn!("skipping, send failed: {:?}", err);
+                tracing::warn!("skipping, send failed: {:?}", _source);
                 return;
             }
 
             #[cfg(feature = "tracing")]
-            tracing::info!("shard {}/{} waiting for allowance", id, total);
+            tracing::info!("shard {}/{} waiting for allowance", _id, _total);
 
             let _ = rx.await;
         })

--- a/gateway/src/cluster/scheme.rs
+++ b/gateway/src/cluster/scheme.rs
@@ -233,6 +233,7 @@ impl ShardScheme {
     /// variant.
     ///
     /// [`Auto`]: Self::Auto
+    #[allow(clippy::iter_not_returning_iterator)]
     pub fn iter(&self) -> Option<ShardSchemeIter> {
         ShardSchemeIter::new(self)
     }

--- a/http/src/request/application/interaction/update_followup_message.rs
+++ b/http/src/request/application/interaction/update_followup_message.rs
@@ -348,7 +348,7 @@ impl<'a> UpdateFollowupMessage<'a> {
         mut self,
         embeds: Option<&'a [Embed]>,
     ) -> Result<Self, UpdateFollowupMessageError> {
-        if let Some(embeds_present) = embeds.as_deref() {
+        if let Some(embeds_present) = embeds {
             if embeds_present.len() > Self::EMBED_COUNT_LIMIT {
                 return Err(UpdateFollowupMessageError {
                     kind: UpdateFollowupMessageErrorType::TooManyEmbeds,
@@ -429,7 +429,7 @@ impl<'a> UpdateFollowupMessage<'a> {
                 }
             }
 
-            if let Some(payload_json) = self.fields.payload_json.as_deref() {
+            if let Some(payload_json) = self.fields.payload_json {
                 form.payload_json(payload_json);
             } else {
                 if self.fields.allowed_mentions.is_none() {

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -346,7 +346,7 @@ impl<'a> UpdateWebhookMessage<'a> {
         mut self,
         embeds: Option<&'a [Embed]>,
     ) -> Result<Self, UpdateWebhookMessageError> {
-        if let Some(embeds_present) = embeds.as_deref() {
+        if let Some(embeds_present) = embeds {
             if embeds_present.len() > Self::EMBED_COUNT_LIMIT {
                 return Err(UpdateWebhookMessageError {
                     kind: UpdateWebhookMessageErrorType::TooManyEmbeds,

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -469,7 +469,7 @@ impl<'de> DeserializeSeed<'de> for GatewayEventDeserializer<'_> {
         deserializer.deserialize_struct(
             "GatewayEvent",
             FIELDS,
-            GatewayEventVisitor(self.op, self.sequence, self.event_type.as_deref()),
+            GatewayEventVisitor(self.op, self.sequence, self.event_type),
         )
     }
 }


### PR DESCRIPTION
Fix a variety of clippy lints across the command parser, gateway queue, gateway, http, and model crates, as well as the lavalink bot example.

These range from lints about unused bindings depending on feature set to new stdlib APIs to simplify operations.