### PR TITLE
feat(http-ratelimiting): support 'scope' header

### DIFF
--- a/http-ratelimiting/src/headers.rs
+++ b/http-ratelimiting/src/headers.rs
@@ -600,12 +600,11 @@ fn header_str(name: HeaderName, value: &[u8]) -> Result<&str, HeaderParsingError
 
 #[cfg(test)]
 mod tests {
-    use crate::headers::RatelimitScope;
-
     use super::{
         GlobalLimited, HeaderName, HeaderParsingError, HeaderParsingErrorType, HeaderType, Present,
         RatelimitHeaders,
     };
+    use crate::headers::RatelimitScope;
     use http::header::{HeaderMap, HeaderName as HttpHeaderName, HeaderValue};
     use static_assertions::{assert_fields, assert_impl_all};
     use std::{

--- a/http-ratelimiting/src/headers.rs
+++ b/http-ratelimiting/src/headers.rs
@@ -6,9 +6,10 @@
 //! [`Ratelimiter`]: super::Ratelimiter
 
 use std::{
+    convert::TryFrom,
     error::Error,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
-    str::{self, Utf8Error},
+    str::{self, FromStr, Utf8Error},
 };
 
 /// Iterator of header name-value pairs failed to be parsed.
@@ -139,6 +140,8 @@ pub enum HeaderName {
     Reset,
     /// How long until a request can be tried again.
     RetryAfter,
+    /// Scope of a ratelimit.
+    Scope,
 }
 
 impl HeaderName {
@@ -164,6 +167,9 @@ impl HeaderName {
     // It's correct for this to not have the `x-ratelimit-` prefix.
     pub const RETRY_AFTER: &'static str = "retry-after";
 
+    /// Lowercased name for the scope header.
+    pub const SCOPE: &'static str = "x-ratelimit-scope";
+
     /// Lowercased name of the header.
     #[must_use]
     pub const fn name(self) -> &'static str {
@@ -175,6 +181,7 @@ impl HeaderName {
             Self::ResetAfter => Self::RESET_AFTER,
             Self::Reset => Self::RESET,
             Self::RetryAfter => Self::RETRY_AFTER,
+            Self::Scope => Self::SCOPE,
         }
     }
 }
@@ -219,6 +226,8 @@ impl Display for HeaderType {
 pub struct GlobalLimited {
     /// Number of seconds until the global ratelimit bucket is reset.
     retry_after: u64,
+    /// Scope of the ratelimit.
+    scope: Option<RatelimitScope>,
 }
 
 impl GlobalLimited {
@@ -226,6 +235,15 @@ impl GlobalLimited {
     #[must_use]
     pub const fn retry_after(&self) -> u64 {
         self.retry_after
+    }
+
+    /// Scope of the ratelimit.
+    ///
+    /// This should always be present and should always be
+    /// [`RatelimitScope::Global`].
+    #[must_use]
+    pub const fn scope(&self) -> Option<RatelimitScope> {
+        self.scope
     }
 }
 
@@ -242,6 +260,8 @@ pub struct Present {
     reset_after: u64,
     /// When the bucket resets as a Unix timestamp in milliseconds.
     reset: u64,
+    /// Scope of a ratelimit when one occurs.
+    scope: Option<RatelimitScope>,
 }
 
 impl Present {
@@ -288,6 +308,67 @@ impl Present {
     #[must_use]
     pub const fn reset(&self) -> u64 {
         self.reset
+    }
+
+    /// Scope of a ratelimit when one occurs.
+    #[must_use]
+    pub const fn scope(&self) -> Option<RatelimitScope> {
+        self.scope
+    }
+}
+
+/// Scope of a ratelimit when one occurs.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum RatelimitScope {
+    /// Ratelimit is a global ratelimit and affects the application as a whole.
+    Global,
+    /// Ratelimit is a shared ratelimit and affects all applications in the
+    /// resource.
+    ///
+    /// This does not affect the application's individual ratelimit buckets or
+    /// global limits.
+    Shared,
+    /// Ratelimit is a per-resource limit, such as for an individual bucket.
+    User,
+}
+
+impl Display for RatelimitScope {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str(match self {
+            Self::Global => "global",
+            Self::Shared => "shared",
+            Self::User => "user",
+        })
+    }
+}
+
+impl FromStr for RatelimitScope {
+    type Err = HeaderParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "global" => Self::Global,
+            "shared" => Self::Shared,
+            "user" => Self::User,
+            _ => {
+                return Err(HeaderParsingError {
+                    kind: HeaderParsingErrorType::Parsing {
+                        kind: HeaderType::String,
+                        name: HeaderName::Scope,
+                        value: s.to_owned(),
+                    },
+                    source: None,
+                })
+            }
+        })
+    }
+}
+
+impl TryFrom<&'_ str> for RatelimitScope {
+    type Error = HeaderParsingError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::from_str(value)
     }
 }
 
