### PR TITLE
fix(model): add scheduled event action types

### DIFF
--- a/model/src/guild/audit_log/event_type.rs
+++ b/model/src/guild/audit_log/event_type.rs
@@ -187,32 +187,32 @@ pub enum AuditLogEventType {
     ///
     /// [`GuildScheduledEvent`]: crate::scheduled_event::GuildScheduledEvent
     GuildScheduledEventCreate = 100,
-    /// [`GuildScheduledEvent`] was deleted.
-    ///
-    /// [`GuildScheduledEvent`]: crate::scheduled_event::GuildScheduledEvent
-    GuildScheduledEventDelete = 102,
     /// [`GuildScheduledEvent`] was updated.
     ///
     /// [`GuildScheduledEvent`]: crate::scheduled_event::GuildScheduledEvent
     GuildScheduledEventUpdate = 101,
+    /// [`GuildScheduledEvent`] was deleted.
+    ///
+    /// [`GuildScheduledEvent`]: crate::scheduled_event::GuildScheduledEvent
+    GuildScheduledEventDelete = 102,
     /// [`NewsThread`], [`PrivateThread`], or [`PublicThread]` was created.
     ///
     /// [`NewsThread`]: crate::channel::thread::NewsThread
     /// [`PrivateThread`]: crate::channel::thread::PrivateThread
     /// [`PublicThread`]: crate::channel::thread::PublicThread
     ThreadCreate = 110,
-    /// [`NewsThread`], [`PrivateThread`], or [`PublicThread]` was deleted.
-    ///
-    /// [`NewsThread`]: crate::channel::thread::NewsThread
-    /// [`PrivateThread`]: crate::channel::thread::PrivateThread
-    /// [`PublicThread`]: crate::channel::thread::PublicThread
-    ThreadDelete = 112,
     /// [`NewsThread`], [`PrivateThread`], or [`PublicThread]` was updated.
     ///
     /// [`NewsThread`]: crate::channel::thread::NewsThread
     /// [`PrivateThread`]: crate::channel::thread::PrivateThread
     /// [`PublicThread`]: crate::channel::thread::PublicThread
     ThreadUpdate = 111,
+    /// [`NewsThread`], [`PrivateThread`], or [`PublicThread]` was deleted.
+    ///
+    /// [`NewsThread`]: crate::channel::thread::NewsThread
+    /// [`PrivateThread`]: crate::channel::thread::PrivateThread
+    /// [`PublicThread`]: crate::channel::thread::PublicThread
+    ThreadDelete = 112,
 }
 
 #[cfg(test)]

--- a/model/src/guild/audit_log/event_type.rs
+++ b/model/src/guild/audit_log/event_type.rs
@@ -159,24 +159,6 @@ pub enum AuditLogEventType {
     ///
     /// [Integration]: super::super::GuildIntegration
     IntegrationDelete = 82,
-    /// [`NewsThread`], [`PrivateThread`], or [`PublicThread]` was created.
-    ///
-    /// [`NewsThread`]: crate::channel::thread::NewsThread
-    /// [`PrivateThread`]: crate::channel::thread::PrivateThread
-    /// [`PublicThread`]: crate::channel::thread::PublicThread
-    ThreadCreate = 110,
-    /// [`NewsThread`], [`PrivateThread`], or [`PublicThread]` was deleted.
-    ///
-    /// [`NewsThread`]: crate::channel::thread::NewsThread
-    /// [`PrivateThread`]: crate::channel::thread::PrivateThread
-    /// [`PublicThread`]: crate::channel::thread::PublicThread
-    ThreadDelete = 112,
-    /// [`NewsThread`], [`PrivateThread`], or [`PublicThread]` was updated.
-    ///
-    /// [`NewsThread`]: crate::channel::thread::NewsThread
-    /// [`PrivateThread`]: crate::channel::thread::PrivateThread
-    /// [`PublicThread`]: crate::channel::thread::PublicThread
-    ThreadUpdate = 111,
     /// [Stage instance] was created.
     ///
     /// [Stage instance]: crate::channel::stage_instance::StageInstance
@@ -213,6 +195,24 @@ pub enum AuditLogEventType {
     ///
     /// [`GuildScheduledEvent`]: crate::scheduled_event::GuildScheduledEvent
     GuildScheduledEventUpdate = 101,
+    /// [`NewsThread`], [`PrivateThread`], or [`PublicThread]` was created.
+    ///
+    /// [`NewsThread`]: crate::channel::thread::NewsThread
+    /// [`PrivateThread`]: crate::channel::thread::PrivateThread
+    /// [`PublicThread`]: crate::channel::thread::PublicThread
+    ThreadCreate = 110,
+    /// [`NewsThread`], [`PrivateThread`], or [`PublicThread]` was deleted.
+    ///
+    /// [`NewsThread`]: crate::channel::thread::NewsThread
+    /// [`PrivateThread`]: crate::channel::thread::PrivateThread
+    /// [`PublicThread`]: crate::channel::thread::PublicThread
+    ThreadDelete = 112,
+    /// [`NewsThread`], [`PrivateThread`], or [`PublicThread]` was updated.
+    ///
+    /// [`NewsThread`]: crate::channel::thread::NewsThread
+    /// [`PrivateThread`]: crate::channel::thread::PrivateThread
+    /// [`PublicThread`]: crate::channel::thread::PublicThread
+    ThreadUpdate = 111,
 }
 
 #[cfg(test)]

--- a/model/src/guild/audit_log/event_type.rs
+++ b/model/src/guild/audit_log/event_type.rs
@@ -201,6 +201,18 @@ pub enum AuditLogEventType {
     ///
     /// [Sticker]: crate::channel::message::sticker::Sticker
     StickerDelete = 92,
+    /// [`GuildScheduledEvent`] was created.
+    ///
+    /// [`GuildScheduledEvent`]: crate::scheduled_event::GuildScheduledEvent
+    GuildScheduledEventCreate = 100,
+    /// [`GuildScheduledEvent`] was deleted.
+    ///
+    /// [`GuildScheduledEvent`]: crate::scheduled_event::GuildScheduledEvent
+    GuildScheduledEventDelete = 102,
+    /// [`GuildScheduledEvent`] was updated.
+    ///
+    /// [`GuildScheduledEvent`]: crate::scheduled_event::GuildScheduledEvent
+    GuildScheduledEventUpdate = 101,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Previously, the `AuditLogEventType` enum did not contain values for guild scheduled events. This PR fixes that.

Closes #1546.
