### PR TITLE
Fix incorrect handling of TlsErrorType

### DIFF
--- a/gateway/src/shard/tls.rs
+++ b/gateway/src/shard/tls.rs
@@ -59,8 +59,10 @@ impl TlsError {
 }
 
 impl Display for TlsError {
+    // If TlsErrorType is an empty type f is not used.
+    #[cfg_attr(not(any(feature = "native", feature = "rustls-native-roots")), allow(unused))]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match &self.kind {
+        match self.kind {
             #[cfg(all(
                 feature = "native",
                 not(any(feature = "rustls-native-roots", feature = "rustls-webpki-roots"))

--- a/gateway/src/shard/tls.rs
+++ b/gateway/src/shard/tls.rs
@@ -60,7 +60,10 @@ impl TlsError {
 
 impl Display for TlsError {
     // If TlsErrorType is an empty type f is not used.
-    #[cfg_attr(not(any(feature = "native", feature = "rustls-native-roots")), allow(unused))]
+    #[cfg_attr(
+        not(any(feature = "native", feature = "rustls-native-roots")),
+        allow(unused)
+    )]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self.kind {
             #[cfg(all(


### PR DESCRIPTION
Handling of TlsErrorType would in some cases cause compilation errors,
this patch remidies that.

This removes a borrow to make sure that the pattern is counted as
empty when it is so. 
This is a compiler issue tracked at https://github.com/rust-lang/rust/issues/24885.



It also adds a gate to let a variable go unused.