### PR TITLE
feat(http)!: support setting `MessageFlags` on applicable methods

### DIFF
--- a/http/src/request/application/interaction/create_followup.rs
+++ b/http/src/request/application/interaction/create_followup.rs
@@ -206,13 +206,13 @@ impl<'a> CreateFollowup<'a> {
         Ok(self)
     }
 
-    /// Set if the followup should be ephemeral.
-    pub const fn ephemeral(mut self, ephemeral: bool) -> Self {
-        if ephemeral {
-            self.fields.flags = Some(MessageFlags::EPHEMERAL);
-        } else {
-            self.fields.flags = None;
-        }
+    /// Set the message's flags.
+    ///
+    /// The only supported flag is [`EPHEMERAL`].
+    ///
+    /// [`EPHEMERAL`]: MessageFlags::EPHEMERAL
+    pub const fn flags(mut self, flags: MessageFlags) -> Self {
+        self.fields.flags = Some(flags);
 
         self
     }

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -13,7 +13,7 @@ use twilight_model::{
     application::component::Component,
     channel::{
         embed::Embed,
-        message::{AllowedMentions, MessageReference},
+        message::{AllowedMentions, MessageFlags, MessageReference},
         Message,
     },
     http::attachment::Attachment,
@@ -40,6 +40,8 @@ pub(crate) struct CreateMessageFields<'a> {
     content: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     embeds: Option<&'a [Embed]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flags: Option<MessageFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]
     message_reference: Option<MessageReference>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -98,6 +100,7 @@ impl<'a> CreateMessage<'a> {
                 components: None,
                 content: None,
                 embeds: None,
+                flags: None,
                 message_reference: None,
                 nonce: None,
                 payload_json: None,
@@ -229,6 +232,17 @@ impl<'a> CreateMessage<'a> {
         };
 
         self.fields.message_reference = Some(reference);
+
+        self
+    }
+
+    /// Set the message's flags.
+    ///
+    /// The only supported flag is [`SUPPRESS_EMBEDS`].
+    ///
+    /// [`SUPPRESS_EMBEDS`]: MessageFlags::SUPPRESS_EMBEDS
+    pub const fn flags(mut self, flags: MessageFlags) -> Self {
+        self.fields.flags = Some(flags);
 
         self
     }

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -246,6 +246,17 @@ impl<'a> UpdateMessage<'a> {
         Ok(self)
     }
 
+    /// Set the message's flags.
+    ///
+    /// The only supported flag is [`SUPPRESS_EMBEDS`].
+    ///
+    /// [`SUPPRESS_EMBEDS`]: MessageFlags::SUPPRESS_EMBEDS
+    pub const fn flags(mut self, flags: MessageFlags) -> Self {
+        self.fields.flags = Some(flags);
+
+        self
+    }
+
     /// Specify multiple [`Id<AttachmentMarker>`]s already present in the target
     /// message to keep.
     ///
@@ -281,26 +292,6 @@ impl<'a> UpdateMessage<'a> {
     /// [`attachments`]: Self::attachments
     pub const fn payload_json(mut self, payload_json: &'a [u8]) -> Self {
         self.fields.payload_json = Some(payload_json);
-
-        self
-    }
-
-    /// Suppress the embeds in the message.
-    pub const fn suppress_embeds(mut self, suppress: bool) -> Self {
-        #[allow(clippy::option_if_let_else)]
-        let mut bits = if let Some(flags) = self.fields.flags {
-            flags.bits()
-        } else {
-            0
-        };
-
-        if suppress {
-            bits |= MessageFlags::SUPPRESS_EMBEDS.bits();
-        } else {
-            bits &= !MessageFlags::SUPPRESS_EMBEDS.bits()
-        }
-
-        self.fields.flags = Some(MessageFlags::from_bits_truncate(bits));
 
         self
     }

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -12,7 +12,10 @@ use crate::{
 use serde::Serialize;
 use twilight_model::{
     application::component::Component,
-    channel::{embed::Embed, message::AllowedMentions},
+    channel::{
+        embed::Embed,
+        message::{AllowedMentions, MessageFlags},
+    },
     http::attachment::Attachment,
     id::{
         marker::{ChannelMarker, WebhookMarker},
@@ -38,6 +41,8 @@ pub(crate) struct ExecuteWebhookFields<'a> {
     content: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     embeds: Option<&'a [Embed]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flags: Option<MessageFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payload_json: Option<&'a [u8]>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -97,6 +102,7 @@ impl<'a> ExecuteWebhook<'a> {
                 components: None,
                 content: None,
                 embeds: None,
+                flags: None,
                 payload_json: None,
                 tts: None,
                 username: None,
@@ -218,6 +224,17 @@ impl<'a> ExecuteWebhook<'a> {
         self.fields.embeds = Some(embeds);
 
         Ok(self)
+    }
+
+    /// Set the message's flags.
+    ///
+    /// The only supported flag is [`SUPPRESS_EMBEDS`].
+    ///
+    /// [`SUPPRESS_EMBEDS`]: MessageFlags::SUPPRESS_EMBEDS
+    pub const fn flags(mut self, flags: MessageFlags) -> Self {
+        self.fields.flags = Some(flags);
+
+        self
     }
 
     /// JSON encoded body of any additional request fields.


### PR DESCRIPTION
This PR replaces all methods of setting `MessageFlags` (`ephemeral`, `suppress_embeds`) with a simpler and more flexible `flags` method.

Closes #1470.
