### PR TITLE
docs(cache/in-memory): stats in crate-level docs

### DIFF
--- a/cache/in-memory/README.md
+++ b/cache/in-memory/README.md
@@ -8,6 +8,14 @@
 [`twilight-rs`] ecosystem. It's responsible for processing events and
 caching things like guilds, channels, users, and voice states.
 
+## Statistics
+
+Statistics can be an important debugging tool for determining how large a
+cache is or determining whether a cache has an expected amount of resources
+within it. [An interface] for retrieving statistics about the amount of a
+resource within the cache as a whole or on a guild-level can be retrieved
+via [`InMemoryCache::stats`].
+
 ## Features
 
 By default no feature is enabled.

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -6,6 +6,14 @@
 //! [`twilight-rs`] ecosystem. It's responsible for processing events and
 //! caching things like guilds, channels, users, and voice states.
 //!
+//! ## Statistics
+//!
+//! Statistics can be an important debugging tool for determining how large a
+//! cache is or determining whether a cache has an expected amount of resources
+//! within it. [An interface] for retrieving statistics about the amount of a
+//! resource within the cache as a whole or on a guild-level can be retrieved
+//! via [`InMemoryCache::stats`].
+//!
 //! ## Features
 //!
 //! By default no feature is enabled.

--- a/cache/in-memory/src/stats.rs
+++ b/cache/in-memory/src/stats.rs
@@ -9,8 +9,8 @@ use super::InMemoryCache;
 /// cache.
 ///
 /// Statistics can be retrieved about the amount of resources on a cache-level
-/// via a method such as [`messages`] or in a particular guild via a method such
-/// as [`guild_messages`].
+/// via a method such as [`users`] or in a particular channel via a method
+/// such as [`channel_messages`].
 ///
 /// # Examples
 ///
@@ -25,8 +25,8 @@ use super::InMemoryCache;
 /// println!("user count: {}", cache.stats().users());
 /// ```
 ///
-/// [`guild_messages`]: Self::guild_messages
-/// [`messages`]: Self::messages
+/// [`channel_messages`]: Self::channel_messages
+/// [`users`]: Self::users
 #[derive(Clone, Debug)]
 pub struct InMemoryCacheStats<'a>(&'a InMemoryCache);
 

--- a/cache/in-memory/src/stats.rs
+++ b/cache/in-memory/src/stats.rs
@@ -7,6 +7,26 @@ use super::InMemoryCache;
 
 /// Retrieve statistics about the number of entities of each resource in the
 /// cache.
+///
+/// Statistics can be retrieved about the amount of resources on a cache-level
+/// via a method such as [`messages`] or in a particular guild via a method such
+/// as [`guild_messages`].
+///
+/// # Examples
+///
+/// Retrieve the number of users stored in the cache:
+///
+/// ```no_run
+/// use twilight_cache_inmemory::InMemoryCache;
+///
+/// let cache = InMemoryCache::new();
+///
+/// // later on...
+/// println!("user count: {}", cache.stats().users());
+/// ```
+///
+/// [`guild_messages`]: Self::guild_messages
+/// [`messages`]: Self::messages
 #[derive(Clone, Debug)]
 pub struct InMemoryCacheStats<'a>(&'a InMemoryCache);
 


### PR DESCRIPTION
Document the ability to retrieve statistics about the resources in the cache in the crate-level documentation, and add an example for using the statistics interface on the `InMemoryCacheStats` type itself.