### PR TITLE
refactor(gateway/session): Remove `Arc` around heartbeat handle

### DIFF
--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -66,9 +66,7 @@ pub enum SessionSendErrorType {
 
 #[derive(Debug)]
 pub struct Session {
-    // Needs to be Arc so it can be cloned in the `Drop` impl when spawned on
-    // the runtime.
-    pub heartbeater_handle: Arc<MutexSync<Option<JoinHandle<()>>>>,
+    pub heartbeater_handle: MutexSync<Option<JoinHandle<()>>>,
     pub heartbeats: Arc<Heartbeats>,
     pub heartbeat_interval: AtomicU64,
     pub id: MutexSync<Option<Box<str>>>,
@@ -81,7 +79,7 @@ pub struct Session {
 impl Session {
     pub fn new(tx: UnboundedSender<TungsteniteMessage>) -> Self {
         Self {
-            heartbeater_handle: Arc::new(MutexSync::new(None)),
+            heartbeater_handle: MutexSync::new(None),
             heartbeats: Arc::new(Heartbeats::default()),
             heartbeat_interval: AtomicU64::new(0),
             id: MutexSync::new(None),


### PR DESCRIPTION
This code is from the first implementation of `gateway`, back then `Drop` contained this code:
```rust
impl Drop for Session {
    fn drop(&mut self) {
        let handle = Arc::clone(&self.heartbeater_handle);

        tokio::spawn(async move {
            if let Some(handle) = handle.lock().await.take() {
                handle.abort();
            }
        });
    }
}
```
Because `handle` is no longer wrapped around an Async Mutex there's no await, and no need to spawn a new task.
The current implementation is just:
```rust
impl Session {
    // ...

    pub fn stop_heartbeater(&self) {
        if let Some(handle) = self
            .heartbeater_handle
            .lock()
            .expect("heartbeater poisoned")
            .take()
        {
            handle.abort();
        }
    }

    // ...
}

impl Drop for Session {
    fn drop(&mut self) {
        self.stop_heartbeater();
    }
}
```
removing the need for `Arc`.