### PR TITLE
change unnecessary u64 in GetChannelMessages::limit to u8

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -454,7 +454,7 @@ impl Client {
     /// let client = Client::new("my token".to_owned());
     /// let channel_id = ChannelId::new(123).expect("non zero");
     /// let message_id = MessageId::new(234).expect("non zero");
-    /// let limit: u64 = 6;
+    /// let limit: u8 = 6;
     ///
     /// let messages = client
     ///     .channel_messages(channel_id)

--- a/http/src/request/channel/message/get_channel_messages.rs
+++ b/http/src/request/channel/message/get_channel_messages.rs
@@ -65,7 +65,7 @@ pub enum GetChannelMessagesErrorType {
 }
 
 struct GetChannelMessagesFields {
-    limit: Option<u64>,
+    limit: Option<u8>,
 }
 
 /// Get channel messages, by [`ChannelId`].
@@ -90,7 +90,7 @@ struct GetChannelMessagesFields {
 /// let messages = client
 ///     .channel_messages(channel_id)
 ///     .before(message_id)
-///     .limit(6u64)?
+///     .limit(6u8)?
 ///     .exec()
 ///     .await?;
 ///
@@ -159,7 +159,7 @@ impl<'a> GetChannelMessages<'a> {
     ///
     /// Returns a [`GetChannelMessagesErrorType::LimitInvalid`] error type if
     /// the amount is less than 1 or greater than 100.
-    pub const fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesError> {
+    pub const fn limit(mut self, limit: u8) -> Result<Self, GetChannelMessagesError> {
         if !validate_inner::get_channel_messages_limit(limit) {
             return Err(GetChannelMessagesError {
                 kind: GetChannelMessagesErrorType::LimitInvalid,

--- a/http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/http/src/request/channel/message/get_channel_messages_configured.rs
@@ -66,7 +66,7 @@ pub enum GetChannelMessagesConfiguredErrorType {
 }
 
 struct GetChannelMessagesConfiguredFields {
-    limit: Option<u64>,
+    limit: Option<u8>,
 }
 
 /// This struct is returned when one of `after`, `around`, or `before` is specified in
@@ -93,7 +93,7 @@ impl<'a> GetChannelMessagesConfigured<'a> {
         after: Option<MessageId>,
         around: Option<MessageId>,
         before: Option<MessageId>,
-        limit: Option<u64>,
+        limit: Option<u8>,
     ) -> Self {
         Self {
             after,
@@ -112,8 +112,8 @@ impl<'a> GetChannelMessagesConfigured<'a> {
     /// # Errors
     ///
     /// Returns a [`GetChannelMessagesConfiguredErrorType::LimitInvalid`] error
-    /// type if the amount is greater than 21600.
-    pub const fn limit(mut self, limit: u64) -> Result<Self, GetChannelMessagesConfiguredError> {
+    /// type if the amount is greater than 100.
+    pub const fn limit(mut self, limit: u8) -> Result<Self, GetChannelMessagesConfiguredError> {
         if !validate_inner::get_channel_messages_limit(limit) {
             return Err(GetChannelMessagesConfiguredError {
                 kind: GetChannelMessagesConfiguredErrorType::LimitInvalid,

--- a/http/src/request/validate.rs
+++ b/http/src/request/validate.rs
@@ -1010,7 +1010,7 @@ pub const fn get_audit_log_limit(value: u64) -> bool {
     value >= 1 && value <= 100
 }
 
-pub const fn get_channel_messages_limit(value: u64) -> bool {
+pub const fn get_channel_messages_limit(value: u8) -> bool {
     // <https://discordapp.com/developers/docs/resources/channel#get-channel-messages-query-string-params>
     value >= 1 && value <= 100
 }

--- a/http/src/routing/route.rs
+++ b/http/src/routing/route.rs
@@ -596,7 +596,7 @@ pub enum Route<'a> {
         /// The ID of the channel.
         channel_id: u64,
         /// The maximum number of messages to get.
-        limit: Option<u64>,
+        limit: Option<u8>,
     },
     /// Route information to get a list of sticker packs available to Nitro
     /// subscribers.


### PR DESCRIPTION
i think this value is only being used in the display impl, so having it be u64 would have no benefits. an error is returned if the value is above 100 or 0 anyway. also could it be NonZeroU8 to further optimize?