### PR TITLE
Fix HTTP API error ratelimited variant ordering

### DIFF
--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -1036,7 +1036,7 @@ mod tests {
         );
     }
 
-    /// Assert that (de)serializing an [`ApiError::Ratelimited`] variant uses
+    /// Assert that deserializing an [`ApiError::Ratelimited`] variant uses
     /// the correct variant.
     ///
     /// Tests for [#1302], which was due to a previously ordered variant having


### PR DESCRIPTION
Fix the ordering of the `ApiError::Ratelimited` variant, which had a lower priority compared to the `ApiError::Message` variant and was erroneously being deserialized into.

Closes #1302.