### PR TITLE
deps: allow `Dashmap` 5

### DIFF
--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.8.1"
 
 [dependencies]
 bitflags = { default-features = false, version = "1" }
-dashmap = { default-features = false, version = "4.0" }
+dashmap = { default-features = false, version = ">=4.0, <6.0" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 twilight-model = { default-features = false, path = "../../model" }
 

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.8.0"
 
 [dependencies]
-dashmap = { default-features = false, version = "4.0" }
+dashmap = { default-features = false, version = ">=4.0, <6.0" }
 futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }
 http = { default-features = false, version = "0.2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }

--- a/standby/Cargo.toml
+++ b/standby/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.8.0"
 
 [dependencies]
-dashmap = { default-features = false, version = "4.0" }
+dashmap = { default-features = false, version = ">=4.0, <6.0" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 tokio = { default-features = false, features = ["sync"], version = "1.0" }
 twilight-model = { default-features = false, path = "../model" }


### PR DESCRIPTION
No relevant API changes so allow 4.0 and 5.0
