### PR TITLE
ci: move deny warnings to only ci

### DIFF
--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -11,7 +11,7 @@ on:
 env:
   # Use `haswell` instead of `native` due to some GitHub Actions runners not
   # supporting some `avx512` instructions.
-  RUSTFLAGS: -C target-cpu=haswell
+  RUSTFLAGS: -C target-cpu=haswell -D warnings
 
 jobs:
   # Run MSRV first to save Actions time if the code doesn't compile at all.

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -69,8 +69,7 @@
     rust_2018_idioms,
     rustdoc::broken_intra_doc_links,
     unsafe_code,
-    unused,
-    warnings
+    unused
 )]
 
 pub mod iter;

--- a/command-parser/src/lib.rs
+++ b/command-parser/src/lib.rs
@@ -74,8 +74,7 @@
     nonstandard_style,
     rust_2018_idioms,
     unsafe_code,
-    unused,
-    warnings
+    unused
 )]
 #![allow(clippy::module_name_repetitions, clippy::must_use_candidate)]
 

--- a/embed-builder/src/lib.rs
+++ b/embed-builder/src/lib.rs
@@ -59,8 +59,7 @@
     rust_2018_idioms,
     rustdoc::broken_intra_doc_links,
     unsafe_code,
-    unused,
-    warnings
+    unused
 )]
 pub mod image_source;
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -143,8 +143,7 @@
     rust_2018_idioms,
     rustdoc::broken_intra_doc_links,
     unsafe_code,
-    unused,
-    warnings
+    unused
 )]
 #![allow(
     clippy::let_unit_value,

--- a/http-ratelimiting/src/lib.rs
+++ b/http-ratelimiting/src/lib.rs
@@ -32,8 +32,7 @@
     rust_2018_idioms,
     rustdoc::broken_intra_doc_links,
     unsafe_code,
-    unused,
-    warnings
+    unused
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -125,8 +125,7 @@
     rust_2018_idioms,
     rustdoc::broken_intra_doc_links,
     unsafe_code,
-    unused,
-    warnings
+    unused
 )]
 #![allow(
     clippy::missing_errors_doc,

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -132,8 +132,7 @@
     rust_2018_idioms,
     rustdoc::broken_intra_doc_links,
     unsafe_code,
-    unused,
-    warnings
+    unused
 )]
 
 pub mod client;

--- a/mention/src/lib.rs
+++ b/mention/src/lib.rs
@@ -41,8 +41,7 @@
     rust_2018_idioms,
     rustdoc::broken_intra_doc_links,
     unsafe_code,
-    unused,
-    warnings
+    unused
 )]
 #![allow(clippy::module_name_repetitions)]
 

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -59,8 +59,7 @@
     rust_2018_idioms,
     rustdoc::broken_intra_doc_links,
     unsafe_code,
-    unused,
-    warnings
+    unused
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -149,8 +149,7 @@
     rust_2018_idioms,
     rustdoc::broken_intra_doc_links,
     unsafe_code,
-    unused,
-    warnings
+    unused
 )]
 
 pub mod future;

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -47,8 +47,7 @@
     nonstandard_style,
     rust_2018_idioms,
     unsafe_code,
-    unused,
-    warnings
+    unused
 )]
 #![allow(clippy::semicolon_if_nothing_returned)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/validate/src/lib.rs
+++ b/validate/src/lib.rs
@@ -31,8 +31,7 @@
     nonstandard_style,
     rust_2018_idioms,
     unsafe_code,
-    unused,
-    warnings
+    unused
 )]
 #![allow(clippy::module_name_repetitions)]
 


### PR DESCRIPTION
See
<https://github.com/rust-unofficial/patterns/blob/main/anti_patterns/deny-warnings.md>

Equivalent to #1598
