### PR TITLE
docs(cache/in-memory,model): fix named anchors

### DIFF
--- a/cache/in-memory/README.md
+++ b/cache/in-memory/README.md
@@ -50,6 +50,7 @@ while let Some(event) = events.next().await {
 All first-party crates are licensed under [ISC][LICENSE.md]
 
 [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
+[`twilight-rs`]: https://github.com/twilight-rs/twilight
 [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
 [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -50,6 +50,7 @@
 //! All first-party crates are licensed under [ISC][LICENSE.md]
 //!
 //! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
+//! [`twilight-rs`]: https://github.com/twilight-rs/twilight
 //! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
 //! [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 //! [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge

--- a/model/README.md
+++ b/model/README.md
@@ -39,6 +39,7 @@ This is enabled by default.
 [ISC][LICENSE.md]
 
 [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
+[`tracing`]: https://crates.io/crates/tracing
 [`twilight-util`]: https://docs.rs/twilight-util
 [`twilight`]: https://docs.rs/twilight
 [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -37,6 +37,7 @@
 //! [ISC][LICENSE.md]
 //!
 //! [LICENSE.md]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
+//! [`tracing`]: https://crates.io/crates/tracing
 //! [`twilight-util`]: https://docs.rs/twilight-util
 //! [`twilight`]: https://docs.rs/twilight
 //! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2


### PR DESCRIPTION
Fix some named anchors that didn't have references in the READMEs of the `twilight-cache-inmemory` and `twilight-model` crates.