### PR TITLE
docs(cache, model): message content intent caveats

### DIFF
--- a/cache/in-memory/src/model/message.rs
+++ b/cache/in-memory/src/model/message.rs
@@ -129,7 +129,12 @@ impl CachedMessage {
         self.application_id
     }
 
-    /// Attached files.
+    /// List of attached files.
+    ///
+    /// Refer to the documentation for [`Message::content`] for caveats with
+    /// receiving the content of messages.
+    ///
+    /// [`Message::content`]: twilight_model::channel::Message::content
     pub fn attachments(&self) -> &[Attachment] {
         &self.attachments
     }
@@ -146,12 +151,22 @@ impl CachedMessage {
         self.channel_id
     }
 
-    /// Components used in the message, such as buttons.
+    /// List of provided components, such as buttons.
+    ///
+    /// Refer to the documentation for [`Message::components`] for caveats with
+    /// receiving the components of messages.
+    ///
+    /// [`Message::components`]: twilight_model::channel::Message::components
     pub fn components(&self) -> &[Component] {
         &self.components
     }
 
-    /// Content of the message.
+    /// Content of a message.
+    ///
+    /// Refer to the documentation for [`Message::content`] for caveats with
+    /// receiving the content of messages.
+    ///
+    /// [`Message::content`]: twilight_model::channel::Message::content
     pub fn content(&self) -> &str {
         &self.content
     }
@@ -161,7 +176,12 @@ impl CachedMessage {
         self.edited_timestamp
     }
 
-    /// Embeds attached to the message.
+    /// List of embeds.
+    ///
+    /// Refer to the documentation for [`Message::embeds`] for caveats with
+    /// receiving the embeds of messages.
+    ///
+    /// [`Message::embeds`]: twilight_model::channel::Message::embeds
     pub fn embeds(&self) -> &[Embed] {
         &self.embeds
     }

