### PR TITLE
feat(model): add new application fields

### DIFF
--- a/model/src/oauth/application.rs
+++ b/model/src/oauth/application.rs
@@ -1,4 +1,4 @@
-use super::{team::Team, ApplicationFlags};
+use super::{team::Team, ApplicationFlags, InstallParams};
 use crate::{
     id::{
         marker::{ApplicationMarker, GuildMarker, OauthSkuMarker},
@@ -14,12 +14,18 @@ pub struct Application {
     pub bot_public: bool,
     pub bot_require_code_grant: bool,
     pub cover_image: Option<ImageHash>,
+    /// Application's default custom authorization link, if enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_install_url: Option<String>,
     pub description: String,
     pub guild_id: Option<Id<GuildMarker>>,
     /// Public flags of the application.
     pub flags: Option<ApplicationFlags>,
     pub icon: Option<ImageHash>,
     pub id: Id<ApplicationMarker>,
+    /// Settings for the application's default in-app authorization, if enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install_params: Option<InstallParams>,
     pub name: String,
     pub owner: User,
     pub primary_sku_id: Option<Id<OauthSkuMarker>>,
@@ -29,6 +35,9 @@ pub struct Application {
     #[serde(default)]
     pub rpc_origins: Vec<String>,
     pub slug: Option<String>,
+    /// Tags describing the content and functionality of the application.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
     pub team: Option<Team>,
     /// URL of the application's terms of service.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -49,17 +58,20 @@ mod tests {
         Application: bot_public,
         bot_require_code_grant,
         cover_image,
+        custom_install_url,
         description,
         guild_id,
         flags,
         icon,
         id,
+        install_params,
         name,
         owner,
         primary_sku_id,
         privacy_policy_url,
         rpc_origins,
         slug,
+        tags,
         team,
         terms_of_service_url,
         verify_key
@@ -82,11 +94,13 @@ mod tests {
             bot_public: true,
             bot_require_code_grant: false,
             cover_image: Some(image_hash::COVER),
+            custom_install_url: None,
             description: "a pretty cool application".to_owned(),
             guild_id: Some(Id::new(1)),
             flags: Some(ApplicationFlags::EMBEDDED),
             icon: Some(image_hash::ICON),
             id: Id::new(2),
+            install_params: None,
             name: "cool application".to_owned(),
             owner: User {
                 accent_color: None,
@@ -109,6 +123,12 @@ mod tests {
             privacy_policy_url: Some("https://privacypolicy".into()),
             rpc_origins: vec!["one".to_owned()],
             slug: Some("app slug".to_owned()),
+            tags: Some(Vec::from([
+                "ponies".to_owned(),
+                "horses".to_owned(),
+                "friendship".to_owned(),
+                "magic".to_owned(),
+            ])),
             team: Some(Team {
                 icon: None,
                 id: Id::new(5),
@@ -125,7 +145,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Application",
-                    len: 17,
+                    len: 18,
                 },
                 Token::Str("bot_public"),
                 Token::Bool(true),
@@ -186,6 +206,14 @@ mod tests {
                 Token::Str("slug"),
                 Token::Some,
                 Token::Str("app slug"),
+                Token::Str("tags"),
+                Token::Some,
+                Token::Seq { len: Some(4) },
+                Token::Str("ponies"),
+                Token::Str("horses"),
+                Token::Str("friendship"),
+                Token::Str("magic"),
+                Token::SeqEnd,
                 Token::Str("team"),
                 Token::Some,
                 Token::Struct {

--- a/model/src/oauth/install_params.rs
+++ b/model/src/oauth/install_params.rs
@@ -1,0 +1,67 @@
+use crate::guild::Permissions;
+use serde::{Deserialize, Serialize};
+
+/// Parameters for in-app authorization links.
+///
+/// Refer to [Discord Docs/Install Params Object].
+///
+/// [Discord Docs/Install Params Object]: https://discord.com/developers/docs/resources/application#install-params-object
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct InstallParams {
+    /// Permissions to request for the bot role.
+    pub permissions: Permissions,
+    /// Scopes to add the application to the guild with.
+    pub scopes: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InstallParams;
+    use crate::guild::Permissions;
+    use serde::{Deserialize, Serialize};
+    use serde_test::Token;
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(
+        InstallParams: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync
+    );
+
+    #[test]
+    fn test_serde() {
+        let value = InstallParams {
+            permissions: Permissions::empty(),
+            scopes: Vec::from([
+                "applications.commands".to_owned(),
+                "applications.commands.permissions.update".to_owned(),
+                "identify".to_owned(),
+            ]),
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "InstallParams",
+                    len: 2,
+                },
+                Token::String("permissions"),
+                Token::String("0"),
+                Token::String("scopes"),
+                Token::Seq { len: Some(3) },
+                Token::String("applications.commands"),
+                Token::String("applications.commands.permissions.update"),
+                Token::String("identify"),
+                Token::SeqEnd,
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/model/src/oauth/mod.rs
+++ b/model/src/oauth/mod.rs
@@ -10,10 +10,11 @@ pub mod current_application_info {
 
 mod application;
 mod application_flags;
+mod install_params;
 mod partial_application;
 
 pub use self::{
-    application::Application, application_flags::ApplicationFlags,
+    application::Application, application_flags::ApplicationFlags, install_params::InstallParams,
     partial_application::PartialApplication,
 };
 


### PR DESCRIPTION
Add the following new fields to the `Application` model:

- `custom_install_url`
- `install_params`
- `tags`

Closes #1664.