### PR TITLE
chore(gateway): handle previously unhandled error codes 4010-4012

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -284,7 +284,7 @@ pub enum ReceivingEventErrorType {
         /// The id of the shard.
         shard_id: u64,
     },
-    /// Sharding is requied for the bot.
+    /// Sharding is required for the bot.
     ShardingRequired,
 }
 

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -230,6 +230,7 @@ impl Display for ReceivingEventError {
                 Debug::fmt(shard_id, f)?;
                 f.write_str(", ")?;
                 Debug::fmt(shard_count, f)?;
+
                 f.write_str("] is invalid")
             }
             ReceivingEventErrorType::ShardingRequired => {
@@ -279,9 +280,9 @@ pub enum ReceivingEventErrorType {
     InvalidApiVersion,
     /// Attempting to identify a invalid shard.
     InvalidShard {
-        /// The shard count.
+        /// Shard count.
         shard_count: u64,
-        /// The id of the shard.
+        /// ID of the shard.
         shard_id: u64,
     },
     /// Sharding is required for the bot.

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -173,6 +173,9 @@ impl ReceivingEventError {
             ReceivingEventErrorType::AuthorizationInvalid { .. }
                 | ReceivingEventErrorType::IntentsDisallowed { .. }
                 | ReceivingEventErrorType::IntentsInvalid { .. }
+                | ReceivingEventErrorType::InvalidApiVersion
+                | ReceivingEventErrorType::InvalidShard { .. }
+                | ReceivingEventErrorType::ShardingRequired
         )
     }
 
@@ -216,6 +219,22 @@ impl Display for ReceivingEventError {
             ReceivingEventErrorType::EventStreamEnded => {
                 f.write_str("event stream from gateway ended")
             }
+            ReceivingEventErrorType::InvalidApiVersion => {
+                f.write_str("invalid api version was used for identifying")
+            }
+            ReceivingEventErrorType::InvalidShard {
+                shard_count,
+                shard_id,
+            } => {
+                f.write_str("The shard [")?;
+                Debug::fmt(shard_id, f)?;
+                f.write_str(", ")?;
+                Debug::fmt(shard_count, f)?;
+                f.write_str("] is invalid")
+            }
+            ReceivingEventErrorType::ShardingRequired => {
+                f.write_str("session handles too many guilds, sharding required")
+            }
         }
     }
 }
@@ -256,6 +275,17 @@ pub enum ReceivingEventErrorType {
         /// ID of the shard.
         shard_id: u64,
     },
+    /// Invalid API version was used for identify.
+    InvalidApiVersion,
+    /// Attempting to identify a invalid shard.
+    InvalidShard {
+        /// The shard count.
+        shard_count: u64,
+        /// The id of the shard.
+        shard_id: u64,
+    },
+    /// Sharding is requied for the bot.
+    ShardingRequired,
 }
 
 #[derive(Deserialize)]
@@ -812,6 +842,27 @@ impl ShardProcessor {
                             shard_id: self.config.shard()[0],
                             token: self.config.token().to_owned(),
                         },
+                        source: None,
+                    });
+                }
+                CloseCode::Library(4010) => {
+                    return Err(ReceivingEventError {
+                        kind: ReceivingEventErrorType::InvalidShard {
+                            shard_count: self.config.shard()[1],
+                            shard_id: self.config.shard()[0],
+                        },
+                        source: None,
+                    });
+                }
+                CloseCode::Library(4011) => {
+                    return Err(ReceivingEventError {
+                        kind: ReceivingEventErrorType::ShardingRequired,
+                        source: None,
+                    });
+                }
+                CloseCode::Library(4012) => {
+                    return Err(ReceivingEventError {
+                        kind: ReceivingEventErrorType::InvalidApiVersion,
                         source: None,
                     });
                 }


### PR DESCRIPTION
Correctly handle gateway close codes 4010, 4011 and 4012

| Code | Description         |
|------|---------------------|
| 4010 | Invalid shard       |
| 4011 | Sharding required   |
| 4012 | Invalid API version |


closes #1377