### PR TITLE
docs(gateway): prominently show member chunking

### DIFF
--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -595,32 +595,38 @@ impl Shard {
     ///
     /// # Examples
     ///
-    /// Request members whose names start with "tw" in a guild:
+    /// Updating the shard's presence after identifying can be done by sending
+    /// an [`UpdatePresence`] command. For example, updating the active presence
+    /// with the custom status "running on twilight":
     ///
     /// ```no_run
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use std::env;
     /// use twilight_gateway::{shard::Shard, Intents};
-    /// use twilight_model::{
-    ///     gateway::payload::outgoing::RequestGuildMembers,
-    ///     id::Id,
+    /// use twilight_model::gateway::{
+    ///     payload::outgoing::UpdatePresence,
+    ///     presence::{Activity, ActivityType, MinimalActivity, Status},
     /// };
     ///
-    /// let intents = Intents::GUILD_VOICE_STATES;
+    /// let intents = Intents::GUILDS;
     /// let token = env::var("DISCORD_TOKEN")?;
     ///
     /// let (shard, _events) = Shard::new(token, intents);
     /// shard.start().await?;
     ///
-    /// // Query members whose names start with "tw" and limit the results to
-    /// // 10 members.
-    /// let request =
-    ///     RequestGuildMembers::builder(Id::new(1))
-    ///         .query("tw", Some(10));
-    ///
-    /// // Send the request over the shard.
-    /// shard.command(&request).await?;
+    /// let minimal_activity = MinimalActivity {
+    ///     kind: ActivityType::Custom,
+    ///     name: "running on twilight".to_owned(),
+    ///     url: None,
+    /// };
+    /// let command = UpdatePresence::new(
+    ///     Vec::from([Activity::from(minimal_activity)]),
+    ///     false,
+    ///     Some(1),
+    ///     Status::Online,
+    /// )?;
+    /// shard.command(&command).await?;
     /// # Ok(()) }
     /// ```
     ///
@@ -635,6 +641,8 @@ impl Shard {
     ///
     /// Returns a [`CommandErrorType::SessionInactive`] error type if the shard
     /// has not been started.
+    ///
+    /// [`UpdatePresence`]: twilight_model::gateway::payload::outgoing::UpdatePresence
     pub async fn command(&self, value: &impl Command) -> Result<(), CommandError> {
         let json = json::to_vec(value).map_err(|source| CommandError {
             source: Some(Box::new(source)),

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -12,8 +12,41 @@
 //! Shards are configurable through the [`ShardBuilder`], which provides a clean
 //! interface for correctly configuring a shard.
 //!
-//! [`Event`]: ::twilight_model::gateway::event::Event
+//! # Member Chunking
+//!
+//! Requesting chunks of a guild's members may be done via [`Shard::command`]
+//! and [`RequestGuildMembers`]. For example, requesting chunks of members whose
+//! names start with "tw":
+//!
+//! ```no_run
+//! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use std::env;
+//! use twilight_gateway::{shard::Shard, Intents};
+//! use twilight_model::{
+//!     gateway::payload::outgoing::RequestGuildMembers,
+//!     id::Id,
+//! };
+//!
+//! let intents = Intents::GUILD_PRESENCES;
+//! let token = env::var("DISCORD_TOKEN")?;
+//!
+//! let (shard, _events) = Shard::new(token, intents);
+//! shard.start().await?;
+//!
+//! // Query members whose names start with "tw" and limit the results to
+//! // 10 members.
+//! let request =
+//!     RequestGuildMembers::builder(Id::new(1))
+//!         .query("tw", Some(10));
+//!
+//! // Send the request over the shard.
+//! shard.command(&request).await?;
+//! # Ok(()) }
+//! ```
+//!
 //! [`Disconnected`]: Stage::Disconnected
+//! [`Event`]: ::twilight_model::gateway::event::Event
+//! [`RequestGuildMembers`]: twilight_model::gateway::payload::outgoing::RequestGuildMembers
 //! [`Resuming`]: Stage::Resuming
 //! [channel deletions]: ::twilight_model::gateway::event::Event::ChannelDelete
 //! [information about itself]: Shard::info

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -27,7 +27,7 @@
 //!     id::Id,
 //! };
 //!
-//! let intents = Intents::GUILD_PRESENCES;
+//! let intents = Intents::GUILD_MEMBERS;
 //! let token = env::var("DISCORD_TOKEN")?;
 //!
 //! let (shard, _events) = Shard::new(token, intents);


### PR DESCRIPTION
Prominently show an example for chunking a guild's members by moving the example from `Shard::command` to the `shard` module-level documentation under its own header. Adds an example to update the shard's presence in its place on `Shard::command`, similar to that of `Cluster::command`.