### PR TITLE
chore: downgrade to `dashmap` 4

### DIFF
--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.8.4"
 
 [dependencies]
 bitflags = { default-features = false, version = "1" }
-dashmap = { default-features = false, version = ">=4.0, <6.0" }
+dashmap = { default-features = false, version = "4" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 twilight-model = { default-features = false, path = "../../model" }
 

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.8.2"
 
 [dependencies]
-dashmap = { default-features = false, version = ">=4.0, <6.0" }
+dashmap = { default-features = false, version = "4" }
 futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }
 http = { default-features = false, version = "0.2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }

--- a/standby/Cargo.toml
+++ b/standby/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.8.2"
 
 [dependencies]
-dashmap = { default-features = false, version = ">=4.0, <6.0" }
+dashmap = { default-features = false, version = "4" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 tokio = { default-features = false, features = ["sync"], version = "1.0" }
 twilight-model = { default-features = false, path = "../model" }


### PR DESCRIPTION
Using `Ref::value` with `dashmap` 5 may produce a reference that outlive the Ref and thus cause undefined behavior. Issues with the cache [have been reported on Discord](https://discord.com/channels/745809834183753828/745811216579952680/929856218120462396) and *may* be related to that. See https://github.com/xacrimon/dashmap/issues/167 for more information.

I think we should downgrade dashmap until a patch is released, as `Ref::value` is used in some places with the cache. The issue is not affecting dashmap 4.

This reverts https://github.com/twilight-rs/twilight/pull/1336.