### PR TITLE
fix(model)!: make CllbackData#embeds an option

### DIFF
--- a/examples/model-webhook-slash/src/main.rs
+++ b/examples/model-webhook-slash/src/main.rs
@@ -145,7 +145,7 @@ async fn debug(i: Interaction) -> Result<InteractionResponse, GenericError> {
             flags: None,
             tts: None,
             content: Some(format!("```rust\n{:?}\n```", i)),
-            embeds: Default::default(),
+            embeds: None,
         },
     ))
 }
@@ -159,7 +159,7 @@ async fn vroom(_: Interaction) -> Result<InteractionResponse, GenericError> {
             flags: None,
             tts: None,
             content: Some("Vroom vroom".to_owned()),
-            embeds: Default::default(),
+            embeds: None,
         },
     ))
 }

--- a/model/src/application/callback/callback_data.rs
+++ b/model/src/application/callback/callback_data.rs
@@ -35,8 +35,8 @@ pub struct CallbackData {
     pub components: Option<Vec<Component>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub embeds: Vec<Embed>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embeds: Option<Vec<Embed>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub flags: Option<MessageFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/model/src/application/callback/mod.rs
+++ b/model/src/application/callback/mod.rs
@@ -243,7 +243,7 @@ mod tests {
             allowed_mentions: None,
             content: Some("test".into()),
             components: None,
-            embeds: Vec::new(),
+            embeds: None,
             flags: Some(MessageFlags::EPHEMERAL),
             tts: None,
         });

--- a/util/src/builder/callback_data.rs
+++ b/util/src/builder/callback_data.rs
@@ -44,7 +44,7 @@ impl CallbackDataBuilder {
             allowed_mentions: None,
             components: None,
             content: None,
-            embeds: Vec::new(),
+            embeds: None,
             flags: None,
             tts: None,
         })
@@ -90,7 +90,7 @@ impl CallbackDataBuilder {
     ///
     /// Defaults to an empty list.
     pub fn embeds(mut self, embeds: impl IntoIterator<Item = Embed>) -> Self {
-        self.0.embeds = embeds.into_iter().collect();
+        self.0.embeds = Some(embeds.into_iter().collect());
 
         self
     }
@@ -186,7 +186,7 @@ mod tests {
             allowed_mentions: Some(allowed_mentions),
             components: Some(vec![component]),
             content: Some("a content".to_owned()),
-            embeds: vec![embed],
+            embeds: Some(vec![embed]),
             flags: Some(MessageFlags::empty()),
             tts: Some(false),
         };


### PR DESCRIPTION
Currently it's not possible to remove embeds of a message from a component interaction in the first response. This PR should fix this.
Example: 
```rs
http.interaction_callback(
    component.id,
    &component.token
    &InteractionResponse::UpdateMessage(
        CallbackData {
            allowed_mentions: None,
            components: None,
            content: None,
            embeds: Vec::new(), // This field gets skipped if empty so embeds cannot be removed
            flags: None,
            tts: None,
        }
    )
)
```