### PR TITLE
ci: revert custom cache key

### DIFF
--- a/.github/workflows/check-lib.yml
+++ b/.github/workflows/check-lib.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
-        with:
-          key: ${{ github.ref_name }}
 
       - name: Output processor info
         run: cat /proc/cpuinfo
@@ -125,8 +123,6 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
-        with:
-          key: ${{ github.ref_name }}
 
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"
@@ -188,8 +184,6 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
-        with:
-          key: ${{ github.ref_name }}
 
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"
@@ -209,8 +203,6 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
-        with:
-          key: ${{ github.ref_name }}
 
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"
@@ -267,8 +259,6 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
-        with:
-          key: ${{ github.ref_name }}-${{ matrix.package }}-${{ matrix.features }}
 
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"


### PR DESCRIPTION
After using these custom keys for a while, I'm noticing more often than not the cache missing resulting in a longer run time overall.

This reverts commit a23f25f7e4bd1784adf909c245c9dac15f5f4401.
