### PR TITLE
ci: automatically sync readme upon changes

### DIFF
--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -111,8 +111,12 @@ jobs:
       - name: Run in validate
         run: cd validate && cargo sync-readme
 
+      - name: Check for changes
+        id: check
+        run: git diff --exit-code
+
       - name: Commit changes
-        if: ${{ git diff --exit-code }}
+        if: ${{ steps.check.conclusion = 'failure' }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -123,7 +123,7 @@ jobs:
           git config user.email github-actions@github.com
           git add .
           git commit -m "sync readme"
-          git push origin HEAD:${{ github.ref_name }}
+          git push ${{ github.repositoryName }} HEAD:${{ github.ref_name }}
 
   # Lints
   clippy:

--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -117,7 +117,7 @@ jobs:
         run: git diff --exit-code
 
       - name: Commit changes
-        if: ${{ steps.check.conclusion == 'failure' }}
+        if: ${{ steps.check.outcome == 'failure' }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -111,19 +111,8 @@ jobs:
       - name: Run in validate
         run: cd validate && cargo sync-readme
 
-      - name: Check for changes
-        id: check
-        continue-on-error: true
-        run: git diff --exit-code
-
       - name: Commit changes
-        if: ${{ steps.check.outcome == 'failure' }}
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add .
-          git commit -m "sync readme"
-          git push ${{ github.repositoryName }} HEAD:${{ github.ref_name }}
+        uses: stefanzweifel/git-auto-commit-action@v4
 
   # Lints
   clippy:

--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -113,6 +113,7 @@ jobs:
 
       - name: Check for changes
         id: check
+        continue-on-error: true
         run: git diff --exit-code
 
       - name: Commit changes

--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -85,31 +85,41 @@ jobs:
           crate: cargo-sync-readme
 
       - name: Run in cache-inmemory
-        run: cd cache/in-memory && cargo sync-readme --check
+        run: cd cache/in-memory && cargo sync-readme
       - name: Run in command-parser
-        run: cd command-parser && cargo sync-readme --check
+        run: cd command-parser && cargo sync-readme
       - name: Run in embed-builder
-        run: cd embed-builder && cargo sync-readme --check
+        run: cd embed-builder && cargo sync-readme
       - name: Run in gateway
-        run: cd gateway && cargo sync-readme --check
+        run: cd gateway && cargo sync-readme
       - name: Run in gateway-queue
-        run: cd gateway-queue && cargo sync-readme --check
+        run: cd gateway-queue && cargo sync-readme
       - name: Run in http
-        run: cd http && cargo sync-readme --check
+        run: cd http && cargo sync-readme
       - name: Run in lavalink
-        run: cd lavalink && cargo sync-readme --check
+        run: cd lavalink && cargo sync-readme
       - name: Run in mention
-        run: cd mention && cargo sync-readme --check
+        run: cd mention && cargo sync-readme
       - name: Run in model
-        run: cd model && cargo sync-readme --check
+        run: cd model && cargo sync-readme
       - name: Run in standby
-        run: cd standby && cargo sync-readme --check
+        run: cd standby && cargo sync-readme
       - name: Run in twilight
-        run: cd twilight && cargo sync-readme --check
+        run: cd twilight && cargo sync-readme
       - name: Run in util
-        run: cd util && cargo sync-readme --check
+        run: cd util && cargo sync-readme
       - name: Run in validate
-        run: cd validate && cargo sync-readme --check
+        run: cd validate && cargo sync-readme
+
+      - name: Commit changes
+        uses: actions/checkout@v2
+        if: ${{ git diff --exit-code }}
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "sync readme"
+          git push
 
   # Lints
   clippy:

--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -123,7 +123,7 @@ jobs:
           git config user.email github-actions@github.com
           git add .
           git commit -m "sync readme"
-          git push
+          git push origin HEAD:${{ github.ref_name }}
 
   # Lints
   clippy:

--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -116,7 +116,7 @@ jobs:
         run: git diff --exit-code
 
       - name: Commit changes
-        if: ${{ steps.check.conclusion = 'failure' }}
+        if: ${{ steps.check.conclusion == 'failure' }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -112,7 +112,6 @@ jobs:
         run: cd validate && cargo sync-readme
 
       - name: Commit changes
-        uses: actions/checkout@v2
         if: ${{ git diff --exit-code }}
         run: |
           git config user.name github-actions

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -146,10 +146,9 @@
 //!         .await?;
 //!     let cluster = Arc::new(cluster);
 //!
-//!     // Start up the cluster.
+//!     // Create a clone of the cluster and pass it to a task to start in the
+//!     // background.
 //!     let cluster_spawn = Arc::clone(&cluster);
-//!
-//!     // Start all shards in the cluster in the background.
 //!     tokio::spawn(async move {
 //!         cluster_spawn.up().await;
 //!     });


### PR DESCRIPTION
This PR updates the sync-readme action to actually sync the readme if it is changed. It uses `actions/checkout` to do this.
