### PR TITLE
docs: remove needless id marker imports

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -288,7 +288,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// use twilight_model::id::{marker::GuildMarker, Id};
+    /// use twilight_model::id::Id;
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -313,7 +313,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// use twilight_model::id::{marker::GuildMarker, Id};
+    /// use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -345,7 +345,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::{request::AuditLogReason, Client};
-    /// use twilight_model::id::{marker::{GuildMarker, UserMarker}, Id};
+    /// use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -376,7 +376,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// use twilight_model::id::{marker::{GuildMarker, UserMarker}, Id};
+    /// use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -404,7 +404,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// # use twilight_model::id::{marker::ChannelMarker, Id};
+    /// # use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -464,7 +464,7 @@ impl Client {
     ///
     /// ```no_run
     /// use twilight_http::Client;
-    /// use twilight_model::id::{marker::{ChannelMarker, MessageMarker}, Id};
+    /// use twilight_model::id::Id;
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -514,7 +514,7 @@ impl Client {
     /// ```no_run
     /// # use twilight_http::Client;
     /// use twilight_model::guild::Permissions;
-    /// use twilight_model::id::{marker::{ChannelMarker, RoleMarker}, Id};
+    /// use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -595,7 +595,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// use twilight_model::id::{marker::GuildMarker, Id};
+    /// use twilight_model::id::Id;
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -634,7 +634,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// # use twilight_model::id::{marker::GuildMarker, Id};
+    /// # use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -883,7 +883,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// use twilight_model::id::{marker::{GuildMarker, UserMarker}, Id};
+    /// use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -915,7 +915,7 @@ impl Client {
     ///
     /// ```no_run
     /// use twilight_http::Client;
-    /// use twilight_model::id::{marker::GuildMarker, Id};
+    /// use twilight_model::id::Id;
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -996,7 +996,7 @@ impl Client {
     /// ```no_run
     /// use std::env;
     /// use twilight_http::Client;
-    /// use twilight_model::id::{marker::{GuildMarker, UserMarker}, Id};
+    /// use twilight_model::id::Id;
     ///
     /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new(env::var("DISCORD_TOKEN")?);
@@ -1044,7 +1044,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::{request::AuditLogReason, Client};
-    /// use twilight_model::id::{marker::{GuildMarker, RoleMarker, UserMarker}, Id};
+    /// use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -1174,7 +1174,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// # use twilight_model::id::{marker::ChannelMarker, Id};
+    /// # use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -1220,7 +1220,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// # use twilight_model::id::{marker::ChannelMarker, Id};
+    /// # use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -1292,7 +1292,7 @@ impl Client {
     ///
     /// ```no_run
     /// use twilight_http::Client;
-    /// use twilight_model::id::{marker::{ChannelMarker, MessageMarker}, Id};
+    /// use twilight_model::id::Id;
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -1308,7 +1308,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// # use twilight_model::id::{marker::{ChannelMarker, MessageMarker}, Id};
+    /// # use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -1381,9 +1381,7 @@ impl Client {
     /// # Examples
     /// ```no_run
     /// # use twilight_http::{Client, request::channel::reaction::RequestReactionType};
-    /// # use twilight_model::{
-    /// #     id::{marker::{ChannelMarker, MessageMarker}, Id},
-    /// # };
+    /// # use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -1477,7 +1475,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// use twilight_model::id::{marker::GuildMarker, Id};
+    /// use twilight_model::id::Id;
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -1851,7 +1849,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// # use twilight_model::id::{marker::ChannelMarker, Id};
+    /// # use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -1899,7 +1897,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// # use twilight_model::id::{marker::WebhookMarker, Id};
+    /// # use twilight_model::id::Id;
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -1941,7 +1939,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// use twilight_model::id::{marker::{MessageMarker, WebhookMarker}, Id};
+    /// use twilight_model::id::Id;
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -1967,7 +1965,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// use twilight_model::id::{marker::{MessageMarker, WebhookMarker}, Id};
+    /// use twilight_model::id::Id;
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -115,7 +115,7 @@ impl Player {
     ///
     /// ```
     /// use twilight_lavalink::{model::{Play, Pause}, Lavalink};
-    /// # use twilight_model::id::{marker::{GuildMarker, UserMarker}, Id};
+    /// # use twilight_model::id::Id;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let (guild_id, user_id) = (Id::new(1).expect("non zero"), Id::new(2).expect("non zero"));
     /// # let track = String::new();

--- a/model/src/gateway/payload/outgoing/request_guild_members.rs
+++ b/model/src/gateway/payload/outgoing/request_guild_members.rs
@@ -142,10 +142,7 @@ impl RequestGuildMembersBuilder {
     /// their presences:
     ///
     /// ```
-    /// use twilight_model::{
-    ///     gateway::payload::outgoing::RequestGuildMembers,
-    ///     id::{marker::GuildMarker, Id},
-    /// };
+    /// use twilight_model::{gateway::payload::outgoing::RequestGuildMembers, id::Id};
     ///
     /// let request = RequestGuildMembers::builder(Id::new(1).expect("non zero"))
     ///     .presences(true)


### PR DESCRIPTION
These were found by running
```sh
grep -R "\`\`\`" --include \*.rs -A 5 | grep marker
```
