### PR TITLE
chore(http): replace `percent-encoding` with `urlencoding`

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -19,13 +19,13 @@ hyper = { default-features = false, features = ["client", "http1", "http2", "run
 hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.23" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
 hyper-trust-dns = { default-features = false, optional = true, version = "0.3.1" }
-percent-encoding = { default-features = false, version = "2" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["sync", "time"], version = "1.0" }
 twilight-http-ratelimiting = { default-features = false, path = "../http-ratelimiting" }
 twilight-model = { default-features = false, path = "../model" }
+urlencoding = { default-features = false, version = "2" }
 
 # Optional dependencies.
 brotli = { default-features = false, features = ["std"], optional = true, version = "3.0.0" }

--- a/http/src/request/channel/reaction/mod.rs
+++ b/http/src/request/channel/reaction/mod.rs
@@ -11,9 +11,9 @@ pub use self::{
     delete_all_reactions::DeleteAllReactions, delete_reaction::DeleteReaction,
     get_reactions::GetReactions,
 };
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use twilight_model::id::EmojiId;
+use urlencoding::Encoded;
 
 /// Handle a reaction of either a custom or unicode emoji.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -102,9 +102,7 @@ impl Display for RequestReactionTypeDisplay<'_> {
 
                 Display::fmt(id, f)
             }
-            RequestReactionType::Unicode { name } => {
-                Display::fmt(&utf8_percent_encode(name, NON_ALPHANUMERIC), f)
-            }
+            RequestReactionType::Unicode { name } => Display::fmt(&Encoded::new(name), f),
         }
     }
 }

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -35,7 +35,6 @@ pub use twilight_http_ratelimiting::request::Method;
 
 use crate::error::{Error, ErrorType};
 use hyper::header::{HeaderName, HeaderValue};
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use serde::{Serialize, Serializer};
 use std::iter;
 
@@ -69,10 +68,10 @@ pub(crate) fn audit_header(
     reason: &str,
 ) -> Result<impl Iterator<Item = (HeaderName, HeaderValue)>, Error> {
     let header_name = HeaderName::from_static("x-audit-log-reason");
-    let encoded_reason = utf8_percent_encode(reason, NON_ALPHANUMERIC).to_string();
-    let header_value = HeaderValue::from_str(&encoded_reason).map_err(|e| Error {
+    let encoded_reason = urlencoding::encode(reason);
+    let header_value = encoded_reason.parse().map_err(|e| Error {
         kind: ErrorType::CreatingHeader {
-            name: encoded_reason.clone(),
+            name: encoded_reason.into_owned(),
         },
         source: Some(Box::new(e)),
     })?;

--- a/http/src/routing/route_display.rs
+++ b/http/src/routing/route_display.rs
@@ -1,7 +1,6 @@
-use urlencoding::Encoded;
-
 use super::route::Route;
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use urlencoding::Encoded;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RouteDisplay<'a>(&'a Route<'a>);

--- a/http/src/routing/route_display.rs
+++ b/http/src/routing/route_display.rs
@@ -1,5 +1,6 @@
+use urlencoding::Encoded;
+
 use super::route::Route;
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -110,7 +111,7 @@ impl Display for RouteDisplay<'_> {
 
                 if let Some(reason) = reason {
                     f.write_str("reason=")?;
-                    let encoded_reason = utf8_percent_encode(reason, NON_ALPHANUMERIC);
+                    let encoded_reason = Encoded::new(reason);
 
                     Display::fmt(&encoded_reason, f)?;
                 }


### PR DESCRIPTION
`urlencoding` avoids some allocations and is better maintained.
