### PR TITLE
refactor(http): rename interaction field structs

### DIFF
--- a/http/src/request/application/interaction/create_followup.rs
+++ b/http/src/request/application/interaction/create_followup.rs
@@ -25,7 +25,7 @@ use twilight_validate::message::{
 };
 
 #[derive(Serialize)]
-pub(crate) struct CreateFollowupMessageFields<'a> {
+struct CreateFollowupFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     allowed_mentions: Option<NullableField<&'a AllowedMentions>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -76,7 +76,7 @@ pub(crate) struct CreateFollowupMessageFields<'a> {
 pub struct CreateFollowup<'a> {
     application_id: Id<ApplicationMarker>,
     attachment_manager: AttachmentManager<'a>,
-    fields: CreateFollowupMessageFields<'a>,
+    fields: CreateFollowupFields<'a>,
     http: &'a Client,
     token: &'a str,
 }
@@ -90,7 +90,7 @@ impl<'a> CreateFollowup<'a> {
         Self {
             application_id,
             attachment_manager: AttachmentManager::new(),
-            fields: CreateFollowupMessageFields {
+            fields: CreateFollowupFields {
                 allowed_mentions: None,
                 attachments: None,
                 components: None,

--- a/http/src/request/application/interaction/update_followup.rs
+++ b/http/src/request/application/interaction/update_followup.rs
@@ -26,7 +26,7 @@ use twilight_validate::message::{
 };
 
 #[derive(Serialize)]
-struct UpdateFollowupMessageFields<'a> {
+struct UpdateFollowupFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     allowed_mentions: Option<NullableField<&'a AllowedMentions>>,
     /// List of attachments to keep, and new attachments to add.
@@ -86,7 +86,7 @@ struct UpdateFollowupMessageFields<'a> {
 pub struct UpdateFollowup<'a> {
     application_id: Id<ApplicationMarker>,
     attachment_manager: AttachmentManager<'a>,
-    fields: UpdateFollowupMessageFields<'a>,
+    fields: UpdateFollowupFields<'a>,
     http: &'a Client,
     message_id: Id<MessageMarker>,
     token: &'a str,
@@ -102,7 +102,7 @@ impl<'a> UpdateFollowup<'a> {
         Self {
             application_id,
             attachment_manager: AttachmentManager::new(),
-            fields: UpdateFollowupMessageFields {
+            fields: UpdateFollowupFields {
                 allowed_mentions: None,
                 attachments: None,
                 components: None,

--- a/http/src/request/application/interaction/update_response.rs
+++ b/http/src/request/application/interaction/update_response.rs
@@ -26,7 +26,7 @@ use twilight_validate::message::{
 };
 
 #[derive(Serialize)]
-struct UpdateOriginalResponseFields<'a> {
+struct UpdateResponseFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     allowed_mentions: Option<NullableField<&'a AllowedMentions>>,
     /// List of attachments to keep, and new attachments to add.
@@ -86,7 +86,7 @@ struct UpdateOriginalResponseFields<'a> {
 pub struct UpdateResponse<'a> {
     application_id: Id<ApplicationMarker>,
     attachment_manager: AttachmentManager<'a>,
-    fields: UpdateOriginalResponseFields<'a>,
+    fields: UpdateResponseFields<'a>,
     http: &'a Client,
     token: &'a str,
 }
@@ -100,7 +100,7 @@ impl<'a> UpdateResponse<'a> {
         Self {
             application_id,
             attachment_manager: AttachmentManager::new(),
-            fields: UpdateOriginalResponseFields {
+            fields: UpdateResponseFields {
                 allowed_mentions: None,
                 attachments: None,
                 components: None,


### PR DESCRIPTION
These were missed in previous refactoring, these are private types.
