### PR TITLE
feat(cache/in-memory): add channel messages iter

### DIFF
--- a/cache/in-memory/src/event/message.rs
+++ b/cache/in-memory/src/event/message.rs
@@ -206,7 +206,7 @@ mod tests {
 
         cache.update(&MessageCreate(msg.clone()));
         msg.id = MessageId::new(5).expect("non zero");
-        cache.update(&MessageCreate(msg.clone()));
+        cache.update(&MessageCreate(msg));
 
         {
             let entry = cache

--- a/cache/in-memory/src/event/message.rs
+++ b/cache/in-memory/src/event/message.rs
@@ -230,5 +230,11 @@ mod tests {
                 .unwrap();
             assert_eq!(entry.value().len(), 1);
         }
+
+        let mut iter = cache
+            .channel_messages(ChannelId::new(2).expect("non zero"))
+            .expect("channel is in cache");
+        assert_eq!(Some(4), iter.next().map(MessageId::get));
+        assert!(iter.next().is_none());
     }
 }

--- a/cache/in-memory/src/iter.rs
+++ b/cache/in-memory/src/iter.rs
@@ -16,8 +16,11 @@ use crate::{
     model::{CachedEmoji, CachedGuild, CachedMember, CachedMessage, CachedPresence, CachedSticker},
     GuildResource, InMemoryCache,
 };
-use dashmap::{iter::Iter, mapref::multiple::RefMulti};
-use std::{hash::Hash, ops::Deref};
+use dashmap::{
+    iter::Iter,
+    mapref::{multiple::RefMulti, one::Ref},
+};
+use std::{collections::VecDeque, hash::Hash, ops::Deref};
 use twilight_model::{
     channel::{message::sticker::StickerId, Group, GuildChannel, PrivateChannel, StageInstance},
     guild::{GuildIntegration, Role},
@@ -251,9 +254,73 @@ impl<'a, K: Eq + Hash, V> Iterator for ResourceIter<'a, K, V> {
     }
 }
 
+/// Iterator over a channel's list of recent message IDs.
+///
+/// The iterator is descending: the first is the most recent ID, the second is
+/// the second most recent ID, and so on.
+///
+/// # Examples
+///
+/// Iterate over the messages in a channel:
+///
+/// ```no_run
+/// # fn try_main() -> Option<()> {
+/// use twilight_cache_inmemory::InMemoryCache;
+/// use twilight_model::id::{ChannelId, MessageId};
+///
+/// let channel_id = ChannelId::new(1).expect("non zero id");
+///
+/// let cache = InMemoryCache::new();
+/// let message_ids = cache.channel_messages(channel_id)?;
+///
+/// for message_id in message_ids {
+///     if let Some(message) = cache.message(message_id) {
+///         println!(
+///             "message {} content: {}",
+///             message_id,
+///             message.content(),
+///         );
+///     }
+/// }
+/// # Some(()) }
+/// ```
+pub struct ChannelMessages<'a> {
+    index: usize,
+    message_ids: Ref<'a, ChannelId, VecDeque<MessageId>>,
+}
+
+impl<'a> ChannelMessages<'a> {
+    pub(super) const fn new(message_ids: Ref<'a, ChannelId, VecDeque<MessageId>>) -> Self {
+        Self {
+            index: 0,
+            message_ids,
+        }
+    }
+}
+
+impl<'a> Iterator for ChannelMessages<'a> {
+    type Item = MessageId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(message_id) = self.message_ids.iter().nth(self.index) {
+            self.index += 1;
+
+            return Some(*message_id);
+        }
+
+        None
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.index = self.index.saturating_add(n);
+
+        self.next()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{InMemoryCacheIter, IterReference, ResourceIter};
+    use super::{ChannelMessages, InMemoryCacheIter, IterReference, ResourceIter};
     use crate::{test, InMemoryCache};
     use static_assertions::assert_impl_all;
     use std::{borrow::Cow, fmt::Debug};
@@ -262,6 +329,7 @@ mod tests {
         user::User,
     };
 
+    assert_impl_all!(ChannelMessages<'_>: Iterator, Send, Sync);
     assert_impl_all!(InMemoryCacheIter<'_>: Debug, Send, Sync);
     assert_impl_all!(IterReference<'_, UserId, User>: Send, Sync);
     assert_impl_all!(ResourceIter<'_, UserId, User>: Iterator, Send, Sync);

--- a/cache/in-memory/src/iter.rs
+++ b/cache/in-memory/src/iter.rs
@@ -302,7 +302,7 @@ impl<'a> Iterator for ChannelMessages<'a> {
     type Item = MessageId;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(message_id) = self.message_ids.iter().nth(self.index) {
+        if let Some(message_id) = self.message_ids.get(self.index) {
             self.index += 1;
 
             return Some(*message_id);

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -949,13 +949,16 @@ impl UpdateCache for Event {
 
 #[cfg(test)]
 mod tests {
-    use crate::{test, InMemoryCache};
+    use crate::{test, ChannelMessages, InMemoryCache};
+    use static_assertions::assert_impl_all;
     use twilight_model::{
         datetime::Timestamp,
         gateway::payload::incoming::RoleDelete,
         guild::{Member, Permissions, Role},
         id::{EmojiId, GuildId, RoleId, UserId},
     };
+
+    assert_impl_all!(ChannelMessages<'_>: Iterator, Send, Sync);
 
     #[test]
     fn test_syntax_update() {


### PR DESCRIPTION
Add a new iterator named `ChannelMessages` returning the message IDs of a channel. This is made available via the `InMemoryCache::channel_messages` method.

Closes #1358.

<img width="824" alt="Screen Shot 2021-12-26 at 09 26 47" src="https://user-images.githubusercontent.com/57759500/147411096-3eccf1ed-00fc-400a-b833-8824f35b6f55.png">
