### PR TITLE
cache-inmemory: Add MEMBER_CURRENT resource type

### DIFF
--- a/cache/in-memory/src/config.rs
+++ b/cache/in-memory/src/config.rs
@@ -36,6 +36,10 @@ bitflags! {
         const INTEGRATION = 1 << 12;
         /// Information relating to guild stickers.
         const STICKER = 1 << 13;
+        /// Information relating to the current user's member.
+        ///
+        /// In order for this to take effect, you must enable [`USER_CURRENT`] too.
+        const MEMBER_CURRENT = 1 << 14;
     }
 }
 

--- a/cache/in-memory/src/config.rs
+++ b/cache/in-memory/src/config.rs
@@ -37,6 +37,8 @@ bitflags! {
         /// Information relating to guild stickers.
         const STICKER = 1 << 13;
         /// Information relating to the current user's member.
+        ///
+        /// This will also enable the [`USER_CURRENT`] resource type.
         const MEMBER_CURRENT = Self::USER_CURRENT.bits | 1 << 14;
     }
 }

--- a/cache/in-memory/src/config.rs
+++ b/cache/in-memory/src/config.rs
@@ -37,9 +37,7 @@ bitflags! {
         /// Information relating to guild stickers.
         const STICKER = 1 << 13;
         /// Information relating to the current user's member.
-        ///
-        /// In order for this to take effect, you must enable [`USER_CURRENT`] too.
-        const MEMBER_CURRENT = 1 << 14;
+        const MEMBER_CURRENT = Self::USER_CURRENT.bits | 1 << 14;
     }
 }
 

