### PR TITLE
refactor(model)!: presence updates are presences

### DIFF
--- a/cache/in-memory/src/event/presence.rs
+++ b/cache/in-memory/src/event/presence.rs
@@ -50,7 +50,7 @@ mod tests {
     use crate::test;
     use twilight_model::gateway::{
         event::Event,
-        presence::{ClientStatus, Status, UserOrId},
+        presence::{ClientStatus, Presence, Status, UserOrId},
     };
 
     #[test]
@@ -60,18 +60,18 @@ mod tests {
         let guild_id = Id::new(1);
         let user_id = Id::new(1);
 
-        cache.update(&Event::PresenceUpdate(Box::new(PresenceUpdate {
+        let payload = PresenceUpdate(Presence {
             activities: Vec::new(),
             client_status: ClientStatus {
                 desktop: Some(Status::Online),
                 mobile: None,
                 web: None,
             },
-            game: None,
             guild_id,
             status: Status::Online,
             user: UserOrId::User(test::user(user_id)),
-        })));
+        });
+        cache.update(&Event::PresenceUpdate(Box::new(payload)));
 
         assert_eq!(1, cache.presences.len());
         assert_eq!(1, cache.guild_presences.len());

--- a/model/src/gateway/payload/incoming/presence_update.rs
+++ b/model/src/gateway/payload/incoming/presence_update.rs
@@ -35,7 +35,23 @@ mod tests {
     use super::PresenceUpdate;
     use serde::{Deserialize, Serialize};
     use static_assertions::assert_impl_all;
-    use std::{fmt::Debug, hash::Hash, ops::{Deref, DerefMut}};
+    use std::{
+        fmt::Debug,
+        hash::Hash,
+        ops::{Deref, DerefMut},
+    };
 
-    assert_impl_all!(PresenceUpdate: Clone, Debug, Deref, DerefMut, Deserialize<'static>, Eq, Hash, PartialEq, Serialize, Send, Sync);
+    assert_impl_all!(
+        PresenceUpdate: Clone,
+        Debug,
+        Deref,
+        DerefMut,
+        Deserialize<'static>,
+        Eq,
+        Hash,
+        PartialEq,
+        Serialize,
+        Send,
+        Sync
+    );
 }

--- a/model/src/gateway/payload/incoming/presence_update.rs
+++ b/model/src/gateway/payload/incoming/presence_update.rs
@@ -1,16 +1,41 @@
-use crate::{
-    gateway::presence::{Activity, ClientStatus, Status, UserOrId},
-    id::{marker::GuildMarker, Id},
-};
+use crate::gateway::presence::Presence;
 use serde::{Deserialize, Serialize};
+use std::ops::{Deref, DerefMut};
 
+/// User's presence was updated.
+///
+/// This may be received when a user's activity, status, or user
+/// information - such as avatar or username - is updated.
+///
+/// Requires the [`Intents::GUILD_PRESENCES`] intent to receive this event.
+///
+/// Refer to [Discord Docs/Presence Update] for additional information.
+///
+/// [`Intents::GUILD_PRESENCES`]: crate::gateway::Intents
+/// [Discord Docs/Presence Update]: https://discord.com/developers/docs/topics/gateway#presence-update
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct PresenceUpdate {
-    #[serde(default)]
-    pub activities: Vec<Activity>,
-    pub client_status: ClientStatus,
-    pub game: Option<Activity>,
-    pub guild_id: Id<GuildMarker>,
-    pub status: Status,
-    pub user: UserOrId,
+pub struct PresenceUpdate(pub Presence);
+
+impl Deref for PresenceUpdate {
+    type Target = Presence;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for PresenceUpdate {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PresenceUpdate;
+    use serde::{Deserialize, Serialize};
+    use static_assertions::assert_impl_all;
+    use std::{fmt::Debug, hash::Hash, ops::{Deref, DerefMut}};
+
+    assert_impl_all!(PresenceUpdate: Clone, Debug, Deref, DerefMut, Deserialize<'static>, Eq, Hash, PartialEq, Serialize, Send, Sync);
 }

--- a/standby/src/event.rs
+++ b/standby/src/event.rs
@@ -43,7 +43,7 @@ pub const fn guild_id(event: &Event) -> Option<Id<GuildMarker>> {
         Event::MemberRemove(e) => Some(e.guild_id),
         Event::MemberUpdate(e) => Some(e.guild_id),
         Event::MessageCreate(e) => e.0.guild_id,
-        Event::PresenceUpdate(e) => Some(e.guild_id),
+        Event::PresenceUpdate(e) => Some(e.0.guild_id),
         Event::ReactionAdd(e) => e.0.guild_id,
         Event::ReactionRemove(e) => e.0.guild_id,
         Event::ReactionRemoveAll(e) => e.guild_id,


### PR DESCRIPTION
Presence Update Events are actually just the same as the Presence model, so we can just make the event a newtype of the presence.