### PR TITLE
fix(model)! Remove suspicious `Ord` implementations

### DIFF
--- a/model/src/application/command/command_type.rs
+++ b/model/src/application/command/command_type.rs
@@ -1,8 +1,6 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum CommandType {
     /// Slash command.
@@ -44,9 +42,7 @@ mod tests {
         Deserialize<'static>,
         Eq,
         Hash,
-        Ord,
         PartialEq,
-        PartialOrd,
         Serialize,
         Send,
         Sync

--- a/model/src/application/command/option.rs
+++ b/model/src/application/command/option.rs
@@ -566,9 +566,7 @@ pub enum CommandOptionValue {
 }
 
 /// Type of a [`CommandOption`].
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum CommandOptionType {
     SubCommand = 1,

--- a/model/src/application/component/kind.rs
+++ b/model/src/application/component/kind.rs
@@ -6,9 +6,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 /// See [Discord Docs/Message Components].
 ///
 /// [Discord Docs/Message Components]: https://discord.com/developers/docs/interactions/message-components#component-types
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum ComponentType {
     /// Component is an [`ActionRow`].
@@ -79,9 +77,7 @@ mod tests {
         Deserialize<'static>,
         Eq,
         Hash,
-        Ord,
         PartialEq,
-        PartialOrd,
         Send,
         Serialize,
         Sync

--- a/model/src/application/interaction/application_command_autocomplete/option.rs
+++ b/model/src/application/interaction/application_command_autocomplete/option.rs
@@ -17,9 +17,7 @@ pub struct ApplicationCommandAutocompleteDataOption {
 }
 
 /// Type of option data received.
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum ApplicationCommandAutocompleteDataOptionType {
     SubCommand = 1,

--- a/model/src/application/interaction/interaction_type.rs
+++ b/model/src/application/interaction/interaction_type.rs
@@ -6,9 +6,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 /// See [Discord Docs/Interaction Object].
 ///
 /// [Discord Docs/Interaction Object]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum InteractionType {
     Ping = 1,
@@ -77,9 +75,7 @@ mod tests {
         Deserialize<'static>,
         Eq,
         Hash,
-        Ord,
         PartialEq,
-        PartialOrd,
         Serialize,
         Send,
         Sync

--- a/model/src/channel/channel_type.rs
+++ b/model/src/channel/channel_type.rs
@@ -1,8 +1,6 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum ChannelType {
     GuildText = 0,

--- a/model/src/channel/message/activity_type.rs
+++ b/model/src/channel/message/activity_type.rs
@@ -1,8 +1,6 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum MessageActivityType {
     Join = 1,

--- a/model/src/channel/message/kind.rs
+++ b/model/src/channel/message/kind.rs
@@ -1,9 +1,7 @@
 use crate::channel::ConversionError;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum MessageType {
     Regular = 0,

--- a/model/src/channel/message/sticker/format_type.rs
+++ b/model/src/channel/message/sticker/format_type.rs
@@ -7,9 +7,7 @@ use std::{
 /// Format type of a [`Sticker`].
 ///
 /// [`Sticker`]: super::Sticker
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum StickerFormatType {
     /// Sticker format is a PNG.

--- a/model/src/channel/message/sticker/kind.rs
+++ b/model/src/channel/message/sticker/kind.rs
@@ -7,9 +7,7 @@ use std::{
 /// Type of a [`Sticker`].
 ///
 /// [`Sticker`]: super::Sticker
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum StickerType {
     /// Official sticker in a pack.

--- a/model/src/channel/webhook/kind.rs
+++ b/model/src/channel/webhook/kind.rs
@@ -1,8 +1,6 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum WebhookType {
     Incoming = 1,

--- a/model/src/gateway/presence/activity_type.rs
+++ b/model/src/gateway/presence/activity_type.rs
@@ -1,8 +1,6 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum ActivityType {
     Playing = 0,

--- a/model/src/gateway/presence/status.rs
+++ b/model/src/gateway/presence/status.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum Status {
     #[serde(rename = "dnd")]
     DoNotDisturb,

--- a/model/src/guild/audit_log/event_type.rs
+++ b/model/src/guild/audit_log/event_type.rs
@@ -3,9 +3,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 /// Action to cause an [`AuditLogEntry`].
 ///
 /// [`AuditLogEntry`]: super::AuditLogEntry
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum AuditLogEventType {
@@ -224,8 +222,6 @@ mod tests {
         Eq,
         Hash,
         PartialEq,
-        PartialOrd,
-        Ord,
         Send,
         Serialize,
         Sync,

--- a/model/src/http/interaction.rs
+++ b/model/src/http/interaction.rs
@@ -77,9 +77,7 @@ pub struct InteractionResponseData {
 }
 
 /// Type of interaction response.
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum InteractionResponseType {
     /// Used when responding to a Ping from Discord.

--- a/model/src/invite/target_type.rs
+++ b/model/src/invite/target_type.rs
@@ -1,8 +1,6 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum TargetType {
     Stream = 1,

--- a/model/src/user/premium_type.rs
+++ b/model/src/user/premium_type.rs
@@ -1,7 +1,5 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum PremiumType {
     None = 0,


### PR DESCRIPTION
These enums have no obvious order to them from the point of view of the user.
Experts knowledgeable of Discords internal integer mapping can still compare them by first casting to an integer.
