### PR TITLE
refactor(http): simplify token invalidation

### DIFF
--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -64,14 +64,19 @@ impl ClientBuilder {
 
         let http = hyper::client::Builder::default().build(connector);
 
+        let token_invalidated = if self.remember_invalid_token {
+            Some(Arc::new(AtomicBool::new(false)))
+        } else {
+            None
+        };
+
         Client {
             http,
             default_headers: self.default_headers,
             proxy: self.proxy,
             ratelimiter: self.ratelimiter,
-            remember_invalid_token: self.remember_invalid_token,
             timeout: self.timeout,
-            token_invalid: Arc::new(AtomicBool::new(false)),
+            token_invalidated,
             token: self.token,
             application_id: self.application_id,
             default_allowed_mentions: self.default_allowed_mentions,

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -84,7 +84,7 @@ use crate::{
         },
         GetGateway, GetUserApplicationInfo, GetVoiceRegions, Method, Request,
     },
-    response::{future::InvalidToken, ResponseFuture},
+    response::ResponseFuture,
     API_VERSION,
 };
 use hyper::{
@@ -202,15 +202,12 @@ pub struct Client {
     http: HyperClient<HttpsConnector<HttpConnector>, Body>,
     proxy: Option<Box<str>>,
     ratelimiter: Option<Box<dyn Ratelimiter>>,
-    /// Whether to short-circuit when a 401 has been encountered with the client
-    /// authorization.
-    ///
-    /// This relates to [`token_invalid`].
-    ///
-    /// [`token_invalid`]: Self::token_invalid
-    remember_invalid_token: bool,
     timeout: Duration,
-    token_invalid: Arc<AtomicBool>,
+    /// Whether the token has been invalidated.
+    ///
+    /// Whether an invalid token is tracked can be configured via
+    /// [`ClientBuilder::remember_invalid_token`].
+    token_invalidated: Option<Arc<AtomicBool>>,
     token: Option<Box<str>>,
     use_http: bool,
 }
@@ -2716,11 +2713,13 @@ impl Client {
 
     #[allow(clippy::too_many_lines)]
     fn try_request<T>(&self, request: Request) -> Result<ResponseFuture<T>, Error> {
-        if self.remember_invalid_token && self.token_invalid.load(Ordering::Relaxed) {
-            return Err(Error {
-                kind: ErrorType::Unauthorized,
-                source: None,
-            });
+        if let Some(token_invalidated) = self.token_invalidated.as_ref() {
+            if token_invalidated.load(Ordering::Relaxed) {
+                return Err(Error {
+                    kind: ErrorType::Unauthorized,
+                    source: None,
+                });
+            }
         }
 
         let Request {
@@ -2843,10 +2842,10 @@ impl Client {
         // For requests that don't use an authorization token we don't need to
         // remember whether the token is invalid. This may be for requests such
         // as webhooks and interactions.
-        let invalid_token = if self.remember_invalid_token && use_authorization_token {
-            InvalidToken::Remember(Arc::clone(&self.token_invalid))
+        let invalid_token = if use_authorization_token {
+            self.token_invalidated.as_ref().map(Arc::clone)
         } else {
-            InvalidToken::Forget
+            None
         };
 
         // Clippy suggests bad code; an `Option::map_or_else` won't work here

--- a/http/src/response/future.rs
+++ b/http/src/response/future.rs
@@ -20,11 +20,6 @@ use tokio::time::{self, Timeout};
 use twilight_http_ratelimiting::{ticket::TicketSender, RatelimitHeaders, WaitForTicketFuture};
 use twilight_model::id::GuildId;
 
-pub enum InvalidToken {
-    Forget,
-    Remember(Arc<AtomicBool>),
-}
-
 type Output<T> = Result<Response<T>, Error>;
 
 enum InnerPoll<T> {
@@ -94,7 +89,7 @@ impl Failed {
 struct InFlight {
     future: Pin<Box<Timeout<HyperResponseFuture>>>,
     guild_id: Option<GuildId>,
-    invalid_token: InvalidToken,
+    invalid_token: Option<Arc<AtomicBool>>,
     tx: Option<TicketSender>,
 }
 
@@ -128,8 +123,8 @@ impl InFlight {
         // configured token is permanently invalid and future requests must be
         // ignored to avoid API bans.
         if resp.status() == HyperStatusCode::UNAUTHORIZED {
-            if let InvalidToken::Remember(state) = self.invalid_token {
-                state.store(true, Ordering::Relaxed);
+            if let Some(invalid_token) = self.invalid_token {
+                invalid_token.store(true, Ordering::Relaxed);
             }
         }
 
@@ -204,7 +199,7 @@ impl InFlight {
 
 struct RatelimitQueue {
     guild_id: Option<GuildId>,
-    invalid_token: InvalidToken,
+    invalid_token: Option<Arc<AtomicBool>>,
     request_timeout: Duration,
     response_future: HyperResponseFuture,
     wait_for_sender: WaitForTicketFuture,
@@ -290,7 +285,7 @@ pub struct ResponseFuture<T> {
 
 impl<T> ResponseFuture<T> {
     pub(crate) fn new(
-        invalid_token: InvalidToken,
+        invalid_token: Option<Arc<AtomicBool>>,
         future: Timeout<HyperResponseFuture>,
         ratelimit_tx: Option<TicketSender>,
     ) -> Self {
@@ -314,7 +309,7 @@ impl<T> ResponseFuture<T> {
 
     pub(crate) fn ratelimit(
         guild_id: Option<GuildId>,
-        invalid_token: InvalidToken,
+        invalid_token: Option<Arc<AtomicBool>>,
         wait_for_sender: WaitForTicketFuture,
         request_timeout: Duration,
         response_future: HyperResponseFuture,


### PR DESCRIPTION
Simplify token invalidation state by removing a field on `Client` and removing a token invalidation state wrapper specific to `ResponseFuture`.