### PR TITLE
docs(http,model): fix broken associated builder links 

### DIFF
--- a/http/src/client/interaction.rs
+++ b/http/src/client/interaction.rs
@@ -76,7 +76,7 @@ impl<'a> InteractionClient<'a> {
     ///
     /// [`CallbackData`]: twilight_model::application::callback::CallbackData
     /// [`twilight-util`]: https://docs.rs/twilight-util/latest/index.html
-    /// [associated builder]: https://docs.rs/twilight-util/latest/builder/struct.CallbackDataBuilder.html
+    /// [associated builder]: https://docs.rs/twilight-util/latest/twilight_util/builder/struct.CallbackDataBuilder.html
     pub const fn interaction_callback(
         &'a self,
         interaction_id: Id<InteractionMarker>,
@@ -214,7 +214,7 @@ impl<'a> InteractionClient<'a> {
     /// [`twilight-util`] crate.
     ///
     /// [`twilight-util`]: https://docs.rs/twilight_util/index.html
-    /// [associated builder]: https://docs.rs/twilight-util/latest/builder/command/struct.CommandBuilder.html
+    /// [associated builder]: https://docs.rs/twilight-util/latest/twilight_util/builder/command/struct.CommandBuilder.html
     pub const fn set_guild_commands(
         &'a self,
         guild_id: Id<GuildMarker>,
@@ -268,7 +268,7 @@ impl<'a> InteractionClient<'a> {
     /// [`twilight-util`] crate.
     ///
     /// [`twilight-util`]: https://docs.rs/twilight-util/latest/index.html
-    /// [associated builder]: https://docs.rs/twilight-util/latest/builder/command/struct.CommandBuilder.html
+    /// [associated builder]: https://docs.rs/twilight-util/latest/twilight_util/builder/command/struct.CommandBuilder.html
     pub const fn set_global_commands(&'a self, commands: &'a [Command]) -> SetGlobalCommands<'a> {
         SetGlobalCommands::new(self.client, self.application_id, commands)
     }

--- a/http/src/request/application/command/set_global_commands.rs
+++ b/http/src/request/application/command/set_global_commands.rs
@@ -19,7 +19,7 @@ use twilight_model::{
 /// [`twilight-util`] crate.
 ///
 /// [`twilight-util`]: https://docs.rs/twilight-util/latest/index.html
-/// [associated builder]: https://docs.rs/twilight-util/latest/builder/command/struct.CommandBuilder.html
+/// [associated builder]: https://docs.rs/twilight-util/latest/twilight_util/builder/command/struct.CommandBuilder.html
 #[must_use = "requests must be configured and executed"]
 pub struct SetGlobalCommands<'a> {
     commands: &'a [Command],

--- a/http/src/request/application/command/set_guild_commands.rs
+++ b/http/src/request/application/command/set_guild_commands.rs
@@ -22,7 +22,7 @@ use twilight_model::{
 /// [`twilight-util`] crate.
 ///
 /// [`twilight-util`]: https://docs.rs/twilight-util/latest/index.html
-/// [associated builder]: https://docs.rs/twilight-util/latest/builder/command/struct.CommandBuilder.html
+/// [associated builder]: https://docs.rs/twilight-util/latest/twilight_util/builder/command/struct.CommandBuilder.html
 #[must_use = "requests must be configured and executed"]
 pub struct SetGuildCommands<'a> {
     commands: &'a [Command],

--- a/model/src/application/callback/callback_data.rs
+++ b/model/src/application/callback/callback_data.rs
@@ -22,7 +22,7 @@ pub(super) enum CallbackDataEnvelope {
 /// This struct has an [associated builder] in the [`twilight-util`] crate.
 ///
 /// [`twilight-util`]: https://docs.rs/twilight-util/latest/index.html
-/// [associated builder]: https://docs.rs/twilight-util/latest/builder/struct.CallbackDataBuilder.html
+/// [associated builder]: https://docs.rs/twilight-util/latest/twilight_util/builder/struct.CallbackDataBuilder.html
 ///
 /// [`Interaction`]: crate::application::interaction::Interaction
 /// [`ApplicationCommand`]: crate::application::interaction::Interaction::ApplicationCommand

--- a/model/src/application/command/mod.rs
+++ b/model/src/application/command/mod.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 /// This struct has an [associated builder] in the [`twilight-util`] crate.
 ///
 /// [`twilight-util`]: https://docs.rs/twilight-util/latest/index.html
-/// [associated builder]: https://docs.rs/twilight-util/latest/builder/command/struct.CommandBuilder.html
+/// [associated builder]: https://docs.rs/twilight-util/latest/twilight_util/builder/command/struct.CommandBuilder.html
 /// [the discord docs]: https://discord.com/developers/docs/interactions/application-commands#applicationcommand
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Command {


### PR DESCRIPTION
it'd be nice if it linked to api.twilight.rs if the link is clicked there, but i don't think that's doable easily.. also is there any other broken links in the docs?