### PR TITLE
fix(model): CachedMember#avatar returning nicknames

### DIFF
--- a/cache/in-memory/src/model/member.rs
+++ b/cache/in-memory/src/model/member.rs
@@ -26,7 +26,7 @@ pub struct CachedMember {
 impl CachedMember {
     /// Member's guild avatar.
     pub fn avatar(&self) -> Option<&str> {
-        self.nick.as_deref()
+        self.avatar.as_deref()
     }
 
     /// Whether the member is deafened in a voice channel.


### PR DESCRIPTION
Currently, the `member.rs` file returns a nickname for the avatar function. This PR makes the function return the proper avatar.

Fixes #1340