### PR TITLE
feat(model): add `#[repr(transparent)]` to `Id`

### DIFF
--- a/model/src/id/mod.rs
+++ b/model/src/id/mod.rs
@@ -73,6 +73,7 @@ use std::{
 /// [marker documentation]: marker
 /// [user]: marker::UserMarker
 #[derive(Clone, Copy)]
+#[repr(transparent)]
 pub struct Id<T> {
     phantom: PhantomData<T>,
     value: NonZeroU64,


### PR DESCRIPTION
This is to ensure layout compatibility with NonZeroU64 (and by extension u64).