### PR TITLE
feat(http): impl `Default` on `InteractionResponseData`

### DIFF
--- a/examples/model-webhook-slash.rs
+++ b/examples/model-webhook-slash.rs
@@ -144,16 +144,8 @@ async fn debug(i: Interaction) -> Result<InteractionResponse, GenericError> {
     Ok(InteractionResponse {
         kind: InteractionResponseType::ChannelMessageWithSource,
         data: Some(InteractionResponseData {
-            allowed_mentions: None,
-            attachments: None,
-            choices: None,
-            components: None,
             content: Some(format!("```rust\n{:?}\n```", i)),
-            custom_id: None,
-            embeds: None,
-            flags: None,
-            title: None,
-            tts: None,
+            ..Default::default()
         }),
     })
 }
@@ -163,16 +155,8 @@ async fn vroom(_: Interaction) -> Result<InteractionResponse, GenericError> {
     Ok(InteractionResponse {
         kind: InteractionResponseType::ChannelMessageWithSource,
         data: Some(InteractionResponseData {
-            allowed_mentions: None,
-            attachments: None,
-            choices: None,
-            components: None,
             content: Some("Vroom vroom".to_owned()),
-            custom_id: None,
-            embeds: None,
-            flags: None,
-            title: None,
-            tts: None,
+            ..Default::default()
         }),
     })
 }

--- a/model/src/http/interaction.rs
+++ b/model/src/http/interaction.rs
@@ -36,7 +36,7 @@ pub struct InteractionResponse {
 }
 
 /// Data included in an interaction response.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct InteractionResponseData {
     /// Allowed mentions of the response.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This PR implements `Default` on `InteractionResponseData`. Since it is a type that is only sent to Discord, it could reasonably be assumed that its default value is empty. This is helpful when users wish to only send `content`, without using a builder:

```rust
let response = InteractionResponse {
    kind: InteractionResponseType::ChannelMessageWithSource,
    data: Some(InteractionResponseData {
        content: Some("some content".into()),
        ..Default::default()
    }),
};
```
