### PR TITLE
feat(cache/in-memory): rule api

### DIFF
--- a/cache/in-memory/src/builder.rs
+++ b/cache/in-memory/src/builder.rs
@@ -1,5 +1,6 @@
 use super::{
     config::{Config, ResourceType},
+    rule::Rule,
     InMemoryCache,
 };
 
@@ -9,7 +10,7 @@ pub struct InMemoryCacheBuilder(Config);
 
 impl InMemoryCacheBuilder {
     /// Creates a builder to configure and construct an [`InMemoryCache`].
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self(Config::new())
     }
 
@@ -23,6 +24,43 @@ impl InMemoryCacheBuilder {
     /// Defaults to all types.
     pub const fn resource_types(mut self, resource_types: ResourceType) -> Self {
         self.0.resource_types = resource_types;
+
+        self
+    }
+
+    /// Sets the list of rules associated with the cache.
+    ///
+    /// Defaults to none.
+    ///
+    /// # Examples
+    ///
+    /// Add a rule to the cache:
+    ///
+    /// ```
+    /// use twilight_cache_inmemory::{config::{Entity, Rule}, InMemoryCache};
+    ///
+    /// #[derive(Clone, Debug, Eq, PartialEq)]
+    /// pub struct HyphenatedRoleFilter;
+    ///
+    /// impl Rule for HyphenatedRoleFilter {
+    ///     fn accept(&self, cache: &InMemoryCache, entity: &Entity) -> bool {
+    ///         let role = if let Entity::Role(role) = entity {
+    ///             role
+    ///         } else {
+    ///             return true;
+    ///         };
+    ///
+    ///         role.name.starts_with('-')
+    ///     }
+    /// }
+    ///
+    /// let rules = Vec::from([Box::new(HyphenatedRoleFilter) as Box<dyn Rule>]);
+    ///
+    /// let cache = InMemoryCache::builder().rules(rules).build();
+    /// assert_eq!(1, cache.config().rules().len());
+    /// ```
+    pub fn rules(mut self, rules: Vec<Box<dyn Rule>>) -> Self {
+        self.0.rules = rules;
 
         self
     }

--- a/cache/in-memory/src/config.rs
+++ b/cache/in-memory/src/config.rs
@@ -1,4 +1,8 @@
+//! Configuration for caches.
+
+use crate::rule::Rule;
 use bitflags::bitflags;
+use std::fmt::Debug;
 
 bitflags! {
     /// A set of bitflags which can be used to specify what resource to process
@@ -42,20 +46,22 @@ bitflags! {
 /// Configuration for an [`InMemoryCache`].
 ///
 /// [`InMemoryCache`]: crate::InMemoryCache
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub struct Config {
-    pub(super) resource_types: ResourceType,
     pub(super) message_cache_size: usize,
+    pub(super) resource_types: ResourceType,
+    pub(super) rules: Vec<Box<dyn Rule>>,
 }
 
 impl Config {
     /// Create a new default configuration.
     ///
     /// Refer to individual getters for their defaults.
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
-            resource_types: ResourceType::all(),
             message_cache_size: 100,
+            resource_types: ResourceType::all(),
+            rules: Vec::new(),
         }
     }
 
@@ -70,6 +76,19 @@ impl Config {
     pub fn message_cache_size_mut(&mut self) -> &mut usize {
         &mut self.message_cache_size
     }
+
+    /// Returns an immutable reference to the resource types enabled.
+    ///
+    /// Defaults to all resource types.
+    pub fn rules(&self) -> &[Box<dyn Rule>] {
+        &self.rules
+    }
+
+    /// Returns a mutable reference to the rules associated with the cache.
+    pub fn rules_mut(&mut self) -> &mut Vec<Box<dyn Rule>> {
+        &mut self.rules
+    }
+
     /// Returns an immutable reference to the resource types enabled.
     ///
     /// Defaults to all resource types.
@@ -99,11 +118,13 @@ mod tests {
     #[test]
     fn test_defaults() {
         let conf = Config {
-            resource_types: ResourceType::all(),
             message_cache_size: 100,
+            resource_types: ResourceType::all(),
+            rules: Vec::new(),
         };
         let default = Config::default();
-        assert_eq!(conf.resource_types, default.resource_types);
         assert_eq!(conf.message_cache_size, default.message_cache_size);
+        assert_eq!(conf.resource_types, default.resource_types);
+        assert!(conf.rules.is_empty());
     }
 }

--- a/cache/in-memory/src/event/channel.rs
+++ b/cache/in-memory/src/event/channel.rs
@@ -1,4 +1,4 @@
-use crate::{config::ResourceType, InMemoryCache, UpdateCache};
+use crate::{config::ResourceType, rule::Entity, InMemoryCache, UpdateCache};
 use twilight_model::{
     channel::{Channel, Group, GuildChannel, PrivateChannel},
     gateway::payload::incoming::{ChannelCreate, ChannelDelete, ChannelPinsUpdate, ChannelUpdate},
@@ -79,6 +79,10 @@ impl UpdateCache for ChannelCreate {
             return;
         }
 
+        if !cache.resolve(Entity::Channel(&self.0)) {
+            return;
+        }
+
         match &self.0 {
             Channel::Group(c) => {
                 crate::upsert_item(&cache.groups, c.id, c.clone());
@@ -98,6 +102,10 @@ impl UpdateCache for ChannelCreate {
 impl UpdateCache for ChannelDelete {
     fn update(&self, cache: &InMemoryCache) {
         if !cache.wants(ResourceType::CHANNEL) {
+            return;
+        }
+
+        if !cache.resolve(Entity::Channel(&self.0)) {
             return;
         }
 
@@ -146,6 +154,10 @@ impl UpdateCache for ChannelPinsUpdate {
 impl UpdateCache for ChannelUpdate {
     fn update(&self, cache: &InMemoryCache) {
         if !cache.wants(ResourceType::CHANNEL) {
+            return;
+        }
+
+        if !cache.resolve(Entity::Channel(&self.0)) {
             return;
         }
 

--- a/cache/in-memory/src/event/integration.rs
+++ b/cache/in-memory/src/event/integration.rs
@@ -1,4 +1,4 @@
-use crate::{config::ResourceType, InMemoryCache, UpdateCache};
+use crate::{config::ResourceType, rule::Entity, InMemoryCache, UpdateCache};
 use twilight_model::{
     gateway::payload::incoming::{IntegrationCreate, IntegrationDelete, IntegrationUpdate},
     guild::GuildIntegration,
@@ -39,6 +39,10 @@ impl UpdateCache for IntegrationCreate {
             return;
         }
 
+        if !cache.resolve(Entity::Integration(&self.0)) {
+            return;
+        }
+
         if let Some(guild_id) = self.guild_id {
             crate::upsert_guild_item(
                 &cache.integrations,
@@ -63,6 +67,10 @@ impl UpdateCache for IntegrationDelete {
 impl UpdateCache for IntegrationUpdate {
     fn update(&self, cache: &InMemoryCache) {
         if !cache.wants(ResourceType::INTEGRATION) {
+            return;
+        }
+
+        if !cache.resolve(Entity::Integration(&self.0)) {
             return;
         }
 

--- a/cache/in-memory/src/event/voice_state.rs
+++ b/cache/in-memory/src/event/voice_state.rs
@@ -1,4 +1,4 @@
-use crate::{config::ResourceType, InMemoryCache, UpdateCache};
+use crate::{rule::Entity, InMemoryCache, ResourceType, UpdateCache};
 use twilight_model::{gateway::payload::incoming::VoiceStateUpdate, voice::VoiceState};
 
 impl InMemoryCache {
@@ -79,6 +79,10 @@ impl InMemoryCache {
 impl UpdateCache for VoiceStateUpdate {
     fn update(&self, cache: &InMemoryCache) {
         if !cache.wants(ResourceType::VOICE_STATE) {
+            return;
+        }
+
+        if !cache.resolve(Entity::VoiceState(&self.0)) {
             return;
         }
 

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -74,6 +74,7 @@
 
 pub mod iter;
 pub mod model;
+pub mod rule;
 
 #[cfg(feature = "permission-calculator")]
 #[cfg_attr(docsrs, doc(cfg(feature = "permission-calculator")))]
@@ -97,7 +98,7 @@ pub use self::{
 #[cfg_attr(docsrs, doc(cfg(feature = "permission-calculator")))]
 pub use self::permission::InMemoryCachePermissions;
 
-use self::{iter::InMemoryCacheIter, model::*};
+use self::{iter::InMemoryCacheIter, model::*, rule::Entity};
 use dashmap::{
     mapref::{entry::Entry, one::Ref},
     DashMap, DashSet,
@@ -297,7 +298,7 @@ impl InMemoryCache {
     }
 
     /// Create a new builder to configure and construct an in-memory cache.
-    pub const fn builder() -> InMemoryCacheBuilder {
+    pub fn builder() -> InMemoryCacheBuilder {
         InMemoryCacheBuilder::new()
     }
 
@@ -757,6 +758,17 @@ impl InMemoryCache {
             config,
             ..Default::default()
         }
+    }
+
+    fn resolve(&self, entity: Entity<'_>) -> bool {
+        rule::resolve_entity(self, entity, &self.config.rules)
+    }
+
+    fn resolve_entities<'a>(
+        &'a self,
+        entities: impl Iterator<Item = Entity<'a>> + 'a,
+    ) -> impl Iterator<Item = Entity<'a>> + 'a {
+        rule::resolve_entities(self, entities, &self.config.rules)
     }
 
     /// Determine whether the configured cache wants a specific resource to be

--- a/cache/in-memory/src/rule.rs
+++ b/cache/in-memory/src/rule.rs
@@ -1,0 +1,168 @@
+//! Rules for accepting entities into the cache.
+
+use crate::InMemoryCache;
+use std::fmt::Debug;
+use twilight_model::{
+    channel::Channel,
+    guild::{Emoji, GuildIntegration, Member, Role},
+    user::User,
+    voice::VoiceState,
+};
+
+/// Entity being checked on whether it should be accepted into the cache.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum Entity<'a> {
+    /// Channel is being resolved.
+    Channel(&'a Channel),
+    /// Emoji is being resolved.
+    Emoji(&'a Emoji),
+    /// Integration is being resolved.
+    Integration(&'a GuildIntegration),
+    /// Member is being resolved.
+    Member(&'a Member),
+    /// Role is being resolved.
+    Role(&'a Role),
+    /// User is being resolved.
+    User(&'a User),
+    /// Voice state is being resolved.
+    VoiceState(&'a VoiceState),
+}
+
+/// Resolution of a [`Rule`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum RuleResolution {
+    /// Accept the entity.
+    Accept,
+    /// Reject the entity.
+    Reject,
+    /// Reject the entity, but only if no other rule has accepted the entity.
+    UnsettledReject,
+}
+
+impl RuleResolution {
+    /// An accepted resolution.
+    pub const ACCEPT: Self = Self::Accept;
+
+    /// A denied resolution.
+    pub const REJECT: Self = Self::Reject;
+
+    /// An unsettled denial resolution.
+    ///
+    /// Refer to [`RuleResolution::UnsettledReject`] for more documentation.
+    pub const UNSETTLED_REJECT: Self = Self::UnsettledReject;
+
+    /// Create a resolution from a boolean.
+    ///
+    /// True maps to [`Self::ACCEPT`] while false maps to [`Self::REJECT`]. This
+    /// does not map to [`Self::UNSETTLED_REJECT`].
+    ///
+    /// # Examples
+    ///
+    /// Create rules from booleans:
+    ///
+    /// ```
+    /// use twilight_cache_inmemory::rule::RuleResolution;
+    ///
+    /// assert_eq!(RuleResolution::ACCEPT, RuleResolution::from_bool(true));
+    /// assert_eq!(RuleResolution::REJECT, RuleResolution::from_bool(true));
+    /// ```
+    pub const fn from_bool(accept: bool) -> Self {
+        if accept {
+            Self::ACCEPT
+        } else {
+            Self::REJECT
+        }
+    }
+}
+
+/// Rules for accepting or rejecting entities into the cache.
+///
+/// The concept of a rule is simple at its heart: given an object, do I want it
+/// to be cached? Rules are predicates that determine this. The cache is
+/// provided to help aid in computing this.
+///
+/// Rules can be added to the cache via [`InMemoryCacheBuilder::rules_mut`].
+///
+/// # Examples
+///
+/// Define a rule to accept only member objects into the cache that are
+/// associated with the current user, rejecting all other member objects:
+///
+/// ```
+/// use twilight_cache_inmemory::{config::{Entity, Rule}, InMemoryCache};
+///
+/// #[derive(Clone, Debug, Eq, PartialEq)]
+/// pub struct CurrentMemberRule;
+///
+/// impl Rule for CurrentMemberRule {
+///     fn accept(&self, cache: &InMemoryCache, entity: &Entity) -> bool {
+///         // We only care about members; if this rule is given something that
+///         // isn't a member then we don't have an opinion about it and allow
+///         // it into the cache.
+///         let member = if let Entity::Member(member) = entity {
+///             member
+///         } else {
+///             return RuleResolution::Accept;
+///         };
+///
+///         // If the current user isn't cached (it should be!) then we don't
+///         // want to accept any members because they may not be the current
+///         // user.
+///         if let Some(current_user) = cache.current_user() {
+///             RuleResolution::from(member.user.id == current_user.id)
+///         } else {
+///             RuleResolution::REJECT
+///         }
+///     }
+/// }
+/// ```
+///
+/// [`InMemoryCacheBuilder::rules_mut`]: super::builder::InMemoryCacheBuilder::rules
+pub trait Rule: Debug + Send + Sync + 'static {
+    /// Whether to accept a given entity into the cache.
+    fn resolve(&self, cache: &InMemoryCache, entity: Entity<'_>) -> RuleResolution;
+}
+
+pub(crate) fn resolve_entity<'a, T: Rule + ?Sized>(
+    cache: &'a InMemoryCache,
+    entity: Entity<'a>,
+    rules: &'a [Box<T>],
+) -> bool {
+    let mut soft_decline = false;
+
+    for rule in rules {
+        match rule.resolve(cache, entity) {
+            RuleResolution::Accept => {}
+            RuleResolution::Reject => return false,
+            RuleResolution::UnsettledReject => {
+                soft_decline = true;
+            }
+        }
+    }
+
+    !soft_decline
+}
+
+pub(crate) fn resolve_entities<'a, T: Rule + ?Sized>(
+    cache: &'a InMemoryCache,
+    entities: impl Iterator<Item = Entity<'a>> + 'a,
+    rules: &'a [Box<T>],
+) -> impl Iterator<Item = Entity<'a>> + 'a {
+    entities.filter(move |entity| {
+        let mut soft_decline = false;
+
+        for rule in rules {
+            match rule.resolve(cache, *entity) {
+                RuleResolution::Accept => {}
+                RuleResolution::Reject => return false,
+                RuleResolution::UnsettledReject => {
+                    soft_decline = true;
+                }
+            }
+        }
+
+        !soft_decline
+    })
+}


### PR DESCRIPTION
Create a Rule API for the cache, allowing users to define programmatic predicate rules that can accept or reject entities into the cache.

The concept is relatively simple: given a particular entity, do I want it in the cache? Using the rules API, one can define or use rule implementations and attach them to the cache via `InMemoryCacheBuilder::rules`.

Motivation for this is due to long-standing requests for better management of what's in the cache, but more particularly being able to cache only the current user's member objects.

**Todo**:
- [ ] better documentation
- [ ] more efficient resolutions via batches? --> *probably* defer to another PR
- [ ] add tests
- [ ] being able to handle both borrowed and owned entities
- [ ] update all events to use resolutions

The Rule API looks like this:

```rust
pub trait Rule: Debug + Send + Sync + 'static {
    /// Whether to accept a given entity into the cache.
    fn resolve(&self, cache: &InMemoryCache, entity: Entity<'_>)
        -> RuleResolution;
}
```

An `Entity` looks like this:

```rust
pub enum Entity<'a> {
    /// Channel is being resolved.
    Channel(&'a Channel),
    /// Emoji is being resolved.
    Emoji(&'a Emoji),
    // ...
}
```

While a `RuleResolution` is:

```rust
pub enum RuleResolution {
    /// Accept the entity.
    Accept,
    /// Reject the entity.
    Reject,
    /// Reject the entity, but only if no other rule has accepted the
    /// entity.
    UnsettledReject,
}

impl RuleResolution {
    pub const ACCEPT: Self = Self::Accept;

    pub const REJECT: Self = Self::Reject;

    pub const UNSETTLED_REJECT: Self = Self::UnsettledReject;

    pub const fn from_bool(accept: bool) -> Self {
        if accept {
            Self::ACCEPT
        } else {
            Self::REJECT
        }
    }
}
```