### PR TITLE
feat(cache/in-memory): new voice state fields

### DIFF
--- a/cache/in-memory/src/model/voice_state.rs
+++ b/cache/in-memory/src/model/voice_state.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 use twilight_model::{
+    datetime::Timestamp,
     id::{
         marker::{ChannelMarker, GuildMarker, UserMarker},
         Id,
@@ -16,9 +17,11 @@ pub struct CachedVoiceState {
     deaf: bool,
     guild_id: Option<Id<GuildMarker>>,
     mute: bool,
+    request_to_speak_timestamp: Option<Timestamp>,
     self_deaf: bool,
     self_mute: bool,
     self_stream: bool,
+    self_video: bool,
     session_id: String,
     suppress: bool,
     token: Option<String>,
@@ -46,6 +49,11 @@ impl CachedVoiceState {
         self.mute
     }
 
+    /// Timestamp of when the user requested to speak.
+    pub const fn request_to_speak_timestamp(&self) -> Option<Timestamp> {
+        self.request_to_speak_timestamp
+    }
+
     /// Whether the user has deafened themself.
     pub const fn self_deaf(&self) -> bool {
         self.self_deaf
@@ -59,6 +67,11 @@ impl CachedVoiceState {
     /// Whether the user is streaming via "Go Live".
     pub const fn self_stream(&self) -> bool {
         self.self_stream
+    }
+
+    /// Whether the user's camera is enabled.
+    pub const fn self_video(&self) -> bool {
+        self.self_video
     }
 
     /// Session ID.
@@ -93,12 +106,12 @@ impl From<VoiceState> for CachedVoiceState {
             self_deaf,
             self_mute,
             self_stream,
-            self_video: _,
+            self_video,
             session_id,
             suppress,
             token,
             user_id,
-            request_to_speak_timestamp: _,
+            request_to_speak_timestamp,
         } = voice_state;
 
         Self {
@@ -106,9 +119,11 @@ impl From<VoiceState> for CachedVoiceState {
             deaf,
             guild_id,
             mute,
+            request_to_speak_timestamp,
             self_deaf,
             self_mute,
             self_stream,
+            self_video,
             session_id,
             suppress,
             token,
@@ -123,9 +138,11 @@ impl PartialEq<VoiceState> for CachedVoiceState {
             && self.deaf == other.deaf
             && self.guild_id == other.guild_id
             && self.mute == other.mute
+            && self.request_to_speak_timestamp == other.request_to_speak_timestamp
             && self.self_deaf == other.self_deaf
             && self.self_mute == other.self_mute
             && self.self_stream == other.self_stream
+            && self.self_video == other.self_video
             && self.session_id == other.session_id
             && self.suppress == other.suppress
             && self.token == other.token
@@ -174,9 +191,14 @@ mod tests {
         assert_eq!(cached.deaf(), voice_state.deaf);
         assert_eq!(cached.guild_id(), voice_state.guild_id);
         assert_eq!(cached.mute(), voice_state.mute);
+        assert_eq!(
+            cached.request_to_speak_timestamp(),
+            voice_state.request_to_speak_timestamp
+        );
         assert_eq!(cached.self_deaf(), voice_state.self_deaf);
         assert_eq!(cached.self_mute(), voice_state.self_mute);
         assert_eq!(cached.self_stream(), voice_state.self_stream);
+        assert_eq!(cached.self_video(), voice_state.self_video);
         assert_eq!(cached.session_id(), voice_state.session_id);
         assert_eq!(cached.suppress(), voice_state.suppress);
         assert_eq!(cached.token(), voice_state.token.as_deref());


### PR DESCRIPTION
Add new fields to the cached voice state type that have since been added to the `twilight_model` variant. These fields are `self_video` and `request_to_speak_timestamp`. Getters have been added for these fields.