### PR TITLE
feat(http,validate)!: validate attachment filenames

### DIFF
--- a/http/src/request/application/interaction/update_followup.rs
+++ b/http/src/request/application/interaction/update_followup.rs
@@ -21,8 +21,8 @@ use twilight_model::{
     },
 };
 use twilight_validate::message::{
-    components as validate_components, content as validate_content, embeds as validate_embeds,
-    MessageValidationError,
+    attachment_filename as validate_attachment_filename, components as validate_components,
+    content as validate_content, embeds as validate_embeds, MessageValidationError,
 };
 
 #[derive(Serialize)]
@@ -129,12 +129,26 @@ impl<'a> UpdateFollowup<'a> {
     /// Attach multiple new files to the message.
     ///
     /// This method clears previous calls.
-    pub fn attachments(mut self, attachments: &'a [Attachment]) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`AttachmentFilename`] if any filename is
+    /// invalid.
+    ///
+    /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
+    pub fn attachments(
+        mut self,
+        attachments: &'a [Attachment],
+    ) -> Result<Self, MessageValidationError> {
+        attachments
+            .iter()
+            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+
         self.attachment_manager = self
             .attachment_manager
             .set_files(attachments.iter().collect());
 
-        self
+        Ok(self)
     }
 
     /// Set the message's list of [`Component`]s.

--- a/http/src/request/application/interaction/update_response.rs
+++ b/http/src/request/application/interaction/update_response.rs
@@ -21,8 +21,8 @@ use twilight_model::{
     },
 };
 use twilight_validate::message::{
-    components as validate_components, content as validate_content, embeds as validate_embeds,
-    MessageValidationError,
+    attachment_filename as validate_attachment_filename, components as validate_components,
+    content as validate_content, embeds as validate_embeds, MessageValidationError,
 };
 
 #[derive(Serialize)]
@@ -126,12 +126,26 @@ impl<'a> UpdateResponse<'a> {
     /// Attach multiple new files to the message.
     ///
     /// This method clears previous calls.
-    pub fn attachments(mut self, attachments: &'a [Attachment]) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`AttachmentFilename`] if any filename is
+    /// invalid.
+    ///
+    /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
+    pub fn attachments(
+        mut self,
+        attachments: &'a [Attachment],
+    ) -> Result<Self, MessageValidationError> {
+        attachments
+            .iter()
+            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+
         self.attachment_manager = self
             .attachment_manager
             .set_files(attachments.iter().collect());
 
-        self
+        Ok(self)
     }
 
     /// Set the message's list of [`Component`]s.

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -23,8 +23,9 @@ use twilight_model::{
     },
 };
 use twilight_validate::message::{
-    components as validate_components, content as validate_content, embeds as validate_embeds,
-    sticker_ids as validate_sticker_ids, MessageValidationError,
+    attachment_filename as validate_attachment_filename, components as validate_components,
+    content as validate_content, embeds as validate_embeds, sticker_ids as validate_sticker_ids,
+    MessageValidationError,
 };
 
 #[derive(Serialize)]
@@ -121,12 +122,26 @@ impl<'a> CreateMessage<'a> {
     /// Attach multiple files to the message.
     ///
     /// Calling this method will clear previous calls.
-    pub fn attachments(mut self, attachments: &'a [Attachment]) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`AttachmentFilename`] if any filename is
+    /// invalid.
+    ///
+    /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
+    pub fn attachments(
+        mut self,
+        attachments: &'a [Attachment],
+    ) -> Result<Self, MessageValidationError> {
+        attachments
+            .iter()
+            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+
         self.attachment_manager = self
             .attachment_manager
             .set_files(attachments.iter().collect());
 
-        self
+        Ok(self)
     }
 
     /// Set the message's list of [`Component`]s.

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -23,8 +23,8 @@ use twilight_model::{
     },
 };
 use twilight_validate::message::{
-    components as validate_components, content as validate_content, embeds as validate_embeds,
-    MessageValidationError,
+    attachment_filename as validate_attachment_filename, components as validate_components,
+    content as validate_content, embeds as validate_embeds, MessageValidationError,
 };
 
 #[derive(Serialize)]
@@ -134,12 +134,26 @@ impl<'a> UpdateMessage<'a> {
     /// Attach multiple new files to the message.
     ///
     /// This method clears previous calls.
-    pub fn attachments(mut self, attachments: &'a [Attachment]) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`AttachmentFilename`] if any filename is
+    /// invalid.
+    ///
+    /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
+    pub fn attachments(
+        mut self,
+        attachments: &'a [Attachment],
+    ) -> Result<Self, MessageValidationError> {
+        attachments
+            .iter()
+            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+
         self.attachment_manager = self
             .attachment_manager
             .set_files(attachments.iter().collect());
 
-        self
+        Ok(self)
     }
 
     /// Set the message's list of [`Component`]s.

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -20,8 +20,8 @@ use twilight_model::{
     },
 };
 use twilight_validate::message::{
-    components as validate_components, content as validate_content, embeds as validate_embeds,
-    MessageValidationError,
+    attachment_filename as validate_attachment_filename, components as validate_components,
+    content as validate_content, embeds as validate_embeds, MessageValidationError,
 };
 
 #[derive(Serialize)]
@@ -123,12 +123,26 @@ impl<'a> ExecuteWebhook<'a> {
     /// Attach multiple files to the message.
     ///
     /// Calling this method will clear any previous calls.
-    pub fn attachments(mut self, attachments: &'a [Attachment]) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`AttachmentFilename`] if any filename is
+    /// invalid.
+    ///
+    /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
+    pub fn attachments(
+        mut self,
+        attachments: &'a [Attachment],
+    ) -> Result<Self, MessageValidationError> {
+        attachments
+            .iter()
+            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+
         self.attachment_manager = self
             .attachment_manager
             .set_files(attachments.iter().collect());
 
-        self
+        Ok(self)
     }
 
     /// The URL of the avatar of the webhook.

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -21,8 +21,8 @@ use twilight_model::{
     },
 };
 use twilight_validate::message::{
-    components as validate_components, content as validate_content, embeds as validate_embeds,
-    MessageValidationError,
+    attachment_filename as validate_attachment_filename, components as validate_components,
+    content as validate_content, embeds as validate_embeds, MessageValidationError,
 };
 
 #[derive(Serialize)]
@@ -126,12 +126,26 @@ impl<'a> UpdateWebhookMessage<'a> {
     /// Attach multiple new files to the message.
     ///
     /// This method clears previous calls.
-    pub fn attachments(mut self, attachments: &'a [Attachment]) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`AttachmentFilename`] if any filename is
+    /// invalid.
+    ///
+    /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
+    pub fn attachments(
+        mut self,
+        attachments: &'a [Attachment],
+    ) -> Result<Self, MessageValidationError> {
+        attachments
+            .iter()
+            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+
         self.attachment_manager = self
             .attachment_manager
             .set_files(attachments.iter().collect());
 
-        self
+        Ok(self)
     }
 
     /// Set the message's list of [`Component`]s.

--- a/validate/src/message.rs
+++ b/validate/src/message.rs
@@ -16,6 +16,12 @@ use twilight_model::{
     id::{marker::StickerMarker, Id},
 };
 
+/// ASCII dash.
+pub const DASH: char = '-';
+
+/// ASCII dot.
+pub const DOT: char = '.';
+
 /// Maximum number of embeds that a message may have.
 pub const EMBED_COUNT_LIMIT: usize = 10;
 
@@ -24,6 +30,9 @@ pub const MESSAGE_CONTENT_LENGTH_MAX: usize = 2000;
 
 /// Maximum amount of stickers.
 pub const STICKER_MAX: usize = 3;
+
+/// ASCII underscore.
+pub const UNDERSCORE: char = '_';
 
 /// A message is not valid.
 #[derive(Debug)]
@@ -62,6 +71,9 @@ impl MessageValidationError {
 impl Display for MessageValidationError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
+            MessageValidationErrorType::AttachmentFilename => {
+                f.write_str("attachment filename is invalid")
+            }
             MessageValidationErrorType::ComponentCount { count } => {
                 Display::fmt(count, f)?;
                 f.write_str(" components were provided, but only ")?;
@@ -98,6 +110,8 @@ impl Error for MessageValidationError {}
 /// Type of [`MessageValidationError`] that occurred.
 #[derive(Debug)]
 pub enum MessageValidationErrorType {
+    /// Attachment filename is not valid.
+    AttachmentFilename,
     /// Too many message components were provided.
     ComponentCount {
         /// Number of components that were provided.
@@ -128,6 +142,31 @@ pub enum MessageValidationErrorType {
     ///
     /// A followup message can have up to 10 embeds.
     TooManyEmbeds,
+}
+
+/// Ensure an attachment's filename is correct.
+///
+/// The filename can contain ASCII alphanumeric characters, dots, dashes, and
+/// underscores.
+///
+/// # Errors
+///
+/// Returns an error of type [`AttachmentFilename`] if the filename is invalid.
+///
+/// [`AttachmentFilename`]: MessageValidationErrorType::AttachmentFilename
+pub fn attachment_filename(filename: impl AsRef<str>) -> Result<(), MessageValidationError> {
+    if filename
+        .as_ref()
+        .chars()
+        .any(|c| !(c.is_ascii_alphanumeric() || c == DOT || c == DASH || c == UNDERSCORE))
+    {
+        Err(MessageValidationError {
+            kind: MessageValidationErrorType::AttachmentFilename,
+            source: None,
+        })
+    } else {
+        Ok(())
+    }
 }
 
 /// Ensure a list of components is correct.
@@ -257,7 +296,17 @@ pub fn sticker_ids(sticker_ids: &[Id<StickerMarker>]) -> Result<(), MessageValid
 
 #[cfg(test)]
 mod tests {
-    use super::content;
+    use super::*;
+
+    #[test]
+    fn test_attachment_filename() {
+        assert!(attachment_filename("one.jpg").is_ok());
+        assert!(attachment_filename("two.png").is_ok());
+        assert!(attachment_filename("three.gif").is_ok());
+        assert!(attachment_filename(".dots-dashes_underscores.gif").is_ok());
+
+        assert!(attachment_filename("????????").is_err());
+    }
 
     #[test]
     fn test_content() {

--- a/validate/src/message.rs
+++ b/validate/src/message.rs
@@ -164,16 +164,16 @@ pub fn attachment_filename(filename: impl AsRef<str>) -> Result<(), MessageValid
     if filename
         .as_ref()
         .chars()
-        .any(|c| !(c.is_ascii_alphanumeric() || c == DOT || c == DASH || c == UNDERSCORE))
+        .all(|c| (c.is_ascii_alphanumeric() || c == DOT || c == DASH || c == UNDERSCORE))
     {
+        Ok(())
+    } else {
         Err(MessageValidationError {
             kind: MessageValidationErrorType::AttachmentFilename {
                 filename: filename.as_ref().to_string(),
             },
             source: None,
         })
-    } else {
-        Ok(())
     }
 }
 

--- a/validate/src/message.rs
+++ b/validate/src/message.rs
@@ -16,12 +16,6 @@ use twilight_model::{
     id::{marker::StickerMarker, Id},
 };
 
-/// ASCII dash.
-pub const DASH: char = '-';
-
-/// ASCII dot.
-pub const DOT: char = '.';
-
 /// Maximum number of embeds that a message may have.
 pub const EMBED_COUNT_LIMIT: usize = 10;
 
@@ -31,8 +25,14 @@ pub const MESSAGE_CONTENT_LENGTH_MAX: usize = 2000;
 /// Maximum amount of stickers.
 pub const STICKER_MAX: usize = 3;
 
+/// ASCII dash.
+const DASH: char = '-';
+
+/// ASCII dot.
+const DOT: char = '.';
+
 /// ASCII underscore.
-pub const UNDERSCORE: char = '_';
+const UNDERSCORE: char = '_';
 
 /// A message is not valid.
 #[derive(Debug)]


### PR DESCRIPTION
Ensure attachment filenames are composed of ASCII alphanumeric characters, dots, dashes, or underscores.

Closes #1465.
