### PR TITLE
docs: add missing tracing crate links

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ async fn handle_event(
 
 ## Note about tracing
 
-When using the `tracing` crate you won't, by default, see logs from any
-libraries that use the `log` crate. You can add that back by using the
+When using the [`tracing`] crate you won't, by default, see logs from any
+libraries that use the [`log`] crate. You can add that back by using the
 [`tracing-log`] crate and initializing it like this:
 
 ```rust
@@ -231,7 +231,9 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png
 [rust badge]: https://img.shields.io/badge/rust-1.57+-93450a.svg?style=for-the-badge&logo=rust
+[`log`]: https://crates.io/crates/log
 [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
+[`tracing`]: https://crates.io/crates/tracing
 [`twilight-cache-inmemory`]: https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html
 [`twilight-embed-builder`]: https://twilight.rs/chapter_1_crates/section_7_first_party/section_1_embed_builder.html
 [`twilight-gateway-queue`]: https://twilight.rs/chapter_1_crates/section_7_first_party/section_5_gateway_queue.html

--- a/gateway-queue/README.md
+++ b/gateway-queue/README.md
@@ -48,6 +48,7 @@ The `tracing` feature enables logging via the [`tracing`] crate.
 
 This is enabled by default.
 
+[`tracing`]: https://crates.io/crates/tracing
 [Sharding for Very Large Bots]: https://discord.com/developers/docs/topics/gateway#sharding-for-very-large-bots
 
 <!-- cargo-sync-readme end -->

--- a/gateway-queue/src/lib.rs
+++ b/gateway-queue/src/lib.rs
@@ -46,6 +46,7 @@
 //!
 //! This is enabled by default.
 //!
+//! [`tracing`]: https://crates.io/crates/tracing
 //! [Sharding for Very Large Bots]: https://discord.com/developers/docs/topics/gateway#sharding-for-very-large-bots
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/http-ratelimiting/README.md
+++ b/http-ratelimiting/README.md
@@ -22,6 +22,7 @@ The `tracing` feature enables logging via the [`tracing`] crate.
 
 This is enabled by default.
 
+[`tracing`]: https://crates.io/crates/tracing
 [Discord's documentation]: https://discord.com/developers/docs/topics/rate-limits
 
 <!-- cargo-sync-readme end -->

--- a/http-ratelimiting/src/lib.rs
+++ b/http-ratelimiting/src/lib.rs
@@ -20,6 +20,7 @@
 //!
 //! This is enabled by default.
 //!
+//! [`tracing`]: https://crates.io/crates/tracing
 //! [Discord's documentation]: https://discord.com/developers/docs/topics/rate-limits
 
 #![deny(

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -110,6 +110,7 @@ There is also an example of a basic bot located in the [root of the
 [`rustls`]: https://crates.io/crates/rustls
 [`rustls-native-certs`]: https://crates.io/crates/rustls-native-certs
 [`tokio-tungstenite`]: https://crates.io/crates/tokio-tungstenite
+[`tracing`]: https://crates.io/crates/tracing
 [`webpki-roots`]: https://crates.io/crates/webpki-roots
 [client]: Lavalink
 [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -108,6 +108,7 @@
 //! [`rustls`]: https://crates.io/crates/rustls
 //! [`rustls-native-certs`]: https://crates.io/crates/rustls-native-certs
 //! [`tokio-tungstenite`]: https://crates.io/crates/tokio-tungstenite
+//! [`tracing`]: https://crates.io/crates/tracing
 //! [`webpki-roots`]: https://crates.io/crates/webpki-roots
 //! [client]: Lavalink
 //! [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -199,8 +199,8 @@
 //!
 //! ## Note about tracing
 //!
-//! When using the `tracing` crate you won't, by default, see logs from any
-//! libraries that use the `log` crate. You can add that back by using the
+//! When using the [`tracing`] crate you won't, by default, see logs from any
+//! libraries that use the [`log`] crate. You can add that back by using the
 //! [`tracing-log`] crate and initializing it like this:
 //!
 //! ```rust
@@ -231,7 +231,9 @@
 //! [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 //! [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png
 //! [rust badge]: https://img.shields.io/badge/rust-1.57+-93450a.svg?style=for-the-badge&logo=rust
+//! [`log`]: https://crates.io/crates/log
 //! [`tracing-log`]: https://github.com/tokio-rs/tracing/tree/master/tracing-log
+//! [`tracing`]: https://crates.io/crates/tracing
 //! [`twilight-cache-inmemory`]: https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html
 //! [`twilight-embed-builder`]: https://twilight.rs/chapter_1_crates/section_7_first_party/section_1_embed_builder.html
 //! [`twilight-gateway-queue`]: https://twilight.rs/chapter_1_crates/section_7_first_party/section_5_gateway_queue.html


### PR DESCRIPTION
Add missing links to the `tracing` crate in crate-level documentation for `gateway-queue`, `http-ratelimiting`, and `lavalink`. This causes rustdoc errors when building individual crates.