### PR TITLE
fix(http,model)!: properly serialize attachments in `CreateResponse`

### DIFF
--- a/http/src/request/attachment.rs
+++ b/http/src/request/attachment.rs
@@ -21,10 +21,10 @@ impl<'a> AttachmentManager<'a> {
     pub fn build_form(&self, fields: &'a [u8]) -> Form {
         let mut form = Form::new().json_part(b"payload_json", fields);
 
-        for (index, file) in self.files.iter().enumerate() {
-            let mut name = Vec::with_capacity(7 + num_digits(index));
+        for file in &self.files {
+            let mut name = Vec::with_capacity(7 + num_digits(file.id));
             name.extend(b"files[");
-            push_digits(index as u64, &mut name);
+            push_digits(file.id, &mut name);
             name.extend(b"]");
 
             form = form.file_part(name.as_ref(), file.filename.as_bytes(), file.file.as_ref())
@@ -36,11 +36,10 @@ impl<'a> AttachmentManager<'a> {
     pub fn get_partial_attachments(&self) -> Vec<PartialAttachment<'a>> {
         self.files
             .iter()
-            .enumerate()
-            .map(|(index, attachment)| PartialAttachment {
+            .map(|attachment| PartialAttachment {
                 description: attachment.description.as_deref(),
                 filename: Some(attachment.filename.as_ref()),
-                id: index as u64,
+                id: attachment.id,
             })
             .chain(self.ids.iter().map(|id| PartialAttachment {
                 description: None,
@@ -79,7 +78,7 @@ pub struct PartialAttachment<'a> {
 }
 
 /// Count the number of digits in a given number.
-const fn num_digits(index: usize) -> usize {
+const fn num_digits(index: u64) -> usize {
     let mut index = index;
     let mut len = 0;
 

--- a/model/src/http/attachment.rs
+++ b/model/src/http/attachment.rs
@@ -6,17 +6,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Attachment {
     pub description: Option<String>,
+    #[serde(skip)]
     pub file: Vec<u8>,
     pub filename: String,
+    pub id: u64,
 }
 
 impl Attachment {
     /// Create a attachment from a filename and bytes.
-    pub const fn from_bytes(filename: String, file: Vec<u8>) -> Self {
+    pub const fn from_bytes(filename: String, file: Vec<u8>, id: u64) -> Self {
         Self {
             description: None,
             file,
             filename,
+            id,
         }
     }
 

--- a/model/src/http/attachment.rs
+++ b/model/src/http/attachment.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Attachment for when creating and updating messages.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Attachment {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(skip)]
     pub file: Vec<u8>,

--- a/model/src/http/interaction.rs
+++ b/model/src/http/interaction.rs
@@ -106,7 +106,13 @@ pub enum InteractionResponseType {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::{
+        channel::message::MessageFlags,
+        http::{
+            attachment::Attachment,
+            interaction::{InteractionResponse, InteractionResponseData, InteractionResponseType},
+        },
+    };
     use serde::{Deserialize, Serialize};
     use serde_test::Token;
     use static_assertions::{assert_fields, assert_impl_all};
@@ -172,6 +178,55 @@ mod tests {
                 Token::Str("flags"),
                 Token::Some,
                 Token::U64(64),
+                Token::StructEnd,
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn test_interaction_response_with_attachments() {
+        let value = InteractionResponse {
+            kind: InteractionResponseType::ChannelMessageWithSource,
+            data: Some(InteractionResponseData {
+                attachments: Some(Vec::from([Attachment {
+                    description: None,
+                    file: "file data".into(),
+                    filename: "filename.jpg".into(),
+                    id: 1,
+                }])),
+                ..InteractionResponseData::default()
+            }),
+        };
+
+        serde_test::assert_ser_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "InteractionResponse",
+                    len: 2,
+                },
+                Token::Str("type"),
+                Token::U8(InteractionResponseType::ChannelMessageWithSource as u8),
+                Token::Str("data"),
+                Token::Some,
+                Token::Struct {
+                    name: "InteractionResponseData",
+                    len: 1,
+                },
+                Token::Str("attachments"),
+                Token::Some,
+                Token::Seq { len: Some(1) },
+                Token::Struct {
+                    name: "Attachment",
+                    len: 2,
+                },
+                Token::Str("filename"),
+                Token::Str("filename.jpg"),
+                Token::Str("id"),
+                Token::U64(1),
+                Token::StructEnd,
+                Token::SeqEnd,
                 Token::StructEnd,
                 Token::StructEnd,
             ],


### PR DESCRIPTION
Previously, `Attachment` structs sent inside `InteractionResponseData` would both serialize the entire file in the JSON body and fail to include its ID, which made it inefficient and impossible for Discord to associate attachment metadata with attachment data.

As a result, users are now required to specify their own ID when adding attachments to all create-message-like request builders. While breaking and annoying, this is a more robust solution than others, which would require a lot more code to temporarily fix a problem.
