### PR TITLE
fix(model): thread sync has channel ids, not guild ids

### DIFF
--- a/model/src/gateway/payload/incoming/thread_list_sync.rs
+++ b/model/src/gateway/payload/incoming/thread_list_sync.rs
@@ -1,13 +1,13 @@
 use crate::{
     channel::{thread::ThreadMember, Channel},
-    id::GuildId,
+    id::{ChannelId, GuildId},
 };
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ThreadListSync {
     #[serde(default)]
-    pub channel_ids: Vec<GuildId>,
+    pub channel_ids: Vec<ChannelId>,
     pub guild_id: GuildId,
     pub members: Vec<ThreadMember>,
     pub threads: Vec<Channel>,


### PR DESCRIPTION
Typing was wrong in this model. Technically a breaking change but targeted at main since it's an an incorrect mapping