### PR TITLE
feat(http,model): scheduled event cover images

### DIFF
--- a/http/src/request/scheduled_event/create_guild_scheduled_event/external.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/external.rs
@@ -60,6 +60,19 @@ impl<'a> CreateGuildExternalScheduledEvent<'a> {
         Ok(self)
     }
 
+    /// Set the cover image of the event.
+    ///
+    /// This must be a Data URI, in the form of
+    /// `data:image/{type};base64,{data}` where `{type}` is the image MIME type
+    /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
+    ///
+    /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
+    pub const fn image(mut self, image: &'a [u8]) -> Self {
+        self.0.fields.image = Some(image);
+
+        self
+    }
+
     /// Execute the request, returning a future resolving to a [`Response`].
     ///
     /// [`Response`]: crate::response::Response

--- a/http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
@@ -39,6 +39,8 @@ struct CreateGuildScheduledEventFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     entity_type: Option<EntityType>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    image: Option<&'a [u8]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     privacy_level: Option<PrivacyLevel>,
@@ -129,6 +131,7 @@ impl<'a> CreateGuildScheduledEvent<'a> {
                 description: None,
                 entity_metadata: None,
                 entity_type: None,
+                image: None,
                 name: None,
                 privacy_level: None,
                 scheduled_end_time: None,

--- a/http/src/request/scheduled_event/create_guild_scheduled_event/stage_instance.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/stage_instance.rs
@@ -54,6 +54,19 @@ impl<'a> CreateGuildStageInstanceScheduledEvent<'a> {
         Ok(self)
     }
 
+    /// Set the cover image of the event.
+    ///
+    /// This must be a Data URI, in the form of
+    /// `data:image/{type};base64,{data}` where `{type}` is the image MIME type
+    /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
+    ///
+    /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
+    pub const fn image(mut self, image: &'a [u8]) -> Self {
+        self.0.fields.image = Some(image);
+
+        self
+    }
+
     /// Set the scheduled end time of the event.
     ///
     /// This is not a required field for stage instance events.

--- a/http/src/request/scheduled_event/create_guild_scheduled_event/voice.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/voice.rs
@@ -54,6 +54,19 @@ impl<'a> CreateGuildVoiceScheduledEvent<'a> {
         Ok(self)
     }
 
+    /// Set the cover image of the event.
+    ///
+    /// This must be a Data URI, in the form of
+    /// `data:image/{type};base64,{data}` where `{type}` is the image MIME type
+    /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
+    ///
+    /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
+    pub const fn image(mut self, image: &'a [u8]) -> Self {
+        self.0.fields.image = Some(image);
+
+        self
+    }
+
     /// Set the scheduled end time of the event.
     ///
     /// This is not a required field for voice channel events.

--- a/http/src/request/scheduled_event/update_guild_scheduled_event.rs
+++ b/http/src/request/scheduled_event/update_guild_scheduled_event.rs
@@ -33,6 +33,8 @@ struct UpdateGuildScheduledEventFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     entity_type: Option<EntityType>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    image: Option<NullableField<&'a [u8]>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     privacy_level: Option<PrivacyLevel>,
@@ -81,6 +83,7 @@ impl<'a> UpdateGuildScheduledEvent<'a> {
                 description: None,
                 entity_metadata: None,
                 entity_type: None,
+                image: None,
                 name: None,
                 privacy_level: None,
                 scheduled_end_time: None,
@@ -138,6 +141,21 @@ impl<'a> UpdateGuildScheduledEvent<'a> {
         }
 
         self.fields.entity_type = Some(entity_type);
+
+        self
+    }
+
+    /// Set the cover image of the event.
+    ///
+    /// Pass [`None`] to clear the image.
+    ///
+    /// This must be a Data URI, in the form of
+    /// `data:image/{type};base64,{data}` where `{type}` is the image MIME type
+    /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
+    ///
+    /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
+    pub const fn image(mut self, image: Option<&'a [u8]>) -> Self {
+        self.fields.image = Some(NullableField(image));
 
         self
     }

--- a/model/src/scheduled_event/mod.rs
+++ b/model/src/scheduled_event/mod.rs
@@ -14,6 +14,7 @@ use crate::{
         Id,
     },
     user::User,
+    util::ImageHash,
 };
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -60,6 +61,9 @@ pub struct GuildScheduledEvent {
     pub guild_id: Id<GuildMarker>,
     /// ID of the event.
     pub id: Id<ScheduledEventMarker>,
+    /// Hash of the event's cover image, if it has one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<ImageHash>,
     /// Name of the event.
     pub name: String,
     /// Privacy level of the event.
@@ -127,6 +131,7 @@ pub enum Status {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test::image_hash::{COVER, COVER_INPUT};
     use serde_test::Token;
     use std::error::Error;
 
@@ -144,6 +149,7 @@ mod tests {
             entity_type: EntityType::StageInstance,
             guild_id: Id::new(3),
             id: Id::new(4),
+            image: Some(COVER),
             name: "garfield dance party".into(),
             privacy_level: PrivacyLevel::GuildOnly,
             scheduled_end_time: None,
@@ -157,7 +163,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "GuildScheduledEvent",
-                    len: 11,
+                    len: 12,
                 },
                 Token::Str("channel_id"),
                 Token::Some,
@@ -178,6 +184,9 @@ mod tests {
                 Token::Str("id"),
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("4"),
+                Token::Str("image"),
+                Token::Some,
+                Token::Str(COVER_INPUT),
                 Token::Str("name"),
                 Token::Str("garfield dance party"),
                 Token::Str("privacy_level"),


### PR DESCRIPTION
Adds `GuildScheduledEvent::image`. Adds methods to `CreateGuildScheduledEvent`'s derivatives and `UpdateGuildScheduledEvent` to add and update the image.

Closes #1502.
