### PR TITLE
feat(http): support get guild bans pagination

### DIFF
--- a/http/src/request/guild/ban/get_bans.rs
+++ b/http/src/request/guild/ban/get_bans.rs
@@ -7,37 +7,105 @@ use crate::{
 };
 use twilight_model::{
     guild::Ban,
-    id::{marker::GuildMarker, Id},
+    id::{
+        marker::{GuildMarker, UserMarker},
+        Id,
+    },
 };
+use twilight_validate::request::{
+    get_guild_bans_limit as validate_get_guild_bans_limit, ValidationError,
+};
+
+struct GetBansFields {
+    after: Option<Id<UserMarker>>,
+    before: Option<Id<UserMarker>>,
+    limit: Option<u16>,
+}
 
 /// Retrieve the bans for a guild.
 ///
 /// # Examples
 ///
-/// Retrieve the bans for guild `1`:
+/// Retrieve the first 25 bans of a guild after a particular user ID:
 ///
 /// ```no_run
+/// use std::env;
 /// use twilight_http::Client;
 /// use twilight_model::id::Id;
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::new("my token".to_owned());
+/// let client = Client::new(env::var("DISCORD_TOKEN")?);
 ///
 /// let guild_id = Id::new(1);
+/// let user_id = Id::new(2);
 ///
-/// let bans = client.bans(guild_id).exec().await?;
+/// let response = client.bans(guild_id).after(user_id).exec().await?;
+/// let bans = response.models().await?;
+///
+/// for ban in bans {
+///     println!("{} was banned for: {:?}", ban.user.name, ban.reason);
+/// }
 /// # Ok(()) }
 /// ```
 #[must_use = "requests must be configured and executed"]
 pub struct GetBans<'a> {
