### PR TITLE
Add the `type` and `target_id` fields to `CommandData`

### DIFF
--- a/model/src/application/interaction/application_command/data/mod.rs
+++ b/model/src/application/interaction/application_command/data/mod.rs
@@ -3,7 +3,7 @@ mod resolved;
 pub use self::resolved::{CommandInteractionDataResolved, InteractionChannel, InteractionMember};
 
 use crate::{
-    application::command::{CommandOptionType, Number},
+    application::command::{CommandOptionType, CommandType, Number},
     id::{
         marker::{ChannelMarker, CommandMarker, GenericMarker, RoleMarker, UserMarker},
         Id,
@@ -28,12 +28,17 @@ pub struct CommandData {
     pub id: Id<CommandMarker>,
     /// Name of the command.
     pub name: String,
+    /// Type of the command.
+    pub kind: CommandType,
     /// List of parsed options specified by the user.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub options: Vec<CommandDataOption>,
     /// Data sent if any of the options are Discord types.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resolved: Option<CommandInteractionDataResolved>,
+    /// If this is a user or message command, the ID of the targeted user/message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_id: Option<Id<GenericMarker>>,
 }
 
 /// Data received when a user fills in a command option.
@@ -360,7 +365,7 @@ mod tests {
     use super::CommandData;
     use crate::{
         application::{
-            command::{CommandOptionType, Number},
+            command::{CommandOptionType, CommandType, Number},
             interaction::application_command::{CommandDataOption, CommandOptionValue},
         },
         id::Id,
@@ -372,8 +377,10 @@ mod tests {
         let value = CommandData {
             id: Id::new(1),
             name: "permissions".to_owned(),
+            kind: CommandType::ChatInput,
             options: Vec::new(),
             resolved: None,
+            target_id: None,
         };
         serde_test::assert_tokens(
             &value,
@@ -397,12 +404,14 @@ mod tests {
         let value = CommandData {
             id: Id::new(1),
             name: "photo".to_owned(),
+            kind: CommandType::ChatInput,
             options: Vec::from([CommandDataOption {
                 focused: false,
                 name: "cat".to_owned(),
                 value: CommandOptionValue::SubCommand(Vec::new()),
             }]),
             resolved: None,
+            target_id: None,
         };
 
         serde_test::assert_tokens(

--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -347,7 +347,7 @@ impl<'de> Visitor<'de> for InteractionVisitor {
 mod test {
     use crate::{
         application::{
-            command::CommandOptionType,
+            command::{CommandOptionType, CommandType},
             interaction::{
                 application_command::{
                     ApplicationCommand, CommandData, CommandDataOption,
@@ -376,6 +376,7 @@ mod test {
             data: CommandData {
                 id: Id::new(300),
                 name: "command name".into(),
+                kind: CommandType::ChatInput,
                 options: Vec::from([CommandDataOption {
                     focused: false,
                     name: "member".into(),
@@ -421,6 +422,7 @@ mod test {
                     )])
                     .collect(),
                 }),
+                target_id: None,
             },
             guild_id: Some(Id::new(400)),
             guild_locale: Some("de".to_owned()),


### PR DESCRIPTION
Resolves #1515

To get around the issue of `target_id` being an ID to either a user or a message, this PR represents it with a generic ID.
It would be possible to make it more strongly typed, e.g. something like:

```rust
enum CommandPayload {
    ChatInput(Vec<CommandDataOption>),
    User(Id<User>),
    Message(Id<Message>),
}
```

That might be overcomplicating things though, and/or diverging too far from the actual API.