### PR TITLE
feat(model): add `image_hash` audit log change key

### DIFF
--- a/model/src/guild/audit_log/change.rs
+++ b/model/src/guild/audit_log/change.rs
@@ -14,7 +14,7 @@ use crate::{
             ApplicationMarker, ChannelMarker, GenericMarker, GuildMarker, RoleMarker, UserMarker,
         },
         Id,
-    },
+    }, util::ImageHash,
 };
 use serde::{Deserialize, Serialize};
 
@@ -317,6 +317,15 @@ pub enum AuditLogChange {
         new: Option<Id<GenericMarker>>,
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
         old: Option<Id<GenericMarker>>,
+    },
+    /// Hash of a guild scheduled event cover.
+    ImageHash {
+        /// New hash of a guild's icon.
+        #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        new: Option<ImageHash>,
+        /// Old hash of a guild's icon.
+        #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        old: Option<ImageHash>,
     },
     /// Invitable state of a private thread.
     Invitable {
@@ -747,6 +756,7 @@ impl AuditLogChange {
             Self::Hoist { .. } => AuditLogChangeKey::Hoist,
             Self::IconHash { .. } => AuditLogChangeKey::IconHash,
             Self::Id { .. } => AuditLogChangeKey::Id,
+            Self::ImageHash { .. } => AuditLogChangeKey::ImageHash,
             Self::Invitable { .. } => AuditLogChangeKey::Invitable,
             Self::InviterId { .. } => AuditLogChangeKey::InviterId,
             Self::Location { .. } => AuditLogChangeKey::Location,
@@ -825,6 +835,7 @@ mod tests {
     assert_fields!(AuditLogChange::Hoist: new, old);
     assert_fields!(AuditLogChange::IconHash: new, old);
     assert_fields!(AuditLogChange::Id: new);
+    assert_fields!(AuditLogChange::ImageHash: new, old);
     assert_fields!(AuditLogChange::Invitable: new, old);
     assert_fields!(AuditLogChange::InviterId: new);
     assert_fields!(AuditLogChange::MaxAge: new);

--- a/model/src/guild/audit_log/change.rs
+++ b/model/src/guild/audit_log/change.rs
@@ -14,7 +14,8 @@ use crate::{
             ApplicationMarker, ChannelMarker, GenericMarker, GuildMarker, RoleMarker, UserMarker,
         },
         Id,
-    }, util::ImageHash,
+    },
+    util::ImageHash,
 };
 use serde::{Deserialize, Serialize};
 

--- a/model/src/guild/audit_log/change_key.rs
+++ b/model/src/guild/audit_log/change_key.rs
@@ -75,6 +75,8 @@ pub enum AuditLogChangeKey {
     IconHash,
     /// ID of an entity.
     Id,
+    /// Hash of a guild scheduled event cover.
+    ImageHash,
     /// Invitable state of a private thread.
     Invitable,
     /// ID of the user who created an invite.
@@ -210,6 +212,7 @@ impl AuditLogChangeKey {
             Self::Hoist => "hoist",
             Self::IconHash => "icon_hash",
             Self::Id => "id",
+            Self::ImageHash => "image_hash",
             Self::Invitable => "invitable",
             Self::InviterId => "inviter_id",
             Self::Location => "location",
@@ -328,6 +331,7 @@ mod tests {
         assert_eq!("hoist", AuditLogChangeKey::Hoist.name());
         assert_eq!("icon_hash", AuditLogChangeKey::IconHash.name());
         assert_eq!("id", AuditLogChangeKey::Id.name());
+        assert_eq!("image_hash", AuditLogChangeKey::ImageHash.name());
         assert_eq!("invitable", AuditLogChangeKey::Invitable.name());
         assert_eq!("inviter_id", AuditLogChangeKey::InviterId.name());
         assert_eq!("max_age", AuditLogChangeKey::MaxAge.name());
@@ -545,6 +549,13 @@ mod tests {
             &[Token::UnitVariant {
                 name: "AuditLogChangeKey",
                 variant: "id",
+            }],
+        );
+        serde_test::assert_tokens(
+            &AuditLogChangeKey::ImageHash,
+            &[Token::UnitVariant {
+                name: "AuditLogChangeKey",
+                variant: "image_hash",
             }],
         );
         serde_test::assert_tokens(


### PR DESCRIPTION
This adds the `image_hash` audit log change key which is being used when a guild scheduled event cover image gets updated.

Reference: https://github.com/discord/discord-api-docs/pull/4707

Closes: #1627