### PR TITLE
fix(http-ratelimiting): rework started at time

### DIFF
--- a/http-ratelimiting/src/in_memory/bucket.rs
+++ b/http-ratelimiting/src/in_memory/bucket.rs
@@ -47,7 +47,7 @@ pub struct Bucket {
     pub remaining: AtomicU64,
     /// Duration after the [`Self::started_at`] time the bucket will refresh.
     pub reset_after: AtomicU64,
-    /// When the bucket's ratelimit refresh countdown started.
+    /// When the bucket last had its headers updated.
     pub started_at: Mutex<Option<Instant>>,
 }
 
@@ -74,7 +74,7 @@ impl Bucket {
         self.remaining.load(Ordering::Relaxed)
     }
 
-    /// Duration after the [`started_at`] time the bucket will refresh.
+    /// Duration after the last response that the bucket will refresh.
     ///
     /// [`started_at`]: Self::started_at
     pub fn reset_after(&self) -> u64 {
@@ -119,26 +119,15 @@ impl Bucket {
 
     /// Update this bucket's ratelimit data after a request has been made.
     pub fn update(&self, ratelimits: Option<(u64, u64, u64)>) {
-        let bucket_limit = self.limit();
-
-        {
-            let mut started_at = self.started_at.lock().expect("bucket poisoned");
-
-            if started_at.is_none() {
-                started_at.replace(Instant::now());
-            }
-        }
-
         if let Some((limit, remaining, reset_after)) = ratelimits {
-            if bucket_limit != limit && bucket_limit == u64::max_value() {
-                self.reset_after.store(reset_after, Ordering::SeqCst);
-                self.limit.store(limit, Ordering::SeqCst);
-            }
-
             self.remaining.store(remaining, Ordering::Relaxed);
+            self.reset_after.store(reset_after, Ordering::SeqCst);
+            self.limit.store(limit, Ordering::SeqCst);
         } else {
             self.remaining.fetch_sub(1, Ordering::Relaxed);
-        }
+        };
+
+        *self.started_at.lock().expect("bucket poisoned") = Some(Instant::now());
     }
 }
 
@@ -191,8 +180,8 @@ pub(super) struct BucketQueueTask {
 }
 
 impl BucketQueueTask {
-    /// Timeout to wait for response headers after initiating a request.
-    const WAIT: Duration = Duration::from_secs(10);
+    /// Timeout to wait for a new request before removing the bucket.
+    const REMOVAL_DELAY: Duration = Duration::from_secs(2);
 
     /// Create a new task to manage the ratelimit for a [`Bucket`].
     pub fn new(
@@ -229,15 +218,11 @@ impl BucketQueueTask {
             #[cfg(feature = "tracing")]
             tracing::debug!(parent: &span, "starting to wait for response headers",);
 
-            match timeout(Self::WAIT, ticket_headers).await {
-                Ok(Ok(Some(headers))) => self.handle_headers(&headers).await,
-                Ok(Ok(None)) => {
+            match ticket_headers.await {
+                Ok(Some(headers)) => self.handle_headers(&headers).await,
+                Ok(None) => {
                     #[cfg(feature = "tracing")]
                     tracing::debug!(parent: &span, "request aborted");
-                }
-                Ok(Err(_)) => {
-                    #[cfg(feature = "tracing")]
-                    tracing::debug!(parent: &span, "ticket channel closed");
                 }
                 Err(_) => {
                     #[cfg(feature = "tracing")]
@@ -294,7 +279,9 @@ impl BucketQueueTask {
 
         self.wait_if_needed().await;
 
-        self.bucket.queue.pop(Self::WAIT).await
+        let wait = Duration::from_millis(self.bucket.reset_after()) + Self::REMOVAL_DELAY;
+
+        self.bucket.queue.pop(wait).await
     }
 
     /// Wait for this bucket to refresh if it isn't ready yet.


### PR DESCRIPTION
Buckets store three headers of note: `remaining`, `retry_after`, and `started_at`. `remaining` is the number of remaining requests in the bucket until the next reset, `retry_after` is the number of milliseconds until the next reset (as of the response generation time), and `started_at` is an internal duration of when the bucket "started" counting up to the reset time (`retry_after`).

In theory, this is all fine: assuming a bucket with 5 requests in a 5000 millisecond time period, when we get the response and process it we start the internal `started_at` timer and wait the `retry_after`.

However, we had an error in our logic. We would only reset the `started_at` clock if the bucket had been manually reset, such as when the `remaining` is 0. This meant that if you waited more than 5000 milliseconds after your first request and performed another, the `started_at` time would not be reset, allowing an additional request to go through when it should not have.

By instead resetting the `started_at` timer on *every* request, we can use it in combination with `reset_after` to wait the correct amount of time.

(this PR also modifies some incorrect related timeouts.)

Closes #1305.