### PR TITLE
docs(model): tweak hypesquad user flag docs

### DIFF
--- a/model/src/user/flags.rs
+++ b/model/src/user/flags.rs
@@ -10,7 +10,7 @@ bitflags! {
         const STAFF = 1;
         /// Partnered server owner.
         const PARTNER = 1 << 1;
-        /// HypeSquad events coordinator.
+        /// HypeSquad events member.
         const HYPESQUAD = 1 << 2;
         /// Bug hunter level 1.
         const BUG_HUNTER_LEVEL_1 = 1 << 3;


### PR DESCRIPTION
Slightly tweak the `UserFlags::HYPESQUAD` flag's documentation to say "HypeSquad events member" instead of "HypeSquad events coordinator" to match Discord's documentation:

<https://github.com/discord/discord-api-docs/pull/4685>