@@ -392,6 +473,7 @@ impl RatelimitHeaders {
         let mut reset = None;
         let mut reset_after = None;
         let mut retry_after = None;
+        let mut scope = None;
 
         for (name, value) in headers {
             match name {
@@ -399,12 +481,6 @@ impl RatelimitHeaders {
                     bucket.replace(header_str(HeaderName::Bucket, value)?);
                 }
                 HeaderName::GLOBAL => {
-                    if let Some(retry_after) = retry_after {
-                        return Ok(RatelimitHeaders::GlobalLimited(GlobalLimited {
-                            retry_after,
-                        }));
-                    }
-
                     global = header_bool(value);
                 }
                 HeaderName::LIMIT => {
@@ -429,16 +505,26 @@ impl RatelimitHeaders {
                 HeaderName::RETRY_AFTER => {
                     let retry_after_value = header_int(HeaderName::RetryAfter, value)?;
 
-                    if global {
-                        return Ok(RatelimitHeaders::GlobalLimited(GlobalLimited {
-                            retry_after: header_int(HeaderName::RetryAfter, value)?,
-                        }));
-                    }
-
                     retry_after.replace(retry_after_value);
+                }
+                HeaderName::SCOPE => {
+                    let scope_value = header_str(HeaderName::Scope, value)?;
+                    let scope_parsed = RatelimitScope::try_from(scope_value)?;
+
+                    scope.replace(scope_parsed);
                 }
                 _ => continue,
             }
+        }
+
+        if global {
+            let retry_after =
+                retry_after.ok_or_else(|| HeaderParsingError::missing(HeaderName::RetryAfter))?;
+
+            return Ok(RatelimitHeaders::GlobalLimited(GlobalLimited {
+                retry_after,
+                scope,
+            }));
         }
 
         // If none of the values have been set then there are no ratelimit headers.
@@ -460,6 +546,7 @@ impl RatelimitHeaders {
             reset: reset.ok_or_else(|| HeaderParsingError::missing(HeaderName::Reset))?,
             reset_after: reset_after
                 .ok_or_else(|| HeaderParsingError::missing(HeaderName::ResetAfter))?,
+            scope,
         }))
     }
 }
