### PR TITLE
fix(validate): text input label min length is 1 and max is 45

### DIFF
--- a/validate/src/component.rs
+++ b/validate/src/component.rs
@@ -316,7 +316,9 @@ impl Display for ComponentValidationError {
             ComponentValidationErrorType::TextInputLabelLength { len: count } => {
                 f.write_str("a text input label length is ")?;
                 Display::fmt(count, f)?;
-                f.write_str(", but it must be at most ")?;
+                f.write_str(", but it must be at least ")?;
+                Display::fmt(&TEXT_INPUT_LABEL_MIN, f)?;
+                f.write_str(" and at most ")?;
 
                 Display::fmt(&TEXT_INPUT_LABEL_MAX, f)
             }


### PR DESCRIPTION
A text input's label has a min length of 1 (since it's a required property) and a max length of 45.

Reference: https://github.com/discord/discord-api-docs/pull/4689

Closes: #1630