### PR TITLE
feat(model,cache-inmemory): communication_disabled_until on member update

### DIFF
--- a/cache/in-memory/src/event/member.rs
+++ b/cache/in-memory/src/event/member.rs
@@ -201,6 +201,7 @@ impl UpdateCache for MemberUpdate {
         member.roles = self.roles.clone();
         member.joined_at = self.joined_at;
         member.pending = self.pending;
+        member.communication_disabled_until = self.communication_disabled_until
     }
 }
 

--- a/cache/in-memory/src/event/member.rs
+++ b/cache/in-memory/src/event/member.rs
@@ -201,7 +201,7 @@ impl UpdateCache for MemberUpdate {
         member.roles = self.roles.clone();
         member.joined_at = self.joined_at;
         member.pending = self.pending;
-        member.communication_disabled_until = self.communication_disabled_until
+        member.communication_disabled_until = self.communication_disabled_until;
     }
 }
 

--- a/cache/in-memory/src/permission.rs
+++ b/cache/in-memory/src/permission.rs
@@ -698,6 +698,7 @@ mod tests {
         cache.update(&MemberAdd(test::member(user_id(), guild_id())));
         cache.update(&MemberUpdate {
             avatar: None,
+            communication_disabled_until: None,
             guild_id: guild_id(),
             deaf: None,
             joined_at,

--- a/model/src/gateway/payload/incoming/member_update.rs
+++ b/model/src/gateway/payload/incoming/member_update.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 pub struct MemberUpdate {
     /// Member's guild avatar.
     pub avatar: Option<String>,
+    pub communication_disabled_until: Option<Timestamp>,
     pub guild_id: GuildId,
     pub deaf: Option<bool>,
     pub joined_at: Timestamp,
@@ -43,9 +44,11 @@ mod tests {
     #[test]
     fn test_member_update() {
         let joined_at = Timestamp::from_micros(1_488_234_110_121_000).expect("non zero");
+        let communication_disabled_until = Timestamp::from_micros(1_641_027_600_000_000).expect("non zero");
 
         let value = MemberUpdate {
             avatar: None,
+            communication_disabled_until: Some(communication_disabled_until),
             guild_id: GuildId::new(1_234).expect("non zero"),
             deaf: Some(false),
             joined_at,
@@ -78,10 +81,13 @@ mod tests {
             &[
                 Token::Struct {
                     name: "MemberUpdate",
-                    len: 10,
+                    len: 11,
                 },
                 Token::Str("avatar"),
                 Token::None,
+                Token::Str("communication_disabled_until"),
+                Token::Some,
+                Token::Str("2022-01-01T09:00:00.000000+00:00"),
                 Token::Str("guild_id"),
                 Token::NewtypeStruct { name: "GuildId" },
                 Token::Str("1234"),

--- a/model/src/gateway/payload/incoming/member_update.rs
+++ b/model/src/gateway/payload/incoming/member_update.rs
@@ -44,7 +44,8 @@ mod tests {
     #[test]
     fn test_member_update() {
         let joined_at = Timestamp::from_micros(1_488_234_110_121_000).expect("non zero");
-        let communication_disabled_until = Timestamp::from_micros(1_641_027_600_000_000).expect("non zero");
+        let communication_disabled_until =
+            Timestamp::from_micros(1_641_027_600_000_000).expect("non zero");
 
         let value = MemberUpdate {
             avatar: None,


### PR DESCRIPTION
adds the field to the member update payload and makes the cache update with it