### PR TITLE
feat(gateway): custom shard presences on identify

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -204,10 +204,8 @@ impl ClusterBuilder {
 
     /// Set specific shard presences to use when identifying with the gateway.
     ///
-    /// If there is no custom presence set for a shard in the provided
-    /// [`HashMap`], the presence set by [`presence`] will be preferred.
-    ///
-    /// [`presence`]: Self::presence
+    /// Accepts a closure. The closure accepts a [`u64`] and returns an
+    /// [`Option<UpdatePresencePayload>`].
     pub fn shard_presence(mut self, shard_presence: ShardPresence) -> Self {
         self.0.shard_presence = Some(shard_presence);
 

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -189,7 +189,7 @@ impl ClusterBuilder {
     ///
     /// Accepts a closure. The closure accepts a [`u64`] and returns an
     /// [`Option<UpdatePresencePayload>`]. This presence will override any set
-    /// by [`presence`], even if the function returns [`None`].
+    /// by [`presence`], even if the provided closure returns [`None`].
     ///
     /// [`presence`]: Self::presence
     pub fn shard_presence<F>(mut self, shard_presence: F) -> Self

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -47,9 +47,10 @@ impl ClusterBuilder {
     pub fn new(token: impl Into<String>, intents: Intents) -> Self {
         Self(
             ClusterConfig {
-                shard_scheme: ShardScheme::Auto,
                 queue: Arc::new(LocalQueue::new()),
                 resume_sessions: HashMap::new(),
+                shard_presences: HashMap::new(),
+                shard_scheme: ShardScheme::Auto,
             },
             ShardBuilder::new(token, intents),
         )
@@ -180,6 +181,19 @@ impl ClusterBuilder {
     /// Refer to the shard's [`ShardBuilder::presence`] for more information.
     pub fn presence(mut self, presence: UpdatePresencePayload) -> Self {
         self.1 = self.1.presence(presence);
+
+        self
+    }
+
+    /// Set specific shard presences to use when identifying with the gateway.
+    ///
+    /// If there is no custom presence set for a shard in the provided
+    /// [`HashMap`], the presence set by [`presence`] will be preferred.
+    ///
+    /// [`presence`]: Self::presence
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn shard_presences(mut self, shard_presences: HashMap<u64, UpdatePresencePayload>) -> Self {
+        self.0.shard_presences = shard_presences;
 
         self
     }

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -27,7 +27,7 @@ pub trait ShardPresence: Fn(u64) -> Option<UpdatePresencePayload> + Send + Sync 
 
 impl Debug for dyn ShardPresence {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_str("Box<dyn ShardPresenceTrait<Output = Option<UpdatePresencePayload>>>")
+        f.write_str("Fn(u64) -> Option<UpdatePresencePayload> + Send + Sync")
     }
 }
 

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -10,7 +10,7 @@ use twilight_gateway_queue::Queue;
 pub struct Config {
     pub(super) queue: Arc<dyn Queue>,
     pub(super) resume_sessions: HashMap<u64, ResumeSession>,
-    pub(super) shard_presence: Option<ShardPresence>,
+    pub(super) shard_presence: Option<Box<dyn ShardPresence>>,
     pub(super) shard_scheme: ShardScheme,
 }
 

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -1,8 +1,7 @@
 use super::scheme::ShardScheme;
-use crate::shard::ResumeSession;
+use crate::{cluster::builder::ShardPresence, shard::ResumeSession};
 use std::{collections::HashMap, sync::Arc};
 use twilight_gateway_queue::Queue;
-use twilight_model::gateway::payload::outgoing::update_presence::UpdatePresencePayload;
 
 /// Built configuration for a [`Cluster`].
 ///
@@ -11,7 +10,7 @@ use twilight_model::gateway::payload::outgoing::update_presence::UpdatePresenceP
 pub struct Config {
     pub(super) queue: Arc<dyn Queue>,
     pub(super) resume_sessions: HashMap<u64, ResumeSession>,
-    pub(super) shard_presences: HashMap<u64, UpdatePresencePayload>,
+    pub(super) shard_presence: Option<ShardPresence>,
     pub(super) shard_scheme: ShardScheme,
 }
 

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -2,15 +2,17 @@ use super::scheme::ShardScheme;
 use crate::shard::ResumeSession;
 use std::{collections::HashMap, sync::Arc};
 use twilight_gateway_queue::Queue;
+use twilight_model::gateway::payload::outgoing::update_presence::UpdatePresencePayload;
 
 /// Built configuration for a [`Cluster`].
 ///
 /// [`Cluster`]: crate::Cluster
 #[derive(Debug)]
 pub struct Config {
-    pub(super) shard_scheme: ShardScheme,
     pub(super) queue: Arc<dyn Queue>,
     pub(super) resume_sessions: HashMap<u64, ResumeSession>,
+    pub(super) shard_presences: HashMap<u64, UpdatePresencePayload>,
+    pub(super) shard_scheme: ShardScheme,
 }
 
 impl Config {

--- a/gateway/src/cluster/config.rs
+++ b/gateway/src/cluster/config.rs
@@ -1,16 +1,20 @@
-use super::scheme::ShardScheme;
-use crate::{cluster::builder::ShardPresence, shard::ResumeSession};
-use std::{collections::HashMap, sync::Arc};
+use crate::{cluster::ShardScheme, shard::ResumeSession};
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Formatter, Result as FmtResult},
+    sync::Arc,
+};
 use twilight_gateway_queue::Queue;
+use twilight_model::gateway::payload::outgoing::update_presence::UpdatePresencePayload;
 
 /// Built configuration for a [`Cluster`].
 ///
 /// [`Cluster`]: crate::Cluster
-#[derive(Debug)]
 pub struct Config {
     pub(super) queue: Arc<dyn Queue>,
     pub(super) resume_sessions: HashMap<u64, ResumeSession>,
-    pub(super) shard_presence: Option<Box<dyn ShardPresence>>,
+    pub(super) shard_presence:
+        Option<Box<dyn Fn(u64) -> Option<UpdatePresencePayload> + Send + Sync + 'static>>,
     pub(super) shard_scheme: ShardScheme,
 }
 
@@ -28,6 +32,17 @@ impl Config {
     /// sessions.
     pub fn queue(&self) -> &Arc<dyn Queue> {
         &self.queue
+    }
+}
+
+impl Debug for Config {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.debug_struct("Config")
+            .field("queue", &self.queue)
+            .field("resume_sessions", &self.resume_sessions)
+            .field("shard_presence", &"<Fn>")
+            .field("shard_scheme", &self.shard_scheme)
+            .finish()
     }
 }
 

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -311,6 +311,10 @@ impl Cluster {
                 shard_config.sequence = Some(data.sequence);
             }
 
+            if let Some(shard_presence) = config.shard_presences.remove(&idx) {
+                shard_config.presence = Some(shard_presence);
+            }
+
             let (shard, stream) = Shard::new_with_config(shard_config);
 
             fold.shards.insert(idx, shard);

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -311,8 +311,10 @@ impl Cluster {
                 shard_config.sequence = Some(data.sequence);
             }
 
-            if let Some(shard_presence) = config.shard_presences.remove(&idx) {
-                shard_config.presence = Some(shard_presence);
+            if let Some(shard_presence) = &config.shard_presence {
+                if let Some(shard_presence) = shard_presence(idx) {
+                    shard_config.presence = Some(shard_presence);
+                }
             }
 
             let (shard, stream) = Shard::new_with_config(shard_config);

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -312,9 +312,7 @@ impl Cluster {
             }
 
             if let Some(shard_presence) = &config.shard_presence {
-                if let Some(shard_presence) = shard_presence(idx) {
-                    shard_config.presence = Some(shard_presence);
-                }
+                shard_config.presence = shard_presence(idx)
             }
 
             let (shard, stream) = Shard::new_with_config(shard_config);

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -21,7 +21,7 @@ pub struct Config {
     pub(super) identify_properties: Option<IdentifyProperties>,
     pub(super) intents: Intents,
     pub(super) large_threshold: u64,
-    pub(super) presence: Option<UpdatePresencePayload>,
+    pub(crate) presence: Option<UpdatePresencePayload>,
     pub(super) queue: Arc<dyn Queue>,
     pub(crate) shard: [u64; 2],
     pub(super) token: Box<str>,


### PR DESCRIPTION
Provides a function that takes a closure which allows setting a shard's presence based on its id.

Closes #1472.
