### PR TITLE
feat(validate): individual component validators

### DIFF
--- a/validate/src/component.rs
+++ b/validate/src/component.rs
@@ -466,9 +466,10 @@ pub enum ComponentValidationErrorType {
 /// Returns an error of type [`ButtonConflict`] if both a custom ID and URL are
 /// specified.
 ///
-/// Returns an error of type [`ButtonStyle`] if [`ButtonStyle::Link`] is
-/// provided and a URL is provided, or if the style is not [`ButtonStyle::Link`]
-/// and a custom ID is not provided.
+/// Returns an error of type
+/// [`ButtonStyle`][`ComponentValidationErrorType::ButtonStyle`] if
+/// [`ButtonStyle::Link`] is provided and a URL is provided, or if the style is
+/// not [`ButtonStyle::Link`] and a custom ID is not provided.
 ///
 /// Returns an error of type [`InvalidChildComponent`] if the provided nested
 /// component is an [`ActionRow`]. Action rows can not contain another action


### PR DESCRIPTION
Separate out the validation logic for each type of component from the `component` function to individual `action_row`, `button`, `select_menu`, and `text_input` functions. This allows users to validate components that aren't wrapped in action rows.