### PR TITLE
feat(gateway): Update `metrics` to 0.18

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -34,7 +34,7 @@ leaky-bucket-lite = { default-features = false, features = ["tokio"], version = 
 # it does not seem to update the total_in of the function to have an offset
 # https://github.com/alexcrichton/flate2-rs/issues/217
 flate2 = { default-features = false, optional = true, version = "1.0" }
-metrics = { default-features = false, features = ["std"], optional = true, version = ">=0.14, <0.18" }
+metrics = { default-features = false, optional = true, version = "0.18" }
 simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.4" }
 tracing = { default-features = false, features = ["std", "attributes"], optional = true, version = "0.1" }
 


### PR DESCRIPTION
`>=0.14, <0.19` can't be used since 0.18 drops the `std` feature

Targeting next so users aren't forced to update metrics locally.
