### PR TITLE
ci: restrict push runs to `main` and `next`

### DIFF
--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -1,7 +1,12 @@
 # Checks performed on our common library crates.
 name: Library
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - next
+  pull_request:
 
 env:
   # Use `haswell` instead of `native` due to some GitHub Actions runners not


### PR DESCRIPTION
This will still run CI on all pull requests, however for more complicated PRs that require authors creating their own branches on the main repository, this prevents CI from running twice, saving resources.