--- a/cache/in-memory/src/event/guild.rs
+++ b/cache/in-memory/src/event/guild.rs
@@ -29,6 +29,18 @@ impl InMemoryCache {
         if self.wants(ResourceType::MEMBER) {
             self.guild_members.insert(guild.id, HashSet::new());
             self.cache_members(guild.id, guild.members);
+        } else if self.wants(ResourceType::MEMBER_CURRENT) {
+            if let Some(current_user) = self.current_user() {
+                let current_member = guild
+                    .members
+                    .iter()
+                    .find(|member| member.user.id == current_user.id);
+
+                if let Some(member) = current_member {
+                    self.guild_members.insert(guild.id, HashSet::new());
+                    self.cache_member(guild.id, member.clone());
+                }
+            }
         }
 
         if self.wants(ResourceType::PRESENCE) {
@@ -154,7 +166,7 @@ impl UpdateCache for GuildDelete {
             cache.voice_state_guilds.remove(&id);
         }
 
-        if cache.wants(ResourceType::MEMBER) {
+        if cache.wants(ResourceType::MEMBER) || cache.wants(ResourceType::MEMBER_CURRENT) {
             if let Some((_, ids)) = cache.guild_members.remove(&id) {
                 for user_id in ids {
                     cache.members.remove(&(id, user_id));

--- a/cache/in-memory/src/event/member.rs
+++ b/cache/in-memory/src/event/member.rs
@@ -135,12 +135,6 @@ impl UpdateCache for MemberAdd {
         }
 
         cache.cache_member(self.guild_id, self.0.clone());
-
-        cache
-            .guild_members
-            .entry(self.guild_id)
-            .or_default()
-            .insert(self.0.user.id);
     }
 }
 
@@ -163,11 +157,6 @@ impl UpdateCache for MemberChunk {
 
                 if let Some(member) = current_member {
                     cache.cache_member(self.guild_id, member.clone());
-                    cache
-                        .guild_members
-                        .entry(self.guild_id)
-                        .or_default()
-                        .insert(member.user.id);
                 }
             }
 
@@ -175,8 +164,6 @@ impl UpdateCache for MemberChunk {
         }
 
         cache.cache_members(self.guild_id, self.members.clone());
-        let mut guild = cache.guild_members.entry(self.guild_id).or_default();
-        guild.extend(self.members.iter().map(|member| member.user.id));
     }
 }
 

--- a/cache/in-memory/src/event/member.rs
+++ b/cache/in-memory/src/event/member.rs
@@ -122,7 +122,7 @@ impl InMemoryCache {
 
 impl UpdateCache for MemberAdd {
     fn update(&self, cache: &InMemoryCache) {
-        if !cache.wants(ResourceType::MEMBER) || !cache.wants(ResourceType::MEMBER_CURRENT) {
+        if !cache.wants(ResourceType::MEMBER) && !cache.wants(ResourceType::MEMBER_CURRENT) {
             return;
         }
 
@@ -146,7 +146,7 @@ impl UpdateCache for MemberAdd {
 
 impl UpdateCache for MemberChunk {
     fn update(&self, cache: &InMemoryCache) {
-        if !cache.wants(ResourceType::MEMBER) || !cache.wants(ResourceType::MEMBER_CURRENT) {
+        if !cache.wants(ResourceType::MEMBER) && !cache.wants(ResourceType::MEMBER_CURRENT) {
             return;
         }
 
@@ -182,7 +182,7 @@ impl UpdateCache for MemberChunk {
 
 impl UpdateCache for MemberRemove {
     fn update(&self, cache: &InMemoryCache) {
-        if !cache.wants(ResourceType::MEMBER) || !cache.wants(ResourceType::MEMBER_CURRENT) {
+        if !cache.wants(ResourceType::MEMBER) && !cache.wants(ResourceType::MEMBER_CURRENT) {
             return;
         }
 
@@ -218,7 +218,7 @@ impl UpdateCache for MemberRemove {
 
 impl UpdateCache for MemberUpdate {
     fn update(&self, cache: &InMemoryCache) {
-        if !cache.wants(ResourceType::MEMBER) || !cache.wants(ResourceType::MEMBER_CURRENT) {
+        if !cache.wants(ResourceType::MEMBER) && !cache.wants(ResourceType::MEMBER_CURRENT) {
             return;
         }
 

--- a/cache/in-memory/src/event/member.rs
+++ b/cache/in-memory/src/event/member.rs
@@ -122,7 +122,15 @@ impl InMemoryCache {
 
 impl UpdateCache for MemberAdd {
     fn update(&self, cache: &InMemoryCache) {
-        if !cache.wants(ResourceType::MEMBER) {
+        if !cache.wants(ResourceType::MEMBER) || !cache.wants(ResourceType::MEMBER_CURRENT) {
+            return;
+        }
+
+        if !cache.wants(ResourceType::MEMBER)
+            && cache
+                .current_user()
+                .map_or(true, |user| user.id != self.0.user.id)
+        {
             return;
         }
 
@@ -138,11 +146,31 @@ impl UpdateCache for MemberAdd {
 
 impl UpdateCache for MemberChunk {
     fn update(&self, cache: &InMemoryCache) {
-        if !cache.wants(ResourceType::MEMBER) {
+        if !cache.wants(ResourceType::MEMBER) || !cache.wants(ResourceType::MEMBER_CURRENT) {
             return;
         }
 
         if self.members.is_empty() {
+            return;
+        }
+
+        if !cache.wants(ResourceType::MEMBER) {
+            if let Some(current_user) = cache.current_user() {
+                let current_member = self
+                    .members
+                    .iter()
+                    .find(|member| member.user.id == current_user.id);
+
+                if let Some(member) = current_member {
+                    cache.cache_member(self.guild_id, member.clone());
+                    cache
+                        .guild_members
+                        .entry(self.guild_id)
+                        .or_default()
+                        .insert(member.user.id);
+                }
+            }
+
             return;
         }
 
@@ -154,7 +182,15 @@ impl UpdateCache for MemberChunk {
 
 impl UpdateCache for MemberRemove {
     fn update(&self, cache: &InMemoryCache) {
-        if !cache.wants(ResourceType::MEMBER) {
+        if !cache.wants(ResourceType::MEMBER) || !cache.wants(ResourceType::MEMBER_CURRENT) {
+            return;
+        }
+
+        if !cache.wants(ResourceType::MEMBER)
+            && cache
+                .current_user()
+                .map_or(true, |user| user.id != self.user.id)
+        {
             return;
         }
 
@@ -182,7 +218,15 @@ impl UpdateCache for MemberRemove {
 
 impl UpdateCache for MemberUpdate {
     fn update(&self, cache: &InMemoryCache) {
-        if !cache.wants(ResourceType::MEMBER) {
+        if !cache.wants(ResourceType::MEMBER) || !cache.wants(ResourceType::MEMBER_CURRENT) {
+            return;
+        }
+
+        if !cache.wants(ResourceType::MEMBER)
+            && cache
+                .current_user()
+                .map_or(true, |user| user.id != self.user.id)
+        {
             return;
         }
 


### PR DESCRIPTION
This type will cache a subset of members that only contains the bot itself when specified and `MEMBER` is not. For this to work, `USER_CURRENT` must be enabled too; this has been documented.