### PR TITLE
feat(cache, model): model getters

### DIFF
--- a/examples/model-webhook-slash/src/main.rs
+++ b/examples/model-webhook-slash/src/main.rs
@@ -1,4 +1,4 @@
-use ed25519_dalek::{PublicKey, Verifier, PUBLIC_KEY_LENGTH};
+use ed25519_dalek::{PublicKey, Signature, Verifier, PUBLIC_KEY_LENGTH};
 use hex::FromHex;
 use hyper::{
     header::CONTENT_TYPE,
@@ -7,7 +7,7 @@ use hyper::{
     Body, Method, Request, Response, Server,
 };
 use once_cell::sync::Lazy;
-use std::future::Future;
+use std::{convert::TryFrom, future::Future};
 use twilight_model::application::{
     callback::{CallbackData, InteractionResponse},
     interaction::Interaction,
@@ -64,7 +64,8 @@ where
         .get("x-signature-ed25519")
         .and_then(|v| v.to_str().ok())
     {
-        hex_sig.parse().unwrap()
+        // hex_sig.parse().unwrap()
+        Signature::try_from(hex_sig.as_bytes()).unwrap()
     } else {
         return Ok(Response::builder()
             .status(StatusCode::BAD_REQUEST)

--- a/model/src/user/connection.rs
+++ b/model/src/user/connection.rs
@@ -4,18 +4,56 @@ use serde::{Deserialize, Serialize};
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Connection {
-    pub friend_sync: bool,
-    pub id: String,
+    pub (crate) friend_sync: bool,
+    pub (crate) id: String,
     #[serde(default)]
-    pub integrations: Vec<GuildIntegration>,
+    pub (crate) integrations: Vec<GuildIntegration>,
     #[serde(rename = "type")]
-    pub kind: String,
-    pub name: String,
+    pub (crate) kind: String,
+    pub (crate) name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub revoked: Option<bool>,
-    pub show_activity: bool,
-    pub verified: bool,
-    pub visibility: ConnectionVisibility,
+    pub (crate) revoked: Option<bool>,
+    pub (crate) show_activity: bool,
+    pub (crate) verified: bool,
+    pub (crate) visibility: ConnectionVisibility,
+}
+
+impl Connection {
+    pub const fn friend_sync(&self) -> bool {
+        self.friend_sync
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn integrations(&self) -> &[GuildIntegration] {
+        &self.integrations
+    }
+
+    pub fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub const fn revoked(&self) -> Option<bool> {
+        self.revoked
+    }
+
+    pub const fn show_activity(&self) -> bool {
+        self.show_activity
+    }
+
+    pub const fn verified(&self) -> bool {
+        self.verified
+    }
+
+    pub const fn visibility(&self) -> ConnectionVisibility {
+        self.visibility
+    }
 }
 
 #[cfg(test)]

--- a/model/src/user/current_user_guild.rs
+++ b/model/src/user/current_user_guild.rs
@@ -10,26 +10,52 @@ use serde::{Deserialize, Serialize};
 /// [Discord documentation]: https://discord.com/developers/docs/resources/user#get-current-user-guilds-example-partial-guild
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CurrentUserGuild {
+    pub(crate) id: Id<GuildMarker>,
+    pub(crate) name: String,
+    pub(crate) icon: Option<String>,
+    pub(crate) owner: bool,
+    pub(crate) permissions: Permissions,
+    pub(crate) features: Vec<String>,
+}
+
+impl CurrentUserGuild {
     /// Unique ID.
-    pub id: Id<GuildMarker>,
+    pub const fn id(&self) -> Id<GuildMarker> {
+        self.id
+    }
+
     /// Name of the guild.
     ///
     /// The name must be at least 2 characters long and at most 100 characters
     /// long.
-    pub name: String,
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     /// Hash of the icon.
     ///
     /// Refer to the [Discord documentation] for more information.
     ///
     /// [Discord documentation]: https://discord.com/developers/docs/reference#image-formatting
-    pub icon: Option<String>,
+    pub fn icon(&self) -> Option<&str> {
+        self.icon.as_deref()
+    }
+
     /// Whether the current user is the owner.
-    pub owner: bool,
+    pub const fn owner(&self) -> bool {
+        self.owner
+    }
+
     /// Permissions of the current user in the guild. This excludes channels'
     /// permission overwrites.
-    pub permissions: Permissions,
-    /// List of enabled guild features.
-    pub features: Vec<String>,
+    pub const fn permissions(&self) -> Permissions {
+        self.permissions
+    }
+
+    /// Get a reference to the current user guild's features.
+    pub fn features(&self) -> &[String] {
+        &self.features
+    }
 }
 
 #[cfg(test)]

--- a/model/src/user/mod.rs
+++ b/model/src/user/mod.rs
@@ -120,15 +120,12 @@ impl Display for DiscriminatorDisplay {
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct User {
-    /// Accent color of the user's banner.
-    ///
-    /// This is an integer representation of a hexadecimal color code.
-    pub accent_color: Option<u64>,
-    pub avatar: Option<String>,
-    /// Hash of the user's banner image.
-    pub banner: Option<String>,
+    pub(crate) accent_color: Option<u64>,
+    pub(crate) avatar: Option<String>,
+    pub(crate) banner: Option<String>,
     #[serde(default)]
-    pub bot: bool,
+    pub(crate) bot: bool,
+    // TODO: find a way to fix this
     /// Discriminator used to differentiate people with the same username.
     ///
     /// # serde
@@ -139,24 +136,24 @@ pub struct User {
     #[serde(with = "discriminator")]
     pub discriminator: u16,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<String>,
+    pub(crate) email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub flags: Option<UserFlags>,
-    pub id: Id<UserMarker>,
+    pub(crate) flags: Option<UserFlags>,
+    pub(crate) id: Id<UserMarker>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub locale: Option<String>,
+    pub(crate) locale: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mfa_enabled: Option<bool>,
+    pub(crate) mfa_enabled: Option<bool>,
     #[serde(rename = "username")]
-    pub name: String,
+    pub(crate) name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub premium_type: Option<PremiumType>,
+    pub(crate) premium_type: Option<PremiumType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub public_flags: Option<UserFlags>,
+    pub(crate) public_flags: Option<UserFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub system: Option<bool>,
+    pub(crate) system: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verified: Option<bool>,
+    pub(crate) verified: Option<bool>,
 }
 
 impl User {
@@ -165,6 +162,67 @@ impl User {
     /// [`Display`]: core::fmt::Display
     pub const fn discriminator(&self) -> DiscriminatorDisplay {
         DiscriminatorDisplay::new(self.discriminator)
+    }
+
+    /// Accent color of the user's banner.
+    ///
+    /// This is an integer representation of a hexadecimal color code.
+    pub const fn accent_color(&self) -> Option<u64> {
+        self.accent_color
+    }
+
+    pub fn avatar(&self) -> Option<&str> {
+        self.avatar.as_deref()
+    }
+
+    /// Hash of the user's banner image.
+    pub fn banner(&self) -> Option<&str> {
+        self.banner.as_deref()
+    }
+
+    pub const fn bot(&self) -> bool {
+        self.bot
+    }
+
+    /// Get a reference to the user's email.
+    pub fn email(&self) -> Option<&str> {
+        self.email.as_deref()
+    }
+
+    pub const fn flags(&self) -> Option<UserFlags> {
+        self.flags
+    }
+
+    pub const fn id(&self) -> Id<UserMarker> {
+        self.id
+    }
+
+    pub fn locale(&self) -> Option<&str> {
+        self.locale.as_deref()
+    }
+
+    pub const fn mfa_enabled(&self) -> Option<bool> {
+        self.mfa_enabled
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub const fn premium_type(&self) -> Option<PremiumType> {
+        self.premium_type
+    }
+
+    pub const fn public_flags(&self) -> Option<UserFlags> {
+        self.public_flags
+    }
+
+    pub const fn system(&self) -> Option<bool> {
+        self.system
+    }
+
+    pub const fn verified(&self) -> Option<bool> {
+        self.verified
     }
 }
 

--- a/model/src/user/profile.rs
+++ b/model/src/user/profile.rs
@@ -4,39 +4,35 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct UserProfile {
-    /// Accent color of the user's banner.
-    ///
-    /// This is an integer representation of a hexadecimal color code.
-    pub accent_color: Option<u64>,
-    pub avatar: Option<String>,
-    /// Hash of the user's banner image.
-    pub banner: Option<String>,
+    pub(crate) accent_color: Option<u64>,
+    pub(crate) avatar: Option<String>,
+    pub(crate) banner: Option<String>,
     #[serde(default)]
-    pub bot: bool,
+    pub(crate) bot: bool,
+    // TODO: figure out how to fix this
     /// Discriminator used to differentiate people with the same username.
     ///
     /// # serde
     ///
     /// The discriminator field can be deserialized from either a string or an
-    /// integer. The field will always serialize into a string due to that being
-    /// the type Discord's API uses.
+    /// integer.
     #[serde(with = "super::discriminator")]
     pub discriminator: u16,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<String>,
+    pub(crate) email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub flags: Option<UserFlags>,
-    pub id: Id<UserMarker>,
+    pub(crate) flags: Option<UserFlags>,
+    pub(crate) id: Id<UserMarker>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub locale: Option<String>,
+    pub(crate) locale: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mfa_enabled: Option<bool>,
+    pub(crate) mfa_enabled: Option<bool>,
     #[serde(rename = "username")]
-    pub name: String,
+    pub(crate) name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub premium_type: Option<PremiumType>,
+    pub(crate) premium_type: Option<PremiumType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verified: Option<bool>,
+    pub(crate) verified: Option<bool>,
 }
 
 impl UserProfile {
@@ -45,6 +41,58 @@ impl UserProfile {
     /// [`Display`]: core::fmt::Display
     pub const fn discriminator(&self) -> DiscriminatorDisplay {
         DiscriminatorDisplay::new(self.discriminator)
+    }
+
+    /// Accent color of the user's banner.
+    ///
+    /// This is an integer representation of a hexadecimal color code.
+    pub const fn accent_color(&self) -> Option<u64> {
+        self.accent_color
+    }
+
+    pub fn avatar(&self) -> Option<&str> {
+        self.avatar.as_deref()
+    }
+
+    /// Hash of the user's banner image.
+    pub fn banner(&self) -> Option<&str> {
+        self.banner.as_deref()
+    }
+
+    pub const fn bot(&self) -> bool {
+        self.bot
+    }
+
+    pub fn email(&self) -> Option<&str> {
+        self.email.as_deref()
+    }
+
+    pub const fn flags(&self) -> Option<UserFlags> {
+        self.flags
+    }
+
+    pub const fn id(&self) -> Id<UserMarker> {
+        self.id
+    }
+
+    pub fn locale(&self) -> Option<&str> {
+        self.locale.as_deref()
+    }
+
+    pub const fn mfa_enabled(&self) -> Option<bool> {
+        self.mfa_enabled
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub const fn premium_type(&self) -> Option<PremiumType> {
+        self.premium_type
+    }
+
+    pub const fn verified(&self) -> Option<bool> {
+        self.verified
     }
 }
 

--- a/model/src/voice/voice_region.rs
+++ b/model/src/voice/voice_region.rs
@@ -3,11 +3,33 @@ use serde::{Deserialize, Serialize};
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct VoiceRegion {
-    pub custom: bool,
-    pub deprecated: bool,
-    pub id: String,
-    pub name: String,
-    pub optimal: bool,
+    pub(crate) custom: bool,
+    pub(crate) deprecated: bool,
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) optimal: bool,
+}
+
+impl VoiceRegion {
+    pub const fn custom(&self) -> bool {
+        self.custom
+    }
+
+    pub const fn deprecated(&self) -> bool {
+        self.deprecated
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub const fn optimal(&self) -> bool {
+        self.optimal
+    }
 }
 
 #[cfg(test)]

--- a/model/src/voice/voice_state.rs
+++ b/model/src/voice/voice_state.rs
@@ -15,30 +15,80 @@ use std::fmt::{Formatter, Result as FmtResult};
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 pub struct VoiceState {
-    pub channel_id: Option<Id<ChannelMarker>>,
-    pub deaf: bool,
+    pub(crate) channel_id: Option<Id<ChannelMarker>>,
+    pub(crate) deaf: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub guild_id: Option<Id<GuildMarker>>,
+    pub(crate) guild_id: Option<Id<GuildMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub member: Option<Member>,
-    pub mute: bool,
-    pub self_deaf: bool,
-    pub self_mute: bool,
-    /// Whether this user is streaming via "Go Live".
+    pub(crate) member: Option<Member>,
+    pub(crate) mute: bool,
+    pub(crate) self_deaf: bool,
+    pub(crate) self_mute: bool,
     #[serde(default)]
-    pub self_stream: bool,
-    pub session_id: String,
-    pub suppress: bool,
+    pub(crate) self_stream: bool,
+    pub(crate) session_id: String,
+    pub(crate) suppress: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub token: Option<String>,
-    pub user_id: Id<UserMarker>,
+    pub(crate) token: Option<String>,
+    pub(crate) user_id: Id<UserMarker>,
+    pub(crate) request_to_speak_timestamp: Option<Timestamp>,
+}
+
+impl VoiceState {
+    pub const fn channel_id(&self) -> Option<Id<ChannelMarker>> {
+        self.channel_id
+    }
+
+    pub const fn deaf(&self) -> bool {
+        self.deaf
+    }
+
+    pub const fn member(&self) -> Option<&Member> {
+        self.member.as_ref()
+    }
+
+    pub const fn mute(&self) -> bool {
+        self.mute
+    }
+
+    pub const fn self_deaf(&self) -> bool {
+        self.self_deaf
+    }
+
+    pub const fn self_mute(&self) -> bool {
+        self.self_mute
+    }
+
+    /// Whether this user is streaming via "Go Live".
+    pub const fn self_stream(&self) -> bool {
+        self.self_stream
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    pub const fn suppress(&self) -> bool {
+        self.suppress
+    }
+
+    pub fn token(&self) -> Option<&str> {
+        self.token.as_deref()
+    }
+
+    pub const fn user_id(&self) -> Id<UserMarker> {
+        self.user_id
+    }
+
     /// When the user requested to speak.
     ///
     /// # serde
     ///
     /// This is serialized as an ISO 8601 timestamp in the format of
     /// "2021-01-01T01-01-01.010000+00:00".
-    pub request_to_speak_timestamp: Option<Timestamp>,
+    pub const fn request_to_speak_timestamp(&self) -> Option<Timestamp> {
+        self.request_to_speak_timestamp
+    }
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Closes #1365, right now the plan is to do all the received models and leave the sent/send and receive models alone.

Edit: forgot to mention, due to internal workings, all model fields are being changed to `pub(crate)` instead of just private