### PR TITLE
refactor(http)!: make Image Data to take a &'a [u8]

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -686,7 +686,7 @@ impl Client {
         &'a self,
         guild_id: Id<GuildMarker>,
         name: &'a str,
-        image: &'a str,
+        image: &'a [u8],
     ) -> CreateEmoji<'a> {
         CreateEmoji::new(self, guild_id, name, image)
     }

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -15,7 +15,7 @@ use twilight_validate::request::{audit_reason as validate_audit_reason, Validati
 #[derive(Serialize)]
 struct CreateWebhookFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<&'a str>,
+    avatar: Option<&'a [u8]>,
     name: &'a str,
 }
 
@@ -67,7 +67,7 @@ impl<'a> CreateWebhook<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn avatar(mut self, avatar: &'a str) -> Self {
+    pub const fn avatar(mut self, avatar: &'a [u8]) -> Self {
         self.fields.avatar = Some(avatar);
 
         self

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -18,7 +18,7 @@ use twilight_validate::request::{audit_reason as validate_audit_reason, Validati
 #[derive(Serialize)]
 struct UpdateWebhookFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<NullableField<&'a str>>,
+    avatar: Option<NullableField<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     channel_id: Option<Id<ChannelMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -56,7 +56,7 @@ impl<'a> UpdateWebhook<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn avatar(mut self, avatar: Option<&'a str>) -> Self {
+    pub const fn avatar(mut self, avatar: Option<&'a [u8]>) -> Self {
         self.fields.avatar = Some(NullableField(avatar));
 
         self

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -14,7 +14,7 @@ use twilight_model::{
 #[derive(Serialize)]
 struct UpdateWebhookWithTokenFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<NullableField<&'a str>>,
+    avatar: Option<NullableField<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<NullableField<&'a str>>,
 }
@@ -52,7 +52,7 @@ impl<'a> UpdateWebhookWithToken<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn avatar(mut self, avatar: Option<&'a str>) -> Self {
+    pub const fn avatar(mut self, avatar: Option<&'a [u8]>) -> Self {
         self.fields.avatar = Some(NullableField(avatar));
 
         self

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -98,7 +98,7 @@ pub enum CreateGuildErrorType {
 }
 
 #[derive(Serialize)]
-struct CreateGuildFields {
+struct CreateGuildFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     afk_channel_id: Option<Id<ChannelMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -110,7 +110,7 @@ struct CreateGuildFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     explicit_content_filter: Option<ExplicitContentFilter>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<String>,
+    icon: Option<&'a [u8]>,
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     roles: Option<Vec<RoleFields>>,
@@ -222,7 +222,7 @@ pub struct VoiceFields {
 /// This endpoint can only be used by bots in less than 10 guilds.
 #[must_use = "requests must be configured and executed"]
 pub struct CreateGuild<'a> {
-    fields: CreateGuildFields,
+    fields: CreateGuildFields<'a>,
     http: &'a Client,
 }
 
@@ -371,7 +371,7 @@ impl<'a> CreateGuild<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub fn icon(mut self, icon: String) -> Self {
+    pub fn icon(mut self, icon: &'a [u8]) -> Self {
         self.fields.icon.replace(icon);
 
         self

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -17,7 +17,7 @@ use twilight_validate::request::{audit_reason as validate_audit_reason, Validati
 
 #[derive(Serialize)]
 struct CreateEmojiFields<'a> {
-    image: &'a str,
+    image: &'a [u8],
     name: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     roles: Option<&'a [Id<RoleMarker>]>,
@@ -43,7 +43,7 @@ impl<'a> CreateEmoji<'a> {
         http: &'a Client,
         guild_id: Id<GuildMarker>,
         name: &'a str,
-        image: &'a str,
+        image: &'a [u8],
     ) -> Self {
         Self {
             fields: CreateEmojiFields {

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -37,7 +37,7 @@ struct UpdateGuildFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     features: Option<&'a [&'a str]>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<NullableField<&'a str>>,
+    icon: Option<NullableField<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -175,7 +175,7 @@ impl<'a> UpdateGuild<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn icon(mut self, icon: Option<&'a str>) -> Self {
+    pub const fn icon(mut self, icon: Option<&'a [u8]>) -> Self {
         self.fields.icon = Some(NullableField(icon));
 
         self

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -12,7 +12,7 @@ use twilight_validate::request::{guild_name as validate_guild_name, ValidationEr
 #[derive(Serialize)]
 struct CreateGuildFromTemplateFields<'a> {
     name: &'a str,
-    icon: Option<&'a str>,
+    icon: Option<&'a [u8]>,
 }
 
 /// Create a new guild based on a template.
@@ -54,7 +54,7 @@ impl<'a> CreateGuildFromTemplate<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn icon(mut self, icon: &'a str) -> Self {
+    pub const fn icon(mut self, icon: &'a [u8]) -> Self {
         self.fields.icon = Some(icon);
 
         self

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -14,7 +14,7 @@ use twilight_validate::request::{
 #[derive(Serialize)]
 struct UpdateCurrentUserFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<NullableField<&'a str>>,
+    avatar: Option<NullableField<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     username: Option<&'a str>,
 }
@@ -49,7 +49,7 @@ impl<'a> UpdateCurrentUser<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn avatar(mut self, avatar: Option<&'a str>) -> Self {
+    pub const fn avatar(mut self, avatar: Option<&'a [u8]>) -> Self {
         self.fields.avatar = Some(NullableField(avatar));
 
         self


### PR DESCRIPTION
For the sake of consistency this changes every Image Data to be provided through a `&'a [u8]`.