### PR TITLE
feat(gateway,http,model)!: discord api v10

### DIFF
--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -172,6 +172,9 @@ pub use twilight_gateway_queue as queue;
 #[doc(no_inline)]
 pub use twilight_model::gateway::event::{Event, EventType};
 
+/// Discord API version used by this crate.
+pub const API_VERSION: u8 = 10;
+
 #[cfg(not(any(
     feature = "native",
     feature = "rustls-native-roots",

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -10,7 +10,7 @@ use super::{
     session::{Session, SessionSendError, SessionSendErrorType},
     socket_forwarder::SocketForwarder,
 };
-use crate::{event::EventTypeFlags, shard::tls::TlsContainer};
+use crate::{event::EventTypeFlags, shard::tls::TlsContainer, API_VERSION};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -329,7 +329,8 @@ impl ShardProcessor {
             tracing::debug!("shard {:?} finished queue", config.shard());
         }
 
-        url.push_str("?v=9");
+        url.push_str("?v=");
+        url.push_str(&API_VERSION.to_string());
 
         // Discord's documentation states:
         //

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -144,7 +144,7 @@ pub mod routing;
 mod json;
 
 /// Discord API version used by this crate.
-pub const API_VERSION: u8 = 9;
+pub const API_VERSION: u8 = 10;
 
 pub use crate::{client::Client, error::Error, response::Response};
 

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -34,6 +34,9 @@ use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use serde::{Serialize, Serializer};
 use std::iter;
 
+/// Name of the audit log reason header.
+const REASON_HEADER_NAME: &str = "x-audit-log-reason";
+
 /// Field that either serializes to null or a value.
 ///
 /// This is particularly useful when combined with an `Option` by allowing three
