### PR TITLE
refactor(model)!: Remove `InteractionType` from `Interaction` variants

### DIFF
--- a/cache/in-memory/src/event/interaction.rs
+++ b/cache/in-memory/src/event/interaction.rs
@@ -72,7 +72,7 @@ mod tests {
                 application_command::{
                     CommandData, CommandInteractionDataResolved, InteractionMember,
                 },
-                ApplicationCommand, InteractionType,
+                ApplicationCommand,
             },
         },
         channel::{
@@ -234,7 +234,6 @@ mod tests {
                 guild_id: Some(Id::new(3)),
                 guild_locale: None,
                 id: Id::new(4),
-                kind: InteractionType::ApplicationCommand,
                 locale: "en-GB".to_owned(),
                 member: Some(PartialMember {
                     avatar: None,

--- a/model/src/application/interaction/application_command/mod.rs
+++ b/model/src/application/interaction/application_command/mod.rs
@@ -17,14 +17,13 @@ use crate::{
     },
     user::User,
 };
-use serde::Serialize;
+use serde::{ser::SerializeStruct, Serialize};
 
 /// Data present in an [`Interaction`] of type [`ApplicationCommand`].
 ///
 /// [`Interaction`]: super::Interaction
 /// [`ApplicationCommand`]: super::Interaction::ApplicationCommand
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename(serialize = "Interaction"))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ApplicationCommand {
     /// ID of the associated application.
     pub application_id: Id<ApplicationMarker>,
@@ -33,32 +32,62 @@ pub struct ApplicationCommand {
     /// Data from the invoked command.
     pub data: CommandData,
     /// ID of the guild the interaction was triggered from.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<Id<GuildMarker>>,
     /// Guild's preferred locale.
     ///
     /// Present when the command is used in a guild.
     ///
     /// Defaults to `en-US`.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_locale: Option<String>,
     /// ID of the interaction.
     pub id: Id<InteractionMarker>,
     /// Kind of the interaction.
-    #[serde(rename = "type")]
     pub kind: InteractionType,
     /// Selected language of the user who triggered the interaction.
     pub locale: String,
     /// Member that triggered the interaction.
     ///
     /// Present when the command is used in a guild.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub member: Option<PartialMember>,
     /// Token of the interaction.
     pub token: String,
     /// User that triggered the interaction.
     ///
     /// Present when the command is used in a direct message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
+}
+
+impl Serialize for ApplicationCommand {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let len = 7
+            + usize::from(self.guild_id.is_some())
+            + usize::from(self.guild_locale.is_some())
+            + usize::from(self.member.is_some())
+            + usize::from(self.user.is_some());
+
+        let mut state = serializer.serialize_struct("Interaction", len)?;
+        state.serialize_field("application_id", &self.application_id)?;
+        state.serialize_field("channel_id", &self.channel_id)?;
+        state.serialize_field("data", &self.data)?;
+        if let Some(guild_id) = self.guild_id {
+            state.serialize_field("guild_id", &guild_id)?;
+        }
+        if let Some(guild_locale) = &self.guild_locale {
+            state.serialize_field("guild_locale", &guild_locale)?;
+        }
+        state.serialize_field("id", &self.id)?;
+        state.serialize_field("type", &InteractionType::ApplicationCommand)?;
+        state.serialize_field("locale", &self.locale)?;
+        if let Some(member) = &self.member {
+            state.serialize_field("member", &member)?;
+        }
+        state.serialize_field("token", &self.token)?;
+        if let Some(user) = &self.user {
+            state.serialize_field("user", &user)?;
+        }
+        state.end()
+    }
 }

--- a/model/src/application/interaction/application_command/mod.rs
+++ b/model/src/application/interaction/application_command/mod.rs
@@ -41,8 +41,6 @@ pub struct ApplicationCommand {
     pub guild_locale: Option<String>,
     /// ID of the interaction.
     pub id: Id<InteractionMarker>,
-    /// Kind of the interaction.
-    pub kind: InteractionType,
     /// Selected language of the user who triggered the interaction.
     pub locale: String,
     /// Member that triggered the interaction.

--- a/model/src/application/interaction/application_command_autocomplete/mod.rs
+++ b/model/src/application/interaction/application_command_autocomplete/mod.rs
@@ -41,8 +41,6 @@ pub struct ApplicationCommandAutocomplete {
     pub guild_locale: Option<String>,
     /// ID of the interaction.
     pub id: Id<InteractionMarker>,
-    /// Kind of the interaction.
-    pub kind: InteractionType,
     /// Selected language of the user who triggered the interaction.
     pub locale: String,
     /// Member that triggered the interaction.
@@ -127,7 +125,6 @@ mod tests {
                 guild_id: Some(Id::new(4)),
                 guild_locale: None,
                 id: Id::new(5),
-                kind: InteractionType::ApplicationCommandAutocomplete,
                 locale: "en-US".into(),
                 member: Some(PartialMember {
                     avatar: None,

--- a/model/src/application/interaction/message_component/mod.rs
+++ b/model/src/application/interaction/message_component/mod.rs
@@ -35,8 +35,6 @@ pub struct MessageComponentInteraction {
     pub guild_locale: Option<String>,
     /// ID of the interaction.
     pub id: Id<InteractionMarker>,
-    /// Type of the interaction.
-    pub kind: InteractionType,
     /// Selected language of the user who triggered the interaction.
     pub locale: String,
     /// Member that triggered the interaction.
@@ -120,7 +118,7 @@ impl Serialize for MessageComponentInteraction {
 mod tests {
     use super::{MessageComponentInteraction, MessageComponentInteractionData};
     use crate::{
-        application::{component::ComponentType, interaction::InteractionType},
+        application::component::ComponentType,
         channel::message::{Message, MessageType},
         datetime::{Timestamp, TimestampParseError},
         guild::PartialMember,
@@ -137,7 +135,6 @@ mod tests {
         data,
         guild_id,
         id,
-        kind,
         member,
         message,
         token,
@@ -191,7 +188,6 @@ mod tests {
             guild_id: Some(Id::new(3)),
             guild_locale: None,
             id: Id::new(4),
-            kind: InteractionType::MessageComponent,
             locale: "en-GB".to_owned(),
             member: Some(PartialMember {
                 avatar: None,

--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -113,15 +113,15 @@ impl<'de> Visitor<'de> for InteractionVisitor {
         let mut application_id: Option<Id<ApplicationMarker>> = None;
         let mut channel_id: Option<Id<ChannelMarker>> = None;
         let mut data: Option<Value> = None;
-        let mut guild_id: Option<Option<Id<GuildMarker>>> = None;
-        let mut guild_locale: Option<Option<String>> = None;
+        let mut guild_id: Option<Id<GuildMarker>> = None;
+        let mut guild_locale: Option<String> = None;
         let mut id: Option<Id<InteractionMarker>> = None;
-        let mut member: Option<Option<PartialMember>> = None;
+        let mut member: Option<PartialMember> = None;
         let mut message: Option<Message> = None;
         let mut token: Option<String> = None;
         let mut kind: Option<InteractionType> = None;
         let mut locale: Option<String> = None;
-        let mut user: Option<Option<User>> = None;
+        let mut user: Option<User> = None;
 
         #[cfg(feature = "tracing")]
         let span = tracing::trace_span!("deserializing interaction");
@@ -281,12 +281,7 @@ impl<'de> Visitor<'de> for InteractionVisitor {
                     .ok_or_else(|| DeError::missing_field("data"))?
                     .deserialize_into()
                     .map_err(DeserializerError::into_error)?;
-
-                let guild_id = guild_id.unwrap_or_default();
-                let guild_locale = guild_locale.unwrap_or_default();
                 let locale = locale.ok_or_else(|| DeError::missing_field("locale"))?;
-                let member = member.unwrap_or_default();
-                let user = user.unwrap_or_default();
 
                 #[cfg(feature = "tracing")]
                 tracing::trace!(%channel_id, "handling application command");
@@ -313,12 +308,7 @@ impl<'de> Visitor<'de> for InteractionVisitor {
                     .ok_or_else(|| DeError::missing_field("data"))?
                     .deserialize_into()
                     .map_err(DeserializerError::into_error)?;
-
-                let guild_id = guild_id.unwrap_or_default();
-                let guild_locale = guild_locale.unwrap_or_default();
                 let locale = locale.ok_or_else(|| DeError::missing_field("locale"))?;
-                let member = member.unwrap_or_default();
-                let user = user.unwrap_or_default();
 
                 #[cfg(feature = "tracing")]
                 tracing::trace!(%channel_id, "handling application command autocomplete");
@@ -348,12 +338,7 @@ impl<'de> Visitor<'de> for InteractionVisitor {
                         DeError::custom("expected MessageComponentInteractionData struct")
                     })?;
                 let message = message.ok_or_else(|| DeError::missing_field("message"))?;
-
-                let guild_id = guild_id.unwrap_or_default();
-                let guild_locale = guild_locale.unwrap_or_default();
                 let locale = locale.ok_or_else(|| DeError::missing_field("locale"))?;
-                let member = member.unwrap_or_default();
-                let user = user.unwrap_or_default();
 
                 Self::Value::MessageComponent(Box::new(MessageComponentInteraction {
                     application_id,
@@ -376,12 +361,7 @@ impl<'de> Visitor<'de> for InteractionVisitor {
                     .ok_or_else(|| DeError::missing_field("data"))?
                     .deserialize_into()
                     .map_err(|_| DeError::custom("expected ModalInteractionData struct"))?;
-
-                let guild_id = guild_id.unwrap_or_default();
-                let guild_locale = guild_locale.unwrap_or_default();
                 let locale = locale.ok_or_else(|| DeError::missing_field("locale"))?;
-                let member = member.unwrap_or_default();
-                let user = user.unwrap_or_default();
 
                 Self::Value::ModalSubmit(Box::new(ModalSubmitInteraction {
                     application_id,
@@ -620,11 +600,9 @@ mod test {
                 Token::StructEnd,
                 Token::StructEnd,
                 Token::Str("guild_id"),
-                Token::Some,
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("400"),
                 Token::Str("guild_locale"),
-                Token::Some,
                 Token::String("de"),
                 Token::Str("id"),
                 Token::NewtypeStruct { name: "Id" },
@@ -634,7 +612,6 @@ mod test {
                 Token::Str("locale"),
                 Token::Str("en-GB"),
                 Token::Str("member"),
-                Token::Some,
                 Token::Struct {
                     name: "PartialMember",
                     len: 8,

--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -387,7 +387,7 @@ mod test {
                     ApplicationCommand, CommandData, CommandDataOption,
                     CommandInteractionDataResolved, CommandOptionValue, InteractionMember,
                 },
-                Interaction,
+                Interaction, InteractionType,
             },
         },
         datetime::{Timestamp, TimestampParseError},
@@ -398,8 +398,6 @@ mod test {
     };
     use serde_test::Token;
     use std::{collections::HashMap, str::FromStr};
-
-    use super::InteractionType;
 
     #[test]
     #[allow(clippy::too_many_lines)]

--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -271,7 +271,6 @@ impl<'de> Visitor<'de> for InteractionVisitor {
                 Self::Value::Ping(Box::new(Ping {
                     application_id,
                     id,
-                    kind,
                     token,
                 }))
             }
@@ -293,7 +292,6 @@ impl<'de> Visitor<'de> for InteractionVisitor {
                     guild_id,
                     guild_locale,
                     id,
-                    kind,
                     locale,
                     member,
                     token,
@@ -320,7 +318,6 @@ impl<'de> Visitor<'de> for InteractionVisitor {
                     guild_id,
                     guild_locale,
                     id,
-                    kind,
                     locale,
                     member,
                     token,
@@ -347,7 +344,6 @@ impl<'de> Visitor<'de> for InteractionVisitor {
                     guild_id,
                     guild_locale,
                     id,
-                    kind,
                     locale,
                     member,
                     message,
@@ -370,7 +366,6 @@ impl<'de> Visitor<'de> for InteractionVisitor {
                     guild_id,
                     guild_locale,
                     id,
-                    kind,
                     locale,
                     member,
                     message,
@@ -392,7 +387,7 @@ mod test {
                     ApplicationCommand, CommandData, CommandDataOption,
                     CommandInteractionDataResolved, CommandOptionValue, InteractionMember,
                 },
-                Interaction, InteractionType,
+                Interaction,
             },
         },
         datetime::{Timestamp, TimestampParseError},
@@ -403,6 +398,8 @@ mod test {
     };
     use serde_test::Token;
     use std::{collections::HashMap, str::FromStr};
+
+    use super::InteractionType;
 
     #[test]
     #[allow(clippy::too_many_lines)]
@@ -467,7 +464,6 @@ mod test {
             guild_id: Some(Id::new(400)),
             guild_locale: Some("de".to_owned()),
             id: Id::new(500),
-            kind: InteractionType::ApplicationCommand,
             locale: "en-GB".to_owned(),
             member: Some(PartialMember {
                 avatar: None,
@@ -608,7 +604,7 @@ mod test {
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("500"),
                 Token::Str("type"),
-                Token::U8(2),
+                Token::U8(InteractionType::ApplicationCommand as u8),
                 Token::Str("locale"),
                 Token::Str("en-GB"),
                 Token::Str("member"),

--- a/model/src/application/interaction/modal/mod.rs
+++ b/model/src/application/interaction/modal/mod.rs
@@ -14,13 +14,12 @@ use crate::{
     },
     user::User,
 };
-use serde::Serialize;
+use serde::{ser::SerializeStruct, Serialize};
 
 /// Information present in an [`Interaction::ModalSubmit`].
 ///
 /// [`Interaction::ModalSubmit`]: super::Interaction::ModalSubmit
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename(serialize = "Interaction"))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModalSubmitInteraction {
     /// ID of the associated application.
     pub application_id: Id<ApplicationMarker>,
@@ -35,19 +34,16 @@ pub struct ModalSubmitInteraction {
     /// Present when the command is used in a guild.
     ///
     /// Defaults to `en-US`.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_locale: Option<String>,
     /// ID of the interaction.
     pub id: Id<InteractionMarker>,
     /// Type of the interaction.
-    #[serde(rename = "type")]
     pub kind: InteractionType,
     /// Selected language of the user who triggered the interaction.
     pub locale: String,
     /// Member that triggered the interaction.
     ///
     /// Present when the command is used in a guild.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub member: Option<PartialMember>,
     /// Message object, if the modal comes from a message component interaction.
     ///
@@ -59,7 +55,6 @@ pub struct ModalSubmitInteraction {
     /// User that triggered the interaction.
     ///
     /// Present when the command is used in a direct message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
 }
 
@@ -84,6 +79,45 @@ impl ModalSubmitInteraction {
         }
 
         None
+    }
+}
+
+impl Serialize for ModalSubmitInteraction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let len = 7
+            + usize::from(self.guild_id.is_some())
+            + usize::from(self.guild_locale.is_some())
+            + usize::from(self.member.is_some())
+            + usize::from(self.message.is_some())
+            + usize::from(self.user.is_some());
+
+        let mut state = serializer.serialize_struct("Interaction", len)?;
+        state.serialize_field("application_id", &self.application_id)?;
+        state.serialize_field("channel_id", &self.channel_id)?;
+        state.serialize_field("data", &self.data)?;
+        if let Some(guild_id) = self.guild_id {
+            state.serialize_field("guild_id", &guild_id)?;
+        }
+        if let Some(guild_locale) = &self.guild_locale {
+            state.serialize_field("guild_locale", &guild_locale)?;
+        }
+        state.serialize_field("id", &self.id)?;
+        state.serialize_field("type", &InteractionType::ModalSubmit)?;
+        state.serialize_field("locale", &self.locale)?;
+        if let Some(member) = &self.member {
+            state.serialize_field("member", &member)?;
+        }
+        if let Some(message) = &self.message {
+            state.serialize_field("message", &message)?;
+        }
+        state.serialize_field("token", &self.token)?;
+        if let Some(user) = &self.user {
+            state.serialize_field("user", &user)?;
+        }
+        state.end()
     }
 }
 

--- a/model/src/application/interaction/modal/mod.rs
+++ b/model/src/application/interaction/modal/mod.rs
@@ -37,8 +37,6 @@ pub struct ModalSubmitInteraction {
     pub guild_locale: Option<String>,
     /// ID of the interaction.
     pub id: Id<InteractionMarker>,
-    /// Type of the interaction.
-    pub kind: InteractionType,
     /// Selected language of the user who triggered the interaction.
     pub locale: String,
     /// Member that triggered the interaction.
@@ -137,7 +135,6 @@ mod tests {
         data,
         guild_id,
         id,
-        kind,
         member,
         token,
         user
@@ -194,7 +191,6 @@ mod tests {
             guild_id: Some(Id::<GuildMarker>::new(1)),
             guild_locale: Some("de".to_owned()),
             id: Id::<InteractionMarker>::new(1),
-            kind: InteractionType::ModalSubmit,
             locale: "en-GB".to_owned(),
             member: Some(PartialMember {
                 avatar: None,

--- a/model/src/application/interaction/ping.rs
+++ b/model/src/application/interaction/ping.rs
@@ -15,8 +15,6 @@ pub struct Ping {
     pub application_id: Id<ApplicationMarker>,
     /// ID of the interaction.
     pub id: Id<InteractionMarker>,
-    /// Kind of the interaction.
-    pub kind: InteractionType,
     /// Token of the interaction.
     pub token: String,
 }

--- a/model/src/application/interaction/ping.rs
+++ b/model/src/application/interaction/ping.rs
@@ -3,22 +3,34 @@ use crate::id::{
     marker::{ApplicationMarker, InteractionMarker},
     Id,
 };
-use serde::Serialize;
+use serde::{ser::SerializeStruct, Serialize};
 
 /// Data present in an [`Interaction`] of type [`Ping`].
 ///
 /// [`Interaction`]: super::Interaction
 /// [`Ping`]: super::Interaction::Ping
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename(serialize = "Interaction"))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ping {
     /// ID of the associated application.
     pub application_id: Id<ApplicationMarker>,
     /// ID of the interaction.
     pub id: Id<InteractionMarker>,
-    #[serde(rename = "type")]
     /// Kind of the interaction.
     pub kind: InteractionType,
     /// Token of the interaction.
     pub token: String,
+}
+
+impl Serialize for Ping {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Interaction", 4)?;
+        state.serialize_field("application_id", &self.application_id)?;
+        state.serialize_field("id", &self.id)?;
+        state.serialize_field("type", &InteractionType::Ping)?;
+        state.serialize_field("token", &self.token)?;
+        state.end()
+    }
 }

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -1220,7 +1220,7 @@ mod tests {
         application::{
             component::ComponentType,
             interaction::{
-                message_component::MessageComponentInteractionData, Interaction, InteractionType,
+                message_component::MessageComponentInteractionData, Interaction,
                 MessageComponentInteraction,
             },
         },
@@ -1315,7 +1315,6 @@ mod tests {
             guild_id: Some(Id::new(3)),
             guild_locale: None,
             id: Id::new(4),
-            kind: InteractionType::MessageComponent,
             locale: "en-GB".to_owned(),
             member: None,
             message: message(),


### PR DESCRIPTION
The information is encoded in the `Interaction` / name (`ApplicationCommand` is of type `ApplicationCommand`).

Required manual `Serialize` implementation on all the variants.
