### PR TITLE
fix(model): correctly deserialize ThreadDelete events

### DIFF
--- a/cache/in-memory/src/event/thread.rs
+++ b/cache/in-memory/src/event/thread.rs
@@ -24,7 +24,7 @@ impl UpdateCache for ThreadDelete {
             return;
         }
 
-        cache.delete_guild_channel(self.0.id());
+        cache.delete_guild_channel(self.id);
     }
 }
 

--- a/model/src/gateway/payload/incoming/thread_delete.rs
+++ b/model/src/gateway/payload/incoming/thread_delete.rs
@@ -1,20 +1,12 @@
-use crate::channel::Channel;
+use crate::channel::ChannelType;
+use crate::id::{ChannelId, GuildId};
 use serde::{Deserialize, Serialize};
-use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct ThreadDelete(pub Channel);
-
-impl Deref for ThreadDelete {
-    type Target = Channel;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for ThreadDelete {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
+pub struct ThreadDelete {
+    pub guild_id: GuildId,
+    pub id: ChannelId,
+    #[serde(rename = "type")]
+    pub kind: ChannelType,
+    pub parent_id: Option<ChannelId>,
 }

--- a/model/src/gateway/payload/incoming/thread_delete.rs
+++ b/model/src/gateway/payload/incoming/thread_delete.rs
@@ -8,5 +8,5 @@ pub struct ThreadDelete {
     pub id: ChannelId,
     #[serde(rename = "type")]
     pub kind: ChannelType,
-    pub parent_id: Option<ChannelId>,
+    pub parent_id: ChannelId,
 }

--- a/standby/src/event.rs
+++ b/standby/src/event.rs
@@ -51,7 +51,7 @@ pub const fn guild_id(event: &Event) -> Option<GuildId> {
         Event::StageInstanceDelete(e) => Some(e.0.guild_id),
         Event::StageInstanceUpdate(e) => Some(e.0.guild_id),
         Event::ThreadCreate(e) => channel_guild_id(&e.0),
-        Event::ThreadDelete(e) => channel_guild_id(&e.0),
+        Event::ThreadDelete(e) => Some(e.guild_id),
         Event::ThreadListSync(e) => Some(e.guild_id),
         Event::ThreadMembersUpdate(e) => Some(e.guild_id),
         Event::ThreadUpdate(e) => channel_guild_id(&e.0),


### PR DESCRIPTION
ThreadDelete could not be deserialized as it expected a full channel struct while we only get a few fields as per the docs: https://discord.com/developers/docs/topics/gateway#thread-delete.

Targeted against main despite being a breaking change as it's an incorrect mapped struct that can't deserialize otherwise