### PR TITLE
feat(validate, http)!: validate command and options names

### DIFF
--- a/http/src/client/interaction.rs
+++ b/http/src/client/interaction.rs
@@ -161,20 +161,11 @@ impl<'a> InteractionClient<'a> {
     }
 
     /// Create a new command in a guild.
-    ///
-    /// The name must be between 1 and 32 characters in length. Creating a
-    /// guild command with the same name as an already-existing guild command in
-    /// the same guild will overwrite the old command. See [the discord docs]
-    /// for more information.
-    ///
-    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
-    /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
     pub const fn create_guild_command(
         &'a self,
         guild_id: Id<GuildMarker>,
-        name: &'a str,
     ) -> CreateGuildCommand<'a> {
-        CreateGuildCommand::new(self.client, self.application_id, guild_id, name)
+        CreateGuildCommand::new(self.client, self.application_id, guild_id)
     }
 
     /// Fetch a guild command for your application.
@@ -233,14 +224,8 @@ impl<'a> InteractionClient<'a> {
     }
 
     /// Create a new global command.
-    ///
-    /// The name must be between 1 and 32 characters in length. Creating a
-    /// command with the same name as an already-existing global command will
-    /// overwrite the old command. See [the discord docs] for more information.
-    ///
-    /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
-    pub const fn create_global_command(&'a self, name: &'a str) -> CreateGlobalCommand<'a> {
-        CreateGlobalCommand::new(self.client, self.application_id, name)
+    pub const fn create_global_command(&'a self) -> CreateGlobalCommand<'a> {
+        CreateGlobalCommand::new(self.client, self.application_id)
     }
 
     /// Fetch a global command for your application.

--- a/http/src/client/interaction.rs
+++ b/http/src/client/interaction.rs
@@ -167,16 +167,13 @@ impl<'a> InteractionClient<'a> {
     /// the same guild will overwrite the old command. See [the discord docs]
     /// for more information.
     ///
-    /// Returns an error of type [`NameInvalid`] error type if the command name
-    /// is not between 1 and 32 characters.
-    ///
     /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
-    pub fn create_guild_command(
+    pub const fn create_guild_command(
         &'a self,
         guild_id: Id<GuildMarker>,
         name: &'a str,
-    ) -> Result<CreateGuildCommand<'a>, CommandValidationError> {
+    ) -> CreateGuildCommand<'a> {
         CreateGuildCommand::new(self.client, self.application_id, guild_id, name)
     }
 
@@ -241,15 +238,8 @@ impl<'a> InteractionClient<'a> {
     /// command with the same name as an already-existing global command will
     /// overwrite the old command. See [the discord docs] for more information.
     ///
-    /// Returns an error of type [`NameInvalid`] if the command name is not
-    /// between 1 and 32 characters.
-    ///
-    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
-    pub fn create_global_command(
-        &'a self,
-        name: &'a str,
-    ) -> Result<CreateGlobalCommand<'a>, CommandValidationError> {
+    pub const fn create_global_command(&'a self, name: &'a str) -> CreateGlobalCommand<'a> {
         CreateGlobalCommand::new(self.client, self.application_id, name)
     }
 

--- a/http/src/request/application/command/create_global_command/chat_input.rs
+++ b/http/src/request/application/command/create_global_command/chat_input.rs
@@ -39,8 +39,9 @@ impl<'a> CreateGlobalChatInputCommand<'a> {
         name: &'a str,
         description: &'a str,
     ) -> Result<Self, CommandValidationError> {
-        validate_name(name)?;
         validate_description(&description)?;
+
+        validate_name(name)?;
 
         Ok(Self {
             application_id,

--- a/http/src/request/application/command/create_global_command/chat_input.rs
+++ b/http/src/request/application/command/create_global_command/chat_input.rs
@@ -11,7 +11,7 @@ use twilight_model::{
     id::{marker::ApplicationMarker, Id},
 };
 use twilight_validate::command::{
-    chat_input_name as validate_name, description as validate_description,
+    chat_input_name as validate_chat_input_name, description as validate_description,
     options as validate_options, CommandValidationError,
 };
 
@@ -41,7 +41,7 @@ impl<'a> CreateGlobalChatInputCommand<'a> {
     ) -> Result<Self, CommandValidationError> {
         validate_description(&description)?;
 
-        validate_name(name)?;
+        validate_chat_input_name(name)?;
 
         Ok(Self {
             application_id,

--- a/http/src/request/application/command/create_global_command/chat_input.rs
+++ b/http/src/request/application/command/create_global_command/chat_input.rs
@@ -39,7 +39,7 @@ impl<'a> CreateGlobalChatInputCommand<'a> {
         name: &'a str,
         description: &'a str,
     ) -> Result<Self, CommandValidationError> {
-        validate_name(name).map_err(CommandValidationError::name_invalid)?;
+        validate_name(name)?;
         validate_description(&description)?;
 
         Ok(Self {

--- a/http/src/request/application/command/create_global_command/chat_input.rs
+++ b/http/src/request/application/command/create_global_command/chat_input.rs
@@ -11,7 +11,8 @@ use twilight_model::{
     id::{marker::ApplicationMarker, Id},
 };
 use twilight_validate::command::{
-    description as validate_description, options as validate_options, CommandValidationError,
+    chat_input_name as validate_name, description as validate_description,
+    options as validate_options, CommandValidationError,
 };
 
 /// Create a new chat input global command.
@@ -38,6 +39,7 @@ impl<'a> CreateGlobalChatInputCommand<'a> {
         name: &'a str,
         description: &'a str,
     ) -> Result<Self, CommandValidationError> {
+        validate_name(name).map_err(CommandValidationError::name_invalid)?;
         validate_description(&description)?;
 
         Ok(Self {
@@ -54,7 +56,7 @@ impl<'a> CreateGlobalChatInputCommand<'a> {
     ///
     /// Required command options must be added before optional options.
     ///
-    /// Errors
+    /// # Errors
     ///
     /// Returns an error of type [`OptionsRequiredFirst`] if a required option
     /// was added after an optional option. The problem option's index is

--- a/http/src/request/application/command/create_global_command/message.rs
+++ b/http/src/request/application/command/create_global_command/message.rs
@@ -10,6 +10,7 @@ use twilight_model::{
     application::command::{Command, CommandType},
     id::{marker::ApplicationMarker, Id},
 };
+use twilight_validate::command::{name as validate_name, CommandValidationError};
 
 /// Create a new message global command.
 ///
@@ -26,17 +27,19 @@ pub struct CreateGlobalMessageCommand<'a> {
 }
 
 impl<'a> CreateGlobalMessageCommand<'a> {
-    pub(crate) const fn new(
+    pub(crate) fn new(
         http: &'a Client,
         application_id: Id<ApplicationMarker>,
         name: &'a str,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, CommandValidationError> {
+        validate_name(name).map_err(CommandValidationError::name_invalid)?;
+
+        Ok(Self {
             application_id,
             default_permission: None,
             http,
             name,
-        }
+        })
     }
 
     /// Whether the command is enabled by default when the app is added to a guild.

--- a/http/src/request/application/command/create_global_command/message.rs
+++ b/http/src/request/application/command/create_global_command/message.rs
@@ -32,7 +32,7 @@ impl<'a> CreateGlobalMessageCommand<'a> {
         application_id: Id<ApplicationMarker>,
         name: &'a str,
     ) -> Result<Self, CommandValidationError> {
-        validate_name(name).map_err(CommandValidationError::name_invalid)?;
+        validate_name(name)?;
 
         Ok(Self {
             application_id,

--- a/http/src/request/application/command/create_global_command/mod.rs
+++ b/http/src/request/application/command/create_global_command/mod.rs
@@ -38,7 +38,8 @@ impl<'a> CreateGlobalCommand<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error of type [`NameLengthInvalid`] or [`NameCharacterInvalid`] if the command name is invalid.
+    /// Returns an error of type [`NameLengthInvalid`] or [`NameCharacterInvalid`]
+    /// if the command name is invalid.
     ///
     /// Returns an error of type [`DescriptionInvalid`] if the
     /// command description is not between 1 and 100 characters.

--- a/http/src/request/application/command/create_global_command/mod.rs
+++ b/http/src/request/application/command/create_global_command/mod.rs
@@ -12,29 +12,17 @@ use twilight_model::id::{marker::ApplicationMarker, Id};
 use twilight_validate::command::CommandValidationError;
 
 /// Create a new global command.
-///
-/// The name must be between 1 and 32 characters in length. Creating a command
-/// with the same name as an already-existing global command will overwrite the
-/// old command. See [the discord docs] for more information.
-///
-/// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
 #[must_use = "the command must have a type"]
 pub struct CreateGlobalCommand<'a> {
     application_id: Id<ApplicationMarker>,
     http: &'a Client,
-    name: &'a str,
 }
 
 impl<'a> CreateGlobalCommand<'a> {
-    pub(crate) const fn new(
-        http: &'a Client,
-        application_id: Id<ApplicationMarker>,
-        name: &'a str,
-    ) -> Self {
+    pub(crate) const fn new(http: &'a Client, application_id: Id<ApplicationMarker>) -> Self {
         Self {
             application_id,
             http,
-            name,
         }
     }
 
@@ -42,11 +30,11 @@ impl<'a> CreateGlobalCommand<'a> {
     ///
     /// The command name must only contain alphanumeric characters and lowercase
     /// variants must be used where possible. Special characters `-` and `_` are
-    /// allowed.
+    /// allowed. The description must be between 1 and 100 characters in length.
     ///
-    /// The description must be between 1 and 100 characters in length. Creating
-    /// a command with the same name as an already-existing global command will
-    /// overwrite the old command. See [the discord docs] for more information.
+    /// Creating a command with the same name as an already-existing global
+    /// command will overwrite the old command. See [the discord docs] for more
+    /// information.
     ///
     /// # Errors
     ///
@@ -61,9 +49,10 @@ impl<'a> CreateGlobalCommand<'a> {
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
     pub fn chat_input(
         self,
+        name: &'a str,
         description: &'a str,
     ) -> Result<CreateGlobalChatInputCommand<'a>, CommandValidationError> {
-        CreateGlobalChatInputCommand::new(self.http, self.application_id, self.name, description)
+        CreateGlobalChatInputCommand::new(self.http, self.application_id, name, description)
     }
 
     /// Create a new message global command.
@@ -79,8 +68,11 @@ impl<'a> CreateGlobalCommand<'a> {
     ///
     /// [`NameLengthInvalid`]: twilight_validate::command::CommandValidationErrorType::NameLengthInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
-    pub fn message(self) -> Result<CreateGlobalMessageCommand<'a>, CommandValidationError> {
-        CreateGlobalMessageCommand::new(self.http, self.application_id, self.name)
+    pub fn message(
+        self,
+        name: &'a str,
+    ) -> Result<CreateGlobalMessageCommand<'a>, CommandValidationError> {
+        CreateGlobalMessageCommand::new(self.http, self.application_id, name)
     }
 
     /// Create a new user global command.
@@ -96,7 +88,10 @@ impl<'a> CreateGlobalCommand<'a> {
     ///
     /// [`NameLengthInvalid`]: twilight_validate::command::CommandValidationErrorType::NameLengthInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
-    pub fn user(self) -> Result<CreateGlobalUserCommand<'a>, CommandValidationError> {
-        CreateGlobalUserCommand::new(self.http, self.application_id, self.name)
+    pub fn user(
+        self,
+        name: &'a str,
+    ) -> Result<CreateGlobalUserCommand<'a>, CommandValidationError> {
+        CreateGlobalUserCommand::new(self.http, self.application_id, name)
     }
 }

--- a/http/src/request/application/command/create_global_command/mod.rs
+++ b/http/src/request/application/command/create_global_command/mod.rs
@@ -50,12 +50,13 @@ impl<'a> CreateGlobalCommand<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error of type [`NameInvalid`] if the command name is invalid.
+    /// Returns an error of type [`NameLengthInvalid`] or [`NameCharacterInvalid`] if the command name is invalid.
     ///
     /// Returns an error of type [`DescriptionInvalid`] if the
     /// command description is not between 1 and 100 characters.
     ///
-    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
+    /// [`NameLengthInvalid`]: twilight_validate::command::CommandValidationErrorType::NameLengthInvalid
+    /// [`NameCharacterInvalid`]: twilight_validate::command::CommandValidationErrorType::NameCharacterInvalid
     /// [`DescriptionInvalid`]: twilight_validate::command::CommandValidationErrorType::DescriptionInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
     pub fn chat_input(
@@ -73,10 +74,10 @@ impl<'a> CreateGlobalCommand<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error of type [`NameInvalid`] if the command name is
+    /// Returns an error of type [`NameLengthInvalid`] if the command name is
     /// not between 1 and 32 characters.
     ///
-    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
+    /// [`NameLengthInvalid`]: twilight_validate::command::CommandValidationErrorType::NameLengthInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
     pub fn message(self) -> Result<CreateGlobalMessageCommand<'a>, CommandValidationError> {
         CreateGlobalMessageCommand::new(self.http, self.application_id, self.name)
@@ -90,10 +91,10 @@ impl<'a> CreateGlobalCommand<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error of type [`NameInvalid`] if the command name is
+    /// Returns an error of type [`NameLengthInvalid`] if the command name is
     /// not between 1 and 32 characters.
     ///
-    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
+    /// [`NameLengthInvalid`]: twilight_validate::command::CommandValidationErrorType::NameLengthInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
     pub fn user(self) -> Result<CreateGlobalUserCommand<'a>, CommandValidationError> {
         CreateGlobalUserCommand::new(self.http, self.application_id, self.name)

--- a/http/src/request/application/command/create_global_command/mod.rs
+++ b/http/src/request/application/command/create_global_command/mod.rs
@@ -9,7 +9,7 @@ pub use self::{
 
 use crate::Client;
 use twilight_model::id::{marker::ApplicationMarker, Id};
-use twilight_validate::command::{name as validate_name, CommandValidationError};
+use twilight_validate::command::CommandValidationError;
 
 /// Create a new global command.
 ///
@@ -26,21 +26,23 @@ pub struct CreateGlobalCommand<'a> {
 }
 
 impl<'a> CreateGlobalCommand<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         application_id: Id<ApplicationMarker>,
         name: &'a str,
-    ) -> Result<Self, CommandValidationError> {
-        validate_name(name)?;
-
-        Ok(Self {
+    ) -> Self {
+        Self {
             application_id,
             http,
             name,
-        })
+        }
     }
 
     /// Create a new chat input global command.
+    ///
+    /// The command name must only contain alphanumeric characters and lowercase
+    /// variants must be used where possible. Special characters `-` and `_` are
+    /// allowed.
     ///
     /// The description must be between 1 and 100 characters in length. Creating
     /// a command with the same name as an already-existing global command will
@@ -48,9 +50,12 @@ impl<'a> CreateGlobalCommand<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error of type [`DescriptionInvalid`] error type if the
+    /// Returns an error of type [`NameInvalid`] if the command name is invalid.
+    ///
+    /// Returns an error of type [`DescriptionInvalid`] if the
     /// command description is not between 1 and 100 characters.
     ///
+    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
     /// [`DescriptionInvalid`]: twilight_validate::command::CommandValidationErrorType::DescriptionInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
     pub fn chat_input(
@@ -66,8 +71,14 @@ impl<'a> CreateGlobalCommand<'a> {
     /// command will overwrite the old command. See [the discord docs] for more
     /// information.
     ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`NameInvalid`] if the command name is
+    /// not between 1 and 32 characters.
+    ///
+    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
-    pub const fn message(self) -> CreateGlobalMessageCommand<'a> {
+    pub fn message(self) -> Result<CreateGlobalMessageCommand<'a>, CommandValidationError> {
         CreateGlobalMessageCommand::new(self.http, self.application_id, self.name)
     }
 
@@ -77,8 +88,14 @@ impl<'a> CreateGlobalCommand<'a> {
     /// command will overwrite the old command. See [the discord docs] for more
     /// information.
     ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`NameInvalid`] if the command name is
+    /// not between 1 and 32 characters.
+    ///
+    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
-    pub const fn user(self) -> CreateGlobalUserCommand<'a> {
+    pub fn user(self) -> Result<CreateGlobalUserCommand<'a>, CommandValidationError> {
         CreateGlobalUserCommand::new(self.http, self.application_id, self.name)
     }
 }

--- a/http/src/request/application/command/create_global_command/user.rs
+++ b/http/src/request/application/command/create_global_command/user.rs
@@ -10,6 +10,7 @@ use twilight_model::{
     application::command::{Command, CommandType},
     id::{marker::ApplicationMarker, Id},
 };
+use twilight_validate::command::{name as validate_name, CommandValidationError};
 
 /// Create a new user global command.
 ///
@@ -26,17 +27,19 @@ pub struct CreateGlobalUserCommand<'a> {
 }
 
 impl<'a> CreateGlobalUserCommand<'a> {
-    pub(crate) const fn new(
+    pub(crate) fn new(
         http: &'a Client,
         application_id: Id<ApplicationMarker>,
         name: &'a str,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, CommandValidationError> {
+        validate_name(name).map_err(CommandValidationError::name_invalid)?;
+
+        Ok(Self {
             application_id,
             default_permission: None,
             http,
             name,
-        }
+        })
     }
 
     /// Whether the command is enabled by default when the app is added to a guild.

--- a/http/src/request/application/command/create_global_command/user.rs
+++ b/http/src/request/application/command/create_global_command/user.rs
@@ -32,7 +32,7 @@ impl<'a> CreateGlobalUserCommand<'a> {
         application_id: Id<ApplicationMarker>,
         name: &'a str,
     ) -> Result<Self, CommandValidationError> {
-        validate_name(name).map_err(CommandValidationError::name_invalid)?;
+        validate_name(name)?;
 
         Ok(Self {
             application_id,

--- a/http/src/request/application/command/create_guild_command/chat_input.rs
+++ b/http/src/request/application/command/create_guild_command/chat_input.rs
@@ -45,8 +45,9 @@ impl<'a> CreateGuildChatInputCommand<'a> {
         name: &'a str,
         description: &'a str,
     ) -> Result<Self, CommandValidationError> {
-        validate_name(name)?;
         validate_description(&description)?;
+
+        validate_name(name)?;
 
         Ok(Self {
             application_id,

--- a/http/src/request/application/command/create_guild_command/chat_input.rs
+++ b/http/src/request/application/command/create_guild_command/chat_input.rs
@@ -14,7 +14,7 @@ use twilight_model::{
     },
 };
 use twilight_validate::command::{
-    chat_input_name as validate_name, description as validate_description,
+    chat_input_name as validate_chat_input_name, description as validate_description,
     options as validate_options, CommandValidationError,
 };
 
@@ -47,7 +47,7 @@ impl<'a> CreateGuildChatInputCommand<'a> {
     ) -> Result<Self, CommandValidationError> {
         validate_description(&description)?;
 
-        validate_name(name)?;
+        validate_chat_input_name(name)?;
 
         Ok(Self {
             application_id,

--- a/http/src/request/application/command/create_guild_command/chat_input.rs
+++ b/http/src/request/application/command/create_guild_command/chat_input.rs
@@ -45,7 +45,7 @@ impl<'a> CreateGuildChatInputCommand<'a> {
         name: &'a str,
         description: &'a str,
     ) -> Result<Self, CommandValidationError> {
-        validate_name(name).map_err(CommandValidationError::name_invalid)?;
+        validate_name(name)?;
         validate_description(&description)?;
 
         Ok(Self {

--- a/http/src/request/application/command/create_guild_command/chat_input.rs
+++ b/http/src/request/application/command/create_guild_command/chat_input.rs
@@ -14,7 +14,8 @@ use twilight_model::{
     },
 };
 use twilight_validate::command::{
-    description as validate_description, options as validate_options, CommandValidationError,
+    chat_input_name as validate_name, description as validate_description,
+    options as validate_options, CommandValidationError,
 };
 
 /// Create a chat input command in a guild.
@@ -44,6 +45,7 @@ impl<'a> CreateGuildChatInputCommand<'a> {
         name: &'a str,
         description: &'a str,
     ) -> Result<Self, CommandValidationError> {
+        validate_name(name).map_err(CommandValidationError::name_invalid)?;
         validate_description(&description)?;
 
         Ok(Self {

--- a/http/src/request/application/command/create_guild_command/message.rs
+++ b/http/src/request/application/command/create_guild_command/message.rs
@@ -13,6 +13,7 @@ use twilight_model::{
         Id,
     },
 };
+use twilight_validate::command::{name as validate_name, CommandValidationError};
 
 /// Create a message command in a guild.
 ///
@@ -31,19 +32,21 @@ pub struct CreateGuildMessageCommand<'a> {
 }
 
 impl<'a> CreateGuildMessageCommand<'a> {
-    pub(crate) const fn new(
+    pub(crate) fn new(
         http: &'a Client,
         application_id: Id<ApplicationMarker>,
         guild_id: Id<GuildMarker>,
         name: &'a str,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, CommandValidationError> {
+        validate_name(name).map_err(CommandValidationError::name_invalid)?;
+
+        Ok(Self {
             application_id,
             default_permission: None,
             guild_id,
             http,
             name,
-        }
+        })
     }
 
     /// Whether the command is enabled by default when the app is added to a

--- a/http/src/request/application/command/create_guild_command/message.rs
+++ b/http/src/request/application/command/create_guild_command/message.rs
@@ -38,7 +38,7 @@ impl<'a> CreateGuildMessageCommand<'a> {
         guild_id: Id<GuildMarker>,
         name: &'a str,
     ) -> Result<Self, CommandValidationError> {
-        validate_name(name).map_err(CommandValidationError::name_invalid)?;
+        validate_name(name)?;
 
         Ok(Self {
             application_id,

--- a/http/src/request/application/command/create_guild_command/mod.rs
+++ b/http/src/request/application/command/create_guild_command/mod.rs
@@ -15,19 +15,11 @@ use twilight_model::id::{
 use twilight_validate::command::CommandValidationError;
 
 /// Create a new command in a guild.
-///
-/// The name must be between 1 and 32 characters in length. Creating a guild
-/// command with the same name as an already-existing guild command in the same
-/// guild will overwrite the old command. See [the discord docs] for more
-/// information.
-///
-/// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
 #[must_use = "the command must have a type"]
 pub struct CreateGuildCommand<'a> {
     application_id: Id<ApplicationMarker>,
     guild_id: Id<GuildMarker>,
     http: &'a Client,
-    name: &'a str,
 }
 
 impl<'a> CreateGuildCommand<'a> {
@@ -35,13 +27,11 @@ impl<'a> CreateGuildCommand<'a> {
         http: &'a Client,
         application_id: Id<ApplicationMarker>,
         guild_id: Id<GuildMarker>,
-        name: &'a str,
     ) -> Self {
         Self {
             application_id,
             guild_id,
             http,
-            name,
         }
     }
 
@@ -49,16 +39,16 @@ impl<'a> CreateGuildCommand<'a> {
     ///
     /// The command name must only contain alphanumeric characters and lowercase
     /// variants must be used where possible. Special characters `-` and `_` are
-    /// allowed.
+    /// allowed. The description must be between 1 and 100 characters in length.
     ///
-    /// The description must be between 1 and 100 characters in length. Creating
-    /// a guild command with the same name as an already-existing guild command
-    /// in the same guild will overwrite the old command. See [the discord docs]
-    /// for more information.
+    /// Creating a guild command with the same name as an already-existing guild
+    /// command in the same guild will overwrite the old command. See [the
+    /// discord docs] for more information.
     ///
     /// # Errors
     ///
-    /// Returns an error of type [`NameLengthInvalid`] or [`NameCharacterInvalid`] if the command name is invalid.
+    /// Returns an error of type [`NameLengthInvalid`] or [`NameCharacterInvalid`]
+    /// if the command name is invalid.
     ///
     /// Returns an error of type [`DescriptionInvalid`] error type if the
     /// command description is not between 1 and 100 characters.
@@ -69,13 +59,14 @@ impl<'a> CreateGuildCommand<'a> {
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
     pub fn chat_input(
         self,
+        name: &'a str,
         description: &'a str,
     ) -> Result<CreateGuildChatInputCommand<'a>, CommandValidationError> {
         CreateGuildChatInputCommand::new(
             self.http,
             self.application_id,
             self.guild_id,
-            self.name,
+            name,
             description,
         )
     }
@@ -93,8 +84,11 @@ impl<'a> CreateGuildCommand<'a> {
     ///
     /// [`NameLengthInvalid`]: twilight_validate::command::CommandValidationErrorType::NameLengthInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
-    pub fn message(self) -> Result<CreateGuildMessageCommand<'a>, CommandValidationError> {
-        CreateGuildMessageCommand::new(self.http, self.application_id, self.guild_id, self.name)
+    pub fn message(
+        self,
+        name: &'a str,
+    ) -> Result<CreateGuildMessageCommand<'a>, CommandValidationError> {
+        CreateGuildMessageCommand::new(self.http, self.application_id, self.guild_id, name)
     }
 
     /// Create a user command in a guild.
@@ -110,7 +104,7 @@ impl<'a> CreateGuildCommand<'a> {
     ///
     /// [`NameLengthInvalid`]: twilight_validate::command::CommandValidationErrorType::NameLengthInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
-    pub fn user(self) -> Result<CreateGuildUserCommand<'a>, CommandValidationError> {
-        CreateGuildUserCommand::new(self.http, self.application_id, self.guild_id, self.name)
+    pub fn user(self, name: &'a str) -> Result<CreateGuildUserCommand<'a>, CommandValidationError> {
+        CreateGuildUserCommand::new(self.http, self.application_id, self.guild_id, name)
     }
 }

--- a/http/src/request/application/command/create_guild_command/mod.rs
+++ b/http/src/request/application/command/create_guild_command/mod.rs
@@ -12,7 +12,7 @@ use twilight_model::id::{
     marker::{ApplicationMarker, GuildMarker},
     Id,
 };
-use twilight_validate::command::{name as validate_name, CommandValidationError};
+use twilight_validate::command::CommandValidationError;
 
 /// Create a new command in a guild.
 ///
@@ -31,23 +31,25 @@ pub struct CreateGuildCommand<'a> {
 }
 
 impl<'a> CreateGuildCommand<'a> {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         http: &'a Client,
         application_id: Id<ApplicationMarker>,
         guild_id: Id<GuildMarker>,
         name: &'a str,
-    ) -> Result<Self, CommandValidationError> {
-        validate_name(name)?;
-
-        Ok(Self {
+    ) -> Self {
+        Self {
             application_id,
             guild_id,
             http,
             name,
-        })
+        }
     }
 
     /// Create a chat input command in a guild.
+    ///
+    /// The command name must only contain alphanumeric characters and lowercase
+    /// variants must be used where possible. Special characters `-` and `_` are
+    /// allowed.
     ///
     /// The description must be between 1 and 100 characters in length. Creating
     /// a guild command with the same name as an already-existing guild command
@@ -56,9 +58,12 @@ impl<'a> CreateGuildCommand<'a> {
     ///
     /// # Errors
     ///
+    /// Returns an error of type [`NameInvalid`] if the command name is invalid.
+    ///
     /// Returns an error of type [`DescriptionInvalid`] error type if the
     /// command description is not between 1 and 100 characters.
     ///
+    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
     /// [`DescriptionInvalid`]: twilight_validate::command::CommandValidationErrorType::DescriptionInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
     pub fn chat_input(
@@ -80,8 +85,14 @@ impl<'a> CreateGuildCommand<'a> {
     /// command in the same guild will overwrite the old command. See [the
     /// discord docs] for more information.
     ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`NameInvalid`] if the command name is
+    /// not between 1 and 32 characters.
+    ///
+    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
-    pub const fn message(self) -> CreateGuildMessageCommand<'a> {
+    pub fn message(self) -> Result<CreateGuildMessageCommand<'a>, CommandValidationError> {
         CreateGuildMessageCommand::new(self.http, self.application_id, self.guild_id, self.name)
     }
 
@@ -91,8 +102,14 @@ impl<'a> CreateGuildCommand<'a> {
     /// command in the same guild will overwrite the old command. See [the
     /// discord docs] for more information.
     ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`NameInvalid`] if the command name is
+    /// not between 1 and 32 characters.
+    ///
+    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
-    pub const fn user(self) -> CreateGuildUserCommand<'a> {
+    pub fn user(self) -> Result<CreateGuildUserCommand<'a>, CommandValidationError> {
         CreateGuildUserCommand::new(self.http, self.application_id, self.guild_id, self.name)
     }
 }

--- a/http/src/request/application/command/create_guild_command/mod.rs
+++ b/http/src/request/application/command/create_guild_command/mod.rs
@@ -58,12 +58,13 @@ impl<'a> CreateGuildCommand<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error of type [`NameInvalid`] if the command name is invalid.
+    /// Returns an error of type [`NameLengthInvalid`] or [`NameCharacterInvalid`] if the command name is invalid.
     ///
     /// Returns an error of type [`DescriptionInvalid`] error type if the
     /// command description is not between 1 and 100 characters.
     ///
-    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
+    /// [`NameLengthInvalid`]: twilight_validate::command::CommandValidationErrorType::NameLengthInvalid
+    /// [`NameCharacterInvalid`]: twilight_validate::command::CommandValidationErrorType::NameCharacterInvalid
     /// [`DescriptionInvalid`]: twilight_validate::command::CommandValidationErrorType::DescriptionInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
     pub fn chat_input(
@@ -87,10 +88,10 @@ impl<'a> CreateGuildCommand<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error of type [`NameInvalid`] if the command name is
+    /// Returns an error of type [`NameLengthInvalid`] if the command name is
     /// not between 1 and 32 characters.
     ///
-    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
+    /// [`NameLengthInvalid`]: twilight_validate::command::CommandValidationErrorType::NameLengthInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
     pub fn message(self) -> Result<CreateGuildMessageCommand<'a>, CommandValidationError> {
         CreateGuildMessageCommand::new(self.http, self.application_id, self.guild_id, self.name)
@@ -104,10 +105,10 @@ impl<'a> CreateGuildCommand<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error of type [`NameInvalid`] if the command name is
+    /// Returns an error of type [`NameLengthInvalid`] if the command name is
     /// not between 1 and 32 characters.
     ///
-    /// [`NameInvalid`]: twilight_validate::command::CommandValidationErrorType::NameInvalid
+    /// [`NameLengthInvalid`]: twilight_validate::command::CommandValidationErrorType::NameLengthInvalid
     /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
     pub fn user(self) -> Result<CreateGuildUserCommand<'a>, CommandValidationError> {
         CreateGuildUserCommand::new(self.http, self.application_id, self.guild_id, self.name)

--- a/http/src/request/application/command/create_guild_command/user.rs
+++ b/http/src/request/application/command/create_guild_command/user.rs
@@ -38,7 +38,7 @@ impl<'a> CreateGuildUserCommand<'a> {
         guild_id: Id<GuildMarker>,
         name: &'a str,
     ) -> Result<Self, CommandValidationError> {
-        validate_name(name).map_err(CommandValidationError::name_invalid)?;
+        validate_name(name)?;
 
         Ok(Self {
             application_id,

--- a/http/src/request/application/command/create_guild_command/user.rs
+++ b/http/src/request/application/command/create_guild_command/user.rs
@@ -13,6 +13,7 @@ use twilight_model::{
         Id,
     },
 };
+use twilight_validate::command::{name as validate_name, CommandValidationError};
 
 /// Create a user command in a guild.
 ///
@@ -31,19 +32,21 @@ pub struct CreateGuildUserCommand<'a> {
 }
 
 impl<'a> CreateGuildUserCommand<'a> {
-    pub(crate) const fn new(
+    pub(crate) fn new(
         http: &'a Client,
         application_id: Id<ApplicationMarker>,
         guild_id: Id<GuildMarker>,
         name: &'a str,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, CommandValidationError> {
+        validate_name(name).map_err(CommandValidationError::name_invalid)?;
+
+        Ok(Self {
             application_id,
             default_permission: None,
             guild_id,
             http,
             name,
-        }
+        })
     }
 
     /// Whether the command is enabled by default when the app is added to a guild.

--- a/validate/src/command.rs
+++ b/validate/src/command.rs
@@ -486,6 +486,8 @@ pub const fn guild_permissions(count: usize) -> Result<(), CommandValidationErro
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::non_ascii_literal)]
+
     use super::*;
     use twilight_model::{application::command::CommandType, id::Id};
 
@@ -521,12 +523,12 @@ mod tests {
         assert!(name_characters("Hello").is_err()); // Latin language with uppercase
         assert!(name_characters("hello!").is_err()); // Latin language with non-alphanumeric
 
-        assert!(name_characters("\u{437}\u{434}\u{440}\u{430}\u{441}\u{442}\u{438}").is_ok()); // Russian
-        assert!(name_characters("\u{417}\u{434}\u{440}\u{430}\u{441}\u{442}\u{438}").is_err()); // Russian with uppercase
-        assert!(name_characters("\u{437}\u{434}\u{440}\u{430}\u{441}\u{442}\u{438}!").is_err()); // Russian with non-alphanumeric
+        assert!(name_characters("здрасти").is_ok()); // Russian
+        assert!(name_characters("Здрасти").is_err()); // Russian with uppercase
+        assert!(name_characters("здрасти!").is_err()); // Russian with non-alphanumeric
 
-        assert!(name_characters("\u{4f60}\u{597d}").is_ok()); // Chinese (no upper and lowercase variants)
-        assert!(name_characters("\u{4f60}\u{597d}\u{3002}").is_err()); // Chinese with non-alphanumeric
+        assert!(name_characters("你好").is_ok()); // Chinese (no upper and lowercase variants)
+        assert!(name_characters("你好。").is_err()); // Chinese with non-alphanumeric
     }
 
     #[test]

--- a/validate/src/command.rs
+++ b/validate/src/command.rs
@@ -521,7 +521,7 @@ mod tests {
         assert!(name_characters("Hello").is_err()); // Latin language with uppercase
         assert!(name_characters("hello!").is_err()); // Latin language with non-alphanumeric
 
-        assert!(chat_input_name("\u{437}\u{434}\u{440}\u{430}\u{441}\u{442}\u{438}").is_ok()); // Russian
+        assert!(name_characters("\u{437}\u{434}\u{440}\u{430}\u{441}\u{442}\u{438}").is_ok()); // Russian
         assert!(name_characters("\u{417}\u{434}\u{440}\u{430}\u{441}\u{442}\u{438}").is_err()); // Russian with uppercase
         assert!(name_characters("\u{437}\u{434}\u{440}\u{430}\u{441}\u{442}\u{438}!").is_err()); // Russian with non-alphanumeric
 

--- a/validate/src/command.rs
+++ b/validate/src/command.rs
@@ -116,6 +116,7 @@ impl Display for CommandValidationError {
                 f.write_str("command name must be between ")?;
                 Display::fmt(&NAME_LENGTH_MIN, f)?;
                 f.write_str(" and ")?;
+
                 Display::fmt(&NAME_LENGTH_MAX, f)
             }
             CommandValidationErrorType::NameCharacterInvalid { character } => {
@@ -123,6 +124,7 @@ impl Display for CommandValidationError {
                     "command name must only contain lowercase alphanumeric characters, found `",
                 )?;
                 Display::fmt(character, f)?;
+
                 f.write_str("`")
             }
             CommandValidationErrorType::OptionDescriptionInvalid => {
@@ -137,11 +139,13 @@ impl Display for CommandValidationError {
                 f.write_str("command option name must be between ")?;
                 Display::fmt(&NAME_LENGTH_MIN, f)?;
                 f.write_str(" and ")?;
+
                 Display::fmt(&NAME_LENGTH_MAX, f)
             }
             CommandValidationErrorType::OptionNameCharacterInvalid { character } => {
                 f.write_str("command option name must only contain lowercase alphanumeric characters, found `")?;
                 Display::fmt(character, f)?;
+
                 f.write_str("`")
             }
             CommandValidationErrorType::OptionsCountInvalid => {
@@ -303,13 +307,7 @@ pub fn name(value: impl AsRef<str>) -> Result<(), CommandValidationError> {
 /// [`NameLengthInvalid`]: CommandValidationErrorType::NameLengthInvalid
 /// [`NameCharacterInvalid`]: CommandValidationErrorType::NameCharacterInvalid
 pub fn chat_input_name(value: impl AsRef<str>) -> Result<(), CommandValidationError> {
-    let len = value.as_ref().chars().count();
-
-    if !(NAME_LENGTH_MIN..=NAME_LENGTH_MAX).contains(&len) {
-        return Err(CommandValidationError {
-            kind: CommandValidationErrorType::NameLengthInvalid,
-        });
-    }
+    self::name(&value)?;
 
     let chars = value.as_ref().chars();
 

--- a/validate/src/command.rs
+++ b/validate/src/command.rs
@@ -210,10 +210,12 @@ pub enum CommandValidationErrorType {
 /// Returns an error of type [`DescriptionInvalid`] if the description is
 /// invalid.
 ///
-/// Returns an error of type [`NameInvalid`] if the name is invalid.
+/// Returns an error of type [`NameLengthInvalid`] or [`NameCharacterInvalid`]
+/// if the name is invalid.
 ///
 /// [`DescriptionInvalid`]: CommandValidationErrorType::DescriptionInvalid
-/// [`NameInvalid`]: CommandValidationErrorType::NameInvalid
+/// [`NameLengthInvalid`]: CommandValidationErrorType::NameLengthInvalid
+/// [`NameCharacterInvalid`]: CommandValidationErrorType::NameCharacterInvalid
 pub fn command(value: &Command) -> Result<(), CommandValidationError> {
     let Command {
         description,
@@ -263,12 +265,12 @@ pub fn description(value: impl AsRef<str>) -> Result<(), CommandValidationError>
 ///
 /// # Errors
 ///
-/// Returns an error of type [`NameInvalid`] if the name is invalid.
+/// Returns an error of type [`NameLengthInvalid`] if the name is invalid.
 ///
 /// [`User`]: CommandType::User
 /// [`Message`]: CommandType::Message
 /// [`ChatInput`]: CommandType::ChatInput
-/// [`NameInvalid`]: CommandValidationErrorType::NameInvalid
+/// [`NameLengthInvalid`]: CommandValidationErrorType::NameLengthInvalid
 pub fn name(value: impl AsRef<str>) -> Result<(), CommandValidationError> {
     let len = value.as_ref().chars().count();
 
@@ -291,18 +293,15 @@ pub fn name(value: impl AsRef<str>) -> Result<(), CommandValidationError> {
 ///
 /// # Errors
 ///
-/// Returns an error of type [`LengthInvalid`] if the length is invalid.
+/// Returns an error of type [`NameLengthInvalid`] if the length is invalid.
 ///
-/// Returns an error of type [`CharacterNotAlphanumeric`] if the name contains
-/// a non-alphanumeric character.
-///
-/// Returns an error of type [`CharacterUppercase`] if the name contains an
-/// uppercase character for which a lowercase variant exists.
+/// Returns an error of type [`NameCharacterInvalid`] if the name contains
+/// a non-alphanumeric character or an uppercase character for which a
+/// lowercase variant exists.
 ///
 /// [`ChatInput`]: CommandType::ChatInput
-/// [`LengthInvalid`]: NameValidationErrorType::LengthInvalid
-/// [`CharacterNotAlphanumeric`]: NameValidationErrorType::CharacterNotAlphanumeric
-/// [`CharacterUppercase`]: NameValidationErrorType::CharacterUppercase
+/// [`NameLengthInvalid`]: CommandValidationErrorType::NameLengthInvalid
+/// [`NameCharacterInvalid`]: CommandValidationErrorType::NameCharacterInvalid
 pub fn chat_input_name(value: impl AsRef<str>) -> Result<(), CommandValidationError> {
     let len = value.as_ref().chars().count();
 
@@ -338,10 +337,12 @@ pub fn chat_input_name(value: impl AsRef<str>) -> Result<(), CommandValidationEr
 /// Returns an error of type [`OptionDescriptionInvalid`] if the description is
 /// invalid.
 ///
-/// Returns an error of type [`OptionNameInvalid`] if the name is invalid.
+/// Returns an error of type [`OptionNameLengthInvalid`] or [`OptionNameCharacterInvalid`]
+/// if the name is invalid.
 ///
 /// [`OptionDescriptionInvalid`]: CommandValidationErrorType::OptionDescriptionInvalid
-/// [`OptionNameInvalid`]: CommandValidationErrorType::OptionNameInvalid
+/// [`OptionNameLengthInvalid`]: CommandValidationErrorType::OptionNameLengthInvalid
+/// [`OptionNameCharacterInvalid`]: CommandValidationErrorType::OptionNameCharacterInvalid
 pub fn option(option: &CommandOption) -> Result<(), CommandValidationError> {
     let (description, name) = match option {
         CommandOption::SubCommand(_) | CommandOption::SubCommandGroup(_) => return Ok(()),

--- a/validate/src/command.rs
+++ b/validate/src/command.rs
@@ -541,12 +541,12 @@ mod tests {
         assert!(chat_input_name("Hello").is_err()); // Latin language with uppercase
         assert!(chat_input_name("hello!").is_err()); // Latin language with non-alphanumeric
 
-        assert!(chat_input_name("здрасти").is_ok()); // Russian
-        assert!(chat_input_name("Здрасти").is_err()); // Russian with uppercase
-        assert!(chat_input_name("здрасти!").is_err()); // Russian with non-alphanumeric
+        assert!(chat_input_name("\u{437}\u{434}\u{440}\u{430}\u{441}\u{442}\u{438}").is_ok()); // Russian
+        assert!(chat_input_name("\u{417}\u{434}\u{440}\u{430}\u{441}\u{442}\u{438}").is_err()); // Russian with uppercase
+        assert!(chat_input_name("\u{437}\u{434}\u{440}\u{430}\u{441}\u{442}\u{438}!").is_err()); // Russian with non-alphanumeric
 
-        assert!(chat_input_name("你好").is_ok()); // Chinese (no upper and lowercase variants)
-        assert!(chat_input_name("你好。").is_err()); // Chinese with non-alphanumeric
+        assert!(chat_input_name("\u{4f60}\u{597d}").is_ok()); // Chinese (no upper and lowercase variants)
+        assert!(chat_input_name("\u{4f60}\u{597d}\u{3002}").is_err()); // Chinese with non-alphanumeric
     }
 
     #[test]


### PR DESCRIPTION
This PR improves validation of slash command names and command options names. It checks that chat input command names and options names does not contain non-alphanumeric characters nor uppercase characters.

As the validation depend on the command type, the name is no longer validated in `create_guild_command` or `create_global_command` methods. The validation has been moved to `chat_input`, `user` and `message` methods.