### PR TITLE
refactor(http): Use macro for `ErrorCode` variants

### DIFF
--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -4,774 +4,351 @@ use serde::{
 };
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum ErrorCode {
-    /// General error (such as a malformed request body, amongst other things)
-    GeneralError,
-    /// Unknown account
-    UnknownAccount,
-    /// Unknown application
-    UnknownApplication,
-    /// Unknown channel
-    UnknownChannel,
-    /// Unknown guild
-    UnknownGuild,
-    /// Unknown integration
-    UnknownIntegration,
-    /// Unknown invite
-    UnknownInvite,
-    /// Unknown member
-    UnknownMember,
-    /// Unknown message
-    UnknownMessage,
-    /// Unknown permission overwrite
-    UnknownPermissionOverwrite,
-    /// Unknown provider
-    UnknownProvider,
-    /// Unknown role
-    UnknownRole,
-    /// Unknown token
-    UnknownToken,
-    /// Unknown user
-    UnknownUser,
-    /// Unknown emoji
-    UnknownEmoji,
-    /// Unknown webhook
-    UnknownWebhook,
-    /// Unknown webhook service
-    UnknownWebhookService,
-    /// Unknown session
-    UnknownSession,
-    /// Unknown ban
-    UnknownBan,
-    /// Unknown SKU
-    #[allow(clippy::upper_case_acronyms)]
-    UnknownSKU,
-    /// Unknown Store Listing
-    UnknownStoreListing,
-    /// Unknown entitlement
-    UnknownEntitlement,
-    /// Unknown build
-    UnknownBuild,
-    /// Unknown lobby
-    UnknownLobby,
-    /// Unknown branch
-    UnknownBranch,
-    /// Unknown store directory layout
-    UnknownStoreDirectoryLayout,
-    /// Unknown redistributable
-    UnknownRedistributable,
-    /// Unknown gift code
-    UnknownGiftCode,
-    /// Unknown stream
-    UnknownStream,
-    /// Unknown premium server subscribe cooldown
-    UnknownPremiumServerSubscribeCooldown,
-    /// Unknown guild template
-    UnknownGuildTemplate,
-    /// Unknown discoverable server category
-    UnknownDiscoverableServerCategory,
-    /// Unknown sticker
-    UnknownSticker,
-    /// Unknown interaction
-    UnknownInteraction,
-    /// Unknown application command
-    UnknownApplicationCommand,
-    /// Unknown application command permissions
-    UnknownApplicationCommandPermissions,
-    /// Unknown Stage Instance
-    UnknownStageInstance,
-    /// Unknown Guild Member Verification Form
-    UnknownGuildMemberVerificationForm,
-    /// Unknown Guild Welcome Screen
-    UnknownGuildWelcomeScreen,
-    /// Unknown guild scheduled event
-    UnknownGuildScheduledEvent,
-    /// Unknown guild scheduled event user
-    UnknownGuildScheduledEventUser,
-    /// Bots cannot use this endpoint
-    BotsCannotUseEndpoint,
-    /// Only bots can use this endpoint
-    OnlyBotsCanUseEndpoint,
-    /// Explicit content cannot be sent to the desired recipient(s)
-    ExplicitContentSendingBlocked,
-    /// You are not authorized to perform this action on this application
-    UnauthorizedApplicationAction,
-    /// This action cannot be performed due to slowmode rate limit
-    SlowModeRateLimitReached,
-    /// Only the owner of this account can perform this action
-    NotAccountOwner,
-    /// Message cannot be edited due to announcement rate limits
-    AnnouncementRateLimitReached,
-    /// The channel you are writing has hit the write rate limit
-    ChannelRateLimitReached,
-    /// The write action you are performing on the server has hit the write
-    /// rate limit
-    WriteActionsReached,
-    /// Your Stage topic, server name, server description, or channel names contain words that are not allowed
-    UnallowedWords,
-    /// Guild premium subscription level too low
-    GuildPremiumTooLow,
-    /// Maximum number of guilds reached (100)
-    MaximumGuildsReached,
-    /// Maximum number of friends reached (1000)
-    MaximumFriendsReached,
-    /// Maximum number of pins reached for the channel (50)
-    MaximumPinsReached,
-    /// Maximum number of recipients reached (10)
-    MaximumRecipientsReached,
-    /// Maximum number of guild roles reached (250)
-    MaximumRolesReached,
-    /// Maximum number of webhooks reached (10)
-    MaximumWebhooksReached,
-    /// Maximum number of emojis reached
-    MaximumEmojisReached,
-    /// Maximum number of reactions reached (20)
-    MaximumReactionsReached,
-    /// Maximum number of guild channels reached (500)
-    MaximumGuildChannelsReached,
-    /// Maximum number of attachments in a message reached (10)
-    MaximumAttachmentsReached,
-    /// Maximum number of invites reached (1000)
-    MaximumInvitesReached,
-    /// Maximum number of animated emojis reached
-    MaximumAnimatedEmojisReached,
-    /// Maximum number of server members reached
-    MaximumGuildMembersReached,
-    /// Maximum number of server categories has been reached
-    MaximumServerCategoriesReached,
-    /// Guild already has a template
-    GuildTemplateAlreadyExist,
-    /// Max number of thread participants has been reached (1000)
-    ThreadMaxParticipants,
-    /// Maximum number of bans for non-guild members have been exceeded
-    MaximumNonGuildBansReached,
-    /// Maximum number of bans fetches has been reached
-    MaximumGuildBansFetchesReached,
-    /// Maximum number of uncompleted guild scheduled events reached (100)
-    MaximumUncompletedEventsReached,
-    /// Maximum number of stickers reached
-    MaximumStickersReached,
-    /// Maximum number of prune requests has been reached. Try again later
-    MaximumPruneRequestsReached,
-    /// Maximum number of guild widget settings updates has been reached. Try again later
-    MaximumGuildWidgets,
-    /// Unauthorized. Provide a valid token and try again
-    Unauthorized,
-    /// You need to verify your account in order to perform this action
-    AccountNeedsVerification,
-    /// You are opening direct messages too fast
-    OpeningDirectMessageRateLimitReached,
-    /// Request entity too large. Try sending something smaller in size
-    RequestEntityTooLarge,
-    /// This feature has been temporarily disabled server-side
-    FeatureTemporarilyDisabled,
-    /// The user is banned from this guild
-    UserBannedFromGuild,
-    /// Target user is not connected to voice
-    UserNotInVoice,
-    /// This message has already been crossposted
-    MessageAlreadyCrossposted,
-    /// An application command with that name already exists
-    CommandNameAlreadyExists,
-    /// Missing access
-    Missingaccess,
-    /// Invalid account type
-    InvalidAccountType,
-    /// Cannot execute action on a DM channel
-    #[allow(clippy::upper_case_acronyms)]
-    InvalidDMChannelAction,
-    /// Guild widget disabled
-    GuildWidgetDisabled,
-    /// Cannot edit a message authored by another user
-    MessageNotAuthoredByUser,
-    /// Cannot send an empty message
-    EmptyMessage,
-    /// Cannot send messages to this user
-    CannotSendMessageToUser,
-    /// Cannot send messages in a voice channel
-    CannotSendMessagesInVoiceChannel,
-    /// Channel verification level is too high for you to gain access
-    VerificationLevelTooHigh,
-    /// OAuth2 application does not have a bot
-    OAuthApplicationHasNoBot,
-    /// OAuth2 application limit reached
-    OAuthApplicationLimitReached,
-    /// Invalid OAuth2 state
-    InvalidOAuthSstate,
-    /// You lack permissions to perform that action
-    PermissionsLacking,
-    /// Invalid authentication token provided
-    InvalidAuthenticationTokenProvided,
-    /// Note was too long
-    NoteTooLong,
-    /// Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete
-    InvalidMessageDeleteRange,
-    /// A message can only be pinned to the channel it was sent in
-    MessagePinnedInWrongChannel,
-    /// Invite code was either invalid or taken
-    InviteCodeInvalidOrTaken,
-    /// Cannot execute action on a system message
-    InvalidActionOnSystemMessage,
-    /// Cannot execute action on this channel type
-    CannotExecuteActionOnChannelType,
-    /// Invalid OAuth2 access token provided
-    InvalidOAuthAccessToken,
-    /// Missing required OAuth2 scope
-    MissingOAuthScope,
-    /// Invalid webhook token provided
-    InvalidWebhookToken,
-    /// Invalid role
-    InvalidRole,
-    /// Invalid recipient(s)
-    InvalidRecipient,
-    /// A message provided was too old to bulk delete
-    MessageTooOldToBulkDelete,
-    /// Invalid form body (returned for both application/json and multipart/form-data bodies), or invalid Content-Type provided
-    InvalidFormBodyOrContentType,
-    /// An invite was accepted to a guild the application's bot is not in
-    InviteAcceptedToGuildBotNotIn,
-    /// Invalid API version provided
-    InvalidApiVersion,
-    /// File uploaded exceeds the maximum size
-    FileTooLarge,
-    /// Invalid file uploaded
-    InvalidFileUploaded,
-    /// Cannot self-redeem this gift
-    CannotSelfRedeemGift,
-    /// Invalid Guild
-    InvalidGuild,
-    /// Payment source required to redeem gift
-    PaymentRequiredForGift,
-    /// Cannot delete a channel required for Community guilds
-    CommunityGuildRequired,
-    /// Invalid sticker sent
-    InvalidStickerSent,
-    /// Tried to perform an operation on an archived thread, such as editing a message or adding a
-    /// user to the thread
-    ThreadArchived,
-    /// Invalid thread notification settings
-    ThreadInvalidNotificationSettings,
-    /// `before` value is earlier than the thread creation date
-    ThreadInvalidBeforeValue,
-    /// This server is not available in your location
-    ServerNotAvailableLocation,
-    /// This server needs monetization enabled in order to perform this action
-    ServerNeedsMonetiazation,
-    /// This server needs more boosts to perform this action
-    ServerNeedsBoosts,
-    /// The request body contains invalid JSON.
-    RequestInvalidJson,
-    /// Two factor is required for this operation.
-    TwoFactorRequired,
-    /// No users with DiscordTag exist
-    NoSuchUser,
-    /// Reaction was blocked
-    ReactionBlocked,
-    /// API resource is currently overloaded. Try again a little later
-    ApiResourceOverloaded,
-    /// The Stage is already open
-    StageAlreadyOpen,
-    /// Cannot reply without permission to read message history
-    CannotReplyWithoutMessageHistory,
-    /// A thread has already been created for this message
-    ThreadAlreadyCreated,
-    /// Thread is locked
-    ThreadLocked,
-    /// Maximum number of active threads reached
-    MaxActiveThreads,
-    /// Maximum number of active announcement threads reached
-    MaxActiveAnnouncementThreads,
-    /// Invalid JSON for uploaded Lottie file
-    InvalidLottieJson,
-    /// Uploaded Lotties cannot contain rasterized images such as PNG or JPEG
-    InvalidLottieContent,
-    /// Sticker maximum framerate exceeded
-    StickerMaximumFramerateExceeded,
-    /// Sticker frame count exceeds maximum of 1000 frames
-    StickerFrameCountExceedsMaximum,
-    /// Lottie animation maximum dimensions exceeded
-    LottieDimensionsTooLarge,
-    /// Sticker frame rate is either too small or too large
-    InvalidStickerFrameRate,
-    /// Sticker animation duration exceeds maximum of 5 seconds
-    StickerAnimationDurationExceedsMaximum,
-    /// Cannot update a finished event
-    CannotUpdateFinishedEvent,
-    /// Failed to create stage needed for stage event
-    FailedToCreateStage,
-    /// A status code that Twilight doesn't have registered.
-    ///
-    /// Please report the number if you see this variant!
-    Other(u64),
-}
-
-impl ErrorCode {
-    #[allow(clippy::too_many_lines)]
-    pub const fn num(&self) -> u64 {
-        match self {
-            Self::GeneralError => 0,
-            Self::UnknownAccount => 10001,
-            Self::UnknownApplication => 10002,
-            Self::UnknownChannel => 10003,
-            Self::UnknownGuild => 10004,
-            Self::UnknownIntegration => 10005,
-            Self::UnknownInvite => 10006,
-            Self::UnknownMember => 10007,
-            Self::UnknownMessage => 10008,
-            Self::UnknownPermissionOverwrite => 10009,
-            Self::UnknownProvider => 10010,
-            Self::UnknownRole => 10011,
-            Self::UnknownToken => 10012,
-            Self::UnknownUser => 10013,
-            Self::UnknownEmoji => 10014,
-            Self::UnknownWebhook => 10015,
-            Self::UnknownWebhookService => 10016,
-            Self::UnknownSession => 10020,
-            Self::UnknownBan => 10026,
-            Self::UnknownSKU => 10027,
-            Self::UnknownStoreListing => 10028,
-            Self::UnknownEntitlement => 10029,
-            Self::UnknownBuild => 10030,
-            Self::UnknownLobby => 10031,
-            Self::UnknownBranch => 10032,
-            Self::UnknownStoreDirectoryLayout => 10033,
-            Self::UnknownRedistributable => 10036,
-            Self::UnknownGiftCode => 10038,
-            Self::UnknownStream => 10049,
-            Self::UnknownPremiumServerSubscribeCooldown => 10050,
-            Self::UnknownGuildTemplate => 10057,
-            Self::UnknownDiscoverableServerCategory => 10059,
-            Self::UnknownSticker => 10060,
-            Self::UnknownInteraction => 10062,
-            Self::UnknownApplicationCommand => 10063,
-            Self::UnknownApplicationCommandPermissions => 10066,
-            Self::UnknownStageInstance => 10067,
-            Self::UnknownGuildMemberVerificationForm => 10068,
-            Self::UnknownGuildWelcomeScreen => 10069,
-            Self::UnknownGuildScheduledEvent => 10070,
-            Self::UnknownGuildScheduledEventUser => 10071,
-            Self::BotsCannotUseEndpoint => 20001,
-            Self::OnlyBotsCanUseEndpoint => 20002,
-            Self::ExplicitContentSendingBlocked => 20009,
-            Self::UnauthorizedApplicationAction => 20012,
-            Self::SlowModeRateLimitReached => 20016,
-            Self::NotAccountOwner => 20018,
-            Self::AnnouncementRateLimitReached => 20022,
-            Self::ChannelRateLimitReached => 20028,
-            Self::WriteActionsReached => 20029,
-            Self::UnallowedWords => 20031,
-            Self::GuildPremiumTooLow => 20035,
-            Self::MaximumGuildsReached => 30001,
-            Self::MaximumFriendsReached => 30002,
-            Self::MaximumPinsReached => 30003,
-            Self::MaximumRecipientsReached => 30004,
-            Self::MaximumRolesReached => 30005,
-            Self::MaximumWebhooksReached => 30007,
-            Self::MaximumEmojisReached => 30008,
-            Self::MaximumReactionsReached => 30010,
-            Self::MaximumGuildChannelsReached => 30013,
-            Self::MaximumAttachmentsReached => 30015,
-            Self::MaximumInvitesReached => 30016,
-            Self::MaximumAnimatedEmojisReached => 30018,
-            Self::MaximumGuildMembersReached => 30019,
-            Self::MaximumServerCategoriesReached => 30030,
-            Self::GuildTemplateAlreadyExist => 30031,
-            Self::ThreadMaxParticipants => 30033,
-            Self::MaximumNonGuildBansReached => 30035,
-            Self::MaximumGuildBansFetchesReached => 30037,
-            Self::MaximumUncompletedEventsReached => 30038,
-            Self::MaximumStickersReached => 30039,
-            Self::MaximumPruneRequestsReached => 30040,
-            Self::MaximumGuildWidgets => 30042,
-            Self::Unauthorized => 40001,
-            Self::AccountNeedsVerification => 40002,
-            Self::OpeningDirectMessageRateLimitReached => 40003,
-            Self::RequestEntityTooLarge => 40005,
-            Self::FeatureTemporarilyDisabled => 40006,
-            Self::UserBannedFromGuild => 40007,
-            Self::UserNotInVoice => 40032,
-            Self::MessageAlreadyCrossposted => 40033,
-            Self::CommandNameAlreadyExists => 40041,
-            Self::Missingaccess => 50001,
-            Self::InvalidAccountType => 50002,
-            Self::InvalidDMChannelAction => 50003,
-            Self::GuildWidgetDisabled => 50004,
-            Self::MessageNotAuthoredByUser => 50005,
-            Self::EmptyMessage => 50006,
-            Self::CannotSendMessageToUser => 50007,
-            Self::CannotSendMessagesInVoiceChannel => 50008,
-            Self::VerificationLevelTooHigh => 50009,
-            Self::OAuthApplicationHasNoBot => 50010,
-            Self::OAuthApplicationLimitReached => 50011,
-            Self::InvalidOAuthSstate => 50012,
-            Self::PermissionsLacking => 50013,
-            Self::InvalidAuthenticationTokenProvided => 50014,
-            Self::NoteTooLong => 50015,
-            Self::InvalidMessageDeleteRange => 50016,
-            Self::MessagePinnedInWrongChannel => 50019,
-            Self::InviteCodeInvalidOrTaken => 50020,
-            Self::InvalidActionOnSystemMessage => 50021,
-            Self::CannotExecuteActionOnChannelType => 50024,
-            Self::InvalidOAuthAccessToken => 50025,
-            Self::MissingOAuthScope => 50026,
-            Self::InvalidWebhookToken => 50027,
-            Self::InvalidRole => 50028,
-            Self::InvalidRecipient => 50033,
-            Self::MessageTooOldToBulkDelete => 50034,
-            Self::InvalidFormBodyOrContentType => 50035,
-            Self::InviteAcceptedToGuildBotNotIn => 50036,
-            Self::InvalidApiVersion => 50041,
-            Self::FileTooLarge => 50045,
-            Self::InvalidFileUploaded => 50046,
-            Self::CannotSelfRedeemGift => 50054,
-            Self::InvalidGuild => 50055,
-            Self::PaymentRequiredForGift => 50070,
-            Self::CommunityGuildRequired => 50074,
-            Self::InvalidStickerSent => 50081,
-            Self::ThreadArchived => 50083,
-            Self::ThreadInvalidNotificationSettings => 50084,
-            Self::ThreadInvalidBeforeValue => 50085,
-            Self::ServerNotAvailableLocation => 50095,
-            Self::ServerNeedsMonetiazation => 50097,
-            Self::ServerNeedsBoosts => 50101,
-            Self::RequestInvalidJson => 50109,
-            Self::TwoFactorRequired => 60003,
-            Self::NoSuchUser => 80004,
-            Self::ReactionBlocked => 90001,
-            Self::ApiResourceOverloaded => 130_000,
-            Self::StageAlreadyOpen => 150_006,
-            Self::CannotReplyWithoutMessageHistory => 160_002,
-            Self::ThreadAlreadyCreated => 160_004,
-            Self::ThreadLocked => 160_005,
-            Self::MaxActiveThreads => 160_006,
-            Self::MaxActiveAnnouncementThreads => 160_007,
-            Self::InvalidLottieJson => 170_001,
-            Self::InvalidLottieContent => 170_002,
-            Self::StickerMaximumFramerateExceeded => 170_003,
-            Self::StickerFrameCountExceedsMaximum => 170_004,
-            Self::LottieDimensionsTooLarge => 170_005,
-            Self::InvalidStickerFrameRate => 170_006,
-            Self::StickerAnimationDurationExceedsMaximum => 170_007,
-            Self::CannotUpdateFinishedEvent => 180_000,
-            Self::FailedToCreateStage => 180_002,
-            Self::Other(other) => *other,
+/// Helper macro for generating error codes.
+///
+/// Takes a list of tuples containing three arguments: display, name & code.
+macro_rules! error_code {
+    ($((
+        $display:literal, $name:ident, $code:literal
+    )),*) => {
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        #[non_exhaustive]
+        pub enum ErrorCode {
+            $(
+                // display + "." = rustdoc comment
+                #[doc = concat!($display, ".")]
+                $name
+            ),*,
+            /// A status code that Twilight doesn't have registered.
+            ///
+            /// Please report the number if you see this variant!
+            Other(u64)
         }
-    }
-}
 
-impl From<u64> for ErrorCode {
-    #[allow(clippy::too_many_lines)]
-    fn from(int: u64) -> Self {
-        match int {
-            0 => Self::GeneralError,
-            10001 => Self::UnknownAccount,
-            10002 => Self::UnknownApplication,
-            10003 => Self::UnknownChannel,
-            10004 => Self::UnknownGuild,
-            10005 => Self::UnknownIntegration,
-            10006 => Self::UnknownInvite,
-            10007 => Self::UnknownMember,
-            10008 => Self::UnknownMessage,
-            10009 => Self::UnknownPermissionOverwrite,
-            10010 => Self::UnknownProvider,
-            10011 => Self::UnknownRole,
-            10012 => Self::UnknownToken,
-            10013 => Self::UnknownUser,
-            10014 => Self::UnknownEmoji,
-            10015 => Self::UnknownWebhook,
-            10016 => Self::UnknownWebhookService,
-            10020 => Self::UnknownSession,
-            10026 => Self::UnknownBan,
-            10027 => Self::UnknownSKU,
-            10028 => Self::UnknownStoreListing,
-            10029 => Self::UnknownEntitlement,
-            10030 => Self::UnknownBuild,
-            10031 => Self::UnknownLobby,
-            10032 => Self::UnknownBranch,
-            10033 => Self::UnknownStoreDirectoryLayout,
-            10036 => Self::UnknownRedistributable,
-            10038 => Self::UnknownGiftCode,
-            10049 => Self::UnknownStream,
-            10050 => Self::UnknownPremiumServerSubscribeCooldown,
-            10057 => Self::UnknownGuildTemplate,
-            10059 => Self::UnknownDiscoverableServerCategory,
-            10060 => Self::UnknownSticker,
-            10062 => Self::UnknownInteraction,
-            10063 => Self::UnknownApplicationCommand,
-            10066 => Self::UnknownApplicationCommandPermissions,
-            10067 => Self::UnknownStageInstance,
-            10068 => Self::UnknownGuildMemberVerificationForm,
-            10069 => Self::UnknownGuildWelcomeScreen,
-            10070 => Self::UnknownGuildScheduledEvent,
-            10071 => Self::UnknownGuildScheduledEventUser,
-            20001 => Self::BotsCannotUseEndpoint,
-            20002 => Self::OnlyBotsCanUseEndpoint,
-            20022 => Self::AnnouncementRateLimitReached,
-            20009 => Self::ExplicitContentSendingBlocked,
-            20012 => Self::UnauthorizedApplicationAction,
-            20016 => Self::SlowModeRateLimitReached,
-            20018 => Self::NotAccountOwner,
-            20028 => Self::ChannelRateLimitReached,
-            20029 => Self::WriteActionsReached,
-            20031 => Self::UnallowedWords,
-            20035 => Self::GuildPremiumTooLow,
-            30001 => Self::MaximumGuildsReached,
-            30002 => Self::MaximumFriendsReached,
-            30003 => Self::MaximumPinsReached,
-            30004 => Self::MaximumRecipientsReached,
-            30005 => Self::MaximumRolesReached,
-            30007 => Self::MaximumWebhooksReached,
-            30008 => Self::MaximumEmojisReached,
-            30010 => Self::MaximumReactionsReached,
-            30013 => Self::MaximumGuildChannelsReached,
-            30015 => Self::MaximumAttachmentsReached,
-            30016 => Self::MaximumInvitesReached,
-            30018 => Self::MaximumAnimatedEmojisReached,
-            30019 => Self::MaximumGuildMembersReached,
-            30030 => Self::MaximumServerCategoriesReached,
-            30031 => Self::GuildTemplateAlreadyExist,
-            30033 => Self::ThreadMaxParticipants,
-            30035 => Self::MaximumNonGuildBansReached,
-            30037 => Self::MaximumGuildBansFetchesReached,
-            30038 => Self::MaximumUncompletedEventsReached,
-            30039 => Self::MaximumStickersReached,
-            30040 => Self::MaximumPruneRequestsReached,
-            30042 => Self::MaximumGuildWidgets,
-            40001 => Self::Unauthorized,
-            40002 => Self::AccountNeedsVerification,
-            40003 => Self::OpeningDirectMessageRateLimitReached,
-            40005 => Self::RequestEntityTooLarge,
-            40006 => Self::FeatureTemporarilyDisabled,
-            40007 => Self::UserBannedFromGuild,
-            40032 => Self::UserNotInVoice,
-            40033 => Self::MessageAlreadyCrossposted,
-            40041 => Self::CommandNameAlreadyExists,
-            50001 => Self::Missingaccess,
-            50002 => Self::InvalidAccountType,
-            50003 => Self::InvalidDMChannelAction,
-            50004 => Self::GuildWidgetDisabled,
-            50005 => Self::MessageNotAuthoredByUser,
-            50006 => Self::EmptyMessage,
-            50007 => Self::CannotSendMessageToUser,
-            50008 => Self::CannotSendMessagesInVoiceChannel,
-            50009 => Self::VerificationLevelTooHigh,
-            50010 => Self::OAuthApplicationHasNoBot,
-            50011 => Self::OAuthApplicationLimitReached,
-            50012 => Self::InvalidOAuthSstate,
-            50013 => Self::PermissionsLacking,
-            50014 => Self::InvalidAuthenticationTokenProvided,
-            50015 => Self::NoteTooLong,
-            50016 => Self::InvalidMessageDeleteRange,
-            50019 => Self::MessagePinnedInWrongChannel,
-            50020 => Self::InviteCodeInvalidOrTaken,
-            50021 => Self::InvalidActionOnSystemMessage,
-            50024 => Self::CannotExecuteActionOnChannelType,
-            50025 => Self::InvalidOAuthAccessToken,
-            50026 => Self::MissingOAuthScope,
-            50027 => Self::InvalidWebhookToken,
-            50028 => Self::InvalidRole,
-            50033 => Self::InvalidRecipient,
-            50034 => Self::MessageTooOldToBulkDelete,
-            50035 => Self::InvalidFormBodyOrContentType,
-            50036 => Self::InviteAcceptedToGuildBotNotIn,
-            50041 => Self::InvalidApiVersion,
-            50045 => Self::FileTooLarge,
-            50046 => Self::InvalidFileUploaded,
-            50054 => Self::CannotSelfRedeemGift,
-            50055 => Self::InvalidGuild,
-            50070 => Self::PaymentRequiredForGift,
-            50074 => Self::CommunityGuildRequired,
-            50081 => Self::InvalidStickerSent,
-            50083 => Self::ThreadArchived,
-            50084 => Self::ThreadInvalidNotificationSettings,
-            50085 => Self::ThreadInvalidBeforeValue,
-            50095 => Self::ServerNotAvailableLocation,
-            50097 => Self::ServerNeedsMonetiazation,
-            50101 => Self::ServerNeedsBoosts,
-            50109 => Self::RequestInvalidJson,
-            60003 => Self::TwoFactorRequired,
-            80004 => Self::NoSuchUser,
-            90001 => Self::ReactionBlocked,
-            130_000 => Self::ApiResourceOverloaded,
-            150_006 => Self::StageAlreadyOpen,
-            160_002 => Self::CannotReplyWithoutMessageHistory,
-            160_004 => Self::ThreadAlreadyCreated,
-            160_005 => Self::ThreadLocked,
-            160_006 => Self::MaxActiveThreads,
-            160_007 => Self::MaxActiveAnnouncementThreads,
-            170_001 => Self::InvalidLottieJson,
-            170_002 => Self::InvalidLottieContent,
-            170_003 => Self::StickerMaximumFramerateExceeded,
-            170_004 => Self::StickerFrameCountExceedsMaximum,
-            170_005 => Self::LottieDimensionsTooLarge,
-            170_006 => Self::InvalidStickerFrameRate,
-            170_007 => Self::StickerAnimationDurationExceedsMaximum,
-            180_000 => Self::CannotUpdateFinishedEvent,
-            180_002 => Self::FailedToCreateStage,
-            other => Self::Other(other),
+        impl ErrorCode {
+            pub const fn num(&self) -> u64 {
+                match self {
+                    $(Self::$name => $code),*,
+                    Self::Other(other) => *other,
+                }
+            }
         }
-    }
-}
 
-impl Display for ErrorCode {
-    #[allow(clippy::too_many_lines)]
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::GeneralError => f.write_str("General error (such as a malformed request body, amongst other things)"),
-            Self::UnknownAccount => f.write_str("Unknown account"),
-            Self::UnknownApplication => f.write_str("Unknown application"),
-            Self::UnknownChannel => f.write_str("Unknown channel"),
-            Self::UnknownGuild => f.write_str("Unknown guild"),
-            Self::UnknownIntegration => f.write_str("Unknown integration"),
-            Self::UnknownInvite => f.write_str("Unknown invite"),
-            Self::UnknownMember => f.write_str("Unknown member"),
-            Self::UnknownMessage => f.write_str("Unknown message"),
-            Self::UnknownPermissionOverwrite => f.write_str("Unknown permission overwrite"),
-            Self::UnknownProvider => f.write_str("Unknown provider"),
-            Self::UnknownRole => f.write_str("Unknown role"),
-            Self::UnknownToken => f.write_str("Unknown token"),
-            Self::UnknownUser => f.write_str("Unknown user"),
-            Self::UnknownEmoji => f.write_str("Unknown emoji"),
-            Self::UnknownWebhook => f.write_str("Unknown webhook"),
-            Self::UnknownWebhookService => f.write_str("Unknown webhook service"),
-            Self::UnknownSession => f.write_str("Unknown session"),
-            Self::UnknownBan => f.write_str("Unknown ban"),
-            Self::UnknownSKU => f.write_str("Unknown SKU"),
-            Self::UnknownStoreListing => f.write_str("Unknown Store Listing"),
-            Self::UnknownEntitlement => f.write_str("Unknown entitlement"),
-            Self::UnknownBuild => f.write_str("Unknown build"),
-            Self::UnknownLobby => f.write_str("Unknown lobby"),
-            Self::UnknownBranch => f.write_str("Unknown branch"),
-            Self::UnknownStoreDirectoryLayout => f.write_str("Unknown store directory layout"),
-            Self::UnknownRedistributable => f.write_str("Unknown redistributable"),
-            Self::UnknownGiftCode => f.write_str("Unknown gift code"),
-            Self::UnknownStream => f.write_str("Unknown stream"),
-            Self::UnknownPremiumServerSubscribeCooldown => f.write_str("Unknown premium server subscribe cooldown"),
-            Self::UnknownGuildTemplate => f.write_str("Unknown guild template"),
-            Self::UnknownDiscoverableServerCategory => f.write_str("Unknown discoverable server category"),
-            Self::UnknownSticker => f.write_str("Unknown sticker"),
-            Self::UnknownInteraction => f.write_str("Unknown interaction"),
-            Self::UnknownApplicationCommand => f.write_str("Unknown application command"),
-            Self::UnknownApplicationCommandPermissions => f.write_str("Unknown application command permissions"),
-            Self::UnknownStageInstance => f.write_str("Unknown Stage Instance"),
-            Self::UnknownGuildMemberVerificationForm => f.write_str("Unknown Guild Member Verification Form"),
-            Self::UnknownGuildWelcomeScreen => f.write_str("Unknown Guild Welcome Screen"),
-            Self::UnknownGuildScheduledEvent => f.write_str("Unknown Guild Scheduled Event"),
-            Self::UnknownGuildScheduledEventUser => f.write_str("Unknown Guild Scheduled Event User"),
-            Self::BotsCannotUseEndpoint => f.write_str("Bots cannot use this endpoint"),
-            Self::OnlyBotsCanUseEndpoint => f.write_str("Only bots can use this endpoint"),
-            Self::ExplicitContentSendingBlocked => f.write_str("Explicit content cannot be sent to the desired recipient(s)"),
-            Self::UnauthorizedApplicationAction => f.write_str("You are not authorized to perform this action on this application"),
-            Self::SlowModeRateLimitReached => f.write_str("This action cannot be performed due to slowmode rate limit"),
-            Self::NotAccountOwner => f.write_str("Only the owner of this account can perform this action"),
-            Self::AnnouncementRateLimitReached => f.write_str("Message cannot be edited due to announcement rate limits"),
-            Self::ChannelRateLimitReached => f.write_str("The channel you are writing has hit the write rate limit"),
-            Self::WriteActionsReached => f.write_str("The write action you are performing on the server has hit the write rate limit"),
-            Self::UnallowedWords => f.write_str("Your Stage topic, server name, server description, or channel names contain words that are not allowed"),
-            Self::GuildPremiumTooLow => f.write_str("Guild premium subscription level too low"),
-            Self::MaximumGuildsReached => f.write_str("Maximum number of guilds reached (100)"),
-            Self::MaximumFriendsReached => f.write_str("Maximum number of friends reached (1000)"),
-            Self::MaximumPinsReached => f.write_str("Maximum number of pins reached for the channel (50)"),
-            Self::MaximumRecipientsReached => f.write_str("Maximum number of recipients reached (10)"),
-            Self::MaximumRolesReached => f.write_str("Maximum number of guild roles reached (250)"),
-            Self::MaximumWebhooksReached => f.write_str("Maximum number of webhooks reached (10)"),
-            Self::MaximumEmojisReached => f.write_str("Maximum number of emojis reached"),
-            Self::MaximumReactionsReached => f.write_str("Maximum number of reactions reached (20)"),
-            Self::MaximumGuildChannelsReached => f.write_str("Maximum number of guild channels reached (500)"),
-            Self::MaximumAttachmentsReached => f.write_str("Maximum number of attachments in a message reached (10)"),
-            Self::MaximumInvitesReached => f.write_str("Maximum number of invites reached (1000)"),
-            Self::MaximumAnimatedEmojisReached => f.write_str("Maximum animated emojis reached"),
-            Self::MaximumGuildMembersReached => f.write_str("Maximum number of server members reached"),
-            Self::MaximumServerCategoriesReached => f.write_str("Maximum number of server categories has been reached"),
-            Self::GuildTemplateAlreadyExist => f.write_str("Guild already has a template"),
-            Self::ThreadMaxParticipants => f.write_str("Max number of thread participants has been reached (1000)"),
-            Self::MaximumNonGuildBansReached => f.write_str("Maximum number of bans for non-guild members have been exceeded"),
-            Self::MaximumGuildBansFetchesReached => f.write_str("Maximum number of bans fetches has been reached"),
-            Self::MaximumUncompletedEventsReached => f.write_str("Maximum number of uncompleted guild scheduled events reached (100)"),
-            Self::MaximumStickersReached => f.write_str("Maximum number of stickers reached"),
-            Self::MaximumPruneRequestsReached => f.write_str("Maximum number of prune requests has been reached. Try again later"),
-            Self::MaximumGuildWidgets => f.write_str("Maximum number of guild widget settings updates has been reached. Try again later"),
-            Self::Unauthorized => f.write_str("Unauthorized. Provide a valid token and try again"),
-            Self::AccountNeedsVerification => f.write_str("You need to verify your account in order to perform this action"),
-            Self::OpeningDirectMessageRateLimitReached => f.write_str("You are opening direct messages too fast"),
-            Self::RequestEntityTooLarge => f.write_str("Request entity too large. Try sending something smaller in size"),
-            Self::FeatureTemporarilyDisabled => f.write_str("This feature has been temporarily disabled server-side"),
-            Self::UserBannedFromGuild => f.write_str("The user is banned from this guild"),
-            Self::UserNotInVoice => f.write_str("Target user is not connected to voice"),
-            Self::MessageAlreadyCrossposted => f.write_str("This message has already been crossposted"),
-            Self::CommandNameAlreadyExists => f.write_str("An application command with that name already exists"),
-            Self::Missingaccess => f.write_str("Missing access"),
-            Self::InvalidAccountType => f.write_str("Invalid account type"),
-            Self::InvalidDMChannelAction => f.write_str("Cannot execute action on a DM channel"),
-            Self::GuildWidgetDisabled => f.write_str("Guild widget disabled"),
-            Self::MessageNotAuthoredByUser => f.write_str("Cannot edit a message authored by another user"),
-            Self::EmptyMessage => f.write_str("Cannot send an empty message"),
-            Self::CannotSendMessageToUser => f.write_str("Cannot send messages to this user"),
-            Self::CannotSendMessagesInVoiceChannel => f.write_str("Cannot send messages in a voice channel"),
-            Self::VerificationLevelTooHigh => f.write_str("Channel verification level is too high for you to gain access"),
-            Self::OAuthApplicationHasNoBot => f.write_str("OAuth2 application does not have a bot"),
-            Self::OAuthApplicationLimitReached => f.write_str("OAuth2 application limit reached"),
-            Self::InvalidOAuthSstate => f.write_str("Invalid OAuth2 state"),
-            Self::PermissionsLacking => f.write_str("You lack permissions to perform that action"),
-            Self::InvalidAuthenticationTokenProvided => f.write_str("Invalid authentication token provided"),
-            Self::NoteTooLong => f.write_str("Note was too long"),
-            Self::InvalidMessageDeleteRange => f.write_str("Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete"),
-            Self::MessagePinnedInWrongChannel => f.write_str("A message can only be pinned to the channel it was sent in"),
-            Self::InviteCodeInvalidOrTaken => f.write_str("Invite code was either invalid or taken"),
-            Self::InvalidActionOnSystemMessage => f.write_str("Cannot execute action on a system message"),
-            Self::CannotExecuteActionOnChannelType => f.write_str("Cannot execute action on channel type"),
-            Self::InvalidOAuthAccessToken => f.write_str("Invalid OAuth2 access token provided"),
-            Self::MissingOAuthScope => f.write_str("Missing required OAuth2 scope"),
-            Self::InvalidWebhookToken => f.write_str("Invalid webhook token provided."),
-            Self::InvalidRole => f.write_str("Invalid role"),
-            Self::InvalidRecipient => f.write_str("Invalid recipient(s)"),
-            Self::MessageTooOldToBulkDelete => f.write_str("A message provided was too old to bulk delete"),
-            Self::InvalidFormBodyOrContentType => f.write_str("Invalid form body (returned for both application/json and multipart/form-data bodies), or invalid Content-Type provided"),
-            Self::InviteAcceptedToGuildBotNotIn => f.write_str("An invite was accepted to a guild the application's bot is not in"),
-            Self::InvalidApiVersion => f.write_str("Invalid API version provided"),
-            Self::FileTooLarge => f.write_str("File uploaded exceeds the maximum size"),
-            Self::InvalidFileUploaded => f.write_str("Invalid file uploaded"),
-            Self::CannotSelfRedeemGift => f.write_str("Cannot self-redeem this gift"),
-            Self::InvalidGuild => f.write_str("Invalid Guild"),
-            Self::PaymentRequiredForGift => f.write_str("Payment source required to redeem gift"),
-            Self::CommunityGuildRequired => f.write_str("Cannot delete a channel required for Community guilds"),
-            Self::InvalidStickerSent => f.write_str("Invalid sticker sent"),
-            Self::ThreadArchived => f.write_str("Tried to perform an operation on an archived thread, such as editing a message or adding a user to the thread"),
-            Self::ThreadInvalidNotificationSettings => f.write_str("Invalid thread notification settings"),
-            Self::ThreadInvalidBeforeValue => f.write_str("`before` value is earlier than the thread creation date"),
-            Self::ServerNotAvailableLocation => f.write_str("This server is not available in your location"),
-            Self::ServerNeedsMonetiazation => f.write_str("This server needs monetization enabled in order to perform this action"),
-            Self::ServerNeedsBoosts => f.write_str("This server needs more boosts to perform this action"),
-            Self::RequestInvalidJson => f.write_str("The request body contains invalid JSON"),
-            Self::TwoFactorRequired => f.write_str("Two factor is required for this operation"),
-            Self::NoSuchUser => f.write_str("No users with DiscordTag exist"),
-            Self::ReactionBlocked => f.write_str("Reaction was blocked"),
-            Self::ApiResourceOverloaded => f.write_str("API resource is currently overloaded. Try again a little later"),
-            Self::StageAlreadyOpen => f.write_str("The Stage is already open"),
-            Self::CannotReplyWithoutMessageHistory => f.write_str("Cannot reply without permission to read message history"),
-            Self::ThreadAlreadyCreated => f.write_str("A thread has already been created for this message"),
-            Self::ThreadLocked => f.write_str("Thread is locked"),
-            Self::MaxActiveThreads => f.write_str("Maximum number of active threads reached"),
-            Self::MaxActiveAnnouncementThreads => f.write_str("Maximum number of active announcement threads reached"),
-            Self::InvalidLottieJson => f.write_str("Invalid JSON for uploaded Lottie file"),
-            Self::InvalidLottieContent => f.write_str("Uploaded Lotties cannot contain rasterized images such as PNG or JPEG"),
-            Self::StickerMaximumFramerateExceeded => f.write_str("Sticker maximum framerate exceeded"),
-            Self::StickerFrameCountExceedsMaximum => f.write_str("Sticker frame count exceeds maximum of 1000 frames"),
-            Self::LottieDimensionsTooLarge => f.write_str("Lottie animation maximum dimensions exceeded"),
-            Self::InvalidStickerFrameRate => f.write_str("Sticker frame rate is either too small or too large"),
-            Self::StickerAnimationDurationExceedsMaximum => f.write_str("Sticker animation duration exceeds maximum of 5 seconds"),
-            Self::CannotUpdateFinishedEvent => f.write_str("Cannot update a finished event"),
-            Self::FailedToCreateStage => f.write_str("Failed to create stage needed for stage event"),
-            Self::Other(number) => {
-                f.write_str("An error code Twilight doesn't have registered: ")?;
+        impl From<u64> for ErrorCode {
+            fn from(int: u64) -> Self {
+                match int {
+                    $($code => Self::$name),*,
+                    other => Self::Other(other),
+                }
+            }
+        }
 
-                Display::fmt(number, f)
+        impl Display for ErrorCode {
+            fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+                match self {
+                    $(Self::$name => f.write_str($display)),*,
+                    Self::Other(number) => {
+                        f.write_str("An error code Twilight doesn't have registered: ")?;
+
+                        Display::fmt(number, f)
+                    }
+
+                }
             }
         }
     }
 }
+
+error_code![
+    (
+        "General error (such as a malformed request body, amongst other things)",
+        GeneralError,
+        0
+    ),
+    ("Unknown account", UnknownAccount, 10001),
+    ("Unknown application", UnknownApplication, 10002),
+    ("Unknown channel", UnknownChannel, 10003),
+    ("Unknown guild", UnknownGuild, 10004),
+    ("Unknown integration", UnknownIntegration, 10005),
+    ("Unknown invite", UnknownInvite, 10006),
+    ("Unknown member", UnknownMember, 10007),
+    ("Unknown message", UnknownMessage, 10008),
+    (
+        "Unknown permission overwrite",
+        UnknownPermissionOverwrite,
+        10009
+    ),
+    ("Unknown provider",
+    UnknownProvider , 10010),
+    ("Unknown role",
+    UnknownRole , 10011),
+    ("Unknown token",
+    UnknownToken , 10012),
+    ("Unknown user",
+    UnknownUser , 10013),
+    ("Unknown emoji",
+    UnknownEmoji , 10014),
+    ("Unknown webhook",
+    UnknownWebhook , 10015),
+    ("Unknown webhook service",
+    UnknownWebhookService , 10016),
+    ("Unknown session",
+    UnknownSession , 10020),
+    ("Unknown ban",
+    UnknownBan , 10026),
+    ("Unknown SKU",
+    UnknownSKU , 10027),
+    ("Unknown Store Listing",
+    UnknownStoreListing , 10028),
+    ("Unknown entitlement",
+    UnknownEntitlement , 10029),
+    ("Unknown build",
+    UnknownBuild , 10030),
+    ("Unknown lobby",
+    UnknownLobby , 10031),
+    ("Unknown branch",
+    UnknownBranch , 10032),
+    ("Unknown store directory layout",
+    UnknownStoreDirectoryLayout , 10033),
+    ("Unknown redistributable",
+    UnknownRedistributable , 10036),
+    ("Unknown gift code",
+    UnknownGiftCode , 10038),
+    ("Unknown stream",
+    UnknownStream , 10049),
+    ("Unknown premium server subscribe cooldown",
+    UnknownPremiumServerSubscribeCooldown , 10050),
+    ("Unknown guild template",
+    UnknownGuildTemplate , 10057),
+    ("Unknown discoverable server category",
+    UnknownDiscoverableServerCategory , 10059),
+    ("Unknown sticker",
+    UnknownSticker , 10060),
+    ("Unknown interaction",
+    UnknownInteraction , 10062),
+    ("Unknown application command",
+    UnknownApplicationCommand , 10063),
+    ("Unknown application command permissions",
+    UnknownApplicationCommandPermissions , 10066),
+    ("Unknown Stage Instance",
+    UnknownStageInstance , 10067),
+    ("Unknown Guild Member Verification Form",
+    UnknownGuildMemberVerificationForm , 10068),
+    ("Unknown Guild Welcome Screen",
+    UnknownGuildWelcomeScreen , 10069),
+    ("Unknown guild scheduled event",
+    UnknownGuildScheduledEvent , 10070),
+    ("Unknown guild scheduled event user",
+    UnknownGuildScheduledEventUser , 10071),
+    ("Bots cannot use this endpoint",
+    BotsCannotUseEndpoint , 20001),
+    ("Only bots can use this endpoint",
+    OnlyBotsCanUseEndpoint , 20002),
+    ("Explicit content cannot be sent to the desired recipient(s)",
+    ExplicitContentSendingBlocked , 20009),
+    ("You are not authorized to perform this action on this application",
+    UnauthorizedApplicationAction , 20012),
+    ("This action cannot be performed due to slowmode rate limit",
+    SlowModeRateLimitReached , 20016),
+    ("Only the owner of this account can perform this action",
+    NotAccountOwner , 20018),
+    ("Message cannot be edited due to announcement rate limits",
+    AnnouncementRateLimitReached , 20022),
+    ("The channel you are writing has hit the write rate limit",
+    ChannelRateLimitReached , 20028),
+    ("The write action you are performing on the server has hit the write rate limit",
+    WriteActionsReached , 20029),
+    ("Your Stage topic, server name, server description, or channel names contain words that are not allowed",
+    UnallowedWords , 20031),
+    ("Guild premium subscription level too low",
+    GuildPremiumTooLow , 20035),
+    ("Maximum number of guilds reached (100)",
+    MaximumGuildsReached , 30001),
+    ("Maximum number of friends reached (1000)",
+    MaximumFriendsReached , 30002),
+    ("Maximum number of pins reached for the channel (50)",
+    MaximumPinsReached , 30003),
+    ("Maximum number of recipients reached (10)",
+    MaximumRecipientsReached , 30004),
+    ("Maximum number of guild roles reached (250)",
+    MaximumRolesReached , 30005),
+    ("Maximum number of webhooks reached (10)",
+    MaximumWebhooksReached , 30007),
+    ("Maximum number of emojis reached",
+    MaximumEmojisReached , 30008),
+    ("Maximum number of reactions reached (20)",
+    MaximumReactionsReached , 30010),
+    ("Maximum number of guild channels reached (500)",
+    MaximumGuildChannelsReached , 30013),
+    ("Maximum number of attachments in a message reached (10)",
+    MaximumAttachmentsReached , 30015),
+    ("Maximum number of invites reached (1000)",
+    MaximumInvitesReached , 30016),
+    ("Maximum number of animated emojis reached",
+    MaximumAnimatedEmojisReached , 30018),
+    ("Maximum number of server members reached",
+    MaximumGuildMembersReached , 30019),
+    ("Maximum number of server categories has been reached",
+    MaximumServerCategoriesReached , 30030),
+    ("Guild already has a template",
+    GuildTemplateAlreadyExist , 30031),
+    ("Max number of thread participants has been reached (1000)",
+    ThreadMaxParticipants , 30033),
+    ("Maximum number of bans for non-guild members have been exceeded",
+    MaximumNonGuildBansReached , 30035),
+    ("Maximum number of bans fetches has been reached",
+    MaximumGuildBansFetchesReached , 30037),
+    ("Maximum number of uncompleted guild scheduled events reached (100)",
+    MaximumUncompletedEventsReached , 30038),
+    ("Maximum number of stickers reached",
+    MaximumStickersReached , 30039),
+    ("Maximum number of prune requests has been reached. Try again later",
+    MaximumPruneRequestsReached , 30040),
+    ("Maximum number of guild widget settings updates has been reached. Try again later",
+    MaximumGuildWidgets , 30042),
+    ("Unauthorized. Provide a valid token and try again",
+    Unauthorized , 40001),
+    ("You need to verify your account in order to perform this action",
+    AccountNeedsVerification , 40002),
+    ("You are opening direct messages too fast",
+    OpeningDirectMessageRateLimitReached , 40003),
+    ("Request entity too large. Try sending something smaller in size",
+    RequestEntityTooLarge , 40005),
+    ("This feature has been temporarily disabled server-side",
+    FeatureTemporarilyDisabled , 40006),
+    ("The user is banned from this guild",
+    UserBannedFromGuild , 40007),
+    ("Target user is not connected to voice",
+    UserNotInVoice , 40032),
+    ("This message has already been crossposted",
+    MessageAlreadyCrossposted , 40033),
+    ("An application command with that name already exists",
+    CommandNameAlreadyExists , 40041),
+    ("Missing access",
+    Missingaccess , 50001),
+    ("Invalid account type",
+    InvalidAccountType , 50002),
+    ("Cannot execute action on a DM channel",
+    InvalidDMChannelAction , 50003),
+    ("Guild widget disabled",
+    GuildWidgetDisabled , 50004),
+    ("Cannot edit a message authored by another user",
+    MessageNotAuthoredByUser , 50005),
+    ("Cannot send an empty message",
+    EmptyMessage , 50006),
+    ("Cannot send messages to this user",
+    CannotSendMessageToUser , 50007),
+    ("Cannot send messages in a voice channel",
+    CannotSendMessagesInVoiceChannel , 50008),
+    ("Channel verification level is too high for you to gain access",
+    VerificationLevelTooHigh , 50009),
+    ("OAuth2 application does not have a bot",
+    OAuthApplicationHasNoBot , 50010),
+    ("OAuth2 application limit reached",
+    OAuthApplicationLimitReached , 50011),
+    ("Invalid OAuth2 state",
+    InvalidOAuthSstate , 50012),
+    ("You lack permissions to perform that action",
+    PermissionsLacking , 50013),
+    ("Invalid authentication token provided",
+    InvalidAuthenticationTokenProvided , 50014),
+    ("Note was too long",
+    NoteTooLong , 50015),
+    ("Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete",
+    InvalidMessageDeleteRange , 50016),
+    ("A message can only be pinned to the channel it was sent in",
+    MessagePinnedInWrongChannel , 50019),
+    ("Invite code was either invalid or taken",
+    InviteCodeInvalidOrTaken , 50020),
+    ("Cannot execute action on a system message",
+    InvalidActionOnSystemMessage , 50021),
+    ("Cannot execute action on this channel type",
+    CannotExecuteActionOnChannelType , 50024),
+    ("Invalid OAuth2 access token provided",
+    InvalidOAuthAccessToken , 50025),
+    ("Missing required OAuth2 scope",
+    MissingOAuthScope , 50026),
+    ("Invalid webhook token provided",
+    InvalidWebhookToken , 50027),
+    ("Invalid role",
+    InvalidRole , 50028),
+    ("Invalid recipient(s)",
+    InvalidRecipient , 50033),
+    ("A message provided was too old to bulk delete",
+    MessageTooOldToBulkDelete , 50034),
+    ("Invalid form body (returned for both application/json and multipart/form-data bodies), or invalid Content-Type provided",
+    InvalidFormBodyOrContentType , 50035),
+    ("An invite was accepted to a guild the application's bot is not in",
+    InviteAcceptedToGuildBotNotIn , 50036),
+    ("Invalid API version provided",
+    InvalidApiVersion , 50041),
+    ("File uploaded exceeds the maximum size",
+    FileTooLarge , 50045),
+    ("Invalid file uploaded",
+    InvalidFileUploaded , 50046),
+    ("Cannot self-redeem this gift",
+    CannotSelfRedeemGift , 50054),
+    ("Invalid Guild",
+    InvalidGuild , 50055),
+    ("Payment source required to redeem gift",
+    PaymentRequiredForGift , 50070),
+    ("Cannot delete a channel required for Community guilds",
+    CommunityGuildRequired , 50074),
+    ("Invalid sticker sent",
+    InvalidStickerSent , 50081),
+    ("Tried to perform an operation on an archived thread, such as editing a message or adding a user to the thread",
+    ThreadArchived , 50083),
+    ("Invalid thread notification settings",
+    ThreadInvalidNotificationSettings , 50084),
+    ("`before` value is earlier than the thread creation date",
+    ThreadInvalidBeforeValue , 50085),
+    ("This server is not available in your location",
+    ServerNotAvailableLocation , 50095),
+    ("This server needs monetization enabled in order to perform this action",
+    ServerNeedsMonetiazation , 50097),
+    ("This server needs more boosts to perform this action",
+    ServerNeedsBoosts , 50101),
+    ("The request body contains invalid JSON",
+    RequestInvalidJson , 50109),
+    ("Two factor is required for this operation",
+    TwoFactorRequired , 60003),
+    ("No users with DiscordTag exist",
+    NoSuchUser , 80004),
+    ("Reaction was blocked",
+    ReactionBlocked , 90001),
+    ("API resource is currently overloaded. Try again a little later",
+    ApiResourceOverloaded , 130_000),
+    ("The Stage is already open",
+    StageAlreadyOpen , 150_006),
+    ("Cannot reply without permission to read message history",
+    CannotReplyWithoutMessageHistory , 160_002),
+    ("A thread has already been created for this message",
+    ThreadAlreadyCreated , 160_004),
+    ("Thread is locked",
+    ThreadLocked , 160_005),
+    ("Maximum number of active threads reached",
+    MaxActiveThreads , 160_006),
+    ("Maximum number of active announcement threads reached",
+    MaxActiveAnnouncementThreads , 160_007),
+    ("Invalid JSON for uploaded Lottie file",
+    InvalidLottieJson , 170_001),
+    ("Uploaded Lotties cannot contain rasterized images such as PNG or JPEG",
+    InvalidLottieContent , 170_002),
+    ("Sticker maximum framerate exceeded",
+    StickerMaximumFramerateExceeded , 170_003),
+    ("Sticker frame count exceeds maximum of 1000 frames",
+    StickerFrameCountExceedsMaximum , 170_004),
+    ("Lottie animation maximum dimensions exceeded",
+    LottieDimensionsTooLarge , 170_005),
+    ("Sticker frame rate is either too small or too large",
+    InvalidStickerFrameRate , 170_006),
+    ("Sticker animation duration exceeds maximum of 5 seconds",
+    StickerAnimationDurationExceedsMaximum , 170_007),
+    ("Cannot update a finished event",
+    CannotUpdateFinishedEvent , 180_000),
+    ("Failed to create stage needed for stage event",
+    FailedToCreateStage , 180_002)
+];
 
 impl<'de> Deserialize<'de> for ErrorCode {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -946,26 +523,9 @@ mod tests {
     };
     use serde_test::Token;
     use static_assertions::assert_impl_all;
-    use std::{convert::TryFrom, fmt::Debug};
+    use std::fmt::Debug;
 
     assert_impl_all!(ErrorCode: Clone, Copy, Debug, Eq, PartialEq, Send, Sync);
-
-    #[derive(Clone, Copy)]
-    struct AssertErrorCode<'a> {
-        code: ErrorCode,
-        display: &'a str,
-        num: u64,
-    }
-
-    /// Test that the provided error code has the correct number and that the
-    /// variant's Display implementation is correct.
-    fn assert_error_code(details: AssertErrorCode<'_>) {
-        let AssertErrorCode { code, display, num } = details;
-
-        assert_eq!(num, code.num());
-        assert_eq!(Ok(code), ErrorCode::try_from(num));
-        assert_eq!(display, code.to_string());
-    }
 
     #[test]
     fn test_api_error_deser() {
@@ -1083,61 +643,5 @@ mod tests {
                 Token::StructEnd,
             ],
         );
-    }
-
-    /// Test the values and display formatters of error codes.
-    #[test]
-    fn test_variants() {
-        assert_error_code(AssertErrorCode {
-            code: ErrorCode::UnknownDiscoverableServerCategory,
-            display: "Unknown discoverable server category",
-            num: 10059,
-        });
-        assert_error_code(AssertErrorCode {
-            code: ErrorCode::UnknownSticker,
-            display: "Unknown sticker",
-            num: 10060,
-        });
-        assert_error_code(AssertErrorCode {
-            code: ErrorCode::UnknownGuildMemberVerificationForm,
-            display: "Unknown Guild Member Verification Form",
-            num: 10068,
-        });
-        assert_error_code(AssertErrorCode {
-            code: ErrorCode::UnknownGuildWelcomeScreen,
-            display: "Unknown Guild Welcome Screen",
-            num: 10069,
-        });
-        assert_error_code(AssertErrorCode {
-            code: ErrorCode::WriteActionsReached,
-            display:
-                "The write action you are performing on the server has hit the write rate limit",
-            num: 20029,
-        });
-        assert_error_code(AssertErrorCode {
-            code: ErrorCode::MaximumServerCategoriesReached,
-            display: "Maximum number of server categories has been reached",
-            num: 30030,
-        });
-        assert_error_code(AssertErrorCode {
-            code: ErrorCode::MaximumStickersReached,
-            display: "Maximum number of stickers reached",
-            num: 30039,
-        });
-        assert_error_code(AssertErrorCode {
-            code: ErrorCode::MaximumPruneRequestsReached,
-            display: "Maximum number of prune requests has been reached. Try again later",
-            num: 30040,
-        });
-        assert_error_code(AssertErrorCode {
-            code: ErrorCode::InvalidGuild,
-            display: "Invalid Guild",
-            num: 50055,
-        });
-        assert_error_code(AssertErrorCode {
-            code: ErrorCode::RequestInvalidJson,
-            display: "The request body contains invalid JSON",
-            num: 50109,
-        })
     }
 }

--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -77,276 +77,521 @@ error_code![
         UnknownPermissionOverwrite,
         10009
     ),
-    ("Unknown provider",
-    UnknownProvider , 10010),
-    ("Unknown role",
-    UnknownRole , 10011),
-    ("Unknown token",
-    UnknownToken , 10012),
-    ("Unknown user",
-    UnknownUser , 10013),
-    ("Unknown emoji",
-    UnknownEmoji , 10014),
-    ("Unknown webhook",
-    UnknownWebhook , 10015),
-    ("Unknown webhook service",
-    UnknownWebhookService , 10016),
-    ("Unknown session",
-    UnknownSession , 10020),
-    ("Unknown ban",
-    UnknownBan , 10026),
-    ("Unknown SKU",
-    UnknownSKU , 10027),
-    ("Unknown Store Listing",
-    UnknownStoreListing , 10028),
-    ("Unknown entitlement",
-    UnknownEntitlement , 10029),
-    ("Unknown build",
-    UnknownBuild , 10030),
-    ("Unknown lobby",
-    UnknownLobby , 10031),
-    ("Unknown branch",
-    UnknownBranch , 10032),
-    ("Unknown store directory layout",
-    UnknownStoreDirectoryLayout , 10033),
-    ("Unknown redistributable",
-    UnknownRedistributable , 10036),
-    ("Unknown gift code",
-    UnknownGiftCode , 10038),
-    ("Unknown stream",
-    UnknownStream , 10049),
-    ("Unknown premium server subscribe cooldown",
-    UnknownPremiumServerSubscribeCooldown , 10050),
-    ("Unknown guild template",
-    UnknownGuildTemplate , 10057),
-    ("Unknown discoverable server category",
-    UnknownDiscoverableServerCategory , 10059),
-    ("Unknown sticker",
-    UnknownSticker , 10060),
-    ("Unknown interaction",
-    UnknownInteraction , 10062),
-    ("Unknown application command",
-    UnknownApplicationCommand , 10063),
-    ("Unknown application command permissions",
-    UnknownApplicationCommandPermissions , 10066),
-    ("Unknown Stage Instance",
-    UnknownStageInstance , 10067),
-    ("Unknown Guild Member Verification Form",
-    UnknownGuildMemberVerificationForm , 10068),
-    ("Unknown Guild Welcome Screen",
-    UnknownGuildWelcomeScreen , 10069),
-    ("Unknown guild scheduled event",
-    UnknownGuildScheduledEvent , 10070),
-    ("Unknown guild scheduled event user",
-    UnknownGuildScheduledEventUser , 10071),
-    ("Bots cannot use this endpoint",
-    BotsCannotUseEndpoint , 20001),
-    ("Only bots can use this endpoint",
-    OnlyBotsCanUseEndpoint , 20002),
-    ("Explicit content cannot be sent to the desired recipient(s)",
-    ExplicitContentSendingBlocked , 20009),
-    ("You are not authorized to perform this action on this application",
-    UnauthorizedApplicationAction , 20012),
-    ("This action cannot be performed due to slowmode rate limit",
-    SlowModeRateLimitReached , 20016),
-    ("Only the owner of this account can perform this action",
-    NotAccountOwner , 20018),
-    ("Message cannot be edited due to announcement rate limits",
-    AnnouncementRateLimitReached , 20022),
-    ("The channel you are writing has hit the write rate limit",
-    ChannelRateLimitReached , 20028),
-    ("The write action you are performing on the server has hit the write rate limit",
-    WriteActionsReached , 20029),
-    ("Your Stage topic, server name, server description, or channel names contain words that are not allowed",
-    UnallowedWords , 20031),
-    ("Guild premium subscription level too low",
-    GuildPremiumTooLow , 20035),
-    ("Maximum number of guilds reached (100)",
-    MaximumGuildsReached , 30001),
-    ("Maximum number of friends reached (1000)",
-    MaximumFriendsReached , 30002),
-    ("Maximum number of pins reached for the channel (50)",
-    MaximumPinsReached , 30003),
-    ("Maximum number of recipients reached (10)",
-    MaximumRecipientsReached , 30004),
-    ("Maximum number of guild roles reached (250)",
-    MaximumRolesReached , 30005),
-    ("Maximum number of webhooks reached (10)",
-    MaximumWebhooksReached , 30007),
-    ("Maximum number of emojis reached",
-    MaximumEmojisReached , 30008),
-    ("Maximum number of reactions reached (20)",
-    MaximumReactionsReached , 30010),
-    ("Maximum number of guild channels reached (500)",
-    MaximumGuildChannelsReached , 30013),
-    ("Maximum number of attachments in a message reached (10)",
-    MaximumAttachmentsReached , 30015),
-    ("Maximum number of invites reached (1000)",
-    MaximumInvitesReached , 30016),
-    ("Maximum number of animated emojis reached",
-    MaximumAnimatedEmojisReached , 30018),
-    ("Maximum number of server members reached",
-    MaximumGuildMembersReached , 30019),
-    ("Maximum number of server categories has been reached",
-    MaximumServerCategoriesReached , 30030),
-    ("Guild already has a template",
-    GuildTemplateAlreadyExist , 30031),
-    ("Max number of thread participants has been reached (1000)",
-    ThreadMaxParticipants , 30033),
-    ("Maximum number of bans for non-guild members have been exceeded",
-    MaximumNonGuildBansReached , 30035),
-    ("Maximum number of bans fetches has been reached",
-    MaximumGuildBansFetchesReached , 30037),
-    ("Maximum number of uncompleted guild scheduled events reached (100)",
-    MaximumUncompletedEventsReached , 30038),
-    ("Maximum number of stickers reached",
-    MaximumStickersReached , 30039),
-    ("Maximum number of prune requests has been reached. Try again later",
-    MaximumPruneRequestsReached , 30040),
-    ("Maximum number of guild widget settings updates has been reached. Try again later",
-    MaximumGuildWidgets , 30042),
-    ("Unauthorized. Provide a valid token and try again",
-    Unauthorized , 40001),
-    ("You need to verify your account in order to perform this action",
-    AccountNeedsVerification , 40002),
-    ("You are opening direct messages too fast",
-    OpeningDirectMessageRateLimitReached , 40003),
-    ("Request entity too large. Try sending something smaller in size",
-    RequestEntityTooLarge , 40005),
-    ("This feature has been temporarily disabled server-side",
-    FeatureTemporarilyDisabled , 40006),
-    ("The user is banned from this guild",
-    UserBannedFromGuild , 40007),
-    ("Target user is not connected to voice",
-    UserNotInVoice , 40032),
-    ("This message has already been crossposted",
-    MessageAlreadyCrossposted , 40033),
-    ("An application command with that name already exists",
-    CommandNameAlreadyExists , 40041),
-    ("Missing access",
-    Missingaccess , 50001),
-    ("Invalid account type",
-    InvalidAccountType , 50002),
-    ("Cannot execute action on a DM channel",
-    InvalidDMChannelAction , 50003),
-    ("Guild widget disabled",
-    GuildWidgetDisabled , 50004),
-    ("Cannot edit a message authored by another user",
-    MessageNotAuthoredByUser , 50005),
-    ("Cannot send an empty message",
-    EmptyMessage , 50006),
-    ("Cannot send messages to this user",
-    CannotSendMessageToUser , 50007),
-    ("Cannot send messages in a voice channel",
-    CannotSendMessagesInVoiceChannel , 50008),
-    ("Channel verification level is too high for you to gain access",
-    VerificationLevelTooHigh , 50009),
-    ("OAuth2 application does not have a bot",
-    OAuthApplicationHasNoBot , 50010),
-    ("OAuth2 application limit reached",
-    OAuthApplicationLimitReached , 50011),
-    ("Invalid OAuth2 state",
-    InvalidOAuthSstate , 50012),
-    ("You lack permissions to perform that action",
-    PermissionsLacking , 50013),
-    ("Invalid authentication token provided",
-    InvalidAuthenticationTokenProvided , 50014),
-    ("Note was too long",
-    NoteTooLong , 50015),
-    ("Provided too few or too many messages to delete. Must provide at least 2 and fewer than 100 messages to delete",
-    InvalidMessageDeleteRange , 50016),
-    ("A message can only be pinned to the channel it was sent in",
-    MessagePinnedInWrongChannel , 50019),
-    ("Invite code was either invalid or taken",
-    InviteCodeInvalidOrTaken , 50020),
-    ("Cannot execute action on a system message",
-    InvalidActionOnSystemMessage , 50021),
-    ("Cannot execute action on this channel type",
-    CannotExecuteActionOnChannelType , 50024),
-    ("Invalid OAuth2 access token provided",
-    InvalidOAuthAccessToken , 50025),
-    ("Missing required OAuth2 scope",
-    MissingOAuthScope , 50026),
-    ("Invalid webhook token provided",
-    InvalidWebhookToken , 50027),
-    ("Invalid role",
-    InvalidRole , 50028),
-    ("Invalid recipient(s)",
-    InvalidRecipient , 50033),
-    ("A message provided was too old to bulk delete",
-    MessageTooOldToBulkDelete , 50034),
-    ("Invalid form body (returned for both application/json and multipart/form-data bodies), or invalid Content-Type provided",
-    InvalidFormBodyOrContentType , 50035),
-    ("An invite was accepted to a guild the application's bot is not in",
-    InviteAcceptedToGuildBotNotIn , 50036),
-    ("Invalid API version provided",
-    InvalidApiVersion , 50041),
-    ("File uploaded exceeds the maximum size",
-    FileTooLarge , 50045),
-    ("Invalid file uploaded",
-    InvalidFileUploaded , 50046),
-    ("Cannot self-redeem this gift",
-    CannotSelfRedeemGift , 50054),
-    ("Invalid Guild",
-    InvalidGuild , 50055),
-    ("Payment source required to redeem gift",
-    PaymentRequiredForGift , 50070),
-    ("Cannot delete a channel required for Community guilds",
-    CommunityGuildRequired , 50074),
-    ("Invalid sticker sent",
-    InvalidStickerSent , 50081),
-    ("Tried to perform an operation on an archived thread, such as editing a message or adding a user to the thread",
-    ThreadArchived , 50083),
-    ("Invalid thread notification settings",
-    ThreadInvalidNotificationSettings , 50084),
-    ("`before` value is earlier than the thread creation date",
-    ThreadInvalidBeforeValue , 50085),
-    ("This server is not available in your location",
-    ServerNotAvailableLocation , 50095),
-    ("This server needs monetization enabled in order to perform this action",
-    ServerNeedsMonetiazation , 50097),
-    ("This server needs more boosts to perform this action",
-    ServerNeedsBoosts , 50101),
-    ("The request body contains invalid JSON",
-    RequestInvalidJson , 50109),
-    ("Two factor is required for this operation",
-    TwoFactorRequired , 60003),
-    ("No users with DiscordTag exist",
-    NoSuchUser , 80004),
-    ("Reaction was blocked",
-    ReactionBlocked , 90001),
-    ("API resource is currently overloaded. Try again a little later",
-    ApiResourceOverloaded , 130_000),
-    ("The Stage is already open",
-    StageAlreadyOpen , 150_006),
-    ("Cannot reply without permission to read message history",
-    CannotReplyWithoutMessageHistory , 160_002),
-    ("A thread has already been created for this message",
-    ThreadAlreadyCreated , 160_004),
-    ("Thread is locked",
-    ThreadLocked , 160_005),
-    ("Maximum number of active threads reached",
-    MaxActiveThreads , 160_006),
-    ("Maximum number of active announcement threads reached",
-    MaxActiveAnnouncementThreads , 160_007),
-    ("Invalid JSON for uploaded Lottie file",
-    InvalidLottieJson , 170_001),
-    ("Uploaded Lotties cannot contain rasterized images such as PNG or JPEG",
-    InvalidLottieContent , 170_002),
-    ("Sticker maximum framerate exceeded",
-    StickerMaximumFramerateExceeded , 170_003),
-    ("Sticker frame count exceeds maximum of 1000 frames",
-    StickerFrameCountExceedsMaximum , 170_004),
-    ("Lottie animation maximum dimensions exceeded",
-    LottieDimensionsTooLarge , 170_005),
-    ("Sticker frame rate is either too small or too large",
-    InvalidStickerFrameRate , 170_006),
-    ("Sticker animation duration exceeds maximum of 5 seconds",
-    StickerAnimationDurationExceedsMaximum , 170_007),
-    ("Cannot update a finished event",
-    CannotUpdateFinishedEvent , 180_000),
-    ("Failed to create stage needed for stage event",
-    FailedToCreateStage , 180_002)
+    ("Unknown provider", UnknownProvider, 10010),
+    ("Unknown role", UnknownRole, 10011),
+    ("Unknown token", UnknownToken, 10012),
+    ("Unknown user", UnknownUser, 10013),
+    ("Unknown emoji", UnknownEmoji, 10014),
+    ("Unknown webhook", UnknownWebhook, 10015),
+    ("Unknown webhook service", UnknownWebhookService, 10016),
+    ("Unknown session", UnknownSession, 10020),
+    ("Unknown ban", UnknownBan, 10026),
+    ("Unknown SKU", UnknownSKU, 10027),
+    ("Unknown Store Listing", UnknownStoreListing, 10028),
+    ("Unknown entitlement", UnknownEntitlement, 10029),
+    ("Unknown build", UnknownBuild, 10030),
+    ("Unknown lobby", UnknownLobby, 10031),
+    ("Unknown branch", UnknownBranch, 10032),
+    (
+        "Unknown store directory layout",
+        UnknownStoreDirectoryLayout,
+        10033
+    ),
+    ("Unknown redistributable", UnknownRedistributable, 10036),
+    ("Unknown gift code", UnknownGiftCode, 10038),
+    ("Unknown stream", UnknownStream, 10049),
+    (
+        "Unknown premium server subscribe cooldown",
+        UnknownPremiumServerSubscribeCooldown,
+        10050
+    ),
+    ("Unknown guild template", UnknownGuildTemplate, 10057),
+    (
+        "Unknown discoverable server category",
+        UnknownDiscoverableServerCategory,
+        10059
+    ),
+    ("Unknown sticker", UnknownSticker, 10060),
+    ("Unknown interaction", UnknownInteraction, 10062),
+    (
+        "Unknown application command",
+        UnknownApplicationCommand,
+        10063
+    ),
+    (
+        "Unknown application command permissions",
+        UnknownApplicationCommandPermissions,
+        10066
+    ),
+    ("Unknown Stage Instance", UnknownStageInstance, 10067),
+    (
+        "Unknown Guild Member Verification Form",
+        UnknownGuildMemberVerificationForm,
+        10068
+    ),
+    (
+        "Unknown Guild Welcome Screen",
+        UnknownGuildWelcomeScreen,
+        10069
+    ),
+    (
+        "Unknown guild scheduled event",
+        UnknownGuildScheduledEvent,
+        10070
+    ),
+    (
+        "Unknown guild scheduled event user",
+        UnknownGuildScheduledEventUser,
+        10071
+    ),
+    (
+        "Bots cannot use this endpoint",
+        BotsCannotUseEndpoint,
+        20001
+    ),
+    (
+        "Only bots can use this endpoint",
+        OnlyBotsCanUseEndpoint,
+        20002
+    ),
+    (
+        "Explicit content cannot be sent to the desired recipient(s)",
+        ExplicitContentSendingBlocked,
+        20009
+    ),
+    (
+        "You are not authorized to perform this action on this application",
+        UnauthorizedApplicationAction,
+        20012
+    ),
+    (
+        "This action cannot be performed due to slowmode rate limit",
+        SlowModeRateLimitReached,
+        20016
+    ),
+    (
+        "Only the owner of this account can perform this action",
+        NotAccountOwner,
+        20018
+    ),
+    (
+        "Message cannot be edited due to announcement rate limits",
+        AnnouncementRateLimitReached,
+        20022
+    ),
+    (
+        "The channel you are writing has hit the write rate limit",
+        ChannelRateLimitReached,
+        20028
+    ),
+    (
+        "The write action you are performing on the server has hit the write rate limit",
+        WriteActionsReached,
+        20029
+    ),
+    (
+        "Your Stage topic, server name, server description, or channel names contain words that \
+         are not allowed",
+        UnallowedWords,
+        20031
+    ),
+    (
+        "Guild premium subscription level too low",
+        GuildPremiumTooLow,
+        20035
+    ),
+    (
+        "Maximum number of guilds reached (100)",
+        MaximumGuildsReached,
+        30001
+    ),
+    (
+        "Maximum number of friends reached (1000)",
+        MaximumFriendsReached,
+        30002
+    ),
+    (
+        "Maximum number of pins reached for the channel (50)",
+        MaximumPinsReached,
+        30003
+    ),
+    (
+        "Maximum number of recipients reached (10)",
+        MaximumRecipientsReached,
+        30004
+    ),
+    (
+        "Maximum number of guild roles reached (250)",
+        MaximumRolesReached,
+        30005
+    ),
+    (
+        "Maximum number of webhooks reached (10)",
+        MaximumWebhooksReached,
+        30007
+    ),
+    (
+        "Maximum number of emojis reached",
+        MaximumEmojisReached,
+        30008
+    ),
+    (
+        "Maximum number of reactions reached (20)",
+        MaximumReactionsReached,
+        30010
+    ),
+    (
+        "Maximum number of guild channels reached (500)",
+        MaximumGuildChannelsReached,
+        30013
+    ),
+    (
+        "Maximum number of attachments in a message reached (10)",
+        MaximumAttachmentsReached,
+        30015
+    ),
+    (
+        "Maximum number of invites reached (1000)",
+        MaximumInvitesReached,
+        30016
+    ),
+    (
+        "Maximum number of animated emojis reached",
+        MaximumAnimatedEmojisReached,
+        30018
+    ),
+    (
+        "Maximum number of server members reached",
+        MaximumGuildMembersReached,
+        30019
+    ),
+    (
+        "Maximum number of server categories has been reached",
+        MaximumServerCategoriesReached,
+        30030
+    ),
+    (
+        "Guild already has a template",
+        GuildTemplateAlreadyExist,
+        30031
+    ),
+    (
+        "Max number of thread participants has been reached (1000)",
+        ThreadMaxParticipants,
+        30033
+    ),
+    (
+        "Maximum number of bans for non-guild members have been exceeded",
+        MaximumNonGuildBansReached,
+        30035
+    ),
+    (
+        "Maximum number of bans fetches has been reached",
+        MaximumGuildBansFetchesReached,
+        30037
+    ),
+    (
+        "Maximum number of uncompleted guild scheduled events reached (100)",
+        MaximumUncompletedEventsReached,
+        30038
+    ),
+    (
+        "Maximum number of stickers reached",
+        MaximumStickersReached,
+        30039
+    ),
+    (
+        "Maximum number of prune requests has been reached. Try again later",
+        MaximumPruneRequestsReached,
+        30040
+    ),
+    (
+        "Maximum number of guild widget settings updates has been reached. Try again later",
+        MaximumGuildWidgets,
+        30042
+    ),
+    (
+        "Unauthorized. Provide a valid token and try again",
+        Unauthorized,
+        40001
+    ),
+    (
+        "You need to verify your account in order to perform this action",
+        AccountNeedsVerification,
+        40002
+    ),
+    (
+        "You are opening direct messages too fast",
+        OpeningDirectMessageRateLimitReached,
+        40003
+    ),
+    (
+        "Request entity too large. Try sending something smaller in size",
+        RequestEntityTooLarge,
+        40005
+    ),
+    (
+        "This feature has been temporarily disabled server-side",
+        FeatureTemporarilyDisabled,
+        40006
+    ),
+    (
+        "The user is banned from this guild",
+        UserBannedFromGuild,
+        40007
+    ),
+    (
+        "Target user is not connected to voice",
+        UserNotInVoice,
+        40032
+    ),
+    (
+        "This message has already been crossposted",
+        MessageAlreadyCrossposted,
+        40033
+    ),
+    (
+        "An application command with that name already exists",
+        CommandNameAlreadyExists,
+        40041
+    ),
+    ("Missing access", Missingaccess, 50001),
+    ("Invalid account type", InvalidAccountType, 50002),
+    (
+        "Cannot execute action on a DM channel",
+        InvalidDMChannelAction,
+        50003
+    ),
+    ("Guild widget disabled", GuildWidgetDisabled, 50004),
+    (
+        "Cannot edit a message authored by another user",
+        MessageNotAuthoredByUser,
+        50005
+    ),
+    ("Cannot send an empty message", EmptyMessage, 50006),
+    (
+        "Cannot send messages to this user",
+        CannotSendMessageToUser,
+        50007
+    ),
+    (
+        "Cannot send messages in a voice channel",
+        CannotSendMessagesInVoiceChannel,
+        50008
+    ),
+    (
+        "Channel verification level is too high for you to gain access",
+        VerificationLevelTooHigh,
+        50009
+    ),
+    (
+        "OAuth2 application does not have a bot",
+        OAuthApplicationHasNoBot,
+        50010
+    ),
+    (
+        "OAuth2 application limit reached",
+        OAuthApplicationLimitReached,
+        50011
+    ),
+    ("Invalid OAuth2 state", InvalidOAuthSstate, 50012),
+    (
+        "You lack permissions to perform that action",
+        PermissionsLacking,
+        50013
+    ),
+    (
+        "Invalid authentication token provided",
+        InvalidAuthenticationTokenProvided,
+        50014
+    ),
+    ("Note was too long", NoteTooLong, 50015),
+    (
+        "Provided too few or too many messages to delete. Must provide at least 2 and fewer than \
+         100 messages to delete",
+        InvalidMessageDeleteRange,
+        50016
+    ),
+    (
+        "A message can only be pinned to the channel it was sent in",
+        MessagePinnedInWrongChannel,
+        50019
+    ),
+    (
+        "Invite code was either invalid or taken",
+        InviteCodeInvalidOrTaken,
+        50020
+    ),
+    (
+        "Cannot execute action on a system message",
+        InvalidActionOnSystemMessage,
+        50021
+    ),
+    (
+        "Cannot execute action on this channel type",
+        CannotExecuteActionOnChannelType,
+        50024
+    ),
+    (
+        "Invalid OAuth2 access token provided",
+        InvalidOAuthAccessToken,
+        50025
+    ),
+    ("Missing required OAuth2 scope", MissingOAuthScope, 50026),
+    ("Invalid webhook token provided", InvalidWebhookToken, 50027),
+    ("Invalid role", InvalidRole, 50028),
+    ("Invalid recipient(s)", InvalidRecipient, 50033),
+    (
+        "A message provided was too old to bulk delete",
+        MessageTooOldToBulkDelete,
+        50034
+    ),
+    (
+        "Invalid form body (returned for both application/json and multipart/form-data bodies), \
+         or invalid Content-Type provided",
+        InvalidFormBodyOrContentType,
+        50035
+    ),
+    (
+        "An invite was accepted to a guild the application's bot is not in",
+        InviteAcceptedToGuildBotNotIn,
+        50036
+    ),
+    ("Invalid API version provided", InvalidApiVersion, 50041),
+    (
+        "File uploaded exceeds the maximum size",
+        FileTooLarge,
+        50045
+    ),
+    ("Invalid file uploaded", InvalidFileUploaded, 50046),
+    ("Cannot self-redeem this gift", CannotSelfRedeemGift, 50054),
+    ("Invalid Guild", InvalidGuild, 50055),
+    (
+        "Payment source required to redeem gift",
+        PaymentRequiredForGift,
+        50070
+    ),
+    (
+        "Cannot delete a channel required for Community guilds",
+        CommunityGuildRequired,
+        50074
+    ),
+    ("Invalid sticker sent", InvalidStickerSent, 50081),
+    (
+        "Tried to perform an operation on an archived thread, such as editing a message or adding \
+         a user to the thread",
+        ThreadArchived,
+        50083
+    ),
+    (
+        "Invalid thread notification settings",
+        ThreadInvalidNotificationSettings,
+        50084
+    ),
+    (
+        "`before` value is earlier than the thread creation date",
+        ThreadInvalidBeforeValue,
+        50085
+    ),
+    (
+        "This server is not available in your location",
+        ServerNotAvailableLocation,
+        50095
+    ),
+    (
+        "This server needs monetization enabled in order to perform this action",
+        ServerNeedsMonetiazation,
+        50097
+    ),
+    (
+        "This server needs more boosts to perform this action",
+        ServerNeedsBoosts,
+        50101
+    ),
+    (
+        "The request body contains invalid JSON",
+        RequestInvalidJson,
+        50109
+    ),
+    (
+        "Two factor is required for this operation",
+        TwoFactorRequired,
+        60003
+    ),
+    ("No users with DiscordTag exist", NoSuchUser, 80004),
+    ("Reaction was blocked", ReactionBlocked, 90001),
+    (
+        "API resource is currently overloaded. Try again a little later",
+        ApiResourceOverloaded,
+        130_000
+    ),
+    ("The Stage is already open", StageAlreadyOpen, 150_006),
+    (
+        "Cannot reply without permission to read message history",
+        CannotReplyWithoutMessageHistory,
+        160_002
+    ),
+    (
+        "A thread has already been created for this message",
+        ThreadAlreadyCreated,
+        160_004
+    ),
+    ("Thread is locked", ThreadLocked, 160_005),
+    (
+        "Maximum number of active threads reached",
+        MaxActiveThreads,
+        160_006
+    ),
+    (
+        "Maximum number of active announcement threads reached",
+        MaxActiveAnnouncementThreads,
+        160_007
+    ),
+    (
+        "Invalid JSON for uploaded Lottie file",
+        InvalidLottieJson,
+        170_001
+    ),
+    (
+        "Uploaded Lotties cannot contain rasterized images such as PNG or JPEG",
+        InvalidLottieContent,
+        170_002
+    ),
+    (
+        "Sticker maximum framerate exceeded",
+        StickerMaximumFramerateExceeded,
+        170_003
+    ),
+    (
+        "Sticker frame count exceeds maximum of 1000 frames",
+        StickerFrameCountExceedsMaximum,
+        170_004
+    ),
+    (
+        "Lottie animation maximum dimensions exceeded",
+        LottieDimensionsTooLarge,
+        170_005
+    ),
+    (
+        "Sticker frame rate is either too small or too large",
+        InvalidStickerFrameRate,
+        170_006
+    ),
+    (
+        "Sticker animation duration exceeds maximum of 5 seconds",
+        StickerAnimationDurationExceedsMaximum,
+        170_007
+    ),
+    (
+        "Cannot update a finished event",
+        CannotUpdateFinishedEvent,
+        180_000
+    ),
+    (
+        "Failed to create stage needed for stage event",
+        FailedToCreateStage,
+        180_002
+    )
 ];
 
 impl<'de> Deserialize<'de> for ErrorCode {

--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -15,8 +15,7 @@ macro_rules! error_code {
         #[non_exhaustive]
         pub enum ErrorCode {
             $(
-                // display + "." = rustdoc comment
-                #[doc = concat!($display, ".")]
+                #[doc = $display]
                 $name
             ),*,
             /// A status code that Twilight doesn't have registered.


### PR DESCRIPTION
Adding a new `ErrorCode` variant was previously a tedious process due to having to duplicate the display implementation as a rustdoc comment and matching `ErrorCode::num()`'s output to `From<u64>`'s input.

To assure this a tests were added (`assert_error_code()`), this is no longer necessary as the macro correctly handles everything.
