### PR TITLE
feat(util): add validate method to CommandBuilder

### DIFF
--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -17,6 +17,7 @@ version = "0.9.1"
 
 [dependencies]
 twilight-model = { default-features = false, optional = true, path = "../model" }
+twilight-validate = { default-features = false, optional = true, path = "../validate" }
 
 [dev-dependencies]
 chrono = { default-features = false, features = ["std"], version = "0.4" }
@@ -25,7 +26,7 @@ time = { default-features = false, features = ["formatting"], version = "0.3" }
 
 [features]
 default = []
-builder = ["twilight-model"]
+builder = ["twilight-model", "twilight-validate"]
 link = ["twilight-model"]
 permission-calculator = ["twilight-model"]
 snowflake = ["twilight-model"]

--- a/util/src/builder/command.rs
+++ b/util/src/builder/command.rs
@@ -35,6 +35,7 @@ use twilight_model::{
     channel::ChannelType,
     id::{marker::GuildMarker, Id},
 };
+use twilight_validate::command::{command as validate_command, CommandValidationError};
 
 /// Builder to create a [`Command`].
 #[allow(clippy::module_name_repetitions)]
@@ -64,6 +65,18 @@ impl CommandBuilder {
     #[must_use = "must be built into a command"]
     pub fn build(self) -> Command {
         self.0
+    }
+
+    /// Ensure the command is valid.
+    ///
+    /// # Errors
+    ///
+    /// Refer to the errors section of [`twilight_validate::command::command`]
+    /// for possible errors.
+    pub fn validate(self) -> Result<Self, CommandValidationError> {
+        validate_command(&self.0)?;
+
+        Ok(self)
     }
 
     /// Set the guild ID of the command.


### PR DESCRIPTION
Adds a simple validate method that calls `twilight_validate::command::command`.

Part of #1187.
