### PR TITLE
refactor(gateway): Move compression logic from `compression` feature to `zlib-*`

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -51,7 +51,7 @@ static_assertions = { default-features = false, version = "1" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.12" }
 
 [features]
-default = ["rustls-native-roots", "tracing", "flate2/zlib"]
+default = ["rustls-native-roots", "tracing", "zlib-stock"]
 compression = []
 native = ["native-tls", "twilight-http/native", "twilight-gateway-queue/native", "tokio-tungstenite/native-tls"]
 rustls-native-roots = ["rustls-tls", "rustls-native-certs", "twilight-http/rustls-native-roots", "twilight-gateway-queue/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -51,13 +51,13 @@ static_assertions = { default-features = false, version = "1" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.12" }
 
 [features]
-default = ["compression", "rustls-native-roots", "tracing", "flate2/zlib"]
-compression = ["flate2"]
+default = ["rustls-native-roots", "tracing", "flate2/zlib"]
+compression = []
 native = ["native-tls", "twilight-http/native", "twilight-gateway-queue/native", "tokio-tungstenite/native-tls"]
 rustls-native-roots = ["rustls-tls", "rustls-native-certs", "twilight-http/rustls-native-roots", "twilight-gateway-queue/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]
 rustls-webpki-roots = ["rustls-tls", "webpki-roots", "twilight-http/rustls-webpki-roots", "twilight-gateway-queue/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
-zlib-simd = ["compression", "flate2/zlib-ng-compat"]
+zlib-simd = ["flate2/zlib-ng-compat"]
 # if the `zlib` feature is enabled anywhere in the dependency tree it will
 # always use stock zlib instead of zlib-ng.
 # https://github.com/rust-lang/libz-sys/blob/main/README.md#zlib-ng
-zlib-stock = ["compression", "flate2/zlib"]
+zlib-stock = ["flate2/zlib"]

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -90,8 +90,8 @@ This should be preferred over `rustls-native-roots` in Docker containers based o
 
 zlib compression is enabled with one of the two `zlib` features described below.
 
-There are 2 zlib features `zlib-stock` and `zlib-simd` for the library to work
-one of them has to be enabled. If both are enabled it will use `zlib-stock`
+There are 2 zlib features `zlib-stock` and `zlib-simd`, if both are enabled it
+will use `zlib-stock`.
 
 `zlib-stock` is enabled by default.
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -88,14 +88,12 @@ This should be preferred over `rustls-native-roots` in Docker containers based o
 
 ### zlib
 
-zlib is enabled with the feature `compression` and one of the two `zlib` features
-described below. Enabling any of the two features below will also enable
-`compression`. `compression` is enabled by default.
+zlib compression is enabled with one of the two `zlib` features described below.
 
 There are 2 zlib features `zlib-stock` and `zlib-simd` for the library to work
 one of them has to be enabled. If both are enabled it will use `zlib-stock`
 
-`zlib-stock` enabled by default.
+`zlib-stock` is enabled by default.
 
 Enabling **only** `zlib-simd` will make the library use [`zlib-ng`] which is a modern
 fork of zlib that is faster and more effective, but it needs `cmake` to compile.

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -88,8 +88,8 @@
 //!
 //! zlib compression is enabled with one of the two `zlib` features described below.
 //!
-//! There are 2 zlib features `zlib-stock` and `zlib-simd` for the library to work
-//! one of them has to be enabled. If both are enabled it will use `zlib-stock`
+//! There are 2 zlib features `zlib-stock` and `zlib-simd`, if both are enabled it
+//! will use `zlib-stock`.
 //!
 //! `zlib-stock` is enabled by default.
 //!

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -86,14 +86,12 @@
 //!
 //! ### zlib
 //!
-//! zlib is enabled with the feature `compression` and one of the two `zlib` features
-//! described below. Enabling any of the two features below will also enable
-//! `compression`. `compression` is enabled by default.
+//! zlib compression is enabled with one of the two `zlib` features described below.
 //!
 //! There are 2 zlib features `zlib-stock` and `zlib-simd` for the library to work
 //! one of them has to be enabled. If both are enabled it will use `zlib-stock`
 //!
-//! `zlib-stock` enabled by default.
+//! `zlib-stock` is enabled by default.
 //!
 //! Enabling **only** `zlib-simd` will make the library use [`zlib-ng`] which is a modern
 //! fork of zlib that is faster and more effective, but it needs `cmake` to compile.

--- a/gateway/src/shard/processor/compression/mod.rs
+++ b/gateway/src/shard/processor/compression/mod.rs
@@ -6,7 +6,8 @@ use super::r#impl::ReceivingEventError;
 #[cfg(any(feature = "zlib-stock", feature = "zlib-simd"))]
 use inflater::Inflater;
 
-/// Interface for working with buffers variable on the `compression` feature flag.
+/// Interface for working with buffers variable on the `zlib-stock` and
+/// `zlib-simd` feature flags.
 #[derive(Debug)]
 pub struct Compression {
     /// Inflater for use with compression.
@@ -18,8 +19,9 @@ pub struct Compression {
 }
 
 impl Compression {
-    /// Create a new buffer, abstracting over an inflater if the `compression`
-    /// feature is enabled or a simple `Vec` if the feature is disabled.
+    /// Create a new buffer, abstracting over an inflater if `zlib-stock` or
+    /// `zlib-simd` features are enabled or a simple `Vec` if the features are
+    /// disabled.
     #[cfg_attr(
         not(any(feature = "zlib-stock", feature = "zlib-simd")),
         allow(clippy::missing_const_for_fn, unused_variables)


### PR DESCRIPTION
~~This feature was broken, hence removing it.~~ Also needed for `cargo hack --feature-powerset check` to work.

Sort of related to #1314

Removing the feature is too breaking even through it was broken since it was publicly recommended, so it's to be removed in another PR on next. This PR "disables" the feature and moves the logic into `cfg(any(feature = "zlib-stock", feature = "zlib-simd"))`, similarly to how http manages it's TLS backends