@@ -513,6 +600,8 @@ fn header_str(name: HeaderName, value: &[u8]) -> Result<&str, HeaderParsingError
 
 #[cfg(test)]
 mod tests {
+    use crate::headers::RatelimitScope;
+
     use super::{
         GlobalLimited, HeaderName, HeaderParsingError, HeaderParsingErrorType, HeaderType, Present,
         RatelimitHeaders,
@@ -577,6 +666,110 @@ mod tests {
     }
 
     #[test]
+    fn test_global_with_scope() -> Result<(), Box<dyn Error>> {
+        let map = {
+            let mut map = HeaderMap::new();
+            map.insert(
+                HttpHeaderName::from_static("x-ratelimit-global"),
+                HeaderValue::from_static("true"),
+            );
+            map.insert(
+                HttpHeaderName::from_static("retry-after"),
+                HeaderValue::from_static("65"),
+            );
+            map.insert(
+                HttpHeaderName::from_static("x-ratelimit-scope"),
+                HeaderValue::from_static("global"),
+            );
+
+            map
+        };
+
+        let iter = map.iter().map(|(k, v)| (k.as_str(), v.as_bytes()));
+        let headers = RatelimitHeaders::from_pairs(iter)?;
+        assert!(matches!(
+            headers,
+            RatelimitHeaders::GlobalLimited(ref global)
+            if global.retry_after() == 65
+        ));
+        assert!(matches!(
+            headers,
+            RatelimitHeaders::GlobalLimited(global)
+            if global.scope() == Some(RatelimitScope::Global)
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_present() -> Result<(), Box<dyn Error>> {
+        let map = {
+            let mut map = HeaderMap::new();
+            map.insert(
+                HttpHeaderName::from_static("x-ratelimit-limit"),
+                HeaderValue::from_static("10"),
+            );
+            map.insert(
+                HttpHeaderName::from_static("x-ratelimit-remaining"),
+                HeaderValue::from_static("9"),
+            );
+            map.insert(
+                HttpHeaderName::from_static("x-ratelimit-reset"),
+                HeaderValue::from_static("1470173023.123"),
+            );
+            map.insert(
+                HttpHeaderName::from_static("x-ratelimit-reset-after"),
+                HeaderValue::from_static("64.57"),
+            );
+            map.insert(
+                HttpHeaderName::from_static("x-ratelimit-bucket"),
+                HeaderValue::from_static("abcd1234"),
+            );
+            map.insert(
+                HttpHeaderName::from_static("x-ratelimit-scope"),
+                HeaderValue::from_static("shared"),
+            );
+
+            map
+        };
+
+        let iter = map.iter().map(|(k, v)| (k.as_str(), v.as_bytes()));
+        let headers = RatelimitHeaders::from_pairs(iter)?;
+        assert!(matches!(
+            headers,
+            RatelimitHeaders::Present(ref present)
+            if present.bucket.as_deref() == Some("abcd1234")
+        ));
+        assert!(matches!(
+            headers,
+            RatelimitHeaders::Present(ref present)
+            if present.limit == 10
+        ));
+        assert!(matches!(
+            headers,
+            RatelimitHeaders::Present(ref present)
+            if present.remaining == 9
+        ));
+        assert!(matches!(
+            headers,
+            RatelimitHeaders::Present(ref present)
+            if present.reset_after == 64_570
+        ));
+        assert!(matches!(
+            headers,
+            RatelimitHeaders::Present(ref present)
+            if present.reset == 1_470_173_023_123
+        ));
+        assert!(matches!(
+            headers,
+            RatelimitHeaders::Present(present)
+            if present.scope() == Some(RatelimitScope::Shared)
+        ));
+
+        Ok(())
+    }
+
+    #[test]
     fn test_name() {
         assert_eq!("x-ratelimit-bucket", HeaderName::BUCKET);
         assert_eq!("x-ratelimit-global", HeaderName::GLOBAL);
@@ -585,6 +778,7 @@ mod tests {
         assert_eq!("x-ratelimit-reset-after", HeaderName::RESET_AFTER);
         assert_eq!("x-ratelimit-reset", HeaderName::RESET);
         assert_eq!("retry-after", HeaderName::RETRY_AFTER);
+        assert_eq!("x-ratelimit-scope", HeaderName::SCOPE);
         assert_eq!(HeaderName::BUCKET, HeaderName::Bucket.name());
         assert_eq!(HeaderName::GLOBAL, HeaderName::Global.name());
         assert_eq!(HeaderName::LIMIT, HeaderName::Limit.name());
@@ -592,6 +786,7 @@ mod tests {
         assert_eq!(HeaderName::RESET_AFTER, HeaderName::ResetAfter.name());
         assert_eq!(HeaderName::RESET, HeaderName::Reset.name());
         assert_eq!(HeaderName::RETRY_AFTER, HeaderName::RetryAfter.name());
+        assert_eq!(HeaderName::SCOPE, HeaderName::Scope.name());
     }
 
     #[test]


### PR DESCRIPTION
Support the `x-ratelimiting-scope` header, which indicates the scope of a ratelimit. Possible values are "global" (an application global ratelimit), "shared" (shared ratelimit between applications across a resource), and "user" (individual ratelimit, e.g. for an individual bucket).