### PR TITLE
docs(cache/in-memory): fix typos in stats docs

### DIFF
--- a/cache/in-memory/src/stats.rs
+++ b/cache/in-memory/src/stats.rs
@@ -132,7 +132,7 @@ impl<'a> InMemoryCacheStats<'a> {
         self.0.roles.len()
     }
 
-    /// Number of unavailable_guilds in the cache.
+    /// Number of unavailable guilds in the cache.
     pub fn unavailable_guilds(&self) -> usize {
         self.0.unavailable_guilds.len()
     }
@@ -142,7 +142,7 @@ impl<'a> InMemoryCacheStats<'a> {
         self.0.users.len()
     }
 
-    /// Number of voice_states in the cache.
+    /// Number of voice states in the cache.
     pub fn voice_states(&self) -> usize {
         self.0.voice_states.len()
     }


### PR DESCRIPTION
Fix some typos in the stats docs that left underscores in place of where there should be spaces.