### PR TITLE
Conditionally invalidate HTTP client token

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -2840,7 +2840,10 @@ impl Client {
 
         let inner = self.http.request(req);
 
-        let invalid_token = if self.remember_invalid_token {
+        // For requests that don't use an authorization token we don't need to
+        // remember whether the token is invalid. This may be for requests such
+        // as webhooks and interactions.
+        let invalid_token = if self.remember_invalid_token && use_authorization_token {
             InvalidToken::Remember(Arc::clone(&self.token_invalid))
         } else {
             InvalidToken::Forget


### PR DESCRIPTION
Conditionally remember whether the configured client token is invalid by only performing the check on requests that are using the client authorization token. This means that requests such as webhooks and interactions will be excluded, as they use their own authorization.

Closes #1299.