### PR TITLE
perf(cache): remove iters, allocation when caching stickers

### DIFF
--- a/cache/in-memory/src/event/sticker.rs
+++ b/cache/in-memory/src/event/sticker.rs
@@ -11,7 +11,8 @@ use twilight_model::{
 impl InMemoryCache {
     pub(crate) fn cache_stickers(&self, guild_id: Id<GuildMarker>, stickers: Vec<Sticker>) {
         if let Some(mut guild_stickers) = self.guild_stickers.get_mut(&guild_id) {
-            let incoming_sticker_ids = stickers.iter()
+            let incoming_sticker_ids = stickers
+                .iter()
                 .map(|sticker| sticker.id)
                 .collect::<HashSet<_>>();
 
@@ -90,8 +91,11 @@ impl UpdateCache for GuildStickersUpdate {
 
 #[cfg(test)]
 mod tests {
-    use crate::{InMemoryCache, test};
-    use twilight_model::id::{marker::{GuildMarker, StickerMarker}, Id};
+    use crate::{test, InMemoryCache};
+    use twilight_model::id::{
+        marker::{GuildMarker, StickerMarker},
+        Id,
+    };
 
     const GUILD_ID: Id<GuildMarker> = Id::new(1);
     const STICKER_ONE_ID: Id<StickerMarker> = Id::new(2);
@@ -115,10 +119,19 @@ mod tests {
         assert_eq!(cache.stickers.len(), 2);
         let one = test::sticker(STICKER_ONE_ID, GUILD_ID);
         let two = test::sticker(STICKER_TWO_ID, GUILD_ID);
-        assert!(cache.stickers.get(&STICKER_ONE_ID).map(|r| r.id == STICKER_ONE_ID).unwrap_or_default());
-        assert!(cache.stickers.get(&STICKER_TWO_ID).map(|r| r.id == STICKER_TWO_ID).unwrap_or_default());
+        assert!(cache
+            .stickers
+            .get(&STICKER_ONE_ID)
+            .map(|r| r.id == STICKER_ONE_ID)
+            .unwrap_or_default());
+        assert!(cache
+            .stickers
+            .get(&STICKER_TWO_ID)
+            .map(|r| r.id == STICKER_TWO_ID)
+            .unwrap_or_default());
 
-        let guild_stickers = cache.guild_stickers
+        let guild_stickers = cache
+            .guild_stickers
             .get(&GUILD_ID)
             .expect("cache has stickers for guild");
         assert_eq!(guild_stickers.len(), 2);
@@ -139,8 +152,13 @@ mod tests {
         let one = test::sticker(STICKER_ONE_ID, GUILD_ID);
         cache.cache_stickers(GUILD_ID, Vec::from([one]));
         assert_eq!(cache.stickers.len(), 1);
-        assert!(cache.stickers.get(&STICKER_ONE_ID).map(|r| r.id == STICKER_ONE_ID).unwrap_or_default());
-        let guild_stickers = cache.guild_stickers
+        assert!(cache
+            .stickers
+            .get(&STICKER_ONE_ID)
+            .map(|r| r.id == STICKER_ONE_ID)
+            .unwrap_or_default());
+        let guild_stickers = cache
+            .guild_stickers
             .get(&GUILD_ID)
             .expect("cache has stickers for guild");
         assert_eq!(guild_stickers.len(), 1);

--- a/cache/in-memory/src/event/sticker.rs
+++ b/cache/in-memory/src/event/sticker.rs
@@ -1,8 +1,7 @@
 use crate::{
     config::ResourceType, model::CachedSticker, GuildResource, InMemoryCache, UpdateCache,
 };
-use std::borrow::Cow;
-use std::collections::HashSet;
+use std::{borrow::Cow, collections::HashSet};
 use twilight_model::{
     channel::message::sticker::Sticker,
     gateway::payload::incoming::GuildStickersUpdate,

--- a/cache/in-memory/src/event/sticker.rs
+++ b/cache/in-memory/src/event/sticker.rs
@@ -93,6 +93,13 @@ mod tests {
     use crate::{InMemoryCache, test};
     use twilight_model::id::{marker::{GuildMarker, StickerMarker}, Id};
 
+    /// Test that caching an updated list of a guild's stickers removes one of
+    /// the existing stickers if not in the updated list, meaning the sticker no
+    /// longer exists.
+    ///
+    /// For example, if two stickers for a guild named "foo" and "bar" are
+    /// cached and a new list of stickers with only "foo" is cached, then "bar"
+    /// will be removed.
     #[test]
     fn test_sticker_removal() {
         const GUILD_ID: Id<GuildMarker> = Id::new(1);

--- a/cache/in-memory/src/event/sticker.rs
+++ b/cache/in-memory/src/event/sticker.rs
@@ -13,18 +13,15 @@ impl InMemoryCache {
         if let Some(mut guild_stickers) = self.guild_stickers.get_mut(&guild_id) {
             let incoming: Vec<_> = stickers.iter().map(|s| s.id).collect();
 
-            let removal_filter: Vec<_> = guild_stickers
+            let removed_ids: Vec<_> = guild_stickers
                 .iter()
                 .copied()
                 .filter(|s| !incoming.contains(s))
                 .collect();
 
-            for to_remove in &removal_filter {
-                guild_stickers.remove(to_remove);
-            }
-
-            for to_remove in &removal_filter {
-                self.stickers.remove(to_remove);
+            for removed_id in &removed_ids {
+                guild_stickers.remove(removed_id);
+                self.stickers.remove(removed_id);
             }
         }
 

--- a/cache/in-memory/src/test.rs
+++ b/cache/in-memory/src/test.rs
@@ -19,6 +19,14 @@ use twilight_model::{
     util::image_hash::ImageHash,
     voice::VoiceState,
 };
+use twilight_model::{
+    channel::message::sticker::{StickerFormatType, StickerType, Sticker},
+    id::marker::StickerMarker,
+};
+
+pub fn cache() -> InMemoryCache {
+    InMemoryCache::new()
+}
 
 pub fn cache_with_message_and_reactions() -> InMemoryCache {
     let joined_at = Timestamp::from_secs(1_632_072_645).expect("non zero");
@@ -270,6 +278,22 @@ pub fn role(id: Id<RoleMarker>) -> Role {
         position: 0,
         tags: None,
         unicode_emoji: None,
+    }
+}
+
+pub fn sticker(id: Id<StickerMarker>, guild_id: Id<GuildMarker>) -> Sticker {
+    Sticker {
+        available: false,
+        description: None,
+        format_type: StickerFormatType::Png,
+        guild_id: Some(guild_id),
+        id,
+        kind: StickerType::Standard,
+        name: String::new(),
+        pack_id: None,
+        sort_value: None,
+        tags: String::new(),
+        user: None
     }
 }
 

--- a/cache/in-memory/src/test.rs
+++ b/cache/in-memory/src/test.rs
@@ -281,7 +281,7 @@ pub fn role(id: Id<RoleMarker>) -> Role {
     }
 }
 
-pub fn sticker(id: Id<StickerMarker>, guild_id: Id<GuildMarker>) -> Sticker {
+pub const fn sticker(id: Id<StickerMarker>, guild_id: Id<GuildMarker>) -> Sticker {
     Sticker {
         available: false,
         description: None,

--- a/cache/in-memory/src/test.rs
+++ b/cache/in-memory/src/test.rs
@@ -1,5 +1,9 @@
 use crate::InMemoryCache;
 use twilight_model::{
+    channel::message::sticker::{Sticker, StickerFormatType, StickerType},
+    id::marker::StickerMarker,
+};
+use twilight_model::{
     channel::{
         message::{Message, MessageFlags, MessageType},
         Channel, ChannelType, Reaction, ReactionType,
@@ -18,10 +22,6 @@ use twilight_model::{
     user::{CurrentUser, User},
     util::image_hash::ImageHash,
     voice::VoiceState,
-};
-use twilight_model::{
-    channel::message::sticker::{StickerFormatType, StickerType, Sticker},
-    id::marker::StickerMarker,
 };
 
 pub fn cache() -> InMemoryCache {
@@ -293,7 +293,7 @@ pub const fn sticker(id: Id<StickerMarker>, guild_id: Id<GuildMarker>) -> Sticke
         pack_id: None,
         sort_value: None,
         tags: String::new(),
-        user: None
+        user: None,
     }
 }
 


### PR DESCRIPTION
`InMemoryCache::cache_stickers` operates by first retrieving a mutable reference to the set of sticker IDs for a guild and then allocating a Vec of the removed delta of sticker IDs between the cached set and the new set of IDs. The list of removed sticker IDs is then iterated over to remove it from the guild's set of IDs, and then iterated over again to remove the stickers from the cache.

We can instead call `HashSet::retain` to mutate over the set of guild stickers and remove from the set as necessary, removing from the cached stickers map at the same time if not retaining.

This removes two iterations (filtering removed IDs and one of the two actual removal iterations) and an allocation.