### PR TITLE
actions: Remove `--workspace` flag

### DIFF
--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Build docs
         env:
-          RUSTDOCFLAGS: --cfg docsrs -D broken_intra_doc_links
+          RUSTDOCFLAGS: --cfg docsrs
         run: |
           cargo doc --no-deps --features=permission-calculator
           cargo doc -p twilight-util --no-deps --all-features

--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"
 
-      - run: cargo check --workspace --all-features --all-targets
+      - run: cargo check --all-features --all-targets
 
   # Check documentation
   build-docs:
@@ -62,7 +62,7 @@ jobs:
         env:
           RUSTDOCFLAGS: --cfg docsrs -D broken_intra_doc_links
         run: |
-          cargo doc --workspace --no-deps --features=permission-calculator
+          cargo doc --no-deps --features=permission-calculator
           cargo doc -p twilight-util --no-deps --all-features
 
   sync-readme:
@@ -121,7 +121,7 @@ jobs:
         run: echo "::add-matcher::.github/rust.json"
 
       - name: Run clippy
-        run: cargo clippy --workspace --all-features --all-targets
+        run: cargo clippy --all-features --all-targets
 
   codespell:
     name: Spelling
@@ -179,7 +179,7 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
-    
+
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"
 

--- a/.github/workflows/codecov-lib.yml
+++ b/.github/workflows/codecov-lib.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Collect coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: "--ignore-tests --workspace --all-features ${{ steps.excluded-examples.outputs.out }}"
+          args: "--ignore-tests --all-features ${{ steps.excluded-examples.outputs.out }}"
 
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v2

--- a/.github/workflows/deploy-lib.yml
+++ b/.github/workflows/deploy-lib.yml
@@ -44,7 +44,7 @@ jobs:
           RUSTDOCFLAGS: --cfg docsrs -D broken_intra_doc_links
         run: |
           exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
-          cargo doc --workspace --no-deps --features=permission-calculator "${exclude_examples[@]}"
+          cargo doc --no-deps --features=permission-calculator "${exclude_examples[@]}"
           cargo doc -p twilight-util --no-deps --all-features
 
       - name: Prepare docs

--- a/.github/workflows/deploy-lib.yml
+++ b/.github/workflows/deploy-lib.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build docs
         env:
-          RUSTDOCFLAGS: --cfg docsrs -D broken_intra_doc_links
+          RUSTDOCFLAGS: --cfg docsrs
         run: |
           exclude_examples=($(grep -h '^name' examples/**/Cargo.toml | cut -d'"' -f2 | xargs -I '{}' echo '--exclude {}'))
           cargo doc --no-deps --features=permission-calculator "${exclude_examples[@]}"


### PR DESCRIPTION
It is implied when root the workspace, i.e. it's only useful when the current directory isn't root.
As it's already left out for most steps never using it is less confusing.
