### PR TITLE
chore(command-parser): deprecate crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 for the Discord API.
 
 The ecosystem of first-class crates includes [`twilight-cache-inmemory`],
-[`twilight-command-parser`], [`twilight-gateway`], [`twilight-http`],
-[`twilight-model`], and more. These are explained in detail below.
+[`twilight-gateway`], [`twilight-http`], [`twilight-model`], and more. These
+are explained in detail below.
 
 The main `twilight` crate is purely an advertisement crate: it has *no*
 functionality. Please use the individual crates listed below instead!
@@ -34,7 +34,7 @@ that dependency in.
 
 These are essential crates that most users will use together for a full
 development experience. You may not need all of these - such as
-[`twilight-command-parser`] - but they are often used together to accomplish
+[`twilight-cache-inmemory`] - but they are often used together to accomplish
 most of what you need.
 
 ### [`twilight-model`]
@@ -61,11 +61,6 @@ from Discord.
 Implementation of Discord's sharding gateway sessions. This is responsible
 for receiving stateful events in real-time from Discord and sending *some*
 stateful information.
-
-### [`twilight-command-parser`]
-
-Helpful crate for parsing commands out of messages received over the
-gateway. It finds messages commanding your bot and parses the arguments out.
 
 ### [`twilight-http`]
 
@@ -238,7 +233,6 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [rust badge]: https://img.shields.io/badge/rust-1.53+-93450a.svg?style=for-the-badge&logo=rust
 [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
 [`twilight-cache-inmemory`]: https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html
-[`twilight-command-parser`]: https://twilight.rs/chapter_1_crates/section_5_command_parser.html
 [`twilight-embed-builder`]: https://twilight.rs/chapter_1_crates/section_7_first_party/section_1_embed_builder.html
 [`twilight-gateway-queue`]: https://twilight.rs/chapter_1_crates/section_7_first_party/section_5_gateway_queue.html
 [`twilight-gateway`]: https://twilight.rs/chapter_1_crates/section_3_gateway.html

--- a/command-parser/README.md
+++ b/command-parser/README.md
@@ -4,6 +4,11 @@
 
 [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
+**This crate has been deprecated. Please use [Discord interactions] via the
+[`twilight-gateway`] or [`twilight-http`] crates.**
+
+**This crate has been deprecated. Please see the above notice.**
+
 `twilight-command-parser` is a command parser for the [`twilight-rs`]
 ecosystem.
 
@@ -46,6 +51,7 @@ match parser.parse("!echo a message") {
 }
 ```
 
+[Discord interactions]: https://discord.com/developers/docs/interactions/application-commands
 [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
 [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
@@ -55,6 +61,8 @@ match parser.parse("!echo a message") {
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [rust badge]: https://img.shields.io/badge/rust-1.53+-93450a.svg?style=for-the-badge&logo=rust
+[`twilight-gateway`]: https://crates.io/crates/twilight-gateway
+[`twilight-http`]: https://crates.io/crates/twilight-http
 [`twilight-rs`]: https://github.com/twilight-rs/twilight
 
 <!-- cargo-sync-readme end -->

--- a/command-parser/README.md
+++ b/command-parser/README.md
@@ -7,8 +7,6 @@
 **This crate has been deprecated. Please use [Discord interactions] via the
 [`twilight-gateway`] or [`twilight-http`] crates.**
 
-**This crate has been deprecated. Please see the above notice.**
-
 `twilight-command-parser` is a command parser for the [`twilight-rs`]
 ecosystem.
 

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -2,6 +2,11 @@
 //!
 //! [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 //!
+//! **This crate has been deprecated. Please use [Discord interactions] via the
+//! [`twilight-gateway`] or [`twilight-http`] crates.**
+//!
+//! **This crate has been deprecated. Please see the above notice.**
+//!
 //! `twilight-command-parser` is a command parser for the [`twilight-rs`]
 //! ecosystem.
 //!
@@ -44,6 +49,7 @@
 //! }
 //! ```
 //!
+//! [Discord interactions]: https://discord.com/developers/docs/interactions/application-commands
 //! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
 //! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
@@ -53,8 +59,14 @@
 //! [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.53+-93450a.svg?style=for-the-badge&logo=rust
+//! [`twilight-gateway`]: https://crates.io/crates/twilight-gateway
+//! [`twilight-http`]: https://crates.io/crates/twilight-http
 //! [`twilight-rs`]: https://github.com/twilight-rs/twilight
 
+#![deprecated(
+    since = "0.8.1",
+    note = "use interactions via `twilight-http` or `twilight-gateway`"
+)]
 #![deny(
     clippy::all,
     clippy::missing_const_for_fn,

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -5,8 +5,6 @@
 //! **This crate has been deprecated. Please use [Discord interactions] via the
 //! [`twilight-gateway`] or [`twilight-http`] crates.**
 //!
-//! **This crate has been deprecated. Please see the above notice.**
-//!
 //! `twilight-command-parser` is a command parser for the [`twilight-rs`]
 //! ecosystem.
 //!

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -8,8 +8,8 @@
 //! for the Discord API.
 //!
 //! The ecosystem of first-class crates includes [`twilight-cache-inmemory`],
-//! [`twilight-command-parser`], [`twilight-gateway`], [`twilight-http`],
-//! [`twilight-model`], and more. These are explained in detail below.
+//! [`twilight-gateway`], [`twilight-http`], [`twilight-model`], and more. These
+//! are explained in detail below.
 //!
 //! The main `twilight` crate is purely an advertisement crate: it has *no*
 //! functionality. Please use the individual crates listed below instead!
@@ -32,7 +32,7 @@
 //!
 //! These are essential crates that most users will use together for a full
 //! development experience. You may not need all of these - such as
-//! [`twilight-command-parser`] - but they are often used together to accomplish
+//! [`twilight-cache-inmemory`] - but they are often used together to accomplish
 //! most of what you need.
 //!
 //! ### [`twilight-model`]
@@ -59,11 +59,6 @@
 //! Implementation of Discord's sharding gateway sessions. This is responsible
 //! for receiving stateful events in real-time from Discord and sending *some*
 //! stateful information.
-//!
-//! ### [`twilight-command-parser`]
-//!
-//! Helpful crate for parsing commands out of messages received over the
-//! gateway. It finds messages commanding your bot and parses the arguments out.
 //!
 //! ### [`twilight-http`]
 //!
@@ -238,7 +233,6 @@
 //! [rust badge]: https://img.shields.io/badge/rust-1.53+-93450a.svg?style=for-the-badge&logo=rust
 //! [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
 //! [`twilight-cache-inmemory`]: https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html
-//! [`twilight-command-parser`]: https://twilight.rs/chapter_1_crates/section_5_command_parser.html
 //! [`twilight-embed-builder`]: https://twilight.rs/chapter_1_crates/section_7_first_party/section_1_embed_builder.html
 //! [`twilight-gateway-queue`]: https://twilight.rs/chapter_1_crates/section_7_first_party/section_5_gateway_queue.html
 //! [`twilight-gateway`]: https://twilight.rs/chapter_1_crates/section_3_gateway.html


### PR DESCRIPTION
Deprecate the Command Parser crate because we now reasonably support interactions and deprecation of the message content intent is around the block.