### PR TITLE
refactor(model)!: use `ImageHash` for image related change values

### DIFF
--- a/model/src/guild/audit_log/change.rs
+++ b/model/src/guild/audit_log/change.rs
@@ -14,7 +14,7 @@ use crate::{
             ApplicationMarker, ChannelMarker, GenericMarker, GuildMarker, RoleMarker, UserMarker,
         },
         Id,
-    },
+    }, util::ImageHash,
 };
 use serde::{Deserialize, Serialize};
 
@@ -116,19 +116,19 @@ pub enum AuditLogChange {
     AvatarHash {
         /// New hash of an avatar.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
-        new: Option<String>,
+        new: Option<ImageHash>,
         /// Old hash of an avatar.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
-        old: Option<String>,
+        old: Option<ImageHash>,
     },
     /// Hash of a guild banner.
     BannerHash {
         /// New hash of a guild's banner.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
-        new: Option<String>,
+        new: Option<ImageHash>,
         /// Old hash of a guild's banner.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
-        old: Option<String>,
+        old: Option<ImageHash>,
     },
     /// Bitrate of an audio channel.
     Bitrate {
@@ -224,10 +224,10 @@ pub enum AuditLogChange {
     DiscoverySplashHash {
         /// New discovery splash hash.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
-        new: Option<String>,
+        new: Option<ImageHash>,
         /// Old discovery splash hash.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
-        old: Option<String>,
+        old: Option<ImageHash>,
     },
     /// Whether emoticons are enabled.
     EnableEmoticons {
@@ -305,10 +305,10 @@ pub enum AuditLogChange {
     IconHash {
         /// New hash of a guild's icon.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
-        new: Option<String>,
+        new: Option<ImageHash>,
         /// Old hash of a guild's icon.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
-        old: Option<String>,
+        old: Option<ImageHash>,
     },
     /// ID of an entity.
     Id {
@@ -556,10 +556,10 @@ pub enum AuditLogChange {
     SplashHash {
         /// Old hash of a guild's splash.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
-        new: Option<String>,
+        new: Option<ImageHash>,
         /// New hash of a guild's splash.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
-        old: Option<String>,
+        old: Option<ImageHash>,
     },
     /// Status of guild scheduled event was changed.
     Status {


### PR DESCRIPTION
For changes related to images Discord sends a valid image hash therefore we should use the `ImageHash` struct accordingly