### PR TITLE
feat(cache): add missing cached model fields

### DIFF
--- a/cache/in-memory/src/event/emoji.rs
+++ b/cache/in-memory/src/event/emoji.rs
@@ -37,25 +37,15 @@ impl InMemoryCache {
             Some(_) | None => {}
         }
 
-        let user_id = emoji.user.as_ref().map(|user| user.id);
-
-        if let Some(user) = emoji.user {
-            self.cache_user(Cow::Owned(user), Some(guild_id));
+        if let Some(user) = emoji.user.as_ref() {
+            self.cache_user(Cow::Borrowed(user), Some(guild_id));
         }
 
-        let cached = CachedEmoji {
-            id: emoji.id,
-            animated: emoji.animated,
-            name: emoji.name,
-            managed: emoji.managed,
-            require_colons: emoji.require_colons,
-            roles: emoji.roles,
-            user_id,
-            available: emoji.available,
-        };
+        let emoji_id = emoji.id;
+        let cached = CachedEmoji::from_model(emoji);
 
         self.emojis.insert(
-            cached.id,
+            emoji_id,
             GuildResource {
                 guild_id,
                 value: cached,
@@ -65,7 +55,7 @@ impl InMemoryCache {
         self.guild_emojis
             .entry(guild_id)
             .or_default()
-            .insert(emoji.id);
+            .insert(emoji_id);
     }
 }
 

--- a/cache/in-memory/src/event/guild.rs
+++ b/cache/in-memory/src/event/guild.rs
@@ -13,20 +13,70 @@ use twilight_model::{
 
 impl InMemoryCache {
     fn cache_guild(&self, guild: Guild) {
+        let Guild {
+            afk_channel_id,
+            afk_timeout,
+            application_id,
+            approximate_member_count: _,
+            approximate_presence_count: _,
+            banner,
+            channels,
+            default_message_notifications,
+            description,
+            discovery_splash,
+            emojis,
+            explicit_content_filter,
+            features,
+            icon,
+            id,
+            joined_at,
+            large,
+            max_members,
+            max_presences,
+            max_video_channel_users,
+            member_count,
+            members,
+            mfa_level,
+            name,
+            nsfw_level,
+            owner_id,
+            owner,
+            permissions,
+            preferred_locale,
+            premium_progress_bar_enabled,
+            premium_subscription_count,
+            premium_tier,
+            presences,
+            roles,
+            rules_channel_id,
+            splash,
+            stage_instances,
+            stickers,
+            system_channel_flags,
+            system_channel_id,
+            threads,
+            unavailable,
+            vanity_url_code,
+            verification_level,
+            voice_states,
+            widget_channel_id,
+            widget_enabled,
+        } = guild;
+
         // The map and set creation needs to occur first, so caching states and
         // objects always has a place to put them.
         if self.wants(ResourceType::CHANNEL) {
-            self.guild_channels.insert(guild.id, HashSet::new());
+            self.guild_channels.insert(id, HashSet::new());
 
-            let mut channels = guild.channels;
-            let mut threads = guild.threads;
+            let mut channels = channels;
+            let mut threads = threads;
 
             for channel in &mut channels {
-                channel.guild_id = Some(guild.id);
+                channel.guild_id = Some(id);
             }
 
             for channel in &mut threads {
-                channel.guild_id = Some(guild.id);
+                channel.guild_id = Some(id);
             }
 
             self.cache_channels(channels);
@@ -34,79 +84,77 @@ impl InMemoryCache {
         }
 
         if self.wants(ResourceType::EMOJI) {
-            self.guild_emojis.insert(guild.id, HashSet::new());
-            self.cache_emojis(guild.id, guild.emojis);
+            self.guild_emojis.insert(id, HashSet::new());
+            self.cache_emojis(id, emojis);
         }
 
         if self.wants(ResourceType::MEMBER) {
-            self.guild_members.insert(guild.id, HashSet::new());
-            self.cache_members(guild.id, guild.members);
+            self.guild_members.insert(id, HashSet::new());
+            self.cache_members(id, members);
         }
 
         if self.wants(ResourceType::PRESENCE) {
-            self.guild_presences.insert(guild.id, HashSet::new());
-            self.cache_presences(
-                guild.id,
-                guild.presences.into_iter().map(CachedPresence::from),
-            );
+            self.guild_presences.insert(id, HashSet::new());
+            self.cache_presences(id, presences.into_iter().map(CachedPresence::from));
         }
 
         if self.wants(ResourceType::ROLE) {
-            self.guild_roles.insert(guild.id, HashSet::new());
-            self.cache_roles(guild.id, guild.roles);
+            self.guild_roles.insert(id, HashSet::new());
+            self.cache_roles(id, roles);
         }
 
         if self.wants(ResourceType::STICKER) {
-            self.guild_stage_instances.insert(guild.id, HashSet::new());
-            self.cache_stickers(guild.id, guild.stickers);
+            self.guild_stage_instances.insert(id, HashSet::new());
+            self.cache_stickers(id, stickers);
         }
 
         if self.wants(ResourceType::VOICE_STATE) {
-            self.voice_state_guilds.insert(guild.id, HashSet::new());
-            self.cache_voice_states(guild.voice_states);
+            self.voice_state_guilds.insert(id, HashSet::new());
+            self.cache_voice_states(voice_states);
         }
 
         if self.wants(ResourceType::STAGE_INSTANCE) {
-            self.guild_stage_instances.insert(guild.id, HashSet::new());
-            self.cache_stage_instances(guild.id, guild.stage_instances);
+            self.guild_stage_instances.insert(id, HashSet::new());
+            self.cache_stage_instances(id, stage_instances);
         }
 
         let guild = CachedGuild {
-            id: guild.id,
-            afk_channel_id: guild.afk_channel_id,
-            afk_timeout: guild.afk_timeout,
-            application_id: guild.application_id,
-            banner: guild.banner,
-            default_message_notifications: guild.default_message_notifications,
-            description: guild.description,
-            discovery_splash: guild.discovery_splash,
-            explicit_content_filter: guild.explicit_content_filter,
-            features: guild.features,
-            icon: guild.icon,
-            joined_at: guild.joined_at,
-            large: guild.large,
-            max_members: guild.max_members,
-            max_presences: guild.max_presences,
-            member_count: guild.member_count,
-            mfa_level: guild.mfa_level,
-            name: guild.name,
-            nsfw_level: guild.nsfw_level,
-            owner: guild.owner,
-            owner_id: guild.owner_id,
-            permissions: guild.permissions,
-            preferred_locale: guild.preferred_locale,
-            premium_progress_bar_enabled: guild.premium_progress_bar_enabled,
-            premium_subscription_count: guild.premium_subscription_count,
-            premium_tier: guild.premium_tier,
-            rules_channel_id: guild.rules_channel_id,
-            splash: guild.splash,
-            system_channel_id: guild.system_channel_id,
-            system_channel_flags: guild.system_channel_flags,
-            unavailable: guild.unavailable,
-            verification_level: guild.verification_level,
-            vanity_url_code: guild.vanity_url_code,
-            widget_channel_id: guild.widget_channel_id,
-            widget_enabled: guild.widget_enabled,
+            id,
+            afk_channel_id,
+            afk_timeout,
+            application_id,
+            banner,
+            default_message_notifications,
+            description,
+            discovery_splash,
+            explicit_content_filter,
+            features,
+            icon,
+            joined_at,
+            large,
+            max_members,
+            max_presences,
+            max_video_channel_users,
+            member_count,
+            mfa_level,
+            name,
+            nsfw_level,
+            owner,
+            owner_id,
+            permissions,
+            preferred_locale,
+            premium_progress_bar_enabled,
+            premium_subscription_count,
+            premium_tier,
+            rules_channel_id,
+            splash,
+            system_channel_id,
+            system_channel_flags,
+            unavailable,
+            verification_level,
+            vanity_url_code,
+            widget_channel_id,
+            widget_enabled,
         };
 
         self.unavailable_guilds.remove(&guild.id());

--- a/cache/in-memory/src/event/member.rs
+++ b/cache/in-memory/src/event/member.rs
@@ -1,4 +1,8 @@
-use crate::{config::ResourceType, model::CachedMember, InMemoryCache, UpdateCache};
+use crate::{
+    config::ResourceType,
+    model::{member::ComputedInteractionMemberFields, CachedMember},
+    InMemoryCache, UpdateCache,
+};
 use std::borrow::Cow;
 use twilight_model::{
     application::interaction::application_command::InteractionMember,
@@ -31,22 +35,8 @@ impl InMemoryCache {
             }
         }
 
-        let user_id = member.user.id;
-
-        self.cache_user(Cow::Owned(member.user), Some(guild_id));
-        let cached = CachedMember {
-            avatar: member.avatar,
-            communication_disabled_until: member.communication_disabled_until,
-            deaf: Some(member.deaf),
-            guild_id,
-            joined_at: member.joined_at,
-            mute: Some(member.mute),
-            nick: member.nick,
-            pending: member.pending,
-            premium_since: member.premium_since,
-            roles: member.roles,
-            user_id,
-        };
+        self.cache_user(Cow::Borrowed(&member.user), Some(guild_id));
+        let cached = CachedMember::from_model(member);
         self.members.insert(id, cached);
         self.guild_members
             .entry(guild_id)
@@ -73,19 +63,7 @@ impl InMemoryCache {
             .or_default()
             .insert(user_id);
 
-        let cached = CachedMember {
-            avatar: member.avatar.to_owned(),
-            communication_disabled_until: member.communication_disabled_until.to_owned(),
-            deaf: Some(member.deaf),
-            guild_id,
-            joined_at: member.joined_at,
-            mute: Some(member.mute),
-            nick: member.nick.to_owned(),
-            pending: false,
-            premium_since: None,
-            roles: member.roles.to_owned(),
-            user_id,
-        };
+        let cached = CachedMember::from_partial_member(guild_id, user_id, member.clone());
         self.members.insert(id, cached);
     }
 
@@ -108,19 +86,12 @@ impl InMemoryCache {
             .or_default()
             .insert(user_id);
 
-        let cached = CachedMember {
-            avatar,
-            communication_disabled_until: member.communication_disabled_until.to_owned(),
-            deaf,
+        let cached = CachedMember::from_interaction_member(
             guild_id,
-            joined_at: member.joined_at,
-            mute,
-            nick: member.nick.to_owned(),
-            pending: false,
-            premium_since: member.premium_since.to_owned(),
-            roles: member.roles.to_owned(),
             user_id,
-        };
+            member.clone(),
+            ComputedInteractionMemberFields { avatar, deaf, mute },
+        );
 
         self.members.insert(id, cached);
     }

--- a/cache/in-memory/src/event/presence.rs
+++ b/cache/in-memory/src/event/presence.rs
@@ -32,13 +32,7 @@ impl UpdateCache for PresenceUpdate {
             return;
         }
 
-        let presence = CachedPresence {
-            activities: self.activities.clone(),
-            client_status: self.client_status.clone(),
-            guild_id: self.guild_id,
-            status: self.status,
-            user_id: self.user.id(),
-        };
+        let presence = CachedPresence::from_update(self.clone());
 
         cache.cache_presence(self.guild_id, presence);
     }

--- a/cache/in-memory/src/event/sticker.rs
+++ b/cache/in-memory/src/event/sticker.rs
@@ -39,25 +39,12 @@ impl InMemoryCache {
             Some(_) | None => {}
         }
 
-        let user_id = sticker.user.as_ref().map(|user| user.id);
-
-        if let Some(user) = sticker.user {
+        if let Some(user) = sticker.user.clone() {
             self.cache_user(Cow::Owned(user), Some(guild_id));
         }
 
-        let cached = CachedSticker {
-            available: sticker.available,
-            description: sticker.description.unwrap_or_default(),
-            format_type: sticker.format_type,
-            guild_id: sticker.guild_id,
-            id: sticker.id,
-            kind: sticker.kind,
-            name: sticker.name,
-            pack_id: sticker.pack_id,
-            sort_value: sticker.sort_value,
-            tags: sticker.tags,
-            user_id,
-        };
+        let sticker_id = sticker.id;
+        let cached = CachedSticker::from_model(sticker);
 
         self.stickers.insert(
             cached.id,
@@ -70,7 +57,7 @@ impl InMemoryCache {
         self.guild_stickers
             .entry(guild_id)
             .or_default()
-            .insert(sticker.id);
+            .insert(sticker_id);
     }
 }
 

--- a/cache/in-memory/src/event/voice_state.rs
+++ b/cache/in-memory/src/event/voice_state.rs
@@ -36,7 +36,7 @@ impl InMemoryCache {
 
         if let Some(channel_id) = voice_state.channel_id {
             let cached_voice_state =
-                CachedVoiceState::from_voice_state(channel_id, guild_id, voice_state);
+                CachedVoiceState::from_model(channel_id, guild_id, voice_state);
 
             self.voice_states
                 .insert((guild_id, user_id), cached_voice_state);
@@ -361,7 +361,7 @@ mod tests {
         let voice_state = test::voice_state(GUILD_ID, Some(CHANNEL_ID), USER_ID);
         cache.update(&VoiceStateUpdate(voice_state.clone()));
 
-        let cached = CachedVoiceState::from_voice_state(CHANNEL_ID, GUILD_ID, voice_state);
+        let cached = CachedVoiceState::from_model(CHANNEL_ID, GUILD_ID, voice_state);
         let in_cache = cache.voice_state(USER_ID, GUILD_ID).unwrap();
         assert_eq!(in_cache.value(), &cached);
     }

--- a/cache/in-memory/src/model/emoji.rs
+++ b/cache/in-memory/src/model/emoji.rs
@@ -64,6 +64,31 @@ impl CachedEmoji {
     pub const fn user_id(&self) -> Option<Id<UserMarker>> {
         self.user_id
     }
+
+    /// Construct a cached emoji from its [`twilight_model`] form.
+    pub(crate) fn from_model(emoji: Emoji) -> Self {
+        let Emoji {
+            animated,
+            available,
+            id,
+            managed,
+            name,
+            require_colons,
+            roles,
+            user,
+        } = emoji;
+
+        CachedEmoji {
+            animated,
+            available,
+            id,
+            managed,
+            name,
+            require_colons,
+            roles,
+            user_id: user.map(|user| user.id),
+        }
+    }
 }
 
 impl PartialEq<Emoji> for CachedEmoji {
@@ -82,6 +107,7 @@ impl PartialEq<Emoji> for CachedEmoji {
 #[cfg(test)]
 mod tests {
     use super::CachedEmoji;
+    use serde::Serialize;
     use static_assertions::{assert_fields, assert_impl_all};
     use std::fmt::Debug;
     use twilight_model::{guild::Emoji, id::Id};
@@ -95,7 +121,16 @@ mod tests {
         roles,
         user_id
     );
-    assert_impl_all!(CachedEmoji: Clone, Debug, Eq, PartialEq);
+    assert_impl_all!(
+        CachedEmoji: Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        PartialEq<Emoji>,
+        Send,
+        Serialize,
+        Sync
+    );
 
     #[test]
     fn test_eq_emoji() {

--- a/cache/in-memory/src/model/guild.rs
+++ b/cache/in-memory/src/model/guild.rs
@@ -34,6 +34,7 @@ pub struct CachedGuild {
     pub(crate) large: bool,
     pub(crate) max_members: Option<u64>,
     pub(crate) max_presences: Option<u64>,
+    pub(crate) max_video_channel_users: Option<u64>,
     pub(crate) member_count: Option<u64>,
     pub(crate) mfa_level: MfaLevel,
     pub(crate) name: String,
@@ -146,6 +147,11 @@ impl CachedGuild {
     /// Maximum presences.
     pub const fn max_presences(&self) -> Option<u64> {
         self.max_presences
+    }
+
+    /// Maximum number of users in a video channel.
+    pub const fn max_video_channel_users(&self) -> Option<u64> {
+        self.max_video_channel_users
     }
 
     /// Total number of members in the guild.
@@ -267,4 +273,61 @@ impl<'a> Iterator for Features<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(AsRef::as_ref)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CachedGuild, Features};
+    use serde::Serialize;
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::fmt::Debug;
+
+    assert_fields!(
+        CachedGuild: afk_channel_id,
+        afk_timeout,
+        application_id,
+        banner,
+        default_message_notifications,
+        description,
+        discovery_splash,
+        explicit_content_filter,
+        features,
+        icon,
+        id,
+        joined_at,
+        large,
+        max_members,
+        max_presences,
+        max_video_channel_users,
+        member_count,
+        mfa_level,
+        name,
+        nsfw_level,
+        owner_id,
+        owner,
+        permissions,
+        preferred_locale,
+        premium_progress_bar_enabled,
+        premium_subscription_count,
+        premium_tier,
+        rules_channel_id,
+        splash,
+        system_channel_id,
+        system_channel_flags,
+        unavailable,
+        vanity_url_code,
+        verification_level,
+        widget_channel_id,
+        widget_enabled
+    );
+    assert_impl_all!(
+        CachedGuild: Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync,
+    );
+    assert_impl_all!(Features<'_>: Iterator, Send, Sync);
 }

--- a/cache/in-memory/src/model/message.rs
+++ b/cache/in-memory/src/model/message.rs
@@ -1,10 +1,13 @@
+//! Cached message-related models.
+
 use serde::Serialize;
 use twilight_model::{
+    application::{component::Component, interaction::InteractionType},
     channel::{
         embed::Embed,
         message::{
             sticker::MessageSticker, Message, MessageActivity, MessageApplication, MessageFlags,
-            MessageReaction, MessageReference, MessageType,
+            MessageInteraction, MessageReaction, MessageReference, MessageType,
         },
         Attachment, ChannelMention,
     },
@@ -12,11 +15,66 @@ use twilight_model::{
     guild::PartialMember,
     id::{
         marker::{
-            ChannelMarker, GuildMarker, MessageMarker, RoleMarker, UserMarker, WebhookMarker,
+            ApplicationMarker, ChannelMarker, GuildMarker, InteractionMarker, MessageMarker,
+            RoleMarker, UserMarker, WebhookMarker,
         },
         Id,
     },
 };
+
+/// Information about the message interaction.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CachedMessageInteraction {
+    id: Id<InteractionMarker>,
+    #[serde(rename = "type")]
+    kind: InteractionType,
+    name: String,
+    user_id: Id<UserMarker>,
+}
+
+impl CachedMessageInteraction {
+    /// ID of the interaction.
+    pub const fn id(&self) -> Id<InteractionMarker> {
+        self.id
+    }
+
+    /// Type of the interaction.
+    pub const fn kind(&self) -> InteractionType {
+        self.kind
+    }
+
+    /// Name of the interaction used.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// ID of the user who invoked the interaction.
+    pub const fn user_id(&self) -> Id<UserMarker> {
+        self.user_id
+    }
+
+    /// Construct a cached message interaction from its [`twilight_model`] form.
+    #[allow(clippy::missing_const_for_fn)]
+    pub(crate) fn from_model(message_interaction: MessageInteraction) -> Self {
+        // Reasons for dropping fields:
+        //
+        // - `member`: we have the user's ID from the `user_id` field
+        let MessageInteraction {
+            id,
+            kind,
+            member: _,
+            name,
+            user,
+        } = message_interaction;
+
+        Self {
+            id,
+            kind,
+            name,
+            user_id: user.id,
+        }
+    }
+}
 
 /// Represents a cached [`Message`].
 ///
@@ -25,15 +83,18 @@ use twilight_model::{
 pub struct CachedMessage {
     activity: Option<MessageActivity>,
     application: Option<MessageApplication>,
+    application_id: Option<Id<ApplicationMarker>>,
     pub(crate) attachments: Vec<Attachment>,
     author: Id<UserMarker>,
     channel_id: Id<ChannelMarker>,
+    components: Vec<Component>,
     pub(crate) content: String,
     pub(crate) edited_timestamp: Option<Timestamp>,
     pub(crate) embeds: Vec<Embed>,
     flags: Option<MessageFlags>,
     guild_id: Option<Id<GuildMarker>>,
     id: Id<MessageMarker>,
+    interaction: Option<CachedMessageInteraction>,
     kind: MessageType,
     member: Option<PartialMember>,
     mention_channels: Vec<ChannelMention>,
@@ -44,6 +105,7 @@ pub struct CachedMessage {
     pub(crate) reactions: Vec<MessageReaction>,
     reference: Option<MessageReference>,
     sticker_items: Vec<MessageSticker>,
+    thread_id: Option<Id<ChannelMarker>>,
     pub(crate) timestamp: Timestamp,
     pub(crate) tts: bool,
     webhook_id: Option<Id<WebhookMarker>>,
@@ -58,6 +120,13 @@ impl CachedMessage {
     /// For interaction responses, the ID of the interaction's application.
     pub const fn application(&self) -> Option<&MessageApplication> {
         self.application.as_ref()
+    }
+
+    /// Associated application's ID.
+    ///
+    /// Sent if the message is a response to an Interaction.
+    pub const fn application_id(&self) -> Option<Id<ApplicationMarker>> {
+        self.application_id
     }
 
     /// Attached files.
@@ -75,6 +144,11 @@ impl CachedMessage {
     /// ID of the channel the message was sent in.
     pub const fn channel_id(&self) -> Id<ChannelMarker> {
         self.channel_id
+    }
+
+    /// Components used in the message, such as buttons.
+    pub fn components(&self) -> &[Component] {
+        &self.components
     }
 
     /// Content of the message.
@@ -105,6 +179,11 @@ impl CachedMessage {
     /// ID of the message.
     pub const fn id(&self) -> Id<MessageMarker> {
         self.id
+    }
+
+    /// Information about the message interaction.
+    pub const fn interaction(&self) -> Option<&CachedMessageInteraction> {
+        self.interaction.as_ref()
     }
 
     /// Type of the message.
@@ -157,6 +236,11 @@ impl CachedMessage {
         &self.sticker_items
     }
 
+    /// ID of the thread the message was sent in.
+    pub const fn thread_id(&self) -> Option<Id<ChannelMarker>> {
+        self.thread_id
+    }
+
     /// [`Timestamp`] of the date the message was sent.
     pub const fn timestamp(&self) -> Timestamp {
         self.timestamp
@@ -171,35 +255,136 @@ impl CachedMessage {
     pub const fn webhook_id(&self) -> Option<Id<WebhookMarker>> {
         self.webhook_id
     }
+
+    /// Construct a cached message from its [`twilight_model`] form.
+    pub(crate) fn from_model(message: Message) -> Self {
+        let Message {
+            activity,
+            application,
+            application_id,
+            attachments,
+            author,
+            channel_id,
+            components,
+            content,
+            edited_timestamp,
+            embeds,
+            flags,
+            guild_id,
+            id,
+            interaction,
+            kind,
+            member,
+            mention_channels,
+            mention_everyone,
+            mention_roles,
+            mentions,
+            pinned,
+            reactions,
+            reference,
+            referenced_message: _,
+            sticker_items,
+            timestamp,
+            thread,
+            tts,
+            webhook_id,
+        } = message;
+
+        Self {
+            id,
+            activity,
+            application,
+            application_id,
+            attachments,
+            author: author.id,
+            channel_id,
+            components,
+            content,
+            edited_timestamp,
+            embeds,
+            flags,
+            guild_id,
+            interaction: interaction.map(CachedMessageInteraction::from_model),
+            kind,
+            member,
+            mention_channels,
+            mention_everyone,
+            mention_roles,
+            mentions: mentions.into_iter().map(|mention| mention.id).collect(),
+            pinned,
+            reactions,
+            reference,
+            sticker_items,
+            thread_id: thread.map(|thread| thread.id),
+            timestamp,
+            tts,
+            webhook_id,
+        }
+    }
 }
 
 impl From<Message> for CachedMessage {
-    fn from(msg: Message) -> Self {
-        Self {
-            id: msg.id,
-            activity: msg.activity,
-            application: msg.application,
-            attachments: msg.attachments,
-            author: msg.author.id,
-            channel_id: msg.channel_id,
-            content: msg.content,
-            edited_timestamp: msg.edited_timestamp,
-            embeds: msg.embeds,
-            flags: msg.flags,
-            guild_id: msg.guild_id,
-            kind: msg.kind,
-            member: msg.member,
-            mention_channels: msg.mention_channels,
-            mention_everyone: msg.mention_everyone,
-            mention_roles: msg.mention_roles,
-            mentions: msg.mentions.iter().map(|mention| mention.id).collect(),
-            pinned: msg.pinned,
-            reactions: msg.reactions,
-            reference: msg.reference,
-            sticker_items: msg.sticker_items,
-            timestamp: msg.timestamp,
-            tts: msg.tts,
-            webhook_id: msg.webhook_id,
-        }
+    fn from(message: Message) -> Self {
+        Self::from_model(message)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CachedMessage, CachedMessageInteraction};
+    use serde::Serialize;
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::fmt::Debug;
+    use twilight_model::channel::message::Message;
+
+    assert_fields!(
+        CachedMessage: activity,
+        application,
+        application_id,
+        attachments,
+        author,
+        channel_id,
+        components,
+        content,
+        edited_timestamp,
+        embeds,
+        flags,
+        guild_id,
+        id,
+        interaction,
+        kind,
+        member,
+        mention_channels,
+        mention_everyone,
+        mention_roles,
+        mentions,
+        pinned,
+        reactions,
+        reference,
+        sticker_items,
+        thread_id,
+        timestamp,
+        tts,
+        webhook_id
+    );
+    assert_impl_all!(
+        CachedMessage: Clone,
+        Debug,
+        Eq,
+        From<Message>,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync,
+    );
+    assert_fields!(CachedMessageInteraction: id, kind, name, user_id);
+    assert_impl_all!(
+        CachedMessageInteraction: Clone,
+        Debug,
+        Eq,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync,
+    );
 }

--- a/cache/in-memory/src/model/mod.rs
+++ b/cache/in-memory/src/model/mod.rs
@@ -1,9 +1,10 @@
 //! Models built for utilizing efficient caching.
 
+pub mod message;
+
 mod emoji;
 mod guild;
-mod member;
-mod message;
+pub(crate) mod member;
 mod presence;
 mod sticker;
 mod voice_state;

--- a/cache/in-memory/src/model/sticker.rs
+++ b/cache/in-memory/src/model/sticker.rs
@@ -130,7 +130,7 @@ impl CachedSticker {
 impl PartialEq<Sticker> for CachedSticker {
     fn eq(&self, other: &Sticker) -> bool {
         self.available == other.available
-            && self.description == other.description
+            && self.description.as_str() == other.description.as_ref().map_or("", String::as_str)
             && self.format_type == other.format_type
             && self.guild_id == other.guild_id
             && self.id == other.id
@@ -221,7 +221,7 @@ mod tests {
 
         let cached = CachedSticker {
             available: true,
-            description: Some("sticker".into()),
+            description: "sticker".into(),
             format_type: StickerFormatType::Png,
             guild_id: Some(Id::new(1)),
             id: Id::new(2),

--- a/cache/in-memory/src/model/voice_state.rs
+++ b/cache/in-memory/src/model/voice_state.rs
@@ -94,12 +94,18 @@ impl CachedVoiceState {
         self.user_id
     }
 
+    /// Construct a cached voice state from its [`twilight_model`] form.
     #[allow(clippy::missing_const_for_fn)]
-    pub(crate) fn from_voice_state(
+    pub(crate) fn from_model(
         channel_id: Id<ChannelMarker>,
         guild_id: Id<GuildMarker>,
         voice_state: VoiceState,
     ) -> Self {
+        // Reasons for dropping fields:
+        //
+        // - `channel_id`: provided as a function parameter
+        // - `guild_id`: provided as a function parameter
+        // - `member`: we have the user's ID from the `user_id` field
         let VoiceState {
             channel_id: _,
             deaf,
@@ -199,7 +205,7 @@ mod tests {
     #[test]
     fn test_eq() {
         let voice_state = test::voice_state(GUILD_ID, Some(CHANNEL_ID), USER_ID);
-        let cached = CachedVoiceState::from_voice_state(CHANNEL_ID, GUILD_ID, voice_state.clone());
+        let cached = CachedVoiceState::from_model(CHANNEL_ID, GUILD_ID, voice_state.clone());
 
         assert_eq!(cached, voice_state);
     }
@@ -207,7 +213,7 @@ mod tests {
     #[test]
     fn test_getters() {
         let voice_state = test::voice_state(GUILD_ID, Some(CHANNEL_ID), USER_ID);
-        let cached = CachedVoiceState::from_voice_state(CHANNEL_ID, GUILD_ID, voice_state.clone());
+        let cached = CachedVoiceState::from_model(CHANNEL_ID, GUILD_ID, voice_state.clone());
 
         assert_eq!(Some(cached.channel_id()), voice_state.channel_id);
         assert_eq!(cached.deaf(), voice_state.deaf);


### PR DESCRIPTION
Update the in-memory cache models with new fields from their `twilight_model` equivalents. To ensure that these models stay up to date in the future, initializers for most models have been extracted from being in the business logic of the library to being initializer functions on the cached model types themselves. To go along with this, initializers now exhaustively destructure models' fields to ensure that when a new field is added to the `twilight_model` variant of a cached model, it must be handled in the cached model's initializer as well.

The following fields have been added:

- `CachedGuild::max_video_channel_users`
- `CachedMessage::application_id`
- `CachedMessage::components`
- `CachedMessage::interaction`
- `CachedMessage::thread_id`

Field and implementation tests for all cached models have also been added.

Closes #1555.