### PR TITLE
fix(cache-inmemory): Proper handling and cleanup on UnavailableGuild

### DIFF
--- a/cache/in-memory/src/event/guild.rs
+++ b/cache/in-memory/src/event/guild.rs
@@ -465,9 +465,7 @@ mod tests {
                 .map(|members| members.len())
                 .unwrap_or_default()
         );
-        assert!(
-            cache.guild(guild_id).unwrap().unavailable
-        );
+        assert!(cache.guild(guild_id).unwrap().unavailable);
 
         cache.update(&GuildCreate(guild));
 
@@ -478,5 +476,6 @@ mod tests {
                 .map(|members| members.len())
                 .unwrap_or_default()
         );
+        assert!(!cache.guild(guild_id).unwrap().unavailable);
     }
 }

--- a/cache/in-memory/src/event/mod.rs
+++ b/cache/in-memory/src/event/mod.rs
@@ -57,7 +57,7 @@ impl InMemoryCache {
 
     fn unavailable_guild(&self, guild_id: Id<GuildMarker>) {
         self.unavailable_guilds.insert(guild_id);
-        self.guilds.remove(&guild_id);
+        self.delete_guild(guild_id, true);
     }
 }
 
@@ -81,8 +81,7 @@ impl UpdateCache for UnavailableGuild {
             return;
         }
 
-        cache.guilds.remove(&self.id);
-        cache.unavailable_guilds.insert(self.id);
+        cache.unavailable_guild(self.id);
     }
 }
 


### PR DESCRIPTION
Added a test to showcase what the behaviour looks like now: Guild gets marked as unavailable, guild entities are removed from the cache.

Previously, the guild was removed from the cache, but entities remained (especially in `guild_members` and `members`). When the guild went available again, it was added to the cache, but `guild_members` was cleared and all member inserts were skipped due to the members already being in `members` cache.