### PR TITLE
feat(model): add CommunicationDisabledUntil audit log

### DIFF
--- a/model/src/guild/audit_log/change.rs
+++ b/model/src/guild/audit_log/change.rs
@@ -4,6 +4,7 @@ use crate::{
         message::sticker::StickerFormatType, permission_overwrite::PermissionOverwrite,
         stage_instance::PrivacyLevel, thread::AutoArchiveDuration,
     },
+    datetime::Timestamp,
     guild::{
         DefaultMessageNotificationLevel, ExplicitContentFilter, MfaLevel, NSFWLevel, Permissions,
         VerificationLevel,
@@ -159,6 +160,15 @@ pub enum AuditLogChange {
         /// Old role color.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
         old: Option<u64>,
+    },
+    /// Member timeout state changed.
+    CommunicationDisabledUntil {
+        /// New timeout timestamp.
+        #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        new: Option<Timestamp>,
+        /// Old timeout timestamp.
+        #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        old: Option<Timestamp>,
     },
     /// Whether a member is guild deafened.
     Deaf {
@@ -698,6 +708,9 @@ impl AuditLogChange {
             Self::ChannelId { .. } => AuditLogChangeKey::ChannelId,
             Self::Code { .. } => AuditLogChangeKey::Code,
             Self::Color { .. } => AuditLogChangeKey::Color,
+            Self::CommunicationDisabledUntil { .. } => {
+                AuditLogChangeKey::CommunicationDisabledUntil
+            }
             Self::Deaf { .. } => AuditLogChangeKey::Deaf,
             Self::DefaultAutoArchiveDuration { .. } => {
                 AuditLogChangeKey::DefaultAutoArchiveDuration
@@ -782,6 +795,7 @@ mod tests {
     assert_fields!(AuditLogChange::ChannelId: new);
     assert_fields!(AuditLogChange::Code: new);
     assert_fields!(AuditLogChange::Color: new, old);
+    assert_fields!(AuditLogChange::CommunicationDisabledUntil: new, old);
     assert_fields!(AuditLogChange::Deaf: new, old);
     assert_fields!(AuditLogChange::DefaultMessageNotifications: new, old);
     assert_fields!(AuditLogChange::Deny: new);

--- a/model/src/guild/audit_log/change_key.rs
+++ b/model/src/guild/audit_log/change_key.rs
@@ -41,6 +41,8 @@ pub enum AuditLogChangeKey {
     Code,
     /// Color of a role.
     Color,
+    /// Member timeout state changed.
+    CommunicationDisabledUntil,
     /// Whether a user is guild deafened.
     Deaf,
     /// Default auto archive duration for new threads.
@@ -189,6 +191,7 @@ impl AuditLogChangeKey {
             Self::ChannelId => "channel_id",
             Self::Code => "code",
             Self::Color => "color",
+            Self::CommunicationDisabledUntil => "communication_disabled_until",
             Self::Deaf => "deaf",
             Self::DefaultAutoArchiveDuration => "default_auto_archive_duration",
             Self::DefaultMessageNotifications => "default_message_notifications",
@@ -291,6 +294,10 @@ mod tests {
         assert_eq!("channel_id", AuditLogChangeKey::ChannelId.name());
         assert_eq!("code", AuditLogChangeKey::Code.name());
         assert_eq!("color", AuditLogChangeKey::Color.name());
+        assert_eq!(
+            "communication_disabled_until",
+            AuditLogChangeKey::CommunicationDisabledUntil.name()
+        );
         assert_eq!("deaf", AuditLogChangeKey::Deaf.name());
         assert_eq!(
             "default_message_notifications",
@@ -443,6 +450,13 @@ mod tests {
             &[Token::UnitVariant {
                 name: "AuditLogChangeKey",
                 variant: "color",
+            }],
+        );
+        serde_test::assert_tokens(
+            &AuditLogChangeKey::CommunicationDisabledUntil,
+            &[Token::UnitVariant {
+                name: "AuditLogChangeKey",
+                variant: "communication_disabled_until",
             }],
         );
         serde_test::assert_tokens(


### PR DESCRIPTION
Reference: https://github.com/discord/discord-api-docs/commit/c63a4d5a604b6c2dbb5e5b5c1e3c2a101e96df44