### PR TITLE
feat(model): add `ChannelType::GuildForum`

### DIFF
--- a/model/src/channel/channel_type.rs
+++ b/model/src/channel/channel_type.rs
@@ -18,6 +18,8 @@ pub enum ChannelType {
     ///
     /// [hub]: https://support.discord.com/hc/en-us/articles/4406046651927-Discord-Student-Hubs-FAQ
     GuildDirectory = 14,
+    /// Channel that can only contain threads.
+    GuildForum = 15,
 }
 
 impl ChannelType {
@@ -71,6 +73,7 @@ impl ChannelType {
             Self::Group => "Group",
             Self::GuildCategory => "GuildCategory",
             Self::GuildDirectory => "GuildDirectory",
+            Self::GuildForum => "GuildForum",
             Self::GuildNews => "GuildNews",
             Self::GuildNewsThread => "GuildNewsThread",
             Self::GuildPrivateThread => "GuildPrivateThread",


### PR DESCRIPTION
As a stopgap before future work on Forum channels, add their channel type in order to stop deserialization errors which would be more correctly fixed in #1550.