--- a/cache/in-memory/src/model/message.rs
+++ b/cache/in-memory/src/model/message.rs
@@ -131,10 +131,10 @@ impl CachedMessage {
 
     /// List of attached files.
     ///
-    /// Refer to the documentation for [`Message::content`] for caveats with
-    /// receiving the content of messages.
+    /// Refer to the documentation for [`Message::attachments`] for caveats with
+    /// receiving the attachments of messages.
     ///
-    /// [`Message::content`]: twilight_model::channel::Message::content
+    /// [`Message::attachments`]: twilight_model::channel::Message::attachments
     pub fn attachments(&self) -> &[Attachment] {
         &self.attachments
     }

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -47,12 +47,12 @@ pub struct Message {
     pub application_id: Option<Id<ApplicationMarker>>,
     /// List of attachments.
     ///
-    /// Receiving the content of messages requires that the
+    /// Receiving the attachments of messages requires that the
     /// [Message Content Intent] be enabled for the application. In the case of
     /// receiving messages over the Gateway, the intent must also be enabled for
     /// the session.
     ///
-    /// Message content will be empty unless the [Message Content Intent] is
+    /// Message attachments will be empty unless the [Message Content Intent] is
     /// enabled, the message was sent by the current user, or the message is in
     /// a direct message channel.
     ///

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -45,14 +45,61 @@ pub struct Message {
     /// Sent if the message is a response to an Interaction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub application_id: Option<Id<ApplicationMarker>>,
+    /// List of attachments.
+    ///
+    /// Receiving the content of messages requires that the
+    /// [Message Content Intent] be enabled for the application. In the case of
+    /// receiving messages over the Gateway, the intent must also be enabled for
+    /// the session.
+    ///
+    /// Message content will be empty unless the [Message Content Intent] is
+    /// enabled, the message was sent by the current user, or the message is in
+    /// a direct message channel.
+    ///
+    /// [Message Content Intent]: crate::gateway::Intents::MESSAGE_CONTENT
     pub attachments: Vec<Attachment>,
     pub author: User,
     pub channel_id: Id<ChannelMarker>,
-    /// List of provided message components.
+    /// List of provided components, such as buttons.
+    ///
+    /// Receiving the components of messages requires that the
+    /// [Message Content Intent] be enabled for the application. In the case of
+    /// receiving messages over the Gateway, the intent must also be enabled for
+    /// the session.
+    ///
+    /// Message components will be empty unless the [Message Content Intent] is
+    /// enabled, the message was sent by the current user, or the message is in
+    /// a direct message channel.
+    ///
+    /// [Message Content Intent]: crate::gateway::Intents::MESSAGE_CONTENT
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub components: Vec<Component>,
+    /// Content of the message.
+    ///
+    /// Receiving the content of messages requires that the
+    /// [Message Content Intent] be enabled for the application. In the case of
+    /// receiving messages over the Gateway, the intent must also be enabled for
+    /// the session.
+    ///
+    /// Message content will be empty unless the [Message Content Intent] is
+    /// enabled, the message was sent by the current user, or the message is in
+    /// a direct message channel.
+    ///
+    /// [Message Content Intent]: crate::gateway::Intents::MESSAGE_CONTENT
     pub content: String,
     pub edited_timestamp: Option<Timestamp>,
+    /// List of embeds.
+    ///
+    /// Receiving the attachments of messages requires that the
+    /// [Message Content Intent] be enabled for the application. In the case of
+    /// receiving messages over the Gateway, the intent must also be enabled for
+    /// the session.
+    ///
+    /// Message attachments will be empty unless the [Message Content Intent] is
+    /// enabled, the message was sent by the current user, or the message is in
+    /// a direct message channel.
+    ///
+    /// [Message Content Intent]: crate::gateway::Intents::MESSAGE_CONTENT
     pub embeds: Vec<Embed>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub flags: Option<MessageFlags>,

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -90,12 +90,12 @@ pub struct Message {
     pub edited_timestamp: Option<Timestamp>,
     /// List of embeds.
     ///
-    /// Receiving the attachments of messages requires that the
+    /// Receiving the embeds of messages requires that the
     /// [Message Content Intent] be enabled for the application. In the case of
     /// receiving messages over the Gateway, the intent must also be enabled for
     /// the session.
     ///
-    /// Message attachments will be empty unless the [Message Content Intent] is
+    /// Message embeds will be empty unless the [Message Content Intent] is
     /// enabled, the message was sent by the current user, or the message is in
     /// a direct message channel.
     ///

--- a/model/src/gateway/payload/incoming/message_update.rs
+++ b/model/src/gateway/payload/incoming/message_update.rs
@@ -15,14 +15,32 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct MessageUpdate {
+    /// List of attachments.
+    ///
+    /// Refer to the documentation for [`Message::attachments`] for caveats with
+    /// receiving the attachments of messages.
+    ///
+    /// [`Message::attachments`]: crate::channel::Message::attachments
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Vec<Attachment>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<User>,
     pub channel_id: Id<ChannelMarker>,
+    /// Content of the message.
+    ///
+    /// Refer to the documentation for [`Message::content`] for caveats with
+    /// receiving the content of messages.
+    ///
+    /// [`Message::content`]: crate::channel::Message::content
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub edited_timestamp: Option<Timestamp>,
+    /// List of embeds.
+    ///
+    /// Refer to the documentation for [`Message::embeds`] for caveats with
+    /// receiving the embeds of messages.
+    ///
+    /// [`Message::embeds`]: crate::channel::Message::embeds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embeds: Option<Vec<Embed>>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Add caveats to the documentation for `twilight_model::channel::Message` about receiving the attachments, components, content, and embeds of messages. Additionally, add light documentation for them on `twilight_cache_inmemory::model::Message` and `twilight_model::gateway::payload::incoming::MessageUpdate`, pointing to the documentation for `Message` for additional information.