### PR TITLE
build(cache-in-memory, lavalink, standby): Update dashmap to 5.1

### DIFF
--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.9.0"
 
 [dependencies]
 bitflags = { default-features = false, version = "1" }
-dashmap = { default-features = false, version = "4" }
+dashmap = { default-features = false, version = "5.1" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 twilight-model = { default-features = false, path = "../../model" }
 

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.9.0"
 
 [dependencies]
-dashmap = { default-features = false, version = "4" }
+dashmap = { default-features = false, version = "5.1" }
 futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }
 http = { default-features = false, version = "0.2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }

--- a/standby/Cargo.toml
+++ b/standby/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.57"
 version = "0.9.0"
 
 [dependencies]
-dashmap = { default-features = false, version = "4" }
+dashmap = { default-features = false, version = "5.1" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 tokio = { default-features = false, features = ["sync"], version = "1.0" }
 twilight-model = { default-features = false, path = "../model" }


### PR DESCRIPTION
The 5.0 release was yanked from crates.io due to critical issues (see e.g. #1434), and a fixed 5.1 release has been drafted by the owner.

This bumps the dependency on `dashmap` to 5.1 and behaves just like 5.0 did - with the exception of the `send_guard` feature now being disabled in 5.1 due to default features being disabled. This prevents unintended behaviour on user side and happens to not be required with how twilight currently uses `dashmap`.