### PR TITLE
feat(http): add `Payload` trait and `payload` methods

### DIFF
--- a/http/src/request/application/command/create_global_command/mod.rs
+++ b/http/src/request/application/command/create_global_command/mod.rs
@@ -7,11 +7,26 @@ pub use self::{
     user::CreateGlobalUserCommand,
 };
 
-use crate::Client;
+use crate::{
+    client::Client,
+    error::Error as HttpError,
+    request::{Payload, Request, RequestBuilder},
+    routing::Route,
+};
+use serde::Serialize;
 use twilight_model::id::{marker::ApplicationMarker, Id};
 use twilight_validate::command::CommandValidationError;
 
 /// Create a new global command.
+///
+/// You may either use the provided request builders for each command type:
+/// [`chat_input`], [`message`], or [`user`], or you may use the [`payload`]
+/// method via the [`Payload`] trait to provide your own Command.
+///
+/// [`chat_input`]: Self::chat_input
+/// [`message`]: Self::message
+/// [`payload`]: Self::payload
+/// [`user`]: Self::user
 #[must_use = "the command must have a type"]
 pub struct CreateGlobalCommand<'a> {
     application_id: Id<ApplicationMarker>,
@@ -38,8 +53,8 @@ impl<'a> CreateGlobalCommand<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error of type [`NameLengthInvalid`] or [`NameCharacterInvalid`]
-    /// if the command name is invalid.
+    /// Returns an error of type [`NameLengthInvalid`] or
+    /// [`NameCharacterInvalid`] if the command name is invalid.
     ///
     /// Returns an error of type [`DescriptionInvalid`] if the
     /// command description is not between 1 and 100 characters.
@@ -94,5 +109,70 @@ impl<'a> CreateGlobalCommand<'a> {
         name: &'a str,
     ) -> Result<CreateGlobalUserCommand<'a>, CommandValidationError> {
         CreateGlobalUserCommand::new(self.http, self.application_id, name)
+    }
+}
+
+impl<'a> Payload<'a> for CreateGlobalCommand<'a> {
+    /// Supply a payload to a request builder, building the request.
+    ///
+    /// This could be a custom struct, or it could be a [`Command`] from the
+    /// [Command Builder].
+    ///
+    /// [`Command`]: twilight_model::application::command::Command
+    /// [Command Builder]: https://docs.rs/twilight-util/latest/twilight_util/builder/command/index.html
+    fn payload(self, payload: &'a impl Serialize) -> Result<Request, HttpError> {
+        Request::builder(&Route::CreateGlobalCommand {
+            application_id: self.application_id.get(),
+        })
+        .json(payload)
+        .map(RequestBuilder::build)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use twilight_http_ratelimiting::Method;
+    use twilight_model::application::command::CommandType;
+
+    const APPLICATION_ID: Id<ApplicationMarker> = Id::new(1);
+
+    #[derive(Serialize)]
+    struct CommandShim {
+        description: String,
+        name: String,
+        #[serde(rename = "type")]
+        kind: CommandType,
+    }
+
+    #[test]
+    fn test_payload() -> Result<(), Box<dyn std::error::Error>> {
+        let client = Client::new("token".into());
+
+        let command = CommandShim {
+            description: String::new(),
+            name: String::from("user command"),
+            kind: CommandType::User,
+        };
+
+        let request = client
+            .interaction(APPLICATION_ID)
+            .create_global_command()
+            .payload(&command)?;
+
+        assert_eq!(
+            request.body,
+            Some(br#"{"description":"","name":"user command","type":2}"#.to_vec())
+        );
+        assert_eq!(request.method, Method::Post);
+        assert_eq!(
+            request.path,
+            Route::CreateGlobalCommand {
+                application_id: APPLICATION_ID.get()
+            }
+            .to_string()
+        );
+
+        Ok(())
     }
 }

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -14,6 +14,7 @@ mod get_gateway_authed;
 mod get_user_application;
 mod get_voice_regions;
 mod multipart;
+mod payload;
 mod try_into_request;
 
 pub use self::{
@@ -24,6 +25,7 @@ pub use self::{
     get_user_application::GetUserApplicationInfo,
     get_voice_regions::GetVoiceRegions,
     multipart::Form,
+    payload::Payload,
     try_into_request::TryIntoRequest,
 };
 pub use twilight_http_ratelimiting::request::Method;

--- a/http/src/request/payload.rs
+++ b/http/src/request/payload.rs
@@ -1,0 +1,26 @@
+use crate::{error::Error as HttpError, request::Request};
+use serde::Serialize;
+
+/// Trait for supplying a payload to a request builder.
+pub trait Payload<'a>: private::Sealed {
+    /// Supply a payload to a request builder, building the request.
+    fn payload(self, payload: &'a impl Serialize) -> Result<Request, HttpError>;
+}
+
+mod private {
+    use crate::request::application::command::{CreateGlobalCommand, CreateGuildCommand};
+    pub trait Sealed {}
+
+    impl Sealed for CreateGlobalCommand<'_> {}
+    impl Sealed for CreateGuildCommand<'_> {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::request::application::command::{CreateGlobalCommand, CreateGuildCommand};
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(CreateGlobalCommand<'_>: Payload<'static>);
+    assert_impl_all!(CreateGuildCommand<'_>: Payload<'static>);
+}


### PR DESCRIPTION
Adds a trait, `Payload`, which accepts anything that implements `Serialize` and returns a built request. This is also implemented on two requests, `CreateGlobalCommand` and `CreateGuildCommand`.

Part of #1370.
