### PR TITLE
refactor(http)!: remove unneeded public modules

### DIFF
--- a/http/src/request/application/interaction/mod.rs
+++ b/http/src/request/application/interaction/mod.rs
@@ -1,12 +1,11 @@
-pub mod create_followup_message;
-pub mod update_followup_message;
-pub mod update_original_response;
-
+mod create_followup_message;
 mod delete_followup_message;
 mod delete_original_response;
 mod get_followup_message;
 mod get_original_response;
 mod interaction_callback;
+mod update_followup_message;
+mod update_original_response;
 
 pub use self::{
     create_followup_message::CreateFollowupMessage, delete_followup_message::DeleteFollowupMessage,

--- a/http/src/request/channel/invite/mod.rs
+++ b/http/src/request/channel/invite/mod.rs
@@ -1,5 +1,4 @@
-pub mod create_invite;
-
+mod create_invite;
 mod delete_invite;
 mod get_channel_invites;
 mod get_invite;

--- a/http/src/request/channel/message/mod.rs
+++ b/http/src/request/channel/message/mod.rs
@@ -1,11 +1,11 @@
 pub mod create_message;
-pub mod crosspost_message;
-pub mod get_channel_messages;
-pub mod get_channel_messages_configured;
 pub mod update_message;
 
+mod crosspost_message;
 mod delete_message;
 mod delete_messages;
+mod get_channel_messages;
+mod get_channel_messages_configured;
 mod get_message;
 
 pub use self::{

--- a/http/src/request/channel/mod.rs
+++ b/http/src/request/channel/mod.rs
@@ -3,7 +3,6 @@ pub mod message;
 pub mod reaction;
 pub mod stage;
 pub mod thread;
-pub mod update_channel;
 pub mod webhook;
 
 mod create_pin;
@@ -15,6 +14,7 @@ mod delete_pin;
 mod follow_news_channel;
 mod get_channel;
 mod get_pins;
+mod update_channel;
 mod update_channel_permission;
 mod update_channel_permission_configured;
 

--- a/http/src/request/channel/reaction/mod.rs
+++ b/http/src/request/channel/reaction/mod.rs
@@ -1,10 +1,9 @@
-pub mod get_reactions;
-
 pub(crate) mod delete_reaction;
 
 mod create_reaction;
 mod delete_all_reaction;
 mod delete_all_reactions;
+mod get_reactions;
 
 pub use self::{
     create_reaction::CreateReaction, delete_all_reaction::DeleteAllReaction,

--- a/http/src/request/channel/stage/mod.rs
+++ b/http/src/request/channel/stage/mod.rs
@@ -1,8 +1,7 @@
-pub mod create_stage_instance;
-pub mod update_stage_instance;
-
+mod create_stage_instance;
 mod delete_stage_instance;
 mod get_stage_instance;
+mod update_stage_instance;
 
 pub use self::{
     create_stage_instance::CreateStageInstance, delete_stage_instance::DeleteStageInstance,

--- a/http/src/request/channel/thread/mod.rs
+++ b/http/src/request/channel/thread/mod.rs
@@ -1,15 +1,15 @@
-pub mod add_thread_member;
-pub mod create_thread;
-pub mod create_thread_from_message;
-pub mod get_joined_private_archived_threads;
-pub mod get_private_archived_threads;
-pub mod get_public_archived_threads;
-pub mod get_thread_member;
-pub mod get_thread_members;
-pub mod join_thread;
-pub mod leave_thread;
-pub mod remove_thread_member;
-pub mod update_thread;
+mod add_thread_member;
+mod create_thread;
+mod create_thread_from_message;
+mod get_joined_private_archived_threads;
+mod get_private_archived_threads;
+mod get_public_archived_threads;
+mod get_thread_member;
+mod get_thread_members;
+mod join_thread;
+mod leave_thread;
+mod remove_thread_member;
+mod update_thread;
 
 pub use self::{
     add_thread_member::AddThreadMember, create_thread::CreateThread,

--- a/http/src/request/guild/ban/mod.rs
+++ b/http/src/request/guild/ban/mod.rs
@@ -1,5 +1,4 @@
-pub mod create_ban;
-
+mod create_ban;
 mod delete_ban;
 mod get_ban;
 mod get_bans;

--- a/http/src/request/guild/member/mod.rs
+++ b/http/src/request/guild/member/mod.rs
@@ -1,12 +1,11 @@
-pub mod add_guild_member;
-pub mod get_guild_members;
-pub mod search_guild_members;
-pub mod update_guild_member;
-
+mod add_guild_member;
 mod add_role_to_member;
+mod get_guild_members;
 mod get_member;
 mod remove_member;
 mod remove_role_from_member;
+mod search_guild_members;
+mod update_guild_member;
 
 pub use self::{
     add_guild_member::AddGuildMember, add_role_to_member::AddRoleToMember,

--- a/http/src/request/guild/mod.rs
+++ b/http/src/request/guild/mod.rs
@@ -1,31 +1,31 @@
 pub mod ban;
 pub mod create_guild;
-pub mod create_guild_channel;
-pub mod create_guild_prune;
 pub mod emoji;
-pub mod get_audit_log;
-pub mod get_guild_prune_count;
 pub mod integration;
 pub mod member;
 pub mod role;
 pub mod sticker;
-pub mod update_current_member;
-pub mod update_guild;
 pub mod update_guild_channel_positions;
 pub mod user;
 
+mod create_guild_channel;
+mod create_guild_prune;
 mod delete_guild;
 mod get_active_threads;
+mod get_audit_log;
 mod get_guild;
 mod get_guild_channels;
 mod get_guild_invites;
 mod get_guild_preview;
+mod get_guild_prune_count;
 mod get_guild_vanity_url;
 mod get_guild_voice_regions;
 mod get_guild_webhooks;
 mod get_guild_welcome_screen;
 mod get_guild_widget;
+mod update_current_member;
 pub(crate) mod update_current_user_nick;
+mod update_guild;
 mod update_guild_welcome_screen;
 mod update_guild_widget;
 

--- a/http/src/request/template/mod.rs
+++ b/http/src/request/template/mod.rs
@@ -1,11 +1,10 @@
-pub mod create_guild_from_template;
-pub mod create_template;
-pub mod update_template;
-
+mod create_guild_from_template;
+mod create_template;
 mod delete_template;
 mod get_template;
 mod get_templates;
 mod sync_template;
+mod update_template;
 
 pub use self::{
     create_guild_from_template::CreateGuildFromTemplate, create_template::CreateTemplate,

--- a/http/src/request/user/mod.rs
+++ b/http/src/request/user/mod.rs
@@ -1,12 +1,11 @@
-pub mod get_current_user_guilds;
-pub mod update_current_user;
-
 mod create_private_channel;
 mod get_current_user;
 mod get_current_user_connections;
 mod get_current_user_guild_member;
+mod get_current_user_guilds;
 mod get_user;
 mod leave_guild;
+mod update_current_user;
 
 pub use self::{
     create_private_channel::CreatePrivateChannel, get_current_user::GetCurrentUser,


### PR DESCRIPTION
These were missed in the validate crate PR. They do not need to be public anymore.
