### PR TITLE
Remove erroneous forward slash

### DIFF
--- a/http/src/routing/route_display.rs
+++ b/http/src/routing/route_display.rs
@@ -668,7 +668,7 @@ impl Display for RouteDisplay<'_> {
 
                 f.write_str("/permissions")
             }
-            Route::GetCurrentUserApplicationInfo => f.write_str("/oauth2/applications/@me"),
+            Route::GetCurrentUserApplicationInfo => f.write_str("oauth2/applications/@me"),
             Route::GetCurrentUser | Route::UpdateCurrentUser => f.write_str("users/@me"),
             Route::GetGateway => f.write_str("gateway"),
             Route::GetGuild {

--- a/http/src/routing/route_display.rs
+++ b/http/src/routing/route_display.rs
@@ -2405,7 +2405,7 @@ mod tests {
     #[test]
     fn test_get_current_user_application_info() {
         let route = Route::GetCurrentUserApplicationInfo;
-        assert_eq!(route.display().to_string(), "/oauth2/applications/@me");
+        assert_eq!(route.display().to_string(), "oauth2/applications/@me");
     }
 
     #[test]


### PR DESCRIPTION
This did not make the endpoint not work, but it may cause isses

The errornous url used: `https://discord.com/api/v9//oauth2/applications/@me`

I have looked through the rest of the file and found no other instances of this.