### PR TITLE
fix(http): properly serialize `CommandBorrowed::kind`

### DIFF
--- a/http/src/request/application/command/mod.rs
+++ b/http/src/request/application/command/mod.rs
@@ -45,6 +45,7 @@ struct CommandBorrowed<'a> {
     pub default_permission: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<&'a str>,
+    #[serde(rename = "type")]
     pub kind: CommandType,
     pub name: &'a str,
     #[serde(default)]


### PR DESCRIPTION
Renames the `kind` field to `type` when serializing a `CommandBorrowed`. Fixes an issue brought up in [a support thread].

[a support thread]: https://discord.com/channels/745809834183753828/745811192102125578/918361932510162984
