### PR TITLE
ci: restore `baptiste0928/cargo-install` action

### DIFF
--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install cargo-sync-readme
-        uses: actions-rs/install@v0.1
+        uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-sync-readme
 
@@ -166,12 +166,12 @@ jobs:
           profile: minimal
 
       - name: Install cargo-hack
-        uses: actions-rs/install@v0.1
+        uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-hack
 
       - name: Install cargo-minimal-versions
-        uses: actions-rs/install@v0.1
+        uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-minimal-versions
 


### PR DESCRIPTION
The issue causing workflows to fail with [`baptiste0928/cargo-install`](https://github.com/baptiste0928/cargo-install) had been fixed in version 1.0.1.