### PR TITLE
refactor: use `if let` on matches over options and results

### DIFF
--- a/cache/in-memory/src/event/emoji.rs
+++ b/cache/in-memory/src/event/emoji.rs
@@ -32,9 +32,10 @@ impl InMemoryCache {
     }
 
     pub(crate) fn cache_emoji(&self, guild_id: Id<GuildMarker>, emoji: Emoji) {
-        match self.emojis.get(&emoji.id) {
-            Some(cached_emoji) if cached_emoji.value == emoji => return,
-            Some(_) | None => {}
+        if let Some(cached_emoji) = self.emojis.get(&emoji.id) {
+            if cached_emoji.value == emoji {
+                return;
+            }
         }
 
         if let Some(user) = emoji.user.as_ref() {

--- a/cache/in-memory/src/event/member.rs
+++ b/cache/in-memory/src/event/member.rs
@@ -175,9 +175,12 @@ impl UpdateCache for MemberUpdate {
             return;
         }
 
-        let mut member = match cache.members.get_mut(&(self.guild_id, self.user.id)) {
-            Some(member) => member,
-            None => return,
+        let key = (self.guild_id, self.user.id);
+
+        let mut member = if let Some(member) = cache.members.get_mut(&key) {
+            member
+        } else {
+            return;
         };
 
         member.avatar = self.avatar;

--- a/cache/in-memory/src/event/mod.rs
+++ b/cache/in-memory/src/event/mod.rs
@@ -30,8 +30,8 @@ impl InMemoryCache {
     }
 
     pub(crate) fn cache_user(&self, user: Cow<'_, User>, guild_id: Option<Id<GuildMarker>>) {
-        match self.users.get_mut(&user.id) {
-            Some(u) if u.value() == user.as_ref() => {
+        if let Some(cached_user) = self.users.get_mut(&user.id) {
+            if cached_user.value() == user.as_ref() {
                 if let Some(guild_id) = guild_id {
                     self.user_guilds
                         .entry(user.id)
@@ -41,8 +41,8 @@ impl InMemoryCache {
 
                 return;
             }
-            Some(_) | None => {}
         }
+
         let user = user.into_owned();
         let user_id = user.id;
 

--- a/cache/in-memory/src/event/reaction.rs
+++ b/cache/in-memory/src/event/reaction.rs
@@ -12,9 +12,12 @@ impl UpdateCache for ReactionAdd {
             return;
         }
 
-        let mut message = match cache.messages.get_mut(&self.0.message_id) {
-            Some(message) => message,
-            None => return,
+        let key = self.0.message_id;
+
+        let mut message = if let Some(message) = cache.messages.get_mut(&key) {
+            message
+        } else {
+            return;
         };
 
         if let Some(reaction) = message
@@ -52,9 +55,10 @@ impl UpdateCache for ReactionRemove {
             return;
         }
 
-        let mut message = match cache.messages.get_mut(&self.0.message_id) {
-            Some(message) => message,
-            None => return,
+        let mut message = if let Some(message) = cache.messages.get_mut(&self.0.message_id) {
+            message
+        } else {
+            return;
         };
 
         if let Some(reaction) = message
@@ -85,9 +89,10 @@ impl UpdateCache for ReactionRemoveAll {
             return;
         }
 
-        let mut message = match cache.messages.get_mut(&self.message_id) {
-            Some(message) => message,
-            None => return,
+        let mut message = if let Some(message) = cache.messages.get_mut(&self.message_id) {
+            message
+        } else {
+            return;
         };
 
         message.reactions.clear();
@@ -100,9 +105,10 @@ impl UpdateCache for ReactionRemoveEmoji {
             return;
         }
 
-        let mut message = match cache.messages.get_mut(&self.message_id) {
-            Some(message) => message,
-            None => return,
+        let mut message = if let Some(message) = cache.messages.get_mut(&self.message_id) {
+            message
+        } else {
+            return;
         };
 
         let maybe_index = message.reactions.iter().position(|r| r.emoji == self.emoji);

--- a/cache/in-memory/src/event/sticker.rs
+++ b/cache/in-memory/src/event/sticker.rs
@@ -39,9 +39,10 @@ impl InMemoryCache {
     }
 
     pub(crate) fn cache_sticker(&self, guild_id: Id<GuildMarker>, sticker: Sticker) {
-        match self.stickers.get(&sticker.id) {
-            Some(cached_sticker) if cached_sticker.value == sticker => return,
-            Some(_) | None => {}
+        if let Some(cached_sticker) = self.stickers.get(&sticker.id) {
+            if cached_sticker.value == sticker {
+                return;
+            }
         }
 
         if let Some(user) = sticker.user.clone() {

--- a/cache/in-memory/src/event/voice_state.rs
+++ b/cache/in-memory/src/event/voice_state.rs
@@ -9,7 +9,7 @@ impl InMemoryCache {
     }
 
     fn cache_voice_state(&self, voice_state: VoiceState) {
-        // This should always exist, but just in case use a match
+        // This should always exist, but let's check just in case.
         let guild_id = if let Some(id) = voice_state.guild_id {
             id
         } else {

--- a/cache/in-memory/src/event/voice_state.rs
+++ b/cache/in-memory/src/event/voice_state.rs
@@ -10,9 +10,10 @@ impl InMemoryCache {
 
     fn cache_voice_state(&self, voice_state: VoiceState) {
         // This should always exist, but just in case use a match
-        let guild_id = match voice_state.guild_id {
-            Some(id) => id,
-            None => return,
+        let guild_id = if let Some(id) = voice_state.guild_id {
+            id
+        } else {
+            return;
         };
 
         let user_id = voice_state.user_id;

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -759,10 +759,7 @@ impl InMemoryCache {
         guild_id: Id<GuildMarker>,
         user_id: Id<UserMarker>,
     ) -> Option<Id<RoleMarker>> {
-        let member = match self.members.get(&(guild_id, user_id)) {
-            Some(member) => member,
-            None => return None,
-        };
+        let member = self.members.get(&(guild_id, user_id))?;
 
         let mut highest_role: Option<(i64, Id<RoleMarker>)> = None;
 

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -570,12 +570,14 @@ impl Shard {
     pub fn info(&self) -> Result<Information, SessionInactiveError> {
         let session = self.session()?;
 
-        let (ratelimit_requests, ratelimit_refill) = match session.ratelimit.get() {
-            Some(limiter) => (
+        let (ratelimit_requests, ratelimit_refill) = if let Some(limiter) = session.ratelimit.get()
+        {
+            (
                 limiter.as_ref().map(LeakyBucket::tokens),
                 limiter.as_ref().map(LeakyBucket::next_refill),
-            ),
-            None => return Err(SessionInactiveError),
+            )
+        } else {
+            return Err(SessionInactiveError);
         };
 
         Ok(Information {

--- a/http-ratelimiting/src/in_memory/bucket.rs
+++ b/http-ratelimiting/src/in_memory/bucket.rs
@@ -84,10 +84,14 @@ impl Bucket {
     /// Time remaining until this bucket will reset.
     pub fn time_remaining(&self) -> TimeRemaining {
         let reset_after = self.reset_after();
-        let started_at = match *self.started_at.lock().expect("bucket poisoned") {
-            Some(v) => v,
-            None => return TimeRemaining::NotStarted,
+        let maybe_started_at = *self.started_at.lock().expect("bucket poisoned");
+
+        let started_at = if let Some(started_at) = maybe_started_at {
+            started_at
+        } else {
+            return TimeRemaining::NotStarted;
         };
+
         let elapsed = started_at.elapsed();
 
         if elapsed > Duration::from_millis(reset_after) {

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -49,9 +49,10 @@ struct NullableField<T>(Option<T>);
 
 impl<T: Serialize> Serialize for NullableField<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self.0.as_ref() {
-            Some(inner) => serializer.serialize_some(inner),
-            None => serializer.serialize_none(),
+        if let Some(inner) = self.0.as_ref() {
+            serializer.serialize_some(inner)
+        } else {
+            serializer.serialize_none()
         }
     }
 }

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -581,18 +581,17 @@ impl Connection {
     }
 
     async fn player_update(&self, update: &PlayerUpdate) -> Result<(), NodeError> {
-        let player = match self.players.get(&update.guild_id) {
-            Some(player) => player,
-            None => {
-                #[cfg(feature = "tracing")]
-                tracing::warn!(
-                    "invalid player update for guild {}: {:?}",
-                    update.guild_id,
-                    update,
-                );
+        let player = if let Some(player) = self.players.get(&update.guild_id) {
+            player
+        } else {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                "invalid player update for guild {}: {:?}",
+                update.guild_id,
+                update,
+            );
 
-                return Ok(());
-            }
+            return Ok(());
         };
 
         player.set_position(update.state.position.unwrap_or(0));

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -555,14 +555,13 @@ impl Connection {
             _ => return Ok(true),
         };
 
-        let event = match serde_json::from_str(&text) {
-            Ok(event) => event,
-            Err(_) => {
-                #[cfg(feature = "tracing")]
-                tracing::warn!("unknown message from lavalink node: {}", text);
+        let event = if let Ok(event) = serde_json::from_str(&text) {
+            event
+        } else {
+            #[cfg(feature = "tracing")]
+            tracing::warn!("unknown message from lavalink node: {}", text);
 
-                return Ok(true);
-            }
+            return Ok(true);
         };
 
         match &event {

--- a/mention/src/parse/iter.rs
+++ b/mention/src/parse/iter.rs
@@ -84,10 +84,12 @@ impl<'a, T: ParseMention> Iterator for MentionIter<'a, T> {
                 continue;
             }
 
-            let end = match self.chars.find(|c| c.1 == '>') {
-                Some((idx, _)) => idx,
-                None => continue,
+            let end = if let Some((idx, _)) = self.chars.find(|c| c.1 == '>') {
+                idx
+            } else {
+                continue;
             };
+
             let buf = self.buf.get(start..=end)?;
 
             if let Ok(id) = T::parse(buf) {


### PR DESCRIPTION
Prefer to use `if let`s over `match`es on Options and Results. This is generally an "idiomatic" thing to do and also reduces indentation.