### PR TITLE
Validate length of every passed embed combined

### DIFF
--- a/validate/src/embed.rs
+++ b/validate/src/embed.rs
@@ -13,7 +13,7 @@ pub const AUTHOR_NAME_LENGTH: usize = 256;
 pub const DESCRIPTION_LENGTH: usize = 4096;
 
 /// The maximum combined embed length in codepoints.
-pub const EMBED_TOTAL_LENGTH: usize = 6000;
+pub const EMBEDS_TOTAL_LENGTH: usize = 6000;
 
 /// The maximum number of fields in an embed.
 pub const FIELD_COUNT: usize = 25;
@@ -84,12 +84,12 @@ impl Display for EmbedValidationError {
 
                 Display::fmt(&DESCRIPTION_LENGTH, f)
             }
-            EmbedValidationErrorType::EmbedTooLarge { chars } => {
-                f.write_str("the combined total length of the embed is ")?;
+            EmbedValidationErrorType::EmbedsTooLarge { chars } => {
+                f.write_str("the combined total length of the embeds is ")?;
                 Display::fmt(chars, f)?;
-                f.write_str(" characters long, but the max is ")?;
+                f.write_str(" characters, but the max is ")?;
 
-                Display::fmt(&EMBED_TOTAL_LENGTH, f)
+                Display::fmt(&EMBEDS_TOTAL_LENGTH, f)
             }
             EmbedValidationErrorType::FieldNameTooLarge { chars } => {
                 f.write_str("a field name is ")?;
@@ -151,7 +151,7 @@ pub enum EmbedValidationErrorType {
     /// The combined content of all embed fields - author name, description,
     /// footer, field names and values, and title - is larger than
     /// [the maximum][`EMBED_TOTAL_LENGTH`].
-    EmbedTooLarge {
+    EmbedsTooLarge {
         /// The number of codepoints that were provided.
         chars: usize,
     },
@@ -214,9 +214,7 @@ pub enum EmbedValidationErrorType {
 /// [`FooterTextTooLarge`]: EmbedValidationErrorType::FooterTextTooLarge
 /// [`TitleTooLarge`]: EmbedValidationErrorType::TitleTooLarge
 /// [`TooManyFields`]: EmbedValidationErrorType::TooManyFields
-pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
-    let mut total = 0;
-
+pub fn embed(total_chars: &mut usize, embed: &Embed) -> Result<(), EmbedValidationError> {
     if embed.fields.len() > FIELD_COUNT {
         return Err(EmbedValidationError {
             kind: EmbedValidationErrorType::TooManyFields {
@@ -234,7 +232,7 @@ pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
             });
         }
 
-        total += chars;
+        *total_chars += chars;
     }
 
     if let Some(description) = embed.description.as_ref() {
@@ -246,7 +244,7 @@ pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
             });
         }
 
-        total += chars;
+        *total_chars += chars;
     }
 
     if let Some(footer) = embed.footer.as_ref() {
@@ -258,7 +256,7 @@ pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
             });
         }
 
-        total += chars;
+        *total_chars += chars;
     }
 
     for field in &embed.fields {
@@ -278,7 +276,7 @@ pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
             });
         }
 
-        total += name_chars + value_chars;
+        *total_chars += name_chars + value_chars;
     }
 
     if let Some(title) = embed.title.as_ref() {
@@ -290,12 +288,14 @@ pub fn embed(embed: &Embed) -> Result<(), EmbedValidationError> {
             });
         }
 
-        total += chars;
+        *total_chars += chars;
     }
 
-    if total > EMBED_TOTAL_LENGTH {
+    if *total_chars > EMBEDS_TOTAL_LENGTH {
         return Err(EmbedValidationError {
-            kind: EmbedValidationErrorType::EmbedTooLarge { chars: total },
+            kind: EmbedValidationErrorType::EmbedsTooLarge {
+                chars: *total_chars,
+            },
         });
     }
 
@@ -334,7 +334,7 @@ mod tests {
     fn test_embed_base() {
         let embed = base_embed();
 
-        assert!(super::embed(&embed).is_ok());
+        assert!(super::embed(&mut 0, &embed).is_ok());
     }
 
     #[test]
@@ -355,7 +355,7 @@ mod tests {
         });
         embed.title.replace("this is a normal title".to_owned());
 
-        assert!(super::embed(&embed).is_ok());
+        assert!(super::embed(&mut 0, &embed).is_ok());
     }
 
     #[test]
@@ -367,7 +367,7 @@ mod tests {
             proxy_icon_url: None,
             url: None,
         });
-        assert!(super::embed(&embed).is_ok());
+        assert!(super::embed(&mut 0, &embed).is_ok());
 
         embed.author.replace(EmbedAuthor {
             icon_url: None,
@@ -376,7 +376,7 @@ mod tests {
             url: None,
         });
         assert!(matches!(
-            super::embed(&embed).unwrap_err().kind(),
+            super::embed(&mut 0, &embed).unwrap_err().kind(),
             EmbedValidationErrorType::AuthorNameTooLarge { chars: 257 }
         ));
     }
@@ -385,14 +385,14 @@ mod tests {
     fn test_embed_description_limit() {
         let mut embed = base_embed();
         embed.description.replace(str::repeat("a", 2048));
-        assert!(super::embed(&embed).is_ok());
+        assert!(super::embed(&mut 0, &embed).is_ok());
 
         embed.description.replace(str::repeat("a", 4096));
-        assert!(super::embed(&embed).is_ok());
+        assert!(super::embed(&mut 0, &embed).is_ok());
 
         embed.description.replace(str::repeat("a", 4097));
         assert!(matches!(
-            super::embed(&embed).unwrap_err().kind(),
+            super::embed(&mut 0, &embed).unwrap_err().kind(),
             EmbedValidationErrorType::DescriptionTooLarge { chars: 4097 }
         ));
     }
@@ -410,7 +410,7 @@ mod tests {
         }
 
         assert!(matches!(
-            super::embed(&embed).unwrap_err().kind(),
+            super::embed(&mut 0, &embed).unwrap_err().kind(),
             EmbedValidationErrorType::TooManyFields { amount: 26 }
         ));
     }
