### PR TITLE
refactor(http,validate)!: move audit reason validation

### DIFF
--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -1,10 +1,7 @@
-use std::{
-    error::Error,
-    fmt::{Display, Formatter, Result as FmtResult},
-};
+use twilight_validate::request::ValidationError;
 
 pub trait AuditLogReason<'a>: private::Sealed {
-    fn reason(self, reason: &'a str) -> Result<Self, AuditLogReasonError>
+    fn reason(self, reason: &'a str) -> Result<Self, ValidationError>
     where
         Self: Sized;
 }
@@ -38,116 +35,47 @@ mod private {
 
     /// Sealed stops crates other crates implementing the trait.
     pub trait Sealed {}
-    impl<'a> Sealed for CreateInvite<'a> {}
-    impl<'a> Sealed for DeleteInvite<'a> {}
-    impl<'a> Sealed for DeleteMessage<'a> {}
-    impl<'a> Sealed for DeleteMessages<'a> {}
-    impl<'a> Sealed for UpdateChannel<'a> {}
-    impl<'a> Sealed for CreateWebhook<'a> {}
-    impl Sealed for DeleteWebhookMessage<'_> {}
-    impl<'a> Sealed for DeleteWebhook<'a> {}
-    impl<'a> Sealed for UpdateWebhook<'a> {}
-    impl<'a> Sealed for CreatePin<'a> {}
-    impl<'a> Sealed for DeleteChannel<'a> {}
-    impl<'a> Sealed for DeleteChannelPermissionConfigured<'a> {}
-    impl<'a> Sealed for DeletePin<'a> {}
-    impl<'a> Sealed for UpdateChannelPermissionConfigured<'a> {}
-    impl<'a> Sealed for CreateBan<'a> {}
-    impl<'a> Sealed for DeleteBan<'a> {}
-    impl<'a> Sealed for CreateGuildChannel<'a> {}
-    impl<'a> Sealed for CreateGuildPrune<'a> {}
-    impl<'a> Sealed for CreateEmoji<'a> {}
-    impl<'a> Sealed for DeleteEmoji<'a> {}
-    impl<'a> Sealed for UpdateEmoji<'a> {}
-    impl<'a> Sealed for DeleteGuildIntegration<'a> {}
-    impl<'a> Sealed for UpdateGuildMember<'a> {}
-    impl<'a> Sealed for AddRoleToMember<'a> {}
-    impl<'a> Sealed for RemoveMember<'a> {}
-    impl<'a> Sealed for RemoveRoleFromMember<'a> {}
-    impl<'a> Sealed for CreateRole<'a> {}
-    impl<'a> Sealed for DeleteRole<'a> {}
-    impl<'a> Sealed for UpdateRole<'a> {}
-    impl<'a> Sealed for CreateGuildSticker<'a> {}
-    impl<'a> Sealed for UpdateGuildSticker<'a> {}
-    impl<'a> Sealed for UpdateGuild<'a> {}
-    impl<'a> Sealed for UpdateThread<'a> {}
-    impl<'a> Sealed for UpdateCurrentUser<'a> {}
-    impl Sealed for UpdateCurrentMember<'_> {}
-    impl Sealed for CreateGuildScheduledEvent<'_> {}
+
+    impl Sealed for AddRoleToMember<'_> {}
+    impl Sealed for CreateBan<'_> {}
+    impl Sealed for CreateEmoji<'_> {}
+    impl Sealed for CreateGuildChannel<'_> {}
     impl Sealed for CreateGuildExternalScheduledEvent<'_> {}
+    impl Sealed for CreateGuildPrune<'_> {}
+    impl Sealed for CreateGuildScheduledEvent<'_> {}
     impl Sealed for CreateGuildStageInstanceScheduledEvent<'_> {}
+    impl Sealed for CreateGuildSticker<'_> {}
     impl Sealed for CreateGuildVoiceScheduledEvent<'_> {}
+    impl Sealed for CreateInvite<'_> {}
+    impl Sealed for CreatePin<'_> {}
+    impl Sealed for CreateRole<'_> {}
+    impl Sealed for CreateWebhook<'_> {}
+    impl Sealed for DeleteBan<'_> {}
+    impl Sealed for DeleteChannel<'_> {}
+    impl Sealed for DeleteChannelPermissionConfigured<'_> {}
+    impl Sealed for DeleteEmoji<'_> {}
+    impl Sealed for DeleteGuildIntegration<'_> {}
+    impl Sealed for DeleteInvite<'_> {}
+    impl Sealed for DeleteMessage<'_> {}
+    impl Sealed for DeleteMessages<'_> {}
+    impl Sealed for DeletePin<'_> {}
+    impl Sealed for DeleteRole<'_> {}
+    impl Sealed for DeleteWebhook<'_> {}
+    impl Sealed for DeleteWebhookMessage<'_> {}
+    impl Sealed for RemoveMember<'_> {}
+    impl Sealed for RemoveRoleFromMember<'_> {}
+    impl Sealed for UpdateChannel<'_> {}
+    impl Sealed for UpdateChannelPermissionConfigured<'_> {}
+    impl Sealed for UpdateCurrentMember<'_> {}
+    impl Sealed for UpdateCurrentUser<'_> {}
+    impl Sealed for UpdateEmoji<'_> {}
+    impl Sealed for UpdateGuild<'_> {}
+    impl Sealed for UpdateGuildMember<'_> {}
     impl Sealed for UpdateGuildScheduledEvent<'_> {}
-}
-
-impl AuditLogReasonError {
-    /// The maximum audit log reason length in UTF-16 codepoints.
-    pub const AUDIT_REASON_LENGTH: usize = 512;
-
-    pub(crate) fn validate(reason: &str) -> Result<&str, AuditLogReasonError> {
-        if reason.chars().count() <= Self::AUDIT_REASON_LENGTH {
-            Ok(reason)
-        } else {
-            Err(AuditLogReasonError {
-                kind: AuditLogReasonErrorType::TooLarge,
-            })
-        }
-    }
-}
-
-/// The error created when a reason can not be used as configured.
-#[derive(Debug)]
-pub struct AuditLogReasonError {
-    kind: AuditLogReasonErrorType,
-}
-
-impl AuditLogReasonError {
-    /// Immutable reference to the type of error that occurred.
-    #[must_use = "retrieving the type has no effect if left unused"]
-    pub const fn kind(&self) -> &AuditLogReasonErrorType {
-        &self.kind
-    }
-
-    /// Consume the error, returning the source error if there is any.
-    #[allow(clippy::unused_self)]
-    #[must_use = "consuming the error and retrieving the source has no effect if left unused"]
-    pub fn into_source(self) -> Option<Box<dyn Error + Send + Sync>> {
-        None
-    }
-
-    /// Consume the error, returning the owned error type and the source error.
-    #[must_use = "consuming the error into its parts has no effect if left unused"]
-    pub fn into_parts(
-        self,
-    ) -> (
-        AuditLogReasonErrorType,
-        Option<Box<dyn Error + Send + Sync>>,
-    ) {
-        (self.kind, None)
-    }
-}
-
-impl Display for AuditLogReasonError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match &self.kind {
-            AuditLogReasonErrorType::TooLarge => {
-                f.write_str("audit log reason is longer than ")?;
-                Display::fmt(&Self::AUDIT_REASON_LENGTH, f)?;
-
-                f.write_str(" characters")
-            }
-        }
-    }
-}
-
-impl Error for AuditLogReasonError {}
-
-/// Type of [`AuditLogReasonError`] that occurred.
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum AuditLogReasonErrorType {
-    /// Returned when the reason is over 512 UTF-16 characters.
-    TooLarge,
+    impl Sealed for UpdateGuildSticker<'_> {}
+    impl Sealed for UpdateRole<'_> {}
+    impl Sealed for UpdateThread<'_> {}
+    impl Sealed for UpdateWebhook<'_> {}
 }
 
 #[cfg(test)]
