### PR TITLE
build(gateway, lavalink): Update to tokio-tungstenite 0.17

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -21,7 +21,7 @@ futures-util = { default-features = false, features = ["std"], version = "0.3" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.5" }
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.16.1" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.17" }
 twilight-gateway-queue = { default-features = false, path = "../gateway-queue" }
 twilight-http = { default-features = false, path = "../http" }
 twilight-model = { default-features = false, path = "../model" }

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -825,7 +825,9 @@ impl ShardProcessor {
             }
             // Discord doesn't appear to send Text messages, so we can ignore
             // these.
-            Message::Ping(_) | Message::Pong(_) => Ok(false),
+            // Message::Frame is send-only and therefore falls into the same group,
+            // see https://docs.rs/tungstenite/latest/tungstenite/enum.Message.html#variant.Frame
+            Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => Ok(false),
         }
     }
 

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -22,7 +22,7 @@ http = { default-features = false, version = "0.2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["macros", "net", "rt", "sync", "time"], version = "1.0" }
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.16" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.17" }
 twilight-model = { default-features = false, path = "../model" }
 
 # Optional dependencies.


### PR DESCRIPTION
This update contains no changes relevant for us, only support for sending raw frames and adaptation to changes regarding the `sha1` crate.