@@ -423,7 +423,7 @@ mod tests {
             name: str::repeat("a", 256),
             value: "a".to_owned(),
         });
-        assert!(super::embed(&embed).is_ok());
+        assert!(super::embed(&mut 0, &embed).is_ok());
 
         embed.fields.push(EmbedField {
             inline: true,
@@ -431,7 +431,7 @@ mod tests {
             value: "a".to_owned(),
         });
         assert!(matches!(
-            super::embed(&embed).unwrap_err().kind(),
+            super::embed(&mut 0, &embed).unwrap_err().kind(),
             EmbedValidationErrorType::FieldNameTooLarge { chars: 257 }
         ));
     }
@@ -444,7 +444,7 @@ mod tests {
             name: "a".to_owned(),
             value: str::repeat("a", 1024),
         });
-        assert!(super::embed(&embed).is_ok());
+        assert!(super::embed(&mut 0, &embed).is_ok());
 
         embed.fields.push(EmbedField {
             inline: true,
@@ -452,7 +452,7 @@ mod tests {
             value: str::repeat("a", 1025),
         });
         assert!(matches!(
-            super::embed(&embed).unwrap_err().kind(),
+            super::embed(&mut 0, &embed).unwrap_err().kind(),
             EmbedValidationErrorType::FieldValueTooLarge { chars: 1025 }
         ));
     }
@@ -465,7 +465,7 @@ mod tests {
             proxy_icon_url: None,
             text: str::repeat("a", 2048),
         });
-        assert!(super::embed(&embed).is_ok());
+        assert!(super::embed(&mut 0, &embed).is_ok());
 
         embed.footer.replace(EmbedFooter {
             icon_url: None,
@@ -473,7 +473,7 @@ mod tests {
             text: str::repeat("a", 2049),
         });
         assert!(matches!(
-            super::embed(&embed).unwrap_err().kind(),
+            super::embed(&mut 0, &embed).unwrap_err().kind(),
             EmbedValidationErrorType::FooterTextTooLarge { chars: 2049 }
         ));
     }
@@ -482,11 +482,11 @@ mod tests {
     fn test_embed_title_limit() {
         let mut embed = base_embed();
         embed.title.replace(str::repeat("a", 256));
-        assert!(super::embed(&embed).is_ok());
+        assert!(super::embed(&mut 0, &embed).is_ok());
 
         embed.title.replace(str::repeat("a", 257));
         assert!(matches!(
-            super::embed(&embed).unwrap_err().kind(),
+            super::embed(&mut 0, &embed).unwrap_err().kind(),
             EmbedValidationErrorType::TitleTooLarge { chars: 257 }
         ));
     }
@@ -506,7 +506,7 @@ mod tests {
         }
 
         // we're at 5304 characters now
-        assert!(super::embed(&embed).is_ok());
+        assert!(super::embed(&mut 0, &embed).is_ok());
 
         embed.footer.replace(EmbedFooter {
             icon_url: None,
@@ -515,8 +515,8 @@ mod tests {
         });
 
         assert!(matches!(
-            super::embed(&embed).unwrap_err().kind(),
-            EmbedValidationErrorType::EmbedTooLarge { chars: 6304 }
+            super::embed(&mut 0, &embed).unwrap_err().kind(),
+            EmbedValidationErrorType::EmbedsTooLarge { chars: 6304 }
         ));
     }
 }

--- a/validate/src/message.rs
+++ b/validate/src/message.rs
@@ -203,8 +203,9 @@ pub fn embeds(embeds: &[Embed]) -> Result<(), MessageValidationError> {
             source: None,
         })
     } else {
+        let mut total = 0;
         for (idx, embed) in embeds.iter().enumerate() {
-            crate::embed::embed(embed).map_err(|source| {
+            crate::embed::embed(&mut total, embed).map_err(|source| {
                 let (kind, source) = source.into_parts();
 
                 MessageValidationError {
@@ -245,6 +246,8 @@ pub fn stickers(stickers: &[Id<StickerMarker>]) -> Result<(), MessageValidationE
 #[cfg(test)]
 mod tests {
     use super::content;
+    use super::embeds;
+    use twilight_model::channel::embed::Embed;
 
     #[test]
     fn test_content() {
@@ -252,5 +255,27 @@ mod tests {
         assert!(content("a".repeat(2000)).is_ok());
 
         assert!(content("a".repeat(2001)).is_err());
+    }
+
+    #[test]
+    fn test_embeds() {
+        let embed = Embed {
+            author: None,
+            color: None,
+            description: Some("a".repeat(3001)),
+            fields: Vec::new(),
+            footer: None,
+            image: None,
+            kind: "rich".to_owned(),
+            provider: None,
+            thumbnail: None,
+            timestamp: None,
+            title: None,
+            url: None,
+            video: None,
+        };
+
+        assert!(embeds(&[embed.clone()]).is_ok());
+        assert!(embeds(&[embed.clone(), embed.clone()]).is_err());
     }
 }


### PR DESCRIPTION
Currently embeds are validated individually, so if none of them have a character length over 6000, it will pass, whereas Discord requires the total character length of every embed in the message combined to not be above 6000. This PR addresses that by taking a mutable reference to the current total length and adding over that length.