### PR TITLE
Send stickers in messages

### DIFF
--- a/model/src/id.rs
+++ b/model/src/id.rs
@@ -759,6 +759,56 @@ impl From<NonZeroU64> for StageId {
     }
 }
 
+/// Unique ID of a sticker.
+#[allow(clippy::unsafe_derive_deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct StickerId(#[serde(with = "string")] pub NonZeroU64);
+
+impl StickerId {
+    /// Create a non-zero sticker ID without checking the value.
+    ///
+    /// Equivalent to [`NonZeroU64::new_unchecked`].
+    ///
+    /// # Safety
+    ///
+    /// The value must not be zero.
+    #[allow(unsafe_code)]
+    pub const unsafe fn new_unchecked(n: u64) -> Self {
+        Self(NonZeroU64::new_unchecked(n))
+    }
+
+    /// Create a non-zero sticker ID if the given value is not zero.
+    ///
+    /// Equivalent to [`NonZeroU64::new`].
+    pub const fn new(n: u64) -> Option<Self> {
+        #[allow(clippy::option_if_let_else)]
+        if let Some(n) = NonZeroU64::new(n) {
+            Some(Self(n))
+        } else {
+            None
+        }
+    }
+
+    /// Return the inner primitive value.
+    ///
+    /// Equivalent to [`NonZeroU64::get`].
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl Display for StickerId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl From<NonZeroU64> for StickerId {
+    fn from(id: NonZeroU64) -> Self {
+        StickerId(id)
+    }
+}
+
 /// Unique ID of an user.
 #[allow(clippy::unsafe_derive_deserialize)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -864,7 +914,7 @@ mod tests {
     use super::{
         ApplicationId, AttachmentId, AuditLogEntryId, ChannelId, CommandId, CommandVersionId,
         EmojiId, GenericId, GuildId, IntegrationId, InteractionId, MessageId, RoleId, StageId,
-        UserId, WebhookId,
+        StickerId, UserId, WebhookId,
     };
     use serde_test::Token;
 
@@ -1088,6 +1138,24 @@ mod tests {
             &StageId::new(114_941_315_417_899_012).expect("non zero"),
             &[
                 Token::NewtypeStruct { name: "StageId" },
+                Token::U64(114_941_315_417_899_012),
+            ],
+        );
+        serde_test::assert_tokens(
+            &StickerId::new(114_941_315_417_899_012).expect("non zero"),
+            &[
+                Token::NewtypeStruct {
+                    name: "StickerId",
+                },
+                Token::Str("114941315417899012"),
+            ],
+        );
+        serde_test::assert_de_tokens(
+            &StickerId::new(114_941_315_417_899_012).expect("non zero"),
+            &[
+                Token::NewtypeStruct {
+                    name: "StickerId",
+                },
                 Token::U64(114_941_315_417_899_012),
             ],
         );

--- a/util/src/snowflake.rs
+++ b/util/src/snowflake.rs
@@ -2,7 +2,7 @@
 
 use twilight_model::id::{
     ApplicationId, AttachmentId, AuditLogEntryId, ChannelId, CommandId, CommandVersionId, EmojiId,
-    GenericId, GuildId, IntegrationId, InteractionId, MessageId, RoleId, StageId, UserId,
+    GenericId, GuildId, IntegrationId, InteractionId, MessageId, RoleId, StageId, StickerId, UserId,
     WebhookId,
 };
 
@@ -170,6 +170,12 @@ impl Snowflake for StageId {
     }
 }
 
+impl Snowflake for StickerId {
+    fn id(&self) -> u64 {
+        self.get()
+    }
+}
+
 impl Snowflake for UserId {
     fn id(&self) -> u64 {
         self.get()
@@ -189,7 +195,7 @@ mod tests {
     use twilight_model::id::{
         ApplicationId, AttachmentId, AuditLogEntryId, ChannelId, CommandId, CommandVersionId,
         EmojiId, GenericId, GuildId, IntegrationId, InteractionId, MessageId, RoleId, StageId,
-        UserId, WebhookId,
+        StickerId, UserId, WebhookId,
     };
 
     assert_impl_all!(ApplicationId: Snowflake);
@@ -206,6 +212,7 @@ mod tests {
     assert_impl_all!(MessageId: Snowflake);
     assert_impl_all!(RoleId: Snowflake);
     assert_impl_all!(StageId: Snowflake);
+    assert_impl_all!(StickerId, Snowflake);
     assert_impl_all!(UserId: Snowflake);
     assert_impl_all!(WebhookId: Snowflake);
     assert_obj_safe!(Snowflake);


### PR DESCRIPTION
Sticker ID is an array of snowflakes in the body of the create_message payload.  This PR adds support for the sticker_ids field.