### PR TITLE
doc: Remove explicit `doc(cfg)`

### DIFF
--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -76,7 +76,6 @@ pub mod iter;
 pub mod model;
 
 #[cfg(feature = "permission-calculator")]
-#[cfg_attr(docsrs, doc(cfg(feature = "permission-calculator")))]
 pub mod permission;
 
 mod builder;
@@ -94,7 +93,6 @@ pub use self::{
 };
 
 #[cfg(feature = "permission-calculator")]
-#[cfg_attr(docsrs, doc(cfg(feature = "permission-calculator")))]
 pub use self::permission::InMemoryCachePermissions;
 
 use self::{iter::InMemoryCacheIter, model::*};
@@ -416,7 +414,6 @@ impl InMemoryCache {
     /// # Ok(()) }
     /// ```
     #[cfg(feature = "permission-calculator")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "permission-calculator")))]
     pub const fn permissions(&self) -> InMemoryCachePermissions<'_> {
         InMemoryCachePermissions::new(self)
     }

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -61,7 +61,7 @@
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [rust badge]: https://img.shields.io/badge/rust-1.53+-93450a.svg?style=for-the-badge&logo=rust
 
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(
     clippy::missing_const_for_fn,
     missing_docs,

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -54,17 +54,13 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "builder")]
-#[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
 pub mod builder;
 
 #[cfg(feature = "link")]
-#[cfg_attr(docsrs, doc(cfg(feature = "link")))]
 pub mod link;
 
 #[cfg(feature = "permission-calculator")]
-#[cfg_attr(docsrs, doc(cfg(feature = "permission-calculator")))]
 pub mod permission_calculator;
 
 #[cfg(feature = "snowflake")]
-#[cfg_attr(docsrs, doc(cfg(feature = "snowflake")))]
 pub mod snowflake;

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -51,7 +51,7 @@
     warnings
 )]
 #![allow(clippy::semicolon_if_nothing_returned)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "builder")]
 pub mod builder;


### PR DESCRIPTION
`#[cfg(feature)]` implies `#[doc(cfg(feature))]`
