### PR TITLE
feat(gateway)!: Allow disabling payload ratelimiting

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -185,6 +185,17 @@ impl ClusterBuilder {
         self
     }
 
+    /// Set whether or not outgoing payloads will be ratelimited.
+    ///
+    /// Useful when running behind a proxy gateway. Running without a
+    /// functional ratelimiter **will** get you ratelimited.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn ratelimit_payloads(mut self, ratelimit_payloads: bool) -> Self {
+        self.1 = self.1.ratelimit_payloads(ratelimit_payloads);
+
+        self
+    }
+
     /// Set specific shard presences to use when identifying with the gateway.
     ///
     /// Accepts a closure. The closure accepts a [`u64`] and returns an

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -189,6 +189,8 @@ impl ClusterBuilder {
     ///
     /// Useful when running behind a proxy gateway. Running without a
     /// functional ratelimiter **will** get you ratelimited.
+    ///
+    /// Defaults to being enabled.
     #[allow(clippy::missing_const_for_fn)]
     pub fn ratelimit_payloads(mut self, ratelimit_payloads: bool) -> Self {
         self.1 = self.1.ratelimit_payloads(ratelimit_payloads);

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -366,6 +366,8 @@ impl ShardBuilder {
     ///
     /// Useful when running behind a proxy gateway. Running without a
     /// functional ratelimiter **will** get you ratelimited.
+    ///
+    /// Defaults to being enabled.
     #[allow(clippy::missing_const_for_fn)]
     pub fn ratelimit_payloads(mut self, ratelimit_payloads: bool) -> Self {
         self.0.ratelimit_payloads = ratelimit_payloads;

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -186,6 +186,7 @@ impl ShardBuilder {
             session_id: None,
             sequence: None,
             tls: None,
+            ratelimit_payloads: true,
         })
     }
 
@@ -357,6 +358,17 @@ impl ShardBuilder {
     /// [`queue`]: crate::queue
     pub fn queue(mut self, queue: Arc<dyn Queue>) -> Self {
         self.0.queue = queue;
+
+        self
+    }
+
+    /// Set whether or not outgoing payloads will be ratelimited.
+    ///
+    /// Useful when running behind a proxy gateway. Running without a
+    /// functional ratelimiter **will** get you ratelimited.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn ratelimit_payloads(mut self, ratelimit_payloads: bool) -> Self {
+        self.0.ratelimit_payloads = ratelimit_payloads;
 
         self
     }

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -28,6 +28,7 @@ pub struct Config {
     pub(crate) session_id: Option<Box<str>>,
     pub(crate) sequence: Option<u64>,
     pub(crate) tls: Option<TlsContainer>,
+    pub(crate) ratelimit_payloads: bool,
 }
 
 impl Config {
@@ -71,6 +72,11 @@ impl Config {
     /// to Do Not Disturb will show the status in the bot's presence.
     pub const fn presence(&self) -> Option<&UpdatePresencePayload> {
         self.presence.as_ref()
+    }
+
+    /// Whether or not payload ratelimiting is enabled.
+    pub const fn ratelimit_payloads(&self) -> bool {
+        self.ratelimit_payloads
     }
 
     /// The shard's ID and the total number of shards used by the bot.

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -290,6 +290,7 @@ impl Information {
     }
 
     /// When the ratelimiter will next refill the [`ratelimit_requests`].
+    ///
     /// This will be `None` if payload ratelimiting has been disabled.
     ///
     /// [`ratelimit_requests`]: Self::ratelimit_requests
@@ -703,7 +704,12 @@ impl Shard {
             kind: SendErrorType::SessionInactive,
         })?;
 
+        // Getting the value of the OnceCell will only return None if it has not been
+        // initialized yet, i.e. ratelimiting is enabled and HELLO has not been
+        // received yet.
         if let Some(maybe_ratelimiter) = session.ratelimit.get() {
+            // The value of the cell has been set, it will be Some if ratelimiting
+            // is enabled, else None. We can ignore the second case.
             if let Some(ratelimiter) = maybe_ratelimiter {
                 ratelimiter.acquire_one().await;
             }

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -10,6 +10,7 @@ use super::{
     stage::Stage,
 };
 use crate::Intents;
+use leaky_bucket_lite::LeakyBucket;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -267,8 +268,8 @@ pub enum ShardStartErrorType {
 pub struct Information {
     id: u64,
     latency: Latency,
-    ratelimit_refill: Instant,
-    ratelimit_requests: u32,
+    ratelimit_refill: Option<Instant>,
+    ratelimit_requests: Option<u32>,
     session_id: Option<Box<str>>,
     seq: u64,
     stage: Stage,
@@ -289,16 +290,18 @@ impl Information {
     }
 
     /// When the ratelimiter will next refill the [`ratelimit_requests`].
+    /// This will be `None` if payload ratelimiting has been disabled.
     ///
     /// [`ratelimit_requests`]: Self::ratelimit_requests
-    pub const fn ratelimit_refill(&self) -> Instant {
+    pub const fn ratelimit_refill(&self) -> Option<Instant> {
         self.ratelimit_refill
     }
 
     /// Number of requests remaining until the next [`ratelimit_refill`].
+    /// This will be `None` if payload ratelimiting has been disabled.
     ///
     /// [`ratelimit_refill`]: Self::ratelimit_refill
-    pub const fn ratelimit_requests(&self) -> u32 {
+    pub const fn ratelimit_requests(&self) -> Option<u32> {
         self.ratelimit_requests
     }
 
@@ -566,7 +569,10 @@ impl Shard {
         let session = self.session()?;
 
         let (ratelimit_requests, ratelimit_refill) = match session.ratelimit.get() {
-            Some(limiter) => (limiter.tokens(), limiter.next_refill()),
+            Some(limiter) => (
+                limiter.as_ref().map(LeakyBucket::tokens),
+                limiter.as_ref().map(LeakyBucket::next_refill),
+            ),
             None => return Err(SessionInactiveError),
         };
 
@@ -697,8 +703,10 @@ impl Shard {
             kind: SendErrorType::SessionInactive,
         })?;
 
-        if let Some(ratelimiter) = session.ratelimit.get() {
-            ratelimiter.acquire_one().await;
+        if let Some(maybe_ratelimiter) = session.ratelimit.get() {
+            if let Some(ratelimiter) = maybe_ratelimiter {
+                ratelimiter.acquire_one().await;
+            }
         } else {
             return Err(SendError {
                 kind: SendErrorType::HeartbeaterNotStarted,

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -299,6 +299,7 @@ impl Information {
     }
 
     /// Number of requests remaining until the next [`ratelimit_refill`].
+    ///
     /// This will be `None` if payload ratelimiting has been disabled.
     ///
     /// [`ratelimit_refill`]: Self::ratelimit_refill

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -350,11 +350,16 @@ impl ShardProcessor {
         tokio::spawn(forwarder.run());
 
         let session = Arc::new(Session::new(tx));
+
         if resumable {
             session.set_id(config.session_id.clone().unwrap());
             session
                 .seq
                 .store(config.sequence.unwrap(), Ordering::Relaxed)
+        }
+
+        if !config.ratelimit_payloads {
+            session.disable_ratelimiter();
         }
 
         let (wtx, wrx) = watch_channel(Arc::clone(&session));

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -76,8 +76,8 @@ pub struct Session {
 }
 
 impl Session {
-    pub fn new(tx: UnboundedSender<TungsteniteMessage>) -> Self {
-        Self {
+    pub fn new(tx: UnboundedSender<TungsteniteMessage>, ratelimit_payloads: bool) -> Self {
+        let session = Self {
             heartbeater_handle: MutexSync::new(None),
             heartbeats: Arc::new(Heartbeats::default()),
             heartbeat_interval: AtomicU64::new(0),
@@ -86,7 +86,13 @@ impl Session {
             stage: AtomicU8::new(Stage::default() as u8),
             tx,
             ratelimit: OnceCell::new(),
+        };
+
+        if !ratelimit_payloads {
+            session.disable_ratelimiter();
         }
+
+        session
     }
 
     /// Sends a payload as a message over the socket.
@@ -122,7 +128,7 @@ impl Session {
         self.tx.send(TungsteniteMessage::Close(close_frame))
     }
 
-    pub fn disable_ratelimiter(&self) {
+    fn disable_ratelimiter(&self) {
         let _result = self.ratelimit.set(None);
     }
 
@@ -140,7 +146,11 @@ impl Session {
         // Number of commands allotted to the user per reset period.
         let commands_allotted = u32::from(available_commands_per_interval(new_heartbeat_interval));
 
-        // We can ignore an error if the ratelimiter has already been set.
+        // This will attempt to set the ratelimiter to a new one based on the
+        // heartbeat interval. The OnceCell may contain either Some if
+        // ratelimiting is enabled, or None if it was disabled.
+        // If it was already disabled or previously enabled, setting the inner
+        // value will fail and therefore errors should be ignored.
         let _result = self.ratelimit.set(Some(
             LeakyBucket::builder()
                 .max(commands_allotted)


### PR DESCRIPTION
Via `Config::payload_ratelimiting`. This logically requires making ratelimiting information on `Information` optional, since it might be disabled.

Part of #1488 