### PR TITLE
refactor(cache/in-memory!): cached voice state

### DIFF
--- a/cache/in-memory/src/iter.rs
+++ b/cache/in-memory/src/iter.rs
@@ -13,7 +13,10 @@
 //! dereferences to the value.
 
 use crate::{
-    model::{CachedEmoji, CachedGuild, CachedMember, CachedMessage, CachedPresence, CachedSticker},
+    model::{
+        CachedEmoji, CachedGuild, CachedMember, CachedMessage, CachedPresence, CachedSticker,
+        CachedVoiceState,
+    },
     GuildResource, InMemoryCache,
 };
 use dashmap::{
@@ -32,7 +35,6 @@ use twilight_model::{
         Id,
     },
     user::User,
-    voice::VoiceState,
 };
 
 /// Reference to a resource value being iterated over in the cache.
@@ -220,7 +222,9 @@ impl<'a> InMemoryCacheIter<'a> {
     }
 
     /// Create an iterator over the voice states in the cache.
-    pub fn voice_states(&self) -> ResourceIter<'a, (Id<GuildMarker>, Id<UserMarker>), VoiceState> {
+    pub fn voice_states(
+        &self,
+    ) -> ResourceIter<'a, (Id<GuildMarker>, Id<UserMarker>), CachedVoiceState> {
         ResourceIter::new(self.0.voice_states.iter())
     }
 }

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -121,7 +121,6 @@ use twilight_model::{
         Id,
     },
     user::{CurrentUser, User},
-    voice::VoiceState,
 };
 
 /// Resource associated with a guild.
@@ -283,7 +282,7 @@ pub struct InMemoryCache {
     /// Mapping of guilds and users currently connected to its voice channels.
     voice_state_guilds: DashMap<Id<GuildMarker>, HashSet<Id<UserMarker>>>,
     /// Mapping of guild ID and user ID pairs to their voice states.
-    voice_states: DashMap<(Id<GuildMarker>, Id<UserMarker>), VoiceState>,
+    voice_states: DashMap<(Id<GuildMarker>, Id<UserMarker>), CachedVoiceState>,
 }
 
 /// Implemented methods and types for the cache.
@@ -773,7 +772,7 @@ impl InMemoryCache {
         &self,
         user_id: Id<UserMarker>,
         guild_id: Id<GuildMarker>,
-    ) -> Option<Reference<'_, (Id<GuildMarker>, Id<UserMarker>), VoiceState>> {
+    ) -> Option<Reference<'_, (Id<GuildMarker>, Id<UserMarker>), CachedVoiceState>> {
         self.voice_states
             .get(&(guild_id, user_id))
             .map(Reference::new)
@@ -901,11 +900,11 @@ pub struct VoiceChannelStates<'a> {
     index: usize,
     #[allow(clippy::type_complexity)]
     user_ids: Ref<'a, Id<ChannelMarker>, HashSet<(Id<GuildMarker>, Id<UserMarker>)>>,
-    voice_states: &'a DashMap<(Id<GuildMarker>, Id<UserMarker>), VoiceState>,
+    voice_states: &'a DashMap<(Id<GuildMarker>, Id<UserMarker>), CachedVoiceState>,
 }
 
 impl<'a> Iterator for VoiceChannelStates<'a> {
-    type Item = Reference<'a, (Id<GuildMarker>, Id<UserMarker>), VoiceState>;
+    type Item = Reference<'a, (Id<GuildMarker>, Id<UserMarker>), CachedVoiceState>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some((guild_id, user_id)) = self.user_ids.iter().nth(self.index) {

--- a/cache/in-memory/src/model/voice_state.rs
+++ b/cache/in-memory/src/model/voice_state.rs
@@ -82,6 +82,41 @@ impl CachedVoiceState {
     }
 }
 
+impl From<VoiceState> for CachedVoiceState {
+    fn from(voice_state: VoiceState) -> Self {
+        let VoiceState {
+            channel_id,
+            deaf,
+            guild_id,
+            member: _,
+            mute,
+            self_deaf,
+            self_mute,
+            self_stream,
+            self_video: _,
+            session_id,
+            suppress,
+            token,
+            user_id,
+            request_to_speak_timestamp: _,
+        } = voice_state;
+
+        Self {
+            channel_id,
+            deaf,
+            guild_id,
+            mute,
+            self_deaf,
+            self_mute,
+            self_stream,
+            session_id,
+            suppress,
+            token,
+            user_id,
+        }
+    }
+}
+
 impl PartialEq<VoiceState> for CachedVoiceState {
     fn eq(&self, other: &VoiceState) -> bool {
         self.channel_id == other.channel_id
@@ -95,5 +130,56 @@ impl PartialEq<VoiceState> for CachedVoiceState {
             && self.suppress == other.suppress
             && self.token == other.token
             && self.user_id == other.user_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CachedVoiceState;
+    use twilight_model::{id::Id, voice::VoiceState};
+
+    fn voice_state() -> VoiceState {
+        VoiceState {
+            channel_id: Some(Id::new(1)),
+            deaf: false,
+            guild_id: Some(Id::new(2)),
+            member: None,
+            mute: true,
+            self_deaf: false,
+            self_mute: true,
+            self_stream: false,
+            self_video: true,
+            session_id: "ba8bd70ac7239ffc710e2fc8db52f240".to_owned(),
+            suppress: false,
+            token: None,
+            user_id: Id::new(3),
+            request_to_speak_timestamp: None,
+        }
+    }
+
+    #[test]
+    fn test_eq() {
+        let voice_state = voice_state();
+        let cached = CachedVoiceState::from(voice_state.clone());
+
+        assert_eq!(cached, voice_state);
+    }
+
+    #[test]
+    fn test_getters() {
+        let voice_state = voice_state();
+        let cached = CachedVoiceState::from(voice_state.clone());
+
+        assert_eq!(cached.channel_id(), voice_state.channel_id);
+        assert_eq!(cached.deaf(), voice_state.deaf);
+        assert_eq!(cached.guild_id(), voice_state.guild_id);
+        assert_eq!(cached.mute(), voice_state.mute);
+        assert_eq!(cached.self_deaf(), voice_state.self_deaf);
+        assert_eq!(cached.self_mute(), voice_state.self_mute);
+        assert_eq!(cached.self_stream(), voice_state.self_stream);
+        assert_eq!(cached.session_id(), voice_state.session_id);
+        assert_eq!(cached.suppress(), voice_state.suppress);
+        assert_eq!(cached.token(), voice_state.token.as_deref());
+        assert_eq!(cached.user_id(), voice_state.user_id);
     }
 }


### PR DESCRIPTION
We have a type, `model::CachedVoiceState`, that is a slimmed down version of a voice state. However, we don't actually use this type anywhere -- instead we cache `twilight_model` voice states. This is an error from back when the cache was made. This makes the cache use the cached voice state type.