### PR TITLE
ci: automatically label pull request

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,100 @@
+version: v1
+
+labels:
+  - label: "c-all"
+    matcher:
+      files: "*"
+
+  - label: "c-cache"
+    sync: true
+    matcher:
+      files: "cache/**/*"
+
+  - label: "c-command-parser"
+    sync: true
+    matcher:
+      files: "command-parser/**/*"
+
+  - label: "c-embed-builder"
+    sync: true
+    matcher:
+      files: "embed-builder/**/*"
+
+  - label: "c-gateway"
+    sync: true
+    matcher:
+      files: "gateway/**/*"
+
+  - label: "c-gateway-queue"
+    sync: true
+    matcher:
+      files: "gateway-queue/**/*"
+
+  - label: "c-http"
+    sync: true
+    matcher:
+      files: "http/**/*"
+
+  - label: "c-http-ratelimiting"
+    sync: true
+    matcher:
+      files: "http-ratelimiting/**/*"
+
+  - label: "c-lavalink"
+    sync: true
+    matcher:
+      files: "lavalink/**/*"
+
+  - label: "c-mention"
+    sync: true
+    matcher:
+      fiiles: "mention/**/*"
+
+  - label: "c-model"
+    sync: true
+    matcher:
+      files: "model/**/*"
+
+  - label: "c-standby"
+    sync: true
+    matcher:
+      files: "standby/**/*"
+
+  - label: "c-util"
+    sync: true
+    matcher:
+      files: "util/**/*"
+
+  - label: "c-validate"
+    sync: true
+    matcher:
+      files: "validate/**/*"
+
+  - label: "t-github-actions"
+    matcher:
+      files: ".github/workflows/*"
+      title: "^ci: .*"
+
+  - label: "m-breaking change"
+    matcher:
+      title: "^[a-z]+(\\(.+\\))!: .*"
+
+  - label: "t-chore"
+    matcher:
+      title: "^chore(\\(.+\\))!?: .*"
+
+  - label: "t-docs"
+    matcher:
+      title: "^docs(\\(.+\\))!?: .*"
+
+  - label: "t-feature"
+    matcher:
+      title: "^feat(\\(.+\\))!?: .*"
+
+  - label: "t-fix"
+    matcher:
+      title: "^fix(\\(.+\\))!?: .*"
+
+  - label: "t-refactor"
+    matcher:
+      title: "^refactor(\\(.+\\))!?: .*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -77,24 +77,24 @@ labels:
 
   - label: "m-breaking change"
     matcher:
-      title: "^[a-z]+(\\(.+\\))!: .*"
+      title: "^[a-z]+(\\(.+\\))?!: .*"
 
   - label: "t-chore"
     matcher:
-      title: "^chore(\\(.+\\))!?: .*"
+      title: "^chore(\\(.+\\))?!?: .*"
 
   - label: "t-docs"
     matcher:
-      title: "^docs(\\(.+\\))!?: .*"
+      title: "^docs(\\(.+\\))?!?: .*"
 
   - label: "t-feature"
     matcher:
-      title: "^feat(\\(.+\\))!?: .*"
+      title: "^feat(\\(.+\\))?!?: .*"
 
   - label: "t-fix"
     matcher:
-      title: "^fix(\\(.+\\))!?: .*"
+      title: "^fix(\\(.+\\))?!?: .*"
 
   - label: "t-refactor"
     matcher:
-      title: "^refactor(\\(.+\\))!?: .*"
+      title: "^refactor(\\(.+\\))?!?: .*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+  pull_request_target:
+    types: [opened, synchronize, edited, reopened]
+
+jobs:
+  labeler:
+    name: Label pull request
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: fuxingloh/multi-labeler@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR add a new GitHub Actions workflow that use [fuxingloh/multi-labeler](https://github.com/fuxingloh/multi-labeler) to automatically label pull requests depending on the file changes and the PR title:

- `c-*` and `t-github-actions` are added depending on the files changed by the PR. These labels are synced (except `c-all` and `t-github-actions`) so they will be automatically removed if the PR does no longer change these files.

- `t-*` and `m-breaking change` are added depending on the PR title. This will only work if the title respects the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

I made an example PR on my fork to test the action: https://github.com/baptiste0928/twilight/pull/1
![image](https://user-images.githubusercontent.com/22115890/147569638-ddd8fb5b-4955-4068-988c-19e04efdae2e.png)
