### PR TITLE
ci: check all feature combinations

### DIFF
--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -214,49 +214,19 @@ jobs:
       - name: Run doctests
         run: cargo test --doc
 
-  test-features:
-    name: Test ${{ matrix.package }} feat. ${{ matrix.features }}
-    needs: [test]
+  feature-combinations:
+    name: Feature combinations
+    needs: [MSRV]
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        package:
-          - http
-          - gateway
-          - lavalink
-        features:
-          - native
-          - rustls-native-roots
-          - simd-json
-
-        include:
-          - package: http
-            features: simd-json
-            additional: --features rustls-native-roots
-          - package: gateway
-            features: rustls-native-roots
-            additional: --features zlib-stock
-          - package: gateway
-            features: native
-            additional: --features zlib-stock
-          - package: gateway
-            features: simd-json
-            additional: --features rustls-native-roots,zlib-stock
-          - package: lavalink
-            additional: --features http-support
-
-          - package: util
-            features: full
-
-        exclude:
-          - package: lavalink
-            features: simd-json
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
+
+      - name: Install cargo-hack
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-hack
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
@@ -264,10 +234,5 @@ jobs:
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"
 
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Test ${{ matrix.package }} feat. ${{ matrix.features }}
-        working-directory: ${{ matrix.package }}
-        run: |
-          cargo nextest --config-file ${{ github.workspace }}/nextest.toml run --profile ci --no-default-features --features ${{ matrix.features }} ${{ matrix.additional }}
+      - name: Check feature combinations
+        run: cargo hack check --feature-powerset

--- a/gateway-queue/Cargo.toml
+++ b/gateway-queue/Cargo.toml
@@ -27,9 +27,9 @@ static_assertions = { default-features = false, version = "1" }
 
 [features]
 default = ["rustls-native-roots"]
-native = ["dep:twilight-http", "twilight-http?/native"]
-rustls-native-roots = ["dep:twilight-http", "twilight-http?/rustls-native-roots"]
-rustls-webpki-roots = ["dep:twilight-http", "twilight-http?/rustls-webpki-roots"]
+native = ["twilight-http/native"]
+rustls-native-roots = ["twilight-http/rustls-native-roots"]
+rustls-webpki-roots = ["twilight-http/rustls-webpki-roots"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gateway-queue/Cargo.toml
+++ b/gateway-queue/Cargo.toml
@@ -27,9 +27,9 @@ static_assertions = { default-features = false, version = "1" }
 
 [features]
 default = ["rustls-native-roots"]
-native = ["twilight-http/native"]
-rustls-native-roots = ["twilight-http/rustls-native-roots"]
-rustls-webpki-roots = ["twilight-http/rustls-webpki-roots"]
+native = ["dep:twilight-http", "twilight-http?/native"]
+rustls-native-roots = ["dep:twilight-http", "twilight-http?/rustls-native-roots"]
+rustls-webpki-roots = ["dep:twilight-http", "twilight-http?/rustls-webpki-roots"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gateway-queue/src/lib.rs
+++ b/gateway-queue/src/lib.rs
@@ -44,12 +44,24 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(unsafe_code)]
 
-#[cfg(feature = "twilight-http")]
+#[cfg(any(
+    feature = "native",
+    feature = "rustls-native-roots",
+    feature = "rustls-webpki-roots"
+))]
 mod day_limiter;
-#[cfg(feature = "twilight-http")]
+#[cfg(any(
+    feature = "native",
+    feature = "rustls-native-roots",
+    feature = "rustls-webpki-roots"
+))]
 mod large_bot_queue;
 
-#[cfg(feature = "twilight-http")]
+#[cfg(any(
+    feature = "native",
+    feature = "rustls-native-roots",
+    feature = "rustls-webpki-roots"
+))]
 pub use large_bot_queue::LargeBotQueue;
 
 use std::{

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -98,27 +98,23 @@ impl ClusterBuilder {
             feature = "rustls-webpki-roots"
         )))]
         let shard_config = self.shard.into_config();
-
         #[cfg(any(
             feature = "native",
             feature = "rustls-native-roots",
             feature = "rustls-webpki-roots"
         ))]
-        let mut shard_config = self.shard.into_config();
+        let shard_config = {
+            let mut shard_config = self.shard.into_config();
 
-        #[cfg(any(
-            feature = "native",
-            feature = "rustls-native-roots",
-            feature = "rustls-webpki-roots"
-        ))]
-        {
             let tls = TlsContainer::new().map_err(|err| ClusterStartError {
                 kind: ClusterStartErrorType::Tls,
                 source: Some(Box::new(err)),
             })?;
 
             shard_config.tls = Some(tls);
-        }
+
+            shard_config
+        };
 
         let config = Config {
             queue: self.queue,

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -92,6 +92,18 @@ impl ClusterBuilder {
             }
         }
 
+        #[cfg(not(any(
+            feature = "native",
+            feature = "rustls-native-roots",
+            feature = "rustls-webpki-roots"
+        )))]
+        let shard_config = self.shard.into_config();
+
+        #[cfg(any(
+            feature = "native",
+            feature = "rustls-native-roots",
+            feature = "rustls-webpki-roots"
+        ))]
         let mut shard_config = self.shard.into_config();
 
         #[cfg(any(


### PR DESCRIPTION
Instead of testing some packages' feature combinations, check them all with `cargo hack check --feature-powerset`. Tests aren't feature dependent so running `cargo check` is good enough and also faster.

depends on ~~#1483~~, ~~#1482~~, ~~#1392~~