### PR TITLE
feat(gateway): drop failed event parsing to debug

### DIFF
--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -407,7 +407,7 @@ impl ShardProcessor {
 
             if let Err(source) = self.process().await {
                 #[cfg(feature = "tracing")]
-                tracing::warn!(
+                tracing::debug!(
                     shard_id = self.config.shard()[0],
                     shard_total = self.config.shard()[1],
                     "processing incoming event failed: {:?}",

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -407,12 +407,24 @@ impl ShardProcessor {
 
             if let Err(source) = self.process().await {
                 #[cfg(feature = "tracing")]
-                tracing::debug!(
-                    shard_id = self.config.shard()[0],
-                    shard_total = self.config.shard()[1],
-                    "processing incoming event failed: {:?}",
-                    source,
-                );
+                match &source.kind {
+                    ProcessErrorType::EventTypeUnknown { .. } => {
+                        tracing::debug!(
+                            shard_id = self.config.shard()[0],
+                            shard_total = self.config.shard()[1],
+                            "processing incoming event failed: {:?}",
+                            source,
+                        );
+                    }
+                    _ => {
+                        tracing::warn!(
+                            shard_id = self.config.shard()[0],
+                            shard_total = self.config.shard()[1],
+                            "processing incoming event failed: {:?}",
+                            source,
+                        );
+                    }
+                }
 
                 if source.fatal() {
                     #[cfg(feature = "tracing")]

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -407,23 +407,20 @@ impl ShardProcessor {
 
             if let Err(source) = self.process().await {
                 #[cfg(feature = "tracing")]
-                match &source.kind {
-                    ProcessErrorType::EventTypeUnknown { .. } => {
-                        tracing::debug!(
-                            shard_id = self.config.shard()[0],
-                            shard_total = self.config.shard()[1],
-                            "processing incoming event failed: {:?}",
-                            source,
-                        );
-                    }
-                    _ => {
-                        tracing::warn!(
-                            shard_id = self.config.shard()[0],
-                            shard_total = self.config.shard()[1],
-                            "processing incoming event failed: {:?}",
-                            source,
-                        );
-                    }
+                if matches!(&source.kind, ProcessErrorType::EventTypeUnknown { .. }) {
+                    tracing::debug!(
+                        shard_id = self.config.shard()[0],
+                        shard_total = self.config.shard()[1],
+                        "processing incoming event failed: {:?}",
+                        source,
+                    );
+                } else {
+                    tracing::warn!(
+                        shard_id = self.config.shard()[0],
+                        shard_total = self.config.shard()[1],
+                        "processing incoming event failed: {:?}",
+                        source,
+                    );
                 }
 
                 if source.fatal() {


### PR DESCRIPTION
This is way too noisy for warnings, the gateway emits events twilight doesn't know about (yet) non stop