### PR TITLE
docs(cache,gateway): remove old clone comments

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -209,7 +209,7 @@ fn upsert_item<K: Eq + Hash, V: PartialEq>(map: &DashMap<K, V>, k: K, v: V) {
     map.insert(k, v);
 }
 
-/// A thread-safe, in-memory-process cache of Discord data.
+/// An in-memory-process cache of Discord data.
 ///
 /// This is an implementation of a cache designed to be used by only the
 /// current process.

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -209,8 +209,7 @@ fn upsert_item<K: Eq + Hash, V: PartialEq>(map: &DashMap<K, V>, k: K, v: V) {
     map.insert(k, v);
 }
 
-/// A thread-safe, in-memory-process cache of Discord data. It can be cloned and
-/// sent to other threads.
+/// A thread-safe, in-memory-process cache of Discord data.
 ///
 /// This is an implementation of a cache designed to be used by only the
 /// current process.

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -209,7 +209,7 @@ fn upsert_item<K: Eq + Hash, V: PartialEq>(map: &DashMap<K, V>, k: K, v: V) {
     map.insert(k, v);
 }
 
-/// An in-memory-process cache of Discord data.
+/// An in-memory cache of Discord data.
 ///
 /// This is an implementation of a cache designed to be used by only the
 /// current process.

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -213,9 +213,6 @@ pub enum ClusterStartErrorType {
 
 /// A manager for multiple shards.
 ///
-/// The Cluster can be cloned and will point to the same cluster, so you can
-/// pass it around as needed.
-///
 /// # Using a cluster in multiple tasks
 ///
 /// To use a cluster instance in multiple tasks, consider wrapping it in an


### PR DESCRIPTION
Remove old interior Arc cloning comments that were missed in #1067.

Closes #1346.