### PR TITLE
refactor: don't use the `ref` keyword

### DIFF
--- a/cache/in-memory/src/event/channel.rs
+++ b/cache/in-memory/src/event/channel.rs
@@ -17,26 +17,26 @@ impl InMemoryCache {
     }
 
     pub(crate) fn cache_guild_channel(&self, guild_id: GuildId, mut channel: GuildChannel) {
-        match channel {
-            GuildChannel::Category(ref mut c) => {
+        match &mut channel {
+            GuildChannel::Category(c) => {
                 c.guild_id.replace(guild_id);
             }
-            GuildChannel::NewsThread(ref mut c) => {
+            GuildChannel::NewsThread(c) => {
                 c.guild_id.replace(guild_id);
             }
-            GuildChannel::PrivateThread(ref mut c) => {
+            GuildChannel::PrivateThread(c) => {
                 c.guild_id.replace(guild_id);
             }
-            GuildChannel::PublicThread(ref mut c) => {
+            GuildChannel::PublicThread(c) => {
                 c.guild_id.replace(guild_id);
             }
-            GuildChannel::Text(ref mut c) => {
+            GuildChannel::Text(c) => {
                 c.guild_id.replace(guild_id);
             }
-            GuildChannel::Voice(ref mut c) => {
+            GuildChannel::Voice(c) => {
                 c.guild_id.replace(guild_id);
             }
-            GuildChannel::Stage(ref mut c) => {
+            GuildChannel::Stage(c) => {
                 c.guild_id.replace(guild_id);
             }
         }
@@ -101,14 +101,14 @@ impl UpdateCache for ChannelDelete {
             return;
         }
 
-        match self.0 {
-            Channel::Group(ref c) => {
+        match &self.0 {
+            Channel::Group(c) => {
                 cache.delete_group(c.id);
             }
-            Channel::Guild(ref c) => {
+            Channel::Guild(c) => {
                 cache.delete_guild_channel(c.id());
             }
-            Channel::Private(ref c) => {
+            Channel::Private(c) => {
                 cache.channels_private.remove(&c.id);
             }
         }
@@ -122,9 +122,7 @@ impl UpdateCache for ChannelPinsUpdate {
         }
 
         if let Some(mut r) = cache.channels_guild.get_mut(&self.channel_id) {
-            let value = r.value_mut();
-
-            if let GuildChannel::Text(ref mut text) = value.value {
+            if let GuildChannel::Text(text) = &mut r.value_mut().value {
                 text.last_pin_timestamp = self.last_pin_timestamp;
             }
 

--- a/cache/in-memory/src/event/guild.rs
+++ b/cache/in-memory/src/event/guild.rs
@@ -342,14 +342,14 @@ mod tests {
         // guild ID to it. So now, the channel's guild ID is present with the
         // correct value.
         match channel.resource() {
-            GuildChannel::Text(ref c) => {
+            GuildChannel::Text(c) => {
                 assert_eq!(Some(GuildId::new(123).expect("non zero")), c.guild_id);
             }
             _ => panic!("{:?}", channel),
         }
 
         match thread.resource() {
-            GuildChannel::PublicThread(ref c) => {
+            GuildChannel::PublicThread(c) => {
                 assert_eq!(Some(GuildId::new(123).expect("non zero")), c.guild_id);
             }
             _ => panic!("{:?}", channel),

--- a/examples/model-webhook-slash/src/main.rs
+++ b/examples/model-webhook-slash/src/main.rs
@@ -126,8 +126,8 @@ where
 /// Interaction handler that matches on the name of the interaction that
 /// have been dispatched from Discord.
 async fn handler(i: Interaction) -> Result<InteractionResponse, GenericError> {
-    match i {
-        Interaction::ApplicationCommand(ref cmd) => match cmd.data.name.as_ref() {
+    match &i {
+        Interaction::ApplicationCommand(cmd) => match cmd.data.name.as_ref() {
             "vroom" => vroom(i).await,
             "debug" => debug(i).await,
             _ => debug(i).await,

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -2744,7 +2744,7 @@ impl Client {
             .uri(&url);
 
         if use_authorization_token {
-            if let Some(ref token) = self.token {
+            if let Some(token) = &self.token {
                 let value = HeaderValue::from_str(token).map_err(|source| {
                     #[allow(clippy::borrow_interior_mutable_const)]
                     let name = AUTHORIZATION.to_string();

--- a/http/src/response/future.rs
+++ b/http/src/response/future.rs
@@ -57,7 +57,7 @@ impl Chunking {
         };
 
         #[cfg(feature = "tracing")]
-        if let ApiError::General(ref general) = error {
+        if let ApiError::General(general) = &error {
             use crate::api_error::ErrorCode;
 
             if let ErrorCode::Other(num) = general.code {
@@ -374,7 +374,7 @@ impl<T> ResponseFuture<T> {
         &mut self,
         pre_flight: Box<dyn FnOnce() -> bool + Send + 'static>,
     ) -> bool {
-        if let ResponseFutureStage::RatelimitQueue(ref mut queue) = &mut self.stage {
+        if let ResponseFutureStage::RatelimitQueue(queue) = &mut self.stage {
             queue.pre_flight_check = Some(pre_flight);
 
             true
@@ -415,10 +415,10 @@ impl<T> ResponseFuture<T> {
     /// Necessary for [`MemberBody`] and [`MemberListBody`] deserialization.
     pub(crate) fn set_guild_id(&mut self, guild_id: GuildId) {
         match &mut self.stage {
-            ResponseFutureStage::InFlight(ref mut stage) => {
+            ResponseFutureStage::InFlight(stage) => {
                 stage.guild_id.replace(guild_id);
             }
-            ResponseFutureStage::RatelimitQueue(ref mut stage) => {
+            ResponseFutureStage::RatelimitQueue(stage) => {
                 stage.guild_id.replace(guild_id);
             }
             _ => {}

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -565,9 +565,9 @@ impl Connection {
             }
         };
 
-        match event {
-            IncomingEvent::PlayerUpdate(ref update) => self.player_update(update).await?,
-            IncomingEvent::Stats(ref stats) => self.stats(stats).await?,
+        match &event {
+            IncomingEvent::PlayerUpdate(update) => self.player_update(update).await?,
+            IncomingEvent::Stats(stats) => self.stats(stats).await?,
             _ => {}
         }
 
@@ -680,7 +680,7 @@ async fn backoff(
                 #[cfg(feature = "tracing")]
                 tracing::warn!("failed to connect to node {}: {:?}", source, config.address);
 
-                if matches!(source, TungsteniteError::Http(ref resp) if resp.status() == StatusCode::UNAUTHORIZED)
+                if matches!(&source, TungsteniteError::Http(resp) if resp.status() == StatusCode::UNAUTHORIZED)
                 {
                     return Err(NodeError {
                         kind: NodeErrorType::Unauthorized {

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -147,9 +147,9 @@ impl Player {
             event
         );
 
-        match event {
-            OutgoingEvent::Pause(ref event) => self.paused.store(event.pause, Ordering::Release),
-            OutgoingEvent::Volume(ref event) => {
+        match &event {
+            OutgoingEvent::Pause(event) => self.paused.store(event.pause, Ordering::Release),
+            OutgoingEvent::Volume(event) => {
                 self.volume.store(event.volume as u16, Ordering::Release)
             }
             _ => {}


### PR DESCRIPTION
Instead borrowing the resource. Follows the Rust ecosystem's move away from this keyword and makes the codebase more consistent.

`&` and `&mut` were previously (rust <1.26) not supported in match statements and is probably why the keyword was used.