@@ -176,37 +104,37 @@ mod test {
 
     assert_obj_safe!(AuditLogReason<'_>);
 
+    assert_impl_all!(AddRoleToMember<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateBan<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateEmoji<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateGuildChannel<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateGuildPrune<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateGuildSticker<'_>: AuditLogReason<'static>);
     assert_impl_all!(CreateInvite<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreatePin<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateRole<'_>: AuditLogReason<'static>);
+    assert_impl_all!(CreateWebhook<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteBan<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteChannel<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteChannelPermissionConfigured<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteEmoji<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteGuildIntegration<'_>: AuditLogReason<'static>);
     assert_impl_all!(DeleteInvite<'_>: AuditLogReason<'static>);
     assert_impl_all!(DeleteMessage<'_>: AuditLogReason<'static>);
     assert_impl_all!(DeleteMessages<'_>: AuditLogReason<'static>);
-    assert_impl_all!(UpdateChannel<'_>: AuditLogReason<'static>);
-    assert_impl_all!(CreateWebhook<'_>: AuditLogReason<'static>);
-    assert_impl_all!(DeleteWebhook<'_>: AuditLogReason<'static>);
-    assert_impl_all!(UpdateWebhook<'_>: AuditLogReason<'static>);
-    assert_impl_all!(CreatePin<'_>: AuditLogReason<'static>);
-    assert_impl_all!(DeleteChannel<'_>: AuditLogReason<'static>);
-    assert_impl_all!(DeleteChannelPermissionConfigured<'_>: AuditLogReason<'static>);
     assert_impl_all!(DeletePin<'_>: AuditLogReason<'static>);
-    assert_impl_all!(UpdateChannelPermissionConfigured<'_>: AuditLogReason<'static>);
-    assert_impl_all!(CreateBan<'_>: AuditLogReason<'static>);
-    assert_impl_all!(DeleteBan<'_>: AuditLogReason<'static>);
-    assert_impl_all!(CreateGuildChannel<'_>: AuditLogReason<'static>);
-    assert_impl_all!(CreateGuildPrune<'_>: AuditLogReason<'static>);
-    assert_impl_all!(CreateEmoji<'_>: AuditLogReason<'static>);
-    assert_impl_all!(DeleteEmoji<'_>: AuditLogReason<'static>);
-    assert_impl_all!(UpdateEmoji<'_>: AuditLogReason<'static>);
-    assert_impl_all!(DeleteGuildIntegration<'_>: AuditLogReason<'static>);
-    assert_impl_all!(UpdateGuildMember<'_>: AuditLogReason<'static>);
-    assert_impl_all!(AddRoleToMember<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteRole<'_>: AuditLogReason<'static>);
+    assert_impl_all!(DeleteWebhook<'_>: AuditLogReason<'static>);
     assert_impl_all!(RemoveMember<'_>: AuditLogReason<'static>);
     assert_impl_all!(RemoveRoleFromMember<'_>: AuditLogReason<'static>);
-    assert_impl_all!(CreateRole<'_>: AuditLogReason<'static>);
-    assert_impl_all!(DeleteRole<'_>: AuditLogReason<'static>);
-    assert_impl_all!(UpdateRole<'_>: AuditLogReason<'static>);
-    assert_impl_all!(CreateGuildSticker<'_>: AuditLogReason<'static>);
-    assert_impl_all!(UpdateGuildSticker<'_>: AuditLogReason<'static>);
-    assert_impl_all!(UpdateGuild<'_>: AuditLogReason<'static>);
-    assert_impl_all!(UpdateCurrentUser<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateChannel<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateChannelPermissionConfigured<'_>: AuditLogReason<'static>);
     assert_impl_all!(UpdateCurrentMember<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateCurrentUser<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateEmoji<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateGuild<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateGuildMember<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateGuildSticker<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateRole<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateWebhook<'_>: AuditLogReason<'static>);
 }

--- a/http/src/request/channel/create_pin.rs
+++ b/http/src/request/channel/create_pin.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -9,6 +9,7 @@ use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker},
     Id,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Create a new pin in a channel.
 #[must_use = "requests must be configured and executed"]
