### PR TITLE
chore: remove needless "rust" tag on doctests

### DIFF
--- a/command-parser/src/arguments.rs
+++ b/command-parser/src/arguments.rs
@@ -30,7 +30,7 @@ impl<'a> Arguments<'a> {
     /// When the command is `"!echo foo bar baz"` and the command is `"echo"`,
     /// then this returns `"foo bar baz"`.
     ///
-    /// ```rust
+    /// ```
     /// use twilight_command_parser::{Command, CommandParserConfig, Parser};
     ///
     /// let mut config = CommandParserConfig::new();
@@ -54,7 +54,7 @@ impl<'a> Arguments<'a> {
     /// If you have extracted two arguments already, then you can consume the
     /// rest of the arguments:
     ///
-    /// ```rust
+    /// ```
     /// use twilight_command_parser::Arguments;
     ///
     /// let mut args = Arguments::new("1 2 3 4 5");

--- a/command-parser/src/config.rs
+++ b/command-parser/src/config.rs
@@ -81,7 +81,7 @@ impl<'a> CommandParserConfig<'a> {
     ///
     /// Add a case-sensitive "ping" command:
     ///
-    /// ```rust
+    /// ```
     /// use twilight_command_parser::CommandParserConfig;
     ///
     /// let mut config = CommandParserConfig::new();
@@ -112,7 +112,7 @@ impl<'a> CommandParserConfig<'a> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use twilight_command_parser::CommandParserConfig;
     ///
     /// let mut config = CommandParserConfig::new();
@@ -132,7 +132,7 @@ impl<'a> CommandParserConfig<'a> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use twilight_command_parser::CommandParserConfig;
     ///
     /// let mut config = CommandParserConfig::new();
@@ -155,7 +155,7 @@ impl<'a> CommandParserConfig<'a> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use twilight_command_parser::CommandParserConfig;
     ///
     /// let mut config = CommandParserConfig::new();

--- a/command-parser/src/parser.rs
+++ b/command-parser/src/parser.rs
@@ -28,7 +28,7 @@ pub struct Command<'a> {
 /// Using a parser configured with the commands `"echo"` and `"ping"` and the
 /// prefix `"!"`, parse the message "!echo foo bar baz":
 ///
-/// ```rust
+/// ```
 /// use twilight_command_parser::{Command, CommandParserConfig, Parser};
 ///
 /// let mut config = CommandParserConfig::new();
@@ -97,7 +97,7 @@ impl<'a> Parser<'a> {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # use twilight_command_parser::{Command, CommandParserConfig, Parser};
     /// # fn example() -> Option<()> {
     /// let mut config = CommandParserConfig::new();

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -476,7 +476,7 @@ impl EmbedBuilder {
     ///
     /// Create an embed author:
     ///
-    /// ```rust
+    /// ```
     /// use twilight_embed_builder::{EmbedAuthorBuilder, EmbedBuilder};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -507,7 +507,7 @@ impl EmbedBuilder {
     ///
     /// Set the color of an embed to `0xfd69b3`:
     ///
-    /// ```rust
+    /// ```
     /// use twilight_embed_builder::EmbedBuilder;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -532,7 +532,7 @@ impl EmbedBuilder {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use twilight_embed_builder::EmbedBuilder;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -555,7 +555,7 @@ impl EmbedBuilder {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use twilight_embed_builder::{EmbedBuilder, EmbedFieldBuilder};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -579,7 +579,7 @@ impl EmbedBuilder {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use twilight_embed_builder::{EmbedBuilder, EmbedFooterBuilder};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -605,7 +605,7 @@ impl EmbedBuilder {
     ///
     /// Set the image source to a URL:
     ///
-    /// ```rust
+    /// ```
     /// use twilight_embed_builder::{EmbedBuilder, EmbedFooterBuilder, ImageSource};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -634,7 +634,7 @@ impl EmbedBuilder {
     /// Set the thumbnail to an image attachment with the filename
     /// `"twilight.png"`:
     ///
-    /// ```rust
+    /// ```
     /// use twilight_embed_builder::{EmbedBuilder, ImageSource};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -671,7 +671,7 @@ impl EmbedBuilder {
     ///
     /// Set the title to "twilight":
     ///
-    /// ```rust
+    /// ```
     /// use twilight_embed_builder::EmbedBuilder;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -699,7 +699,7 @@ impl EmbedBuilder {
     ///
     /// Set the URL to [twilight's repository]:
     ///
-    /// ```rust
+    /// ```
     /// use twilight_embed_builder::{EmbedBuilder, EmbedFooterBuilder};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/embed-builder/src/field.rs
+++ b/embed-builder/src/field.rs
@@ -50,7 +50,7 @@ impl EmbedFieldBuilder {
     ///
     /// Create an inlined field:
     ///
-    /// ```rust
+    /// ```
     /// use twilight_embed_builder::EmbedFieldBuilder;
     ///
     /// let field = EmbedFieldBuilder::new("twilight", "is cool")

--- a/embed-builder/src/footer.rs
+++ b/embed-builder/src/footer.rs
@@ -44,7 +44,7 @@ impl EmbedFooterBuilder {
     ///
     /// Create a footer by Twilight with a URL to an image of its logo:
     ///
-    /// ```rust
+    /// ```
     /// use twilight_embed_builder::{EmbedFooterBuilder, ImageSource};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/model-webhook-slash/src/main.rs
+++ b/examples/model-webhook-slash/src/main.rs
@@ -144,7 +144,7 @@ async fn debug(i: Interaction) -> Result<InteractionResponse, GenericError> {
             components: None,
             flags: None,
             tts: None,
-            content: Some(format!("```\n{:?}\n```", i)),
+            content: Some(format!("```rust\n{:?}\n```", i)),
             embeds: Default::default(),
         },
     ))

--- a/examples/model-webhook-slash/src/main.rs
+++ b/examples/model-webhook-slash/src/main.rs
@@ -144,7 +144,7 @@ async fn debug(i: Interaction) -> Result<InteractionResponse, GenericError> {
             components: None,
             flags: None,
             tts: None,
-            content: Some(format!("```rust\n{:?}\n```", i)),
+            content: Some(format!("```\n{:?}\n```", i)),
             embeds: Default::default(),
         },
     ))

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -23,7 +23,7 @@ use twilight_model::gateway::{
 /// Create a cluster with only the `GUILD_MESSAGES` intents with a
 /// [`large_threshold`] of 100.
 ///
-/// ```,no_run
+/// ```no_run
 /// use std::env;
 /// use twilight_gateway::{Cluster, Intents};
 ///

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -23,7 +23,7 @@ use twilight_model::gateway::{
 /// Create a cluster with only the `GUILD_MESSAGES` intents with a
 /// [`large_threshold`] of 100.
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use std::env;
 /// use twilight_gateway::{Cluster, Intents};
 ///

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -143,7 +143,7 @@ pub enum ShardIdErrorType {
 /// Create a new shard, setting the [`large_threshold`] to 100 and the
 /// [`shard`] ID to 5 out of 10:
 ///
-/// ```,no_run
+/// ```no_run
 /// use std::env;
 /// use twilight_gateway::{Intents, Shard};
 ///

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -143,7 +143,7 @@ pub enum ShardIdErrorType {
 /// Create a new shard, setting the [`large_threshold`] to 100 and the
 /// [`shard`] ID to 5 out of 10:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use std::env;
 /// use twilight_gateway::{Intents, Shard};
 ///

--- a/http-ratelimiting/src/request.rs
+++ b/http-ratelimiting/src/request.rs
@@ -272,7 +272,7 @@ impl FromStr for Path {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use twilight_http_ratelimiting::Path;
     /// use std::str::FromStr;
     ///

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -104,7 +104,7 @@ impl ClientBuilder {
     ///
     /// Set the proxy to `twilight_http_proxy.internal`:
     ///
-    /// ```rust
+    /// ```
     /// use twilight_http::Client;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -166,7 +166,7 @@ type HttpConnector = hyper::client::HttpConnector;
 /// # Examples
 ///
 /// Create a client called `client`:
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 ///
 /// # #[tokio::main]
@@ -177,7 +177,7 @@ type HttpConnector = hyper::client::HttpConnector;
 ///
 /// Use [`ClientBuilder`] to create a client called `client`, with a shorter
 /// timeout:
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use std::time::Duration;
 ///
@@ -280,7 +280,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::GuildId;
     ///
@@ -305,7 +305,7 @@ impl Client {
     ///
     /// Retrieve the bans for guild `1`:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::GuildId;
     /// #
@@ -337,7 +337,7 @@ impl Client {
     /// Ban user `200` from guild `100`, deleting
     /// 1 day's worth of messages, for the reason `"memes"`:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::{request::AuditLogReason, Client};
     /// use twilight_model::id::{GuildId, UserId};
     /// #
@@ -364,7 +364,7 @@ impl Client {
     ///
     /// Unban user `200` from guild `100`:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::{GuildId, UserId};
     /// #
@@ -388,7 +388,7 @@ impl Client {
     ///
     /// Get channel `100`:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::ChannelId;
     /// #
@@ -448,7 +448,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```,no_run
+    /// ```no_run
     /// use twilight_http::Client;
     /// use twilight_model::id::{ChannelId, MessageId};
     ///
@@ -497,7 +497,7 @@ impl Client {
     ///
     /// Create permission overrides for a role to view the channel, but not send messages:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// use twilight_model::guild::Permissions;
     /// use twilight_model::id::{ChannelId, RoleId};
@@ -579,7 +579,7 @@ impl Client {
     /// Get the first 25 guilds with an ID after `300` and before
     /// `400`:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::GuildId;
     ///
@@ -618,7 +618,7 @@ impl Client {
     ///
     /// Get the emojis for guild `100`:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::GuildId;
     /// #
@@ -641,7 +641,7 @@ impl Client {
     ///
     /// Get emoji `100` from guild `50`:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::{EmojiId, GuildId};
     /// #
@@ -692,7 +692,7 @@ impl Client {
     ///
     /// Get the gateway connection URL without bot information:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// #
     /// # #[tokio::main]
@@ -706,7 +706,7 @@ impl Client {
     /// Get the gateway connection URL with additional shard and session information, which
     /// requires specifying a bot token:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// #
     /// # #[tokio::main]
@@ -855,7 +855,7 @@ impl Client {
     ///
     /// Get the first 500 members of guild `100` after user ID `3000`:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::{GuildId, UserId};
     /// #
@@ -887,7 +887,7 @@ impl Client {
     ///
     /// Get the first 10 members of guild `100` matching `Wumpus`:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// use twilight_http::Client;
     /// use twilight_model::id::GuildId;
     ///
@@ -963,7 +963,7 @@ impl Client {
     ///
     /// Update a member's nickname to "pinky pie" and server mute them:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// use std::env;
     /// use twilight_http::Client;
     /// use twilight_model::id::{GuildId, UserId};
@@ -1009,7 +1009,7 @@ impl Client {
     ///
     /// In guild `1`, add role `2` to user `3`, for the reason `"test"`:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::{request::AuditLogReason, Client};
     /// use twilight_model::id::{GuildId, RoleId, UserId};
     /// #
@@ -1109,7 +1109,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// #
     /// # #[tokio::main]
@@ -1136,7 +1136,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::ChannelId;
     /// #
@@ -1178,7 +1178,7 @@ impl Client {
     ///
     /// # Example
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::ChannelId;
     /// #
@@ -1250,7 +1250,7 @@ impl Client {
     ///
     /// Replace the content with `"test update"`:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// use twilight_http::Client;
     /// use twilight_model::id::{ChannelId, MessageId};
     ///
@@ -1266,7 +1266,7 @@ impl Client {
     ///
     /// Remove the message's content:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::{ChannelId, MessageId};
     /// #
@@ -1331,7 +1331,7 @@ impl Client {
     /// The reaction must be a variant of [`RequestReactionType`].
     ///
     /// # Examples
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::{Client, request::channel::reaction::RequestReactionType};
     /// # use twilight_model::{
     /// #     id::{ChannelId, MessageId},
@@ -1421,7 +1421,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::GuildId;
     ///
@@ -1781,7 +1781,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::ChannelId;
     /// #
@@ -1829,7 +1829,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::WebhookId;
     /// #

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -166,7 +166,7 @@ type HttpConnector = hyper::client::HttpConnector;
 /// # Examples
 ///
 /// Create a client called `client`:
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 ///
 /// # #[tokio::main]
@@ -177,7 +177,7 @@ type HttpConnector = hyper::client::HttpConnector;
 ///
 /// Use [`ClientBuilder`] to create a client called `client`, with a shorter
 /// timeout:
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use std::time::Duration;
 ///
@@ -280,7 +280,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::GuildId;
     ///
@@ -305,7 +305,7 @@ impl Client {
     ///
     /// Retrieve the bans for guild `1`:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::GuildId;
     /// #
@@ -337,7 +337,7 @@ impl Client {
     /// Ban user `200` from guild `100`, deleting
     /// 1 day's worth of messages, for the reason `"memes"`:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::{request::AuditLogReason, Client};
     /// use twilight_model::id::{GuildId, UserId};
     /// #
@@ -364,7 +364,7 @@ impl Client {
     ///
     /// Unban user `200` from guild `100`:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::{GuildId, UserId};
     /// #
@@ -388,7 +388,7 @@ impl Client {
     ///
     /// Get channel `100`:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::ChannelId;
     /// #
@@ -448,7 +448,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// use twilight_http::Client;
     /// use twilight_model::id::{ChannelId, MessageId};
     ///
@@ -497,7 +497,7 @@ impl Client {
     ///
     /// Create permission overrides for a role to view the channel, but not send messages:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// use twilight_model::guild::Permissions;
     /// use twilight_model::id::{ChannelId, RoleId};
@@ -579,7 +579,7 @@ impl Client {
     /// Get the first 25 guilds with an ID after `300` and before
     /// `400`:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::GuildId;
     ///
@@ -618,7 +618,7 @@ impl Client {
     ///
     /// Get the emojis for guild `100`:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::GuildId;
     /// #
@@ -641,7 +641,7 @@ impl Client {
     ///
     /// Get emoji `100` from guild `50`:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::{EmojiId, GuildId};
     /// #
@@ -692,7 +692,7 @@ impl Client {
     ///
     /// Get the gateway connection URL without bot information:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// #
     /// # #[tokio::main]
@@ -706,7 +706,7 @@ impl Client {
     /// Get the gateway connection URL with additional shard and session information, which
     /// requires specifying a bot token:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// #
     /// # #[tokio::main]
@@ -855,7 +855,7 @@ impl Client {
     ///
     /// Get the first 500 members of guild `100` after user ID `3000`:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::{GuildId, UserId};
     /// #
@@ -887,7 +887,7 @@ impl Client {
     ///
     /// Get the first 10 members of guild `100` matching `Wumpus`:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// use twilight_http::Client;
     /// use twilight_model::id::GuildId;
     ///
@@ -963,7 +963,7 @@ impl Client {
     ///
     /// Update a member's nickname to "pinky pie" and server mute them:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// use std::env;
     /// use twilight_http::Client;
     /// use twilight_model::id::{GuildId, UserId};
@@ -1009,7 +1009,7 @@ impl Client {
     ///
     /// In guild `1`, add role `2` to user `3`, for the reason `"test"`:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::{request::AuditLogReason, Client};
     /// use twilight_model::id::{GuildId, RoleId, UserId};
     /// #
@@ -1109,7 +1109,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// #
     /// # #[tokio::main]
@@ -1136,7 +1136,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::ChannelId;
     /// #
@@ -1178,7 +1178,7 @@ impl Client {
     ///
     /// # Example
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::ChannelId;
     /// #
@@ -1250,7 +1250,7 @@ impl Client {
     ///
     /// Replace the content with `"test update"`:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// use twilight_http::Client;
     /// use twilight_model::id::{ChannelId, MessageId};
     ///
@@ -1266,7 +1266,7 @@ impl Client {
     ///
     /// Remove the message's content:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::{ChannelId, MessageId};
     /// #
@@ -1331,7 +1331,7 @@ impl Client {
     /// The reaction must be a variant of [`RequestReactionType`].
     ///
     /// # Examples
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::{Client, request::channel::reaction::RequestReactionType};
     /// # use twilight_model::{
     /// #     id::{ChannelId, MessageId},
@@ -1421,7 +1421,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::GuildId;
     ///
@@ -1781,7 +1781,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::ChannelId;
     /// #
@@ -1829,7 +1829,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// # use twilight_model::id::WebhookId;
     /// #

--- a/http/src/request/application/interaction/create_followup_message.rs
+++ b/http/src/request/application/interaction/create_followup_message.rs
@@ -122,7 +122,7 @@ pub(crate) struct CreateFollowupMessageFields<'a> {
 ///
 /// # Examples
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use std::env;
 /// use twilight_http::Client;
@@ -275,7 +275,7 @@ impl<'a> CreateFollowupMessage<'a> {
     ///
     /// Without [`payload_json`]:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use std::env;
@@ -300,7 +300,7 @@ impl<'a> CreateFollowupMessage<'a> {
     ///
     /// With [`payload_json`]:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use std::env;

--- a/http/src/request/application/interaction/create_followup_message.rs
+++ b/http/src/request/application/interaction/create_followup_message.rs
@@ -122,7 +122,7 @@ pub(crate) struct CreateFollowupMessageFields<'a> {
 ///
 /// # Examples
 ///
-/// ```,no_run
+/// ```no_run
 /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use std::env;
 /// use twilight_http::Client;
@@ -275,7 +275,7 @@ impl<'a> CreateFollowupMessage<'a> {
     ///
     /// Without [`payload_json`]:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use std::env;
@@ -300,7 +300,7 @@ impl<'a> CreateFollowupMessage<'a> {
     ///
     /// With [`payload_json`]:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use std::env;

--- a/http/src/request/channel/get_channel.rs
+++ b/http/src/request/channel/get_channel.rs
@@ -7,7 +7,7 @@ use twilight_model::{channel::Channel, id::ChannelId};
 ///
 /// Get channel `100`:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::ChannelId;
 ///

--- a/http/src/request/channel/get_channel.rs
+++ b/http/src/request/channel/get_channel.rs
@@ -7,7 +7,7 @@ use twilight_model::{channel::Channel, id::ChannelId};
 ///
 /// Get channel `100`:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::ChannelId;
 ///

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -86,7 +86,7 @@ struct CreateInviteFields {
 ///
 /// # Examples
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::ChannelId;
 ///
@@ -140,7 +140,7 @@ impl<'a> CreateInvite<'a> {
     /// Create an invite for a channel with a maximum of 1 use and an age of 1
     /// hour:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// use std::env;
     /// use twilight_http::Client;
     /// use twilight_model::id::ChannelId;
@@ -178,7 +178,7 @@ impl<'a> CreateInvite<'a> {
     ///
     /// Create an invite for a channel with a maximum of 5 uses:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// use std::env;
     /// use twilight_http::Client;
     /// use twilight_model::id::ChannelId;

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -86,7 +86,7 @@ struct CreateInviteFields {
 ///
 /// # Examples
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::ChannelId;
 ///
@@ -140,7 +140,7 @@ impl<'a> CreateInvite<'a> {
     /// Create an invite for a channel with a maximum of 1 use and an age of 1
     /// hour:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// use std::env;
     /// use twilight_http::Client;
     /// use twilight_model::id::ChannelId;
@@ -178,7 +178,7 @@ impl<'a> CreateInvite<'a> {
     ///
     /// Create an invite for a channel with a maximum of 5 uses:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// use std::env;
     /// use twilight_http::Client;
     /// use twilight_model::id::ChannelId;

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -14,7 +14,7 @@ struct GetInviteFields {
 ///
 /// # Examples
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 ///
 /// # #[tokio::main]

--- a/http/src/request/channel/invite/get_invite.rs
+++ b/http/src/request/channel/invite/get_invite.rs
@@ -14,7 +14,7 @@ struct GetInviteFields {
 ///
 /// # Examples
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 ///
 /// # #[tokio::main]

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -144,7 +144,7 @@ pub(crate) struct CreateMessageFields<'a> {
 ///
 /// # Example
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::ChannelId;
 ///

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -144,7 +144,7 @@ pub(crate) struct CreateMessageFields<'a> {
 ///
 /// # Example
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::ChannelId;
 ///

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -77,7 +77,7 @@ struct GetChannelMessagesFields {
 ///
 /// # Examples
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::{ChannelId, MessageId};
 ///

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -77,7 +77,7 @@ struct GetChannelMessagesFields {
 ///
 /// # Examples
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::{ChannelId, MessageId};
 ///

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -142,7 +142,7 @@ struct UpdateMessageFields<'a> {
 ///
 /// Replace the content with `"test update"`:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::{ChannelId, MessageId};
 ///
@@ -158,7 +158,7 @@ struct UpdateMessageFields<'a> {
 ///
 /// Remove the message's content:
 ///
-/// ```,no_run
+/// ```no_run
 /// # use twilight_http::Client;
 /// # use twilight_model::id::{ChannelId, MessageId};
 /// #

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -142,7 +142,7 @@ struct UpdateMessageFields<'a> {
 ///
 /// Replace the content with `"test update"`:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::{ChannelId, MessageId};
 ///
@@ -158,7 +158,7 @@ struct UpdateMessageFields<'a> {
 ///
 /// Remove the message's content:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// # use twilight_http::Client;
 /// # use twilight_model::id::{ChannelId, MessageId};
 /// #

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -12,7 +12,7 @@ use twilight_model::id::{ChannelId, MessageId};
 /// The reaction must be a variant of [`RequestReactionType`].
 ///
 /// # Examples
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::{Client, request::channel::reaction::RequestReactionType};
 /// use twilight_model::{
 ///     id::{ChannelId, MessageId},

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -12,7 +12,7 @@ use twilight_model::id::{ChannelId, MessageId};
 /// The reaction must be a variant of [`RequestReactionType`].
 ///
 /// # Examples
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::{Client, request::channel::reaction::RequestReactionType};
 /// use twilight_model::{
 ///     id::{ChannelId, MessageId},

--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -12,7 +12,7 @@ use twilight_model::{
 ///
 /// Create permission overrides for a role to view the channel, but not send messages:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::guild::Permissions;
 /// use twilight_model::id::{ChannelId, RoleId};

--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -12,7 +12,7 @@ use twilight_model::{
 ///
 /// Create permission overrides for a role to view the channel, but not send messages:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::guild::Permissions;
 /// use twilight_model::id::{ChannelId, RoleId};

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -18,7 +18,7 @@ struct CreateWebhookFields<'a> {
 ///
 /// # Examples
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::ChannelId;
 ///

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -18,7 +18,7 @@ struct CreateWebhookFields<'a> {
 ///
 /// # Examples
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::ChannelId;
 ///

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -122,7 +122,7 @@ pub(crate) struct ExecuteWebhookFields<'a> {
 ///
 /// # Examples
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::WebhookId;
 ///
@@ -265,7 +265,7 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// Without [`payload_json`]:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// use twilight_embed_builder::EmbedBuilder;
     /// # use twilight_http::Client;
     /// use twilight_model::id::{MessageId, WebhookId};
@@ -288,7 +288,7 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// With [`payload_json`]:
     ///
-    /// ```,no_run
+    /// ```no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::{MessageId, WebhookId};
     ///

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -122,7 +122,7 @@ pub(crate) struct ExecuteWebhookFields<'a> {
 ///
 /// # Examples
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::WebhookId;
 ///
@@ -265,7 +265,7 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// Without [`payload_json`]:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// use twilight_embed_builder::EmbedBuilder;
     /// # use twilight_http::Client;
     /// use twilight_model::id::{MessageId, WebhookId};
@@ -288,7 +288,7 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// With [`payload_json`]:
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// # use twilight_http::Client;
     /// use twilight_model::id::{MessageId, WebhookId};
     ///

--- a/http/src/request/channel/webhook/execute_webhook_and_wait.rs
+++ b/http/src/request/channel/webhook/execute_webhook_and_wait.rs
@@ -7,7 +7,7 @@ use twilight_model::channel::Message;
 ///
 /// # Examples
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::WebhookId;
 ///

--- a/http/src/request/channel/webhook/execute_webhook_and_wait.rs
+++ b/http/src/request/channel/webhook/execute_webhook_and_wait.rs
@@ -7,7 +7,7 @@ use twilight_model::channel::Message;
 ///
 /// # Examples
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::WebhookId;
 ///

--- a/http/src/request/get_gateway.rs
+++ b/http/src/request/get_gateway.rs
@@ -13,7 +13,7 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 ///
 /// Get the gateway connection URL without bot information:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 ///
 /// # #[tokio::main]
@@ -27,7 +27,7 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 /// Get the gateway connection URL with additional shard and session information, which
 /// requires specifying a bot token:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 ///
 /// # #[tokio::main]

--- a/http/src/request/get_gateway.rs
+++ b/http/src/request/get_gateway.rs
@@ -13,7 +13,7 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 ///
 /// Get the gateway connection URL without bot information:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 ///
 /// # #[tokio::main]
@@ -27,7 +27,7 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 /// Get the gateway connection URL with additional shard and session information, which
 /// requires specifying a bot token:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 ///
 /// # #[tokio::main]

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -70,7 +70,7 @@ struct CreateBanFields<'a> {
 /// Ban user `200` from guild `100`, deleting
 /// 1 day's worth of messages, for the reason `"memes"`:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::{request::AuditLogReason, Client};
 /// use twilight_model::id::{GuildId, UserId};
 ///

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -70,7 +70,7 @@ struct CreateBanFields<'a> {
 /// Ban user `200` from guild `100`, deleting
 /// 1 day's worth of messages, for the reason `"memes"`:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::{request::AuditLogReason, Client};
 /// use twilight_model::id::{GuildId, UserId};
 ///

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -12,7 +12,7 @@ use twilight_model::id::{GuildId, UserId};
 ///
 /// Unban user `200` from guild `100`:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::{GuildId, UserId};
 ///

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -12,7 +12,7 @@ use twilight_model::id::{GuildId, UserId};
 ///
 /// Unban user `200` from guild `100`:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::{GuildId, UserId};
 ///

--- a/http/src/request/guild/ban/get_bans.rs
+++ b/http/src/request/guild/ban/get_bans.rs
@@ -12,7 +12,7 @@ use twilight_model::{guild::Ban, id::GuildId};
 ///
 /// Retrieve the bans for guild `1`:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::GuildId;
 ///

--- a/http/src/request/guild/ban/get_bans.rs
+++ b/http/src/request/guild/ban/get_bans.rs
@@ -12,7 +12,7 @@ use twilight_model::{guild::Ban, id::GuildId};
 ///
 /// Retrieve the bans for guild `1`:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::GuildId;
 ///

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -284,7 +284,7 @@ impl<'a> CreateGuild<'a> {
     ///
     /// # Examples
     ///
-    /// ```,no_run
+    /// ```no_run
     /// use twilight_http::{
     ///     Client,
     ///     request::guild::create_guild::{
@@ -413,7 +413,7 @@ impl<'a> CreateGuild<'a> {
     ///
     /// # Examples
     ///
-    /// ```,no_run
+    /// ```no_run
     /// use twilight_http::{Client, request::guild::create_guild::RoleFieldsBuilder};
     /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token".to_owned());

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -284,7 +284,7 @@ impl<'a> CreateGuild<'a> {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// use twilight_http::{
     ///     Client,
     ///     request::guild::create_guild::{
@@ -413,7 +413,7 @@ impl<'a> CreateGuild<'a> {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```,no_run
     /// use twilight_http::{Client, request::guild::create_guild::RoleFieldsBuilder};
     /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token".to_owned());

--- a/http/src/request/guild/emoji/get_emoji.rs
+++ b/http/src/request/guild/emoji/get_emoji.rs
@@ -10,7 +10,7 @@ use twilight_model::{
 ///
 /// Get emoji `100` from guild `50`:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::{EmojiId, GuildId};
 ///

--- a/http/src/request/guild/emoji/get_emoji.rs
+++ b/http/src/request/guild/emoji/get_emoji.rs
@@ -10,7 +10,7 @@ use twilight_model::{
 ///
 /// Get emoji `100` from guild `50`:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::{EmojiId, GuildId};
 ///

--- a/http/src/request/guild/emoji/get_emojis.rs
+++ b/http/src/request/guild/emoji/get_emojis.rs
@@ -12,7 +12,7 @@ use twilight_model::{guild::Emoji, id::GuildId};
 ///
 /// Get the emojis for guild `100`:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::GuildId;
 ///

--- a/http/src/request/guild/emoji/get_emojis.rs
+++ b/http/src/request/guild/emoji/get_emojis.rs
@@ -12,7 +12,7 @@ use twilight_model::{guild::Emoji, id::GuildId};
 ///
 /// Get the emojis for guild `100`:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::GuildId;
 ///

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -69,7 +69,7 @@ struct GetAuditLogFields {
 ///
 /// # Examples
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::GuildId;
 ///

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -69,7 +69,7 @@ struct GetAuditLogFields {
 ///
 /// # Examples
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::GuildId;
 ///

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -12,7 +12,7 @@ use twilight_model::id::{GuildId, RoleId, UserId};
 ///
 /// In guild `1`, add role `2` to user `3`, for the reason `"test"`:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::{request::AuditLogReason, Client};
 /// use twilight_model::id::{GuildId, RoleId, UserId};
 ///

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -12,7 +12,7 @@ use twilight_model::id::{GuildId, RoleId, UserId};
 ///
 /// In guild `1`, add role `2` to user `3`, for the reason `"test"`:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::{request::AuditLogReason, Client};
 /// use twilight_model::id::{GuildId, RoleId, UserId};
 ///

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -78,7 +78,7 @@ struct GetGuildMembersFields {
 ///
 /// Get the first 500 members of guild `100` after user ID `3000`:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::{GuildId, UserId};
 ///

--- a/http/src/request/guild/member/get_guild_members.rs
+++ b/http/src/request/guild/member/get_guild_members.rs
@@ -78,7 +78,7 @@ struct GetGuildMembersFields {
 ///
 /// Get the first 500 members of guild `100` after user ID `3000`:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::{GuildId, UserId};
 ///

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -76,7 +76,7 @@ struct SearchGuildMembersFields<'a> {
 ///
 /// Get the first 10 members of guild `100` matching `Wumpus`:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::GuildId;
 ///

--- a/http/src/request/guild/member/search_guild_members.rs
+++ b/http/src/request/guild/member/search_guild_members.rs
@@ -76,7 +76,7 @@ struct SearchGuildMembersFields<'a> {
 ///
 /// Get the first 10 members of guild `100` matching `Wumpus`:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::GuildId;
 ///

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -32,7 +32,7 @@ struct CreateRoleFields<'a> {
 ///
 /// # Examples
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::GuildId;
 ///

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -32,7 +32,7 @@ struct CreateRoleFields<'a> {
 ///
 /// # Examples
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::GuildId;
 ///

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -73,7 +73,7 @@ struct GetCurrentUserGuildsFields {
 /// Get the first 25 guilds with an ID after `300` and before
 /// `400`:
 ///
-/// ```,no_run
+/// ```no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::GuildId;
 ///

--- a/http/src/request/user/get_current_user_guilds.rs
+++ b/http/src/request/user/get_current_user_guilds.rs
@@ -73,7 +73,7 @@ struct GetCurrentUserGuildsFields {
 /// Get the first 25 guilds with an ID after `300` and before
 /// `400`:
 ///
-/// ```rust,no_run
+/// ```,no_run
 /// use twilight_http::Client;
 /// use twilight_model::id::GuildId;
 ///

--- a/mention/src/fmt.rs
+++ b/mention/src/fmt.rs
@@ -17,7 +17,7 @@ use twilight_model::{
 ///
 /// Mention a `UserId`:
 ///
-/// ```rust
+/// ```
 /// use twilight_mention::Mention;
 /// use twilight_model::id::UserId;
 ///
@@ -92,7 +92,7 @@ impl Display for MentionFormat<UserId> {
 ///
 /// Mention a `ChannelId`:
 ///
-/// ```rust
+/// ```
 /// use twilight_mention::Mention;
 /// use twilight_model::id::ChannelId;
 ///

--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -50,7 +50,7 @@ impl Ord for Role {
     ///
     /// Compare the position of two roles:
     ///
-    /// ```rust
+    /// ```
     /// # use twilight_model::{guild::{Permissions, Role}, id::RoleId};
     /// # use std::cmp::Ordering;
     /// let role_a = Role {
@@ -89,7 +89,7 @@ impl Ord for Role {
     ///
     /// Compare the position of two roles with the same position:
     ///
-    /// ```rust
+    /// ```
     /// # use twilight_model::{guild::{Permissions, Role}, id::RoleId};
     /// # use std::cmp::Ordering;
     /// let role_a = Role {

--- a/util/src/permission_calculator/mod.rs
+++ b/util/src/permission_calculator/mod.rs
@@ -27,7 +27,7 @@
 //!
 //! Let's see that in code:
 //!
-//! ```rust
+//! ```
 //! use twilight_util::permission_calculator::PermissionCalculator;
 //! use twilight_model::{
 //!     channel::{


### PR DESCRIPTION
doctests are inferred to be rust unless stated otherwise
