### PR TITLE
feat(http/response): pre-flight cancelation

### DIFF
--- a/http/src/response/future.rs
+++ b/http/src/response/future.rs
@@ -205,7 +205,7 @@ impl InFlight {
 struct RatelimitQueue {
     guild_id: Option<GuildId>,
     invalid_token: InvalidToken,
-    pre_flight_check: Option<Box<dyn FnOnce() -> bool + 'static>>,
+    pre_flight_check: Option<Box<dyn FnOnce() -> bool + Send + 'static>>,
     request_timeout: Duration,
     response_future: HyperResponseFuture,
     wait_for_sender: WaitForTicketFuture,
@@ -375,7 +375,10 @@ impl<T> ResponseFuture<T> {
     /// ));
     /// # Ok(()) }
     /// ```
-    pub fn set_pre_flight(&mut self, pre_flight: Box<dyn FnOnce() -> bool + 'static>) -> bool {
+    pub fn set_pre_flight(
+        &mut self,
+        pre_flight: Box<dyn FnOnce() -> bool + Send + 'static>,
+    ) -> bool {
         if let ResponseFutureStage::RatelimitQueue(ref mut queue) = &mut self.stage {
             queue.pre_flight_check = Some(pre_flight);
 


### PR DESCRIPTION
Support pre-flight request cancelation via a new method, `ResponseFuture::set_pre_flight`. This allows users to configure pre-flight checks to determine whether the request should be sent once it has cleared ratelimit queues.

Closes #574.