+    fields: GetBansFields,
     guild_id: Id<GuildMarker>,
     http: &'a Client,
 }
 
 impl<'a> GetBans<'a> {
     pub(crate) const fn new(http: &'a Client, guild_id: Id<GuildMarker>) -> Self {
-        Self { guild_id, http }
+        Self {
+            fields: GetBansFields {
+                after: None,
+                before: None,
+                limit: None,
+            },
+            guild_id,
+            http,
+        }
+    }
+
+    /// Set the user ID after which to retrieve bans.
+    ///
+    /// Mutually exclusive with [`before`]. If both are provided then [`before`]
+    /// is respected.
+    ///
+    /// [`before`]: Self::before
+    pub const fn after(mut self, user_id: Id<UserMarker>) -> Self {
+        self.fields.after = Some(user_id);
+
+        self
+    }
+
+    /// Set the user ID before which to retrieve bans.
+    ///
+    /// Mutually exclusive with [`after`]. If both are provided then [`before`]
+    /// is respected.
+    ///
+    /// [`after`]: Self::after
+    /// [`before`]: Self::before
+    pub const fn before(mut self, user_id: Id<UserMarker>) -> Self {
+        self.fields.before = Some(user_id);
+
+        self
+    }
+
+    /// Set the maximum number of bans to retrieve.
+    ///
+    /// Defaults to Discord's default.
+    ///
+    /// Refer to [Discord Docs/Get Guild Bans] for more information.
+    pub const fn limit(mut self, limit: u16) -> Result<Self, ValidationError> {
+        if let Err(source) = validate_get_guild_bans_limit(limit) {
+            return Err(source);
+        }
+
+        self.fields.limit = Some(limit);
+
+        Ok(self)
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
@@ -55,7 +123,10 @@ impl<'a> GetBans<'a> {
 
 impl TryIntoRequest for GetBans<'_> {
     fn try_into_request(self) -> Result<Request, Error> {
-        Ok(Request::from_route(&Route::GetBans {
+        Ok(Request::from_route(&Route::GetBansWithParameters {
+            after: self.fields.after.map(Id::get),
+            before: self.fields.before.map(Id::get),
+            limit: self.fields.limit,
             guild_id: self.guild_id.get(),
         }))
     }

--- a/http/src/request/guild/ban/get_bans.rs
+++ b/http/src/request/guild/ban/get_bans.rs
@@ -40,7 +40,7 @@ struct GetBansFields {
 /// let guild_id = Id::new(1);
 /// let user_id = Id::new(2);
 ///
-/// let response = client.bans(guild_id).after(user_id).exec().await?;
+/// let response = client.bans(guild_id).after(user_id).limit(25).exec().await?;
 /// let bans = response.models().await?;
 ///
 /// for ban in bans {

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -367,6 +367,17 @@ pub enum Route<'a> {
         /// The ID of the guild.
         guild_id: u64,
     },
+    /// Route information to get a guild's bans with parameters.
+    GetBansWithParameters {
+        /// User ID after which to retrieve bans.
+        after: Option<u64>,
+        /// User ID before which to retrieve bans.
+        before: Option<u64>,
+        /// Maximum number of bans to retrieve.
+        limit: Option<u16>,
+        /// The ID of the guild.
+        guild_id: u64,
+    },
     /// Route information to get a channel.
     GetChannel {
         /// The ID of the channel.
@@ -1085,6 +1096,7 @@ impl<'a> Route<'a> {
             | Self::GetAuditLogs { .. }
             | Self::GetBan { .. }
             | Self::GetBans { .. }
+            | Self::GetBansWithParameters { .. }
             | Self::GetGatewayBot
             | Self::GetChannel { .. }
             | Self::GetChannelInvites { .. }
@@ -1434,7 +1446,9 @@ impl<'a> Route<'a> {
             Self::GetActiveThreads { guild_id, .. } => Path::GuildsIdThreads(guild_id),
             Self::GetAuditLogs { guild_id, .. } => Path::GuildsIdAuditLogs(guild_id),
             Self::GetBan { guild_id, .. } => Path::GuildsIdBansId(guild_id),
-            Self::GetBans { guild_id } => Path::GuildsIdBans(guild_id),
+            Self::GetBans { guild_id } | Self::GetBansWithParameters { guild_id, .. } => {
+                Path::GuildsIdBans(guild_id)
+            }
             Self::GetGatewayBot => Path::GatewayBot,
             Self::GetChannel { channel_id } | Self::UpdateChannel { channel_id } => {
                 Path::ChannelsId(channel_id)
@@ -2156,6 +2170,33 @@ impl Display for Route<'_> {
                 Display::fmt(guild_id, f)?;
 
                 f.write_str("/bans")
+            }
+            Route::GetBansWithParameters {
+                after,
+                before,
+                guild_id,
+                limit,
+            } => {
+                f.write_str("guilds/")?;
+                Display::fmt(guild_id, f)?;
+                f.write_str("/bans?")?;
+
+                if let Some(after) = after {
+                    f.write_str("after=")?;
+                    Display::fmt(after, f)?;
+                }
+
+                if let Some(before) = before {
+                    f.write_str("&before=")?;
+                    Display::fmt(before, f)?;
+                }
+
+                if let Some(limit) = limit {
+                    f.write_str("&limit=")?;
+                    Display::fmt(limit, f)?;
+                }
+
+                Ok(())
             }
             Route::GetGatewayBot => f.write_str("gateway/bot"),
             Route::GetCommandPermissions {
@@ -3979,6 +4020,82 @@ mod tests {
         assert_eq!(
             route.to_string(),
             format!("guilds/{guild_id}/bans", guild_id = GUILD_ID)
+        );
+    }
+
+    #[test]
+    fn test_get_bans_with_parameters() {
+        let route = Route::GetBansWithParameters {
+            after: None,
+            before: None,
+            guild_id: GUILD_ID,
+            limit: None,
+        };
+        assert_eq!(
+            route.to_string(),
+            format!("guilds/{guild_id}/bans?", guild_id = GUILD_ID)
+        );
+
+        let route = Route::GetBansWithParameters {
+            after: Some(USER_ID),
+            before: None,
+            guild_id: GUILD_ID,
+            limit: None,
+        };
+        assert_eq!(
+            route.to_string(),
+            format!(
+                "guilds/{guild_id}/bans?after={after}",
+                after = USER_ID,
+                guild_id = GUILD_ID
+            )
+        );
+
+        let route = Route::GetBansWithParameters {
+            after: None,
+            before: Some(USER_ID),
+            guild_id: GUILD_ID,
+            limit: None,
+        };
+        assert_eq!(
+            route.to_string(),
+            format!(
+                "guilds/{guild_id}/bans?&before={before}",
+                before = USER_ID,
+                guild_id = GUILD_ID
+            )
+        );
+
+        let route = Route::GetBansWithParameters {
+            after: None,
+            before: None,
+            guild_id: GUILD_ID,
+            limit: Some(100),
+        };
+        assert_eq!(
+            route.to_string(),
+            format!(
+                "guilds/{guild_id}/bans?&limit={limit}",
+                guild_id = GUILD_ID,
+                limit = 100,
+            )
+        );
+
+        let route = Route::GetBansWithParameters {
+            after: Some(USER_ID),
+            before: Some(USER_ID + 100),
+            guild_id: GUILD_ID,
+            limit: Some(25),
+        };
+        assert_eq!(
+            route.to_string(),
+            format!(
+                "guilds/{guild_id}/bans?after={after}&before={before}&limit={limit}",
+                after = USER_ID,
+                before = USER_ID + 100,
+                guild_id = GUILD_ID,
+                limit = 25,
+            )
         );
     }
 

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -375,7 +375,7 @@ pub enum Route<'a> {
         before: Option<u64>,
         /// Maximum number of bans to retrieve.
         limit: Option<u16>,
-        /// The ID of the guild.
+        /// ID of the guild.
         guild_id: u64,
     },
     /// Route information to get a channel.

--- a/validate/src/request.rs
+++ b/validate/src/request.rs
@@ -1019,10 +1019,10 @@ mod tests {
 
     #[test]
     fn test_get_guild_bans_limit() {
-        assert!(get_guild_audit_log_limit(0).is_ok());
-        assert!(get_guild_audit_log_limit(1000).is_ok());
+        assert!(get_guild_bans_limit(0).is_ok());
+        assert!(get_guild_bans_limit(1000).is_ok());
 
-        assert!(get_guild_audit_log_limit(1001).is_err());
+        assert!(get_guild_bans_limit(1001).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Support pagination on the `GetGuildBans` request via three new builder methods:

- `after`, to retrieve bans after a user ID
- `before`, to retrieve bans before a user ID
- `limit`, to specify the maximum number of bans to retrieve, up to 1000

A new route, `GetBansWithParameters`, has been added due to being unable to modify the `GetBans` variant.

`twilight_validate::request::get_guild_bans_limit` has been added, checking the new constant `GET_GUILD_BANS_LIMIT_MAX` and returning an error of type `GetGuildBans` if the provided limit is over the maximum.

Closes #1656.