@@ -47,8 +48,10 @@ impl<'a> CreatePin<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreatePin<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/delete_channel.rs
+++ b/http/src/request/channel/delete_channel.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -9,6 +9,7 @@ use twilight_model::{
     channel::Channel,
     id::{marker::ChannelMarker, Id},
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Delete a channel by ID.
 #[must_use = "requests must be configured and executed"]
@@ -41,8 +42,10 @@ impl<'a> DeleteChannel<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for DeleteChannel<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/delete_channel_permission_configured.rs
+++ b/http/src/request/channel/delete_channel_permission_configured.rs
@@ -1,11 +1,12 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::{marker::ChannelMarker, Id};
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Clear the permissions for a target ID in a channel.
 ///
@@ -46,8 +47,10 @@ impl<'a> DeleteChannelPermissionConfigured<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for DeleteChannelPermissionConfigured<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/delete_pin.rs
+++ b/http/src/request/channel/delete_pin.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -9,6 +9,7 @@ use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker},
     Id,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Delete a pin in a channel, by ID.
 #[must_use = "requests must be configured and executed"]
@@ -47,8 +48,10 @@ impl<'a> DeletePin<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for DeletePin<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -14,8 +14,8 @@ use twilight_model::{
     invite::{Invite, TargetType},
 };
 use twilight_validate::request::{
-    invite_max_age as validate_invite_max_age, invite_max_uses as validate_invite_max_uses,
-    ValidationError,
+    audit_reason as validate_audit_reason, invite_max_age as validate_invite_max_age,
+    invite_max_uses as validate_invite_max_uses, ValidationError,
 };
 
 #[derive(Serialize)]
