### PR TITLE
feat(gateway): make parse errors much more visible

### DIFF
--- a/gateway/src/shard/json.rs
+++ b/gateway/src/shard/json.rs
@@ -78,7 +78,7 @@ pub fn parse_gateway_event(
         .deserialize(&mut json_deserializer)
         .map_err(|source| {
             #[cfg(feature = "tracing")]
-            tracing::debug!("invalid JSON: {}", String::from_utf8_lossy(json));
+            tracing::error!("invalid JSON: {}", String::from_utf8_lossy(json));
 
             GatewayEventParsingError {
                 kind: GatewayEventParsingErrorType::Deserializing,
@@ -120,7 +120,7 @@ pub fn parse_gateway_event(
         .deserialize(&mut json_deserializer)
         .map_err(|source| {
             #[cfg(feature = "tracing")]
-            tracing::debug!("invalid JSON: {}", String::from_utf8_lossy(json));
+            tracing::error!("invalid JSON: {}", String::from_utf8_lossy(json));
 
             GatewayEventParsingError {
                 kind: GatewayEventParsingErrorType::Deserializing,

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -415,7 +415,7 @@ impl ShardProcessor {
                         source,
                     );
                 } else {
-                    tracing::warn!(
+                    tracing::error!(
                         shard_id = self.config.shard()[0],
                         shard_total = self.config.shard()[1],
                         "processing incoming event failed: {:?}",
@@ -460,7 +460,7 @@ impl ShardProcessor {
                     (op, seq, event_type.map(ToOwned::to_owned))
                 } else {
                     #[cfg(feature = "tracing")]
-                    tracing::warn!(
+                    tracing::error!(
                         json = ?self.compression.buffer_slice_mut(),
                         shard_id = self.config.shard()[0],
                         shard_total = self.config.shard()[1],


### PR DESCRIPTION
Bumping it up to error for visibility on both the general error and the payload. This allows easier tracking down of broken payloads even in production environments where the debug level is way too verbose when you are looking for a single broken payload type without knowing what event type is failing.