### PR TITLE
refactor(mention)!: remove nickname mention support

### DIFF
--- a/mention/src/parse/error.rs
+++ b/mention/src/parse/error.rs
@@ -242,12 +242,12 @@ mod tests {
             .to_string(),
         );
 
-        expected = "expected to find a mention sigil ('@!', '@') but instead found '#'";
+        expected = "expected to find a mention sigil ('@') but instead found '#'";
         assert_eq!(
             expected,
             ParseMentionError {
                 kind: ParseMentionErrorType::Sigil {
-                    expected: &["@!", "@"],
+                    expected: &["@"],
                     found: Some('#'),
                 },
                 source: None,
@@ -255,12 +255,12 @@ mod tests {
             .to_string(),
         );
 
-        expected = "expected to find a mention sigil ('@!', '@') but instead found nothing";
+        expected = "expected to find a mention sigil ('@') but instead found nothing";
         assert_eq!(
             expected,
             ParseMentionError {
                 kind: ParseMentionErrorType::Sigil {
-                    expected: &["@!", "@"],
+                    expected: &["@"],
                     found: None
                 },
                 source: None,

--- a/mention/src/parse/impl.rs
+++ b/mention/src/parse/impl.rs
@@ -19,7 +19,7 @@ pub trait ParseMention: private::Sealed {
     /// Leading sigil(s) of the mention after the leading arrow (`<`).
     ///
     /// In a channel mention, the sigil is `#`. In the case of a user mention,
-    /// the sigil may be either `@` or `@!`.
+    /// the sigil would be `@`.
     const SIGILS: &'static [&'static str];
 
     /// Parse a mention out of a buffer.
@@ -102,7 +102,7 @@ impl ParseMention for MentionType {
     /// Sigils for any type of mention.
     ///
     /// Contains all of the sigils of every other type of mention.
-    const SIGILS: &'static [&'static str] = &["#", ":", "@&", "@!", "@", "t:"];
+    const SIGILS: &'static [&'static str] = &["#", ":", "@&", "@", "t:"];
 
     /// Parse a mention from a string slice.
     ///
@@ -193,10 +193,8 @@ impl ParseMention for Timestamp {
 }
 
 impl ParseMention for Id<UserMarker> {
-    /// Sigils for User ID mentions.
-    ///
-    /// Unlike other IDs, user IDs have two possible sigils: `@!` and `@`.
-    const SIGILS: &'static [&'static str] = &["@!", "@"];
+    /// Sigil for User ID mentions.
+    const SIGILS: &'static [&'static str] = &["@"];
 
     fn parse(buf: &str) -> Result<Self, ParseMentionError<'_>>
     where
@@ -380,9 +378,9 @@ mod tests {
     fn test_sigils() {
         assert_eq!(&["#"], Id::<ChannelMarker>::SIGILS);
         assert_eq!(&[":"], Id::<EmojiMarker>::SIGILS);
-        assert_eq!(&["#", ":", "@&", "@!", "@", "t:"], MentionType::SIGILS);
+        assert_eq!(&["#", ":", "@&", "@", "t:"], MentionType::SIGILS);
         assert_eq!(&["@&"], Id::<RoleMarker>::SIGILS);
-        assert_eq!(&["@!", "@"], Id::<UserMarker>::SIGILS);
+        assert_eq!(&["@"], Id::<UserMarker>::SIGILS);
     }
 
     #[test]
@@ -432,7 +430,7 @@ mod tests {
         );
         assert_eq!(
             &ParseMentionErrorType::Sigil {
-                expected: &["#", ":", "@&", "@!", "@", "t:"],
+                expected: &["#", ":", "@&", "@", "t:"],
                 found: Some(';'),
             },
             MentionType::parse("<;123>").unwrap_err().kind(),

--- a/mention/src/parse/iter.rs
+++ b/mention/src/parse/iter.rs
@@ -154,12 +154,11 @@ mod tests {
 
     #[test]
     fn test_iter_mention_type() {
-        let mut iter = MentionType::iter("<#12><:name:34><@&56><@!78><@90>");
+        let mut iter = MentionType::iter("<#12><:name:34><@&56><@78>");
         assert_eq!(MentionType::Channel(Id::new(12)), iter.next().unwrap().0);
         assert_eq!(MentionType::Emoji(Id::new(34)), iter.next().unwrap().0);
         assert_eq!(MentionType::Role(Id::new(56)), iter.next().unwrap().0);
         assert_eq!(MentionType::User(Id::new(78)), iter.next().unwrap().0);
-        assert_eq!(MentionType::User(Id::new(90)), iter.next().unwrap().0);
         assert!(iter.next().is_none());
     }
 

--- a/mention/src/parse/mod.rs
+++ b/mention/src/parse/mod.rs
@@ -105,10 +105,6 @@ use twilight_model::id::{
 ///     MentionType::Role(Id::<RoleMarker>::new(123)),
 ///     MentionType::parse("<@&123>")?,
 /// );
-/// assert_eq!(
-///     MentionType::User(Id::<UserMarker>::new(123)),
-///     MentionType::parse("<@!123>")?,
-/// );
 ///
 /// let timestamp = Timestamp::new(123, None);
 /// assert_eq!(MentionType::Timestamp(timestamp), MentionType::parse("<t:123>")?);


### PR DESCRIPTION
Remove support for nickname mentions due to Discord removing them from documentation:

<https://github.com/discord/discord-api-docs/commit/a8f7638e79391bb70e15996d1d88488a3b6364b2>