### PR TITLE
Don't send auth header for HTTP interactions

### DIFF
--- a/http/src/request/application/interaction/create_followup_message.rs
+++ b/http/src/request/application/interaction/create_followup_message.rs
@@ -378,7 +378,7 @@ impl<'a> CreateFollowupMessage<'a> {
             request = request.json(&self.fields)?;
         }
 
-        Ok(request.build())
+        Ok(request.use_authorization_token(false).build())
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
@@ -389,5 +389,34 @@ impl<'a> CreateFollowupMessage<'a> {
             Ok(request) => self.http.request(request),
             Err(source) => ResponseFuture::error(source),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::client::Client;
+    use std::error::Error;
+    use twilight_http_ratelimiting::Path;
+    use twilight_model::id::ApplicationId;
+
+    #[test]
+    fn test_create_followup_message() -> Result<(), Box<dyn Error>> {
+        let application_id = ApplicationId::new(1).expect("non zero id");
+        let token = "foo".to_owned().into_boxed_str();
+
+        let client = Client::new(String::new());
+        client.set_application_id(application_id);
+        let req = client
+            .create_followup_message(&token)?
+            .content("test")
+            .request()?;
+
+        assert!(!req.use_authorization_token());
+        assert_eq!(
+            &Path::WebhooksIdToken(application_id.get(), token),
+            req.ratelimit_path()
+        );
+
+        Ok(())
     }
 }

--- a/http/src/request/application/interaction/delete_followup_message.rs
+++ b/http/src/request/application/interaction/delete_followup_message.rs
@@ -47,12 +47,14 @@ impl<'a> DeleteFollowupMessage<'a> {
     }
 
     fn request(self) -> Request {
-        Request::from_route(&Route::DeleteWebhookMessage {
+        Request::builder(&Route::DeleteWebhookMessage {
             message_id: self.message_id.get(),
             thread_id: None,
             token: self.token,
             webhook_id: self.application_id.get(),
         })
+        .use_authorization_token(false)
+        .build()
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
@@ -89,5 +91,6 @@ mod tests {
         });
 
         assert_eq!(expected.path, actual.path);
+        assert!(!actual.use_authorization_token());
     }
 }

--- a/http/src/request/application/interaction/delete_original_response.rs
+++ b/http/src/request/application/interaction/delete_original_response.rs
@@ -47,15 +47,45 @@ impl<'a> DeleteOriginalResponse<'a> {
         }
     }
 
+    fn request(&self) -> Request {
+        Request::builder(&Route::DeleteInteractionOriginal {
+            application_id: self.application_id.get(),
+            interaction_token: self.token,
+        })
+        .use_authorization_token(false)
+        .build()
+    }
+
     /// Execute the request, returning a future resolving to a [`Response`].
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let request = Request::from_route(&Route::DeleteInteractionOriginal {
-            application_id: self.application_id.get(),
-            interaction_token: self.token,
-        });
+        self.http.request(self.request())
+    }
+}
 
-        self.http.request(request)
+#[cfg(test)]
+mod tests {
+    use crate::client::Client;
+    use std::error::Error;
+    use twilight_http_ratelimiting::Path;
+    use twilight_model::id::ApplicationId;
+
+    #[test]
+    fn test_delete_followup_message() -> Result<(), Box<dyn Error>> {
+        let application_id = ApplicationId::new(1).expect("non zero id");
+        let token = "foo".to_owned().into_boxed_str();
+
+        let client = Client::new(String::new());
+        client.set_application_id(application_id);
+        let req = client.delete_interaction_original(&token)?.request();
+
+        assert!(!req.use_authorization_token());
+        assert_eq!(
+            &Path::WebhooksIdTokenMessagesId(application_id.get(), token),
+            req.ratelimit_path()
+        );
+
+        Ok(())
     }
 }

--- a/http/src/request/application/interaction/get_followup_message.rs
+++ b/http/src/request/application/interaction/get_followup_message.rs
@@ -49,12 +49,14 @@ impl<'a> GetFollowupMessage<'a> {
     }
 
     fn request(&self) -> Request {
-        Request::from_route(&Route::GetFollowupMessage {
+        Request::builder(&Route::GetFollowupMessage {
             application_id: self.application_id.get(),
             interaction_token: self.interaction_token,
             thread_id: None,
             message_id: self.message_id.get(),
         })
+        .use_authorization_token(false)
+        .build()
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
@@ -91,16 +93,22 @@ mod tests {
         client.set_application_id(application_id());
 
         let actual = client.followup_message(TOKEN, message_id())?.request();
-        let expected = Request::from_route(&Route::GetFollowupMessage {
+        let expected = Request::builder(&Route::GetFollowupMessage {
             application_id: application_id().get(),
             interaction_token: TOKEN,
             thread_id: None,
             message_id: message_id().get(),
-        });
+        })
+        .use_authorization_token(false)
+        .build();
 
         assert!(expected.body().is_none());
         assert_eq!(expected.path(), actual.path());
         assert_eq!(expected.ratelimit_path(), actual.ratelimit_path());
+        assert_eq!(
+            expected.use_authorization_token(),
+            actual.use_authorization_token()
+        );
 
         Ok(())
     }

--- a/http/src/request/application/interaction/get_original_response.rs
+++ b/http/src/request/application/interaction/get_original_response.rs
@@ -42,15 +42,45 @@ impl<'a> GetOriginalResponse<'a> {
         }
     }
 
+    fn request(&self) -> Request {
+        Request::builder(&Route::GetInteractionOriginal {
+            application_id: self.application_id.get(),
+            interaction_token: self.token,
+        })
+        .use_authorization_token(false)
+        .build()
+    }
+
     /// Execute the request, returning a future resolving to a [`Response`].
     ///
     /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<Message> {
-        let request = Request::from_route(&Route::GetInteractionOriginal {
-            application_id: self.application_id.get(),
-            interaction_token: self.token,
-        });
+        self.http.request(self.request())
+    }
+}
 
-        self.http.request(request)
+#[cfg(test)]
+mod tests {
+    use crate::client::Client;
+    use std::error::Error;
+    use twilight_http_ratelimiting::Path;
+    use twilight_model::id::ApplicationId;
+
+    #[test]
+    fn test_delete_followup_message() -> Result<(), Box<dyn Error>> {
+        let application_id = ApplicationId::new(1).expect("non zero id");
+        let token = "foo".to_owned().into_boxed_str();
+
+        let client = Client::new(String::new());
+        client.set_application_id(application_id);
+        let req = client.get_interaction_original(&token)?.request();
+
+        assert!(!req.use_authorization_token());
+        assert_eq!(
+            &Path::WebhooksIdTokenMessagesId(application_id.get(), token),
+            req.ratelimit_path()
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Don't send the configured bot token authorization header for interaction requests. The interaction token is the authorization, and so sending the bot token is unnecessary and may count towards the bot's global ratelimits.