@@ -223,8 +223,10 @@ impl<'a> CreateInvite<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreateInvite<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/invite/delete_invite.rs
+++ b/http/src/request/channel/invite/delete_invite.rs
@@ -1,10 +1,11 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Delete an invite by its code.
 ///
@@ -43,8 +44,10 @@ impl<'a> DeleteInvite<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for DeleteInvite<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/message/delete_message.rs
+++ b/http/src/request/channel/message/delete_message.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -9,6 +9,7 @@ use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker},
     Id,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Delete a message by [`Id<ChannelMarker>`] and [`Id<MessageMarker>`].
 #[must_use = "requests must be configured and executed"]
@@ -47,8 +48,10 @@ impl<'a> DeleteMessage<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for DeleteMessage<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/message/delete_messages.rs
+++ b/http/src/request/channel/message/delete_messages.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -10,6 +10,7 @@ use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker},
     Id,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 #[derive(Serialize)]
 struct DeleteMessagesFields<'a> {
@@ -60,8 +61,10 @@ impl<'a> DeleteMessages<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for DeleteMessages<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/thread/update_thread.rs
+++ b/http/src/request/channel/thread/update_thread.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -10,9 +10,12 @@ use twilight_model::{
     channel::{thread::AutoArchiveDuration, Channel},
     id::{marker::ChannelMarker, Id},
 };
-use twilight_validate::channel::{
-    name as validate_name, rate_limit_per_user as validate_rate_limit_per_user,
-    ChannelValidationError,
+use twilight_validate::{
+    channel::{
+        name as validate_name, rate_limit_per_user as validate_rate_limit_per_user,
+        ChannelValidationError,
+    },
+    request::{audit_reason as validate_audit_reason, ValidationError},
 };
 
 #[derive(Serialize)]
@@ -166,8 +169,10 @@ impl<'a> UpdateThread<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for UpdateThread<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, AuditLogReasonError, NullableField, Request, TryIntoRequest},
+    request::{self, AuditLogReason, NullableField, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -10,8 +10,9 @@ use twilight_model::{
     channel::{permission_overwrite::PermissionOverwrite, Channel, ChannelType, VideoQualityMode},
     id::{marker::ChannelMarker, Id},
 };
-use twilight_validate::channel::{
-    name as validate_name, topic as validate_topic, ChannelValidationError,
+use twilight_validate::{
+    channel::{name as validate_name, topic as validate_topic, ChannelValidationError},
+    request::{audit_reason as validate_audit_reason, ValidationError},
 };
 
 // The Discord API doesn't require the `name` and `kind` fields to be present,
@@ -228,8 +229,10 @@ impl<'a> UpdateChannel<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for UpdateChannel<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/update_channel_permission_configured.rs
+++ b/http/src/request/channel/update_channel_permission_configured.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -11,6 +11,7 @@ use twilight_model::{
     guild::Permissions,
     id::{marker::ChannelMarker, Id},
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 #[derive(Serialize)]
 struct UpdateChannelPermissionConfiguredFields {
@@ -74,8 +75,10 @@ impl<'a> UpdateChannelPermissionConfigured<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for UpdateChannelPermissionConfigured<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -10,6 +10,7 @@ use twilight_model::{
     channel::Webhook,
     id::{marker::ChannelMarker, Id},
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 #[derive(Serialize)]
 struct CreateWebhookFields<'a> {
@@ -86,8 +87,10 @@ impl<'a> CreateWebhook<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreateWebhook<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/webhook/delete_webhook.rs
+++ b/http/src/request/channel/webhook/delete_webhook.rs
@@ -1,11 +1,12 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use twilight_model::id::{marker::WebhookMarker, Id};
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 struct DeleteWebhookParams<'a> {
     token: Option<&'a str>,
@@ -51,8 +52,10 @@ impl<'a> DeleteWebhook<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for DeleteWebhook<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/webhook/delete_webhook_message.rs
+++ b/http/src/request/channel/webhook/delete_webhook_message.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -9,6 +9,7 @@ use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker, WebhookMarker},
     Id,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Delete a message created by a webhook.
 ///
@@ -78,8 +79,10 @@ impl<'a> DeleteWebhookMessage<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for DeleteWebhookMessage<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, NullableField, Request, TryIntoRequest},
+    request::{self, AuditLogReason, NullableField, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -13,6 +13,7 @@ use twilight_model::{
         Id,
     },
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 #[derive(Serialize)]
 struct UpdateWebhookFields<'a> {
@@ -89,8 +90,10 @@ impl<'a> UpdateWebhook<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for UpdateWebhook<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -10,6 +10,7 @@ use twilight_model::id::{
     Id,
 };
 use twilight_validate::request::{
+    audit_reason as validate_audit_reason,
     create_guild_ban_delete_message_days as validate_create_guild_ban_delete_message_days,
     ValidationError,
 };
@@ -103,10 +104,10 @@ impl<'a> CreateBan<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreateBan<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.fields
-            .reason
-            .replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.fields.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/ban/delete_ban.rs
+++ b/http/src/request/guild/ban/delete_ban.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -9,6 +9,7 @@ use twilight_model::id::{
     marker::{GuildMarker, UserMarker},
     Id,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Remove a ban from a user in a guild.
 ///
@@ -66,8 +67,10 @@ impl<'a> DeleteBan<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for DeleteBan<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/create_guild_channel.rs
+++ b/http/src/request/guild/create_guild_channel.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -13,9 +13,12 @@ use twilight_model::{
         Id,
     },
 };
-use twilight_validate::channel::{
-    name as validate_name, rate_limit_per_user as validate_rate_limit_per_user,
-    topic as validate_topic, ChannelValidationError,
+use twilight_validate::{
+    channel::{
+        name as validate_name, rate_limit_per_user as validate_rate_limit_per_user,
+        topic as validate_topic, ChannelValidationError,
+    },
+    request::{audit_reason as validate_audit_reason, ValidationError},
 };
 
 #[derive(Serialize)]
@@ -201,8 +204,10 @@ impl<'a> CreateGuildChannel<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreateGuildChannel<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/create_guild_prune.rs
+++ b/http/src/request/guild/create_guild_prune.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -12,7 +12,10 @@ use twilight_model::{
         Id,
     },
 };
-use twilight_validate::request::{guild_prune_days as validate_guild_prune_days, ValidationError};
+use twilight_validate::request::{
+    audit_reason as validate_audit_reason, guild_prune_days as validate_guild_prune_days,
+    ValidationError,
+};
 
 struct CreateGuildPruneFields<'a> {
     compute_prune_count: Option<bool>,
@@ -95,8 +98,10 @@ impl<'a> CreateGuildPrune<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreateGuildPrune<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -13,6 +13,7 @@ use twilight_model::{
         Id,
     },
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 #[derive(Serialize)]
 struct CreateEmojiFields<'a> {
@@ -81,8 +82,10 @@ impl<'a> CreateEmoji<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreateEmoji<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/emoji/delete_emoji.rs
+++ b/http/src/request/guild/emoji/delete_emoji.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -9,6 +9,7 @@ use twilight_model::id::{
     marker::{EmojiMarker, GuildMarker},
     Id,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Delete an emoji in a guild, by id.
 #[must_use = "requests must be configured and executed"]
@@ -47,8 +48,10 @@ impl<'a> DeleteEmoji<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for DeleteEmoji<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/emoji/update_emoji.rs
+++ b/http/src/request/guild/emoji/update_emoji.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -13,6 +13,7 @@ use twilight_model::{
         Id,
     },
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 #[derive(Serialize)]
 struct UpdateEmojiFields<'a> {
@@ -78,8 +79,10 @@ impl<'a> UpdateEmoji<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for UpdateEmoji<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/integration/delete_guild_integration.rs
+++ b/http/src/request/guild/integration/delete_guild_integration.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -9,6 +9,7 @@ use twilight_model::id::{
     marker::{GuildMarker, IntegrationMarker},
     Id,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Delete an integration for a guild, by the integration's id.
 #[must_use = "requests must be configured and executed"]
@@ -47,8 +48,10 @@ impl<'a> DeleteGuildIntegration<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for DeleteGuildIntegration<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/add_role_to_member.rs
+++ b/http/src/request/guild/member/add_role_to_member.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -9,6 +9,7 @@ use twilight_model::id::{
     marker::{GuildMarker, RoleMarker, UserMarker},
     Id,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Add a role to a member in a guild.
 ///
@@ -73,8 +74,10 @@ impl<'a> AddRoleToMember<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for AddRoleToMember<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/remove_member.rs
+++ b/http/src/request/guild/member/remove_member.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -9,6 +9,7 @@ use twilight_model::id::{
     marker::{GuildMarker, UserMarker},
     Id,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Kick a member from a guild, by their id.
 #[must_use = "requests must be configured and executed"]
@@ -47,8 +48,10 @@ impl<'a> RemoveMember<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for RemoveMember<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/remove_role_from_member.rs
+++ b/http/src/request/guild/member/remove_role_from_member.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -9,6 +9,7 @@ use twilight_model::id::{
     marker::{GuildMarker, RoleMarker, UserMarker},
     Id,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Remove a role from a member in a guild, by id.
 #[must_use = "requests must be configured and executed"]
@@ -50,8 +51,10 @@ impl<'a> RemoveRoleFromMember<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for RemoveRoleFromMember<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, AuditLogReasonError, NullableField, Request, TryIntoRequest},
+    request::{self, AuditLogReason, NullableField, Request, TryIntoRequest},
     response::{marker::MemberBody, ResponseFuture},
     routing::Route,
 };
@@ -14,6 +14,7 @@ use twilight_model::{
     },
 };
 use twilight_validate::request::{
+    audit_reason as validate_audit_reason,
     communication_disabled_until as validate_communication_disabled_until,
     nickname as validate_nickname, ValidationError,
 };
@@ -166,8 +167,10 @@ impl<'a> UpdateGuildMember<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for UpdateGuildMember<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/role/create_role.rs
+++ b/http/src/request/guild/role/create_role.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -10,6 +10,7 @@ use twilight_model::{
     guild::{Permissions, Role},
     id::{marker::GuildMarker, Id},
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 #[derive(Serialize)]
 struct CreateRoleFields<'a> {
@@ -146,8 +147,10 @@ impl<'a> CreateRole<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreateRole<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/role/delete_role.rs
+++ b/http/src/request/guild/role/delete_role.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -9,6 +9,7 @@ use twilight_model::id::{
     marker::{GuildMarker, RoleMarker},
     Id,
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Delete a role in a guild, by id.
 #[must_use = "requests must be configured and executed"]
@@ -47,8 +48,10 @@ impl<'a> DeleteRole<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for DeleteRole<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, AuditLogReasonError, NullableField, Request, TryIntoRequest},
+    request::{self, AuditLogReason, NullableField, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -13,6 +13,7 @@ use twilight_model::{
         Id,
     },
 };
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 #[derive(Serialize)]
 struct UpdateRoleFields<'a> {
@@ -134,8 +135,10 @@ impl<'a> UpdateRole<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for UpdateRole<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/sticker/create_guild_sticker.rs
+++ b/http/src/request/guild/sticker/create_guild_sticker.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{multipart::Form, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{multipart::Form, AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -9,9 +9,12 @@ use twilight_model::{
     channel::message::Sticker,
     id::{marker::GuildMarker, Id},
 };
-use twilight_validate::sticker::{
-    description as validate_description, name as validate_name, tags as validate_tags,
-    StickerValidationError,
+use twilight_validate::{
+    request::{audit_reason as validate_audit_reason, ValidationError},
+    sticker::{
+        description as validate_description, name as validate_name, tags as validate_tags,
+        StickerValidationError,
+    },
 };
 
 struct CreateGuildStickerFields<'a> {
@@ -99,8 +102,10 @@ impl<'a> CreateGuildSticker<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreateGuildSticker<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/sticker/update_guild_sticker.rs
+++ b/http/src/request/guild/sticker/update_guild_sticker.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -13,9 +13,12 @@ use twilight_model::{
         Id,
     },
 };
-use twilight_validate::sticker::{
-    description as validate_description, name as validate_name, tags as validate_tags,
-    StickerValidationError,
+use twilight_validate::{
+    request::{audit_reason as validate_audit_reason, ValidationError},
+    sticker::{
+        description as validate_description, name as validate_name, tags as validate_tags,
+        StickerValidationError,
+    },
 };
 
 #[derive(Serialize)]
@@ -115,8 +118,10 @@ impl<'a> UpdateGuildSticker<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for UpdateGuildSticker<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/update_current_member.rs
+++ b/http/src/request/guild/update_current_member.rs
@@ -1,13 +1,15 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
 use twilight_model::id::{marker::GuildMarker, Id};
-use twilight_validate::request::{nickname as validate_nickname, ValidationError};
+use twilight_validate::request::{
+    audit_reason as validate_audit_reason, nickname as validate_nickname, ValidationError,
+};
 
 #[derive(Serialize)]
 struct UpdateCurrentMemberFields<'a> {
@@ -70,8 +72,10 @@ impl<'a> UpdateCurrentMember<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for UpdateCurrentMember<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, AuditLogReasonError, NullableField, Request, TryIntoRequest},
+    request::{self, AuditLogReason, NullableField, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -16,7 +16,9 @@ use twilight_model::{
         Id,
     },
 };
-use twilight_validate::request::{guild_name as validate_guild_name, ValidationError};
+use twilight_validate::request::{
+    audit_reason as validate_audit_reason, guild_name as validate_guild_name, ValidationError,
+};
 
 #[derive(Serialize)]
 struct UpdateGuildFields<'a> {
@@ -303,8 +305,10 @@ impl<'a> UpdateGuild<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for UpdateGuild<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -17,7 +17,7 @@ mod multipart;
 mod try_into_request;
 
 pub use self::{
-    audit_reason::{AuditLogReason, AuditLogReasonError},
+    audit_reason::AuditLogReason,
     base::{Request, RequestBuilder},
     get_gateway::GetGateway,
     get_gateway_authed::GetGatewayAuthed,

--- a/http/src/request/scheduled_event/create_guild_scheduled_event/external.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/external.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    request::{AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
 };
 use twilight_model::{
@@ -11,6 +11,7 @@ use twilight_model::{
     scheduled_event::{EntityType, GuildScheduledEvent},
 };
 use twilight_validate::request::{
+    audit_reason as validate_audit_reason,
     scheduled_event_description as validate_scheduled_event_description, ValidationError,
 };
 
@@ -69,10 +70,10 @@ impl<'a> CreateGuildExternalScheduledEvent<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreateGuildExternalScheduledEvent<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.0
-            .reason
-            .replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.0.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
@@ -11,7 +11,7 @@ use super::EntityMetadataFields;
 use crate::{
     client::Client,
     error::Error,
-    request::{AuditLogReason, AuditLogReasonError, Request, RequestBuilder, TryIntoRequest},
+    request::{AuditLogReason, Request, RequestBuilder, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -25,7 +25,8 @@ use twilight_model::{
     scheduled_event::{EntityType, GuildScheduledEvent, PrivacyLevel},
 };
 use twilight_validate::request::{
-    scheduled_event_name as validate_scheduled_event_name, ValidationError,
+    audit_reason as validate_audit_reason, scheduled_event_name as validate_scheduled_event_name,
+    ValidationError,
 };
 
 #[derive(Serialize)]
@@ -226,8 +227,10 @@ impl<'a> CreateGuildScheduledEvent<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreateGuildScheduledEvent<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/scheduled_event/create_guild_scheduled_event/stage_instance.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/stage_instance.rs
@@ -1,7 +1,7 @@
 use super::{CreateGuildScheduledEvent, CreateGuildScheduledEventFields};
 use crate::{
     error::Error,
-    request::{AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
 };
 use twilight_model::{
@@ -10,6 +10,7 @@ use twilight_model::{
     scheduled_event::{EntityType, GuildScheduledEvent},
 };
 use twilight_validate::request::{
+    audit_reason as validate_audit_reason,
     scheduled_event_description as validate_scheduled_event_description, ValidationError,
 };
 
@@ -72,10 +73,10 @@ impl<'a> CreateGuildStageInstanceScheduledEvent<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreateGuildStageInstanceScheduledEvent<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.0
-            .reason
-            .replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.0.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/scheduled_event/create_guild_scheduled_event/voice.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/voice.rs
@@ -1,7 +1,7 @@
 use super::{CreateGuildScheduledEvent, CreateGuildScheduledEventFields};
 use crate::{
     error::Error,
-    request::{AuditLogReason, AuditLogReasonError, Request, TryIntoRequest},
+    request::{AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
 };
 use twilight_model::{
@@ -10,6 +10,7 @@ use twilight_model::{
     scheduled_event::{EntityType, GuildScheduledEvent},
 };
 use twilight_validate::request::{
+    audit_reason as validate_audit_reason,
     scheduled_event_description as validate_scheduled_event_description, ValidationError,
 };
 
@@ -72,10 +73,10 @@ impl<'a> CreateGuildVoiceScheduledEvent<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for CreateGuildVoiceScheduledEvent<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.0
-            .reason
-            .replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.0.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/scheduled_event/update_guild_scheduled_event.rs
+++ b/http/src/request/scheduled_event/update_guild_scheduled_event.rs
@@ -2,9 +2,7 @@ use super::EntityMetadataFields;
 use crate::{
     client::Client,
     error::Error,
-    request::{
-        AuditLogReason, AuditLogReasonError, NullableField, Request, RequestBuilder, TryIntoRequest,
-    },
+    request::{AuditLogReason, NullableField, Request, RequestBuilder, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -18,6 +16,7 @@ use twilight_model::{
     scheduled_event::{EntityType, GuildScheduledEvent, PrivacyLevel, Status},
 };
 use twilight_validate::request::{
+    audit_reason as validate_audit_reason,
     scheduled_event_description as validate_scheduled_event_description,
     scheduled_event_name as validate_scheduled_event_name, ValidationError,
 };
@@ -216,8 +215,10 @@ impl<'a> UpdateGuildScheduledEvent<'a> {
 }
 
 impl<'a> AuditLogReason<'a> for UpdateGuildScheduledEvent<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
 
         Ok(self)
     }

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -1,13 +1,15 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, AuditLogReasonError, NullableField, Request, TryIntoRequest},
+    request::{self, AuditLogReason, NullableField, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
 use serde::Serialize;
 use twilight_model::user::User;
-use twilight_validate::request::{username as validate_username, ValidationError};
+use twilight_validate::request::{
+    audit_reason as validate_audit_reason, username as validate_username, ValidationError,
+};
 
 #[derive(Serialize)]
 struct UpdateCurrentUserFields<'a> {
@@ -84,6 +86,16 @@ impl<'a> UpdateCurrentUser<'a> {
     }
 }
 
+impl<'a> AuditLogReason<'a> for UpdateCurrentUser<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.reason.replace(reason);
+
+        Ok(self)
+    }
+}
+
 impl TryIntoRequest for UpdateCurrentUser<'_> {
     fn try_into_request(self) -> Result<Request, HttpError> {
         let mut request = Request::builder(&Route::UpdateCurrentUser);
@@ -95,13 +107,5 @@ impl TryIntoRequest for UpdateCurrentUser<'_> {
         }
 
         Ok(request.build())
-    }
-}
-
-impl<'a> AuditLogReason<'a> for UpdateCurrentUser<'a> {
-    fn reason(mut self, reason: &'a str) -> Result<Self, AuditLogReasonError> {
-        self.reason.replace(AuditLogReasonError::validate(reason)?);
-
-        Ok(self)
     }
 }

--- a/validate/src/request.rs
+++ b/validate/src/request.rs
@@ -9,6 +9,9 @@ use std::{
 };
 use twilight_model::datetime::Timestamp;
 
+/// The maximum audit log reason length in UTF-16 codepoints.
+pub const AUDIT_REASON_MAX: usize = 512;
+
 /// Maximum amount of days for messages to be deleted upon ban.
 pub const CREATE_GUILD_BAN_DELETE_MESSAGE_DAYS_MAX: u64 = 7;
 
@@ -146,6 +149,13 @@ impl Display for ValidationError {
     #[allow(clippy::too_many_lines)]
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
+            ValidationErrorType::AuditReason { len } => {
+                f.write_str("provided audit reason length is ")?;
+                Display::fmt(len, f)?;
+                f.write_str(", but it must be at most ")?;
+
+                Display::fmt(&AUDIT_REASON_MAX, f)
+            }
             ValidationErrorType::CreateGuildBanDeleteMessageDays {
                 days: delete_message_days,
             } => {
@@ -323,6 +333,11 @@ impl Error for ValidationError {}
 /// Type of [`ValidationError`] that occurred.
 #[derive(Debug)]
 pub enum ValidationErrorType {
+    /// Provided audit reason was too large.
+    AuditReason {
+        /// Invalid length.
+        len: usize,
+    },
     /// Provided create guild ban delete message days was invalid.
     CreateGuildBanDeleteMessageDays {
         /// Invalid days.
@@ -423,6 +438,29 @@ pub enum ValidationErrorType {
         /// Invalid length.
         len: usize,
     },
+}
+
+/// Ensure that an audit reason is correct.
+///
+/// The length must be at most [`AUDIT_REASON_MAX`]. This is based on
+/// [this documentation entry].
+///
+/// # Errors
+///
+/// Returns an error of type [`AuditReason`] if the length is invalid.
+///
+/// [`AuditReason`]: ValidationErrorType::AuditReason
+/// [this documentation entry]: https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-entry-structure
+pub fn audit_reason(audit_reason: impl AsRef<str>) -> Result<(), ValidationError> {
+    let len = audit_reason.as_ref().chars().count();
+
+    if len <= AUDIT_REASON_MAX {
+        Ok(())
+    } else {
+        Err(ValidationError {
+            kind: ValidationErrorType::AuditReason { len },
+        })
+    }
 }
 
 /// Ensure that the delete message days amount for the Create Guild Ban request
@@ -879,6 +917,15 @@ pub fn username(value: impl AsRef<str>) -> Result<(), ValidationError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_audit_reason() {
+        assert!(audit_reason("").is_ok());
+        assert!(audit_reason("a").is_ok());
+        assert!(audit_reason("a".repeat(500)).is_ok());
+
+        assert!(audit_reason("a".repeat(1000)).is_err());
+    }
 
     #[test]
     fn test_create_guild_ban_delete_message_days() {


### PR DESCRIPTION
Removes `AuditLogReasonError` and its `Type`. Move audit reason's validation to the `validate` crate, and update all implementations.

Closes #1476.
