### PR TITLE
Use tinyset to optimize in memory cache RAM usage

### DIFF
--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -20,6 +20,7 @@ bitflags = { default-features = false, version = "1" }
 dashmap = { default-features = false, version = "4" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 twilight-model = { default-features = false, path = "../../model" }
+tinyset = { default-features = false, version = "0.4" }
 
 # Optional dependencies.
 twilight-util = { default-features = false, features = ["permission-calculator"], optional = true, path = "../../util" }

--- a/cache/in-memory/src/event/emoji.rs
+++ b/cache/in-memory/src/event/emoji.rs
@@ -13,7 +13,6 @@ impl InMemoryCache {
 
             let removal_filter: Vec<_> = guild_emojis
                 .iter()
-                .copied()
                 .filter(|e| !incoming.contains(e))
                 .collect();
 

--- a/cache/in-memory/src/event/mod.rs
+++ b/cache/in-memory/src/event/mod.rs
@@ -14,7 +14,8 @@ pub mod thread;
 pub mod voice_state;
 
 use crate::{config::ResourceType, InMemoryCache, UpdateCache};
-use std::{borrow::Cow, collections::BTreeSet};
+use std::borrow::Cow;
+use tinyset::Set64;
 use twilight_model::{
     gateway::payload::incoming::{Ready, UnavailableGuild, UserUpdate},
     id::{marker::GuildMarker, Id},
@@ -49,7 +50,7 @@ impl InMemoryCache {
         self.users.insert(user_id, user);
 
         if let Some(guild_id) = guild_id {
-            let mut guild_id_set = BTreeSet::new();
+            let mut guild_id_set = Set64::new();
             guild_id_set.insert(guild_id);
             self.user_guilds.insert(user_id, guild_id_set);
         }

--- a/cache/in-memory/src/event/sticker.rs
+++ b/cache/in-memory/src/event/sticker.rs
@@ -15,7 +15,6 @@ impl InMemoryCache {
 
             let removal_filter: Vec<_> = guild_stickers
                 .iter()
-                .copied()
                 .filter(|s| !incoming.contains(s))
                 .collect();
 

--- a/cache/in-memory/src/iter.rs
+++ b/cache/in-memory/src/iter.rs
@@ -120,7 +120,7 @@ impl<K: Eq + Hash, V> Deref for IterReference<'_, K, V> {
 ///
 /// if let Some(guild_members) = maybe_guild_members {
 ///     for user_id in guild_members.iter() {
-///         if let Some(member) = cache.member(guild_id, *user_id) {
+///         if let Some(member) = cache.member(guild_id, user_id) {
 ///             println!(
 ///                 "member id {}'s nickname: {:?}",
 ///                 member.user_id(),

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -21,6 +21,7 @@ serde = { default-features = false, features = ["derive", "std"], version = "1.0
 serde-value = { default-features = false, version = "0.7" }
 serde_repr = { default-features = false, version = "0.1.5" }
 time = { default-features = false, features = ["parsing", "std"], version = "0.3" }
+tinyset = { default-features = false, version = "0.4" }
 
 # Optional dependencies.
 tracing = { default-features = false, optional = true, version = "0.1.16" }


### PR DESCRIPTION
A good chunk of the overhead of in-memory cache comes from the large number of `HashSets` used in a lot of it's data structures. 

`tinyset` provides a set type optimized for holding types that boil down to 64-bit integers. For a good number of cases, it will not allocate any heap memory until several elements are inserted (like small/arrayvec), and is only the size of a pointer otherwise.

This PR includes one `unsafe` function, because `tinyset::Fits64` requires one unsafe fn as a part of the trait.

To likewise maximize memory savings, when converting to a `u64` for use in `Set64`, `Id<T>` shuffles the snowflake parts around to shift most of the 1s towards the lower bits.

As an alternative, a roaring bitmap might be another alternative.