### PR TITLE
docs(http): update guild community feature notice

### DIFF
--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -163,7 +163,7 @@ impl<'a> UpdateGuild<'a> {
 
     /// Set the enabled features of the guild.
     ///
-    /// Attempting to add or remove the "COMMUNITY" feature requires the
+    /// Attempting to add or remove the `COMMUNITY` feature requires the
     /// [`Permissions::ADMINISTRATOR`] permission.
     ///
     /// [`Permissions::ADMINISTRATOR`]: twilight_model::guild::Permissions::ADMINISTRATOR

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -162,6 +162,11 @@ impl<'a> UpdateGuild<'a> {
     }
 
     /// Set the enabled features of the guild.
+    ///
+    /// Attempting to add or remove the "COMMUNITY" feature requires the
+    /// [`Permissions::ADMINISTRATOR`] permission.
+    ///
+    /// [`Permissions::ADMINISTRATOR`]: twilight_model::guild::Permissions::ADMINISTRATOR
     pub const fn features(mut self, features: &'a [&'a str]) -> Self {
         self.fields.features = Some(features);
 


### PR DESCRIPTION
Add a notice to the `UpdateGuild::features` method that adding or removing the "COMMUNITY" feature requires the `ADMINISTRATOR` permission.

Closes #1662.