### PR TITLE
Allow retrieving the `NonZeroU64` from `Id<T>`

### DIFF
--- a/model/src/id/mod.rs
+++ b/model/src/id/mod.rs
@@ -168,6 +168,24 @@ impl<T> Id<T> {
         self.value.get()
     }
 
+    /// Return the inner value directly as a [`NonZeroU64`].
+    ///
+    /// # Examples
+    ///
+    /// Crate an ID with a value and then confirmt its inner value:
+    ///
+    /// ```
+    /// use std::num::NonZeroU64;
+    /// use twilight_model::id::{marker::ChannelMarker, Id};
+    ///
+    /// let channel_id = Id::<ChannelMarker>::new(7);
+    ///
+    /// assert_eq!(NonZeroU64::new(7).unwrap(), channel_id.get_nonzero());
+    /// ```
+    pub const fn get_nonzero(self) -> NonZeroU64 {
+        self.value
+    }
+
     /// Cast an ID from one type to another.
     ///
     /// # Examples
@@ -278,6 +296,18 @@ impl<T> FromStr for Id<T> {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         NonZeroU64::from_str(s).map(Self::from_nonzero)
+    }
+}
+
+impl<T> From<Id<T>> for u64 {
+    fn from(id: Id<T>) -> Self {
+        id.get()
+    }
+}
+
+impl<T> From<Id<T>> for NonZeroU64 {
+    fn from(id: Id<T>) -> Self {
+        id.get_nonzero()
     }
 }
 

--- a/model/src/id/mod.rs
+++ b/model/src/id/mod.rs
@@ -291,15 +291,15 @@ impl<T> From<Id<T>> for u64 {
     }
 }
 
-impl<T> From<Id<T>> for NonZeroU64 {
-    fn from(id: Id<T>) -> Self {
-        id.inner()
-    }
-}
-
 impl<T> From<NonZeroU64> for Id<T> {
     fn from(id: NonZeroU64) -> Self {
         Self::from_nonzero(id)
+    }
+}
+
+impl<T> From<Id<T>> for NonZeroU64 {
+    fn from(id: Id<T>) -> Self {
+        id.inner()
     }
 }
 
@@ -461,8 +461,8 @@ mod tests {
     assert_impl_all!(WebhookMarker: Clone, Copy, Debug, Send, Sync);
     assert_impl_all!(Id<GenericMarker>:
         Clone, Copy, Debug, Deserialize<'static>, Display, Eq, From<NonZeroU64>,
-        FromStr, Hash, Ord, PartialEq, PartialEq<i64>, PartialEq<u64>, PartialOrd, Send, Serialize, Sync,
-        TryFrom<i64>, TryFrom<u64>, Into<u64>, Into<NonZeroU64>
+        FromStr, Hash, Into<NonZeroU64>, Into<u64>, Ord, PartialEq, PartialEq<i64>, PartialEq<u64>, PartialOrd, Send, Serialize, Sync,
+        TryFrom<i64>, TryFrom<u64>
     );
     assert_impl_all!(IdStringDisplay<GenericMarker>: Debug, Display, Send, Serialize, Sync);
 

--- a/model/src/id/mod.rs
+++ b/model/src/id/mod.rs
@@ -172,7 +172,7 @@ impl<T> Id<T> {
     ///
     /// # Examples
     ///
-    /// Crate an ID with a value and then confirmt its inner value:
+    /// Crate an ID with a value and then confirm its inner value:
     ///
     /// ```
     /// use std::num::NonZeroU64;
@@ -180,9 +180,9 @@ impl<T> Id<T> {
     ///
     /// let channel_id = Id::<ChannelMarker>::new(7);
     ///
-    /// assert_eq!(NonZeroU64::new(7).unwrap(), channel_id.get_nonzero());
+    /// assert_eq!(NonZeroU64::new(7).unwrap(), channel_id.inner());
     /// ```
-    pub const fn get_nonzero(self) -> NonZeroU64 {
+    pub const fn inner(self) -> NonZeroU64 {
         self.value
     }
 
@@ -307,7 +307,7 @@ impl<T> From<Id<T>> for u64 {
 
 impl<T> From<Id<T>> for NonZeroU64 {
     fn from(id: Id<T>) -> Self {
-        id.get_nonzero()
+        id.inner()
     }
 }
 

--- a/model/src/id/mod.rs
+++ b/model/src/id/mod.rs
@@ -285,6 +285,18 @@ impl<T> Display for Id<T> {
     }
 }
 
+impl<T> From<Id<T>> for u64 {
+    fn from(id: Id<T>) -> Self {
+        id.get()
+    }
+}
+
+impl<T> From<Id<T>> for NonZeroU64 {
+    fn from(id: Id<T>) -> Self {
+        id.inner()
+    }
+}
+
 impl<T> From<NonZeroU64> for Id<T> {
     fn from(id: NonZeroU64) -> Self {
         Self::from_nonzero(id)
@@ -296,18 +308,6 @@ impl<T> FromStr for Id<T> {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         NonZeroU64::from_str(s).map(Self::from_nonzero)
-    }
-}
-
-impl<T> From<Id<T>> for u64 {
-    fn from(id: Id<T>) -> Self {
-        id.get()
-    }
-}
-
-impl<T> From<Id<T>> for NonZeroU64 {
-    fn from(id: Id<T>) -> Self {
-        id.inner()
     }
 }
 

--- a/model/src/id/mod.rs
+++ b/model/src/id/mod.rs
@@ -498,6 +498,17 @@ mod tests {
         Ok(())
     }
 
+    /// Test that conversion methods are correct.
+    #[test]
+    fn test_conversions() {
+        // `Into`
+        assert_eq!(1, u64::from(Id::<GenericMarker>::new(1)));
+        assert_eq!(
+            NonZeroU64::new(1).expect("non zero"),
+            NonZeroU64::from(Id::<GenericMarker>::new(1))
+        );
+    }
+
     /// Test that creating an ID via [`Id::new`] with a value of zero panics.
     #[should_panic]
     #[test]

--- a/model/src/id/mod.rs
+++ b/model/src/id/mod.rs
@@ -168,11 +168,11 @@ impl<T> Id<T> {
         self.value.get()
     }
 
-    /// Return the inner value directly as a [`NonZeroU64`].
+    /// Return the [`NonZeroU64`] representation of the ID.
     ///
     /// # Examples
     ///
-    /// Crate an ID with a value and then confirm its inner value:
+    /// Create an ID with a value and then confirm its nonzero value:
     ///
     /// ```
     /// use std::num::NonZeroU64;
@@ -180,9 +180,9 @@ impl<T> Id<T> {
     ///
     /// let channel_id = Id::<ChannelMarker>::new(7);
     ///
-    /// assert_eq!(NonZeroU64::new(7).unwrap(), channel_id.inner());
+    /// assert_eq!(NonZeroU64::new(7).unwrap(), channel_id.into_nonzero());
     /// ```
-    pub const fn inner(self) -> NonZeroU64 {
+    pub const fn into_nonzero(self) -> NonZeroU64 {
         self.value
     }
 
@@ -299,7 +299,7 @@ impl<T> From<NonZeroU64> for Id<T> {
 
 impl<T> From<Id<T>> for NonZeroU64 {
     fn from(id: Id<T>) -> Self {
-        id.inner()
+        id.into_nonzero()
     }
 }
 

--- a/model/src/id/mod.rs
+++ b/model/src/id/mod.rs
@@ -462,7 +462,7 @@ mod tests {
     assert_impl_all!(Id<GenericMarker>:
         Clone, Copy, Debug, Deserialize<'static>, Display, Eq, From<NonZeroU64>,
         FromStr, Hash, Ord, PartialEq, PartialEq<i64>, PartialEq<u64>, PartialOrd, Send, Serialize, Sync,
-        TryFrom<i64>, TryFrom<u64>
+        TryFrom<i64>, TryFrom<u64>, Into<u64>, Into<NonZeroU64>
     );
     assert_impl_all!(IdStringDisplay<GenericMarker>: Debug, Display, Send, Serialize, Sync);
 


### PR DESCRIPTION
Just wanted to update to the latest `0.9.0` release and noticed that you can get the `Id<T>` as a `u64` but not the real inner value `NonZeroU64`.

This is especially helpful if you already used the inner `NonZeroU64` from the old ID types (as in my case). Currently the only way to get the value as that type is to do `NonZeroU64::new(id.get()).unwrap()` and I would like to avoid the `unwrap` (even though it can't fail).


This PR adds convenient `From` conversions for `u64` and `NonZeroU64` as well, so you can call `into()` in many cases.
﻿