@@ -56,7 +59,7 @@ impl<T: Serialize> Serialize for NullableField<T> {
 pub(crate) fn audit_header(
     reason: &str,
 ) -> Result<impl Iterator<Item = (HeaderName, HeaderValue)>, Error> {
-    let header_name = HeaderName::from_static("x-audit-log-reason");
+    let header_name = HeaderName::from_static(REASON_HEADER_NAME);
     let encoded_reason = utf8_percent_encode(reason, NON_ALPHANUMERIC).to_string();
     let header_value = HeaderValue::from_str(&encoded_reason).map_err(|e| Error {
         kind: ErrorType::CreatingHeader {

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -1,7 +1,6 @@
 pub use twilight_http_ratelimiting::request::{Path, PathParseError, PathParseErrorType};
 
 use crate::request::{channel::reaction::RequestReactionType, Method};
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use twilight_model::id::{marker::RoleMarker, Id};
 
@@ -33,8 +32,6 @@ pub enum Route<'a> {
         delete_message_days: Option<u64>,
         /// The ID of the guild.
         guild_id: u64,
-        /// The reason for the ban.
-        reason: Option<&'a str>,
         /// The ID of the user.
         user_id: u64,
     },
@@ -1607,7 +1604,6 @@ impl Display for Route<'_> {
             Route::CreateBan {
                 guild_id,
                 delete_message_days,
-                reason,
                 user_id,
             } => {
                 f.write_str("guilds/")?;
@@ -1619,17 +1615,6 @@ impl Display for Route<'_> {
                 if let Some(delete_message_days) = delete_message_days {
                     f.write_str("delete_message_days=")?;
                     Display::fmt(delete_message_days, f)?;
-
-                    if reason.is_some() {
-                        f.write_str("&")?;
-                    }
-                }
-
-                if let Some(reason) = reason {
-                    f.write_str("reason=")?;
-                    let encoded_reason = utf8_percent_encode(reason, NON_ALPHANUMERIC);
-
-                    Display::fmt(&encoded_reason, f)?;
                 }
 
                 Ok(())
@@ -4445,7 +4430,6 @@ mod tests {
         let mut route = Route::CreateBan {
             guild_id: GUILD_ID,
             delete_message_days: None,
-            reason: None,
             user_id: USER_ID,
         };
         assert_eq!(
@@ -4460,43 +4444,12 @@ mod tests {
         route = Route::CreateBan {
             guild_id: GUILD_ID,
             delete_message_days: Some(3),
-            reason: None,
             user_id: USER_ID,
         };
         assert_eq!(
             route.to_string(),
             format!(
                 "guilds/{guild_id}/bans/{user_id}?delete_message_days=3",
-                guild_id = GUILD_ID,
-                user_id = USER_ID
-            )
-        );
-
-        route = Route::CreateBan {
-            guild_id: GUILD_ID,
-            delete_message_days: None,
-            reason: Some("test"),
-            user_id: USER_ID,
-        };
-        assert_eq!(
-            route.to_string(),
-            format!(
-                "guilds/{guild_id}/bans/{user_id}?reason=test",
-                guild_id = GUILD_ID,
-                user_id = USER_ID
-            )
-        );
-
-        route = Route::CreateBan {
-            guild_id: GUILD_ID,
-            delete_message_days: Some(3),
-            reason: Some("test"),
-            user_id: USER_ID,
-        };
-        assert_eq!(
-            route.to_string(),
-            format!(
-                "guilds/{guild_id}/bans/{user_id}?delete_message_days=3&reason=test",
                 guild_id = GUILD_ID,
                 user_id = USER_ID
             )

--- a/model/src/gateway/intents.rs
+++ b/model/src/gateway/intents.rs
@@ -191,6 +191,14 @@ bitflags! {
         /// [`TYPING_START`]: super::event::Event::TypingStart
         /// [`GUILD_MESSAGE_TYPING`]: Self::GUILD_MESSAGE_TYPING
         const DIRECT_MESSAGE_TYPING = 1 << 14;
+        /// Message content intent.
+        ///
+        /// This intent is privileged. See [Discord Docs/Privileged Intents].
+        ///
+        /// This intent allows you to receive the contents of all messages.
+        ///
+        /// [Discord Docs/Privileged Intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents
+        const MESSAGE_CONTENT = 1 << 15;
     }
 }
 

--- a/model/src/oauth/current_application_info/mod.rs
+++ b/model/src/oauth/current_application_info/mod.rs
@@ -33,7 +33,6 @@ pub struct CurrentApplicationInfo {
     #[serde(default)]
     pub rpc_origins: Vec<String>,
     pub slug: Option<String>,
-    pub summary: String,
     pub team: Option<Team>,
     /// URL of the application's terms of service.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -65,7 +64,6 @@ mod tests {
         privacy_policy_url,
         rpc_origins,
         slug,
-        summary,
         team,
         terms_of_service_url,
         verify_key
@@ -115,7 +113,6 @@ mod tests {
             privacy_policy_url: Some("https://privacypolicy".into()),
             rpc_origins: vec!["one".to_owned()],
             slug: Some("app slug".to_owned()),
-            summary: "a summary".to_owned(),
             team: Some(Team {
                 icon: None,
                 id: Id::new(5),
@@ -132,7 +129,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "CurrentApplicationInfo",
-                    len: 18,
+                    len: 17,
                 },
                 Token::Str("bot_public"),
                 Token::Bool(true),
@@ -193,8 +190,6 @@ mod tests {
                 Token::Str("slug"),
                 Token::Some,
                 Token::Str("app slug"),
-                Token::Str("summary"),
-                Token::Str("a summary"),
                 Token::Str("team"),
                 Token::Some,
                 Token::Struct {


### PR DESCRIPTION
Update from Discord gateway and HTTP API v9 to v10. Details about the upgrade are detailed in Discord's announcement: <https://github.com/discord/discord-api-docs/discussions/4510>

Many of the details do not apply to us as they were already removed due to deprecation. The following changes have been made:

- abstract gateway version to a public constant and increment to 10
- increment http version constant to 10
- add `Intents::MESSAGE_CONTENT` intent flag
- update `CreateBan` to specify the reason in the headers, not URL
- remove `CurrentApplicationInfo`'s `summary` field
- remove `Route::CreateBan`'s `reason` structfield

BREAKING CHANGES: Third party Discord API version incremented from 9 to 10, `CurrentApplicationInfo::summary` and `Route::CreateBan::reason` have been removed.