### PR TITLE
build(gateway,http): revert #1596

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -35,11 +35,8 @@ leaky-bucket-lite = { default-features = false, features = ["tokio"], version = 
 # https://github.com/alexcrichton/flate2-rs/issues/217
 flate2 = { default-features = false, optional = true, version = "1.0" }
 metrics = { default-features = false, optional = true, version = "0.18" }
-dep-simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, package = "simd-json", version = "0.4" }
+simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.4" }
 tracing = { default-features = false, features = ["std", "attributes"], optional = true, version = "0.1" }
-
-# `value-trait` updated its MSRV in a minor release, so use previous versions.
-value-trait = { default-features = false, optional = true, version = ">=0.2, <0.2.11" }
 
 # TLS libraries
 # They are needed to track what is used in tokio-tungstenite
@@ -58,7 +55,6 @@ default = ["rustls-native-roots", "tracing", "zlib-stock"]
 native = ["native-tls", "twilight-http/native", "twilight-gateway-queue/native", "tokio-tungstenite/native-tls"]
 rustls-native-roots = ["rustls-tls", "rustls-native-certs", "twilight-http/rustls-native-roots", "twilight-gateway-queue/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]
 rustls-webpki-roots = ["rustls-tls", "webpki-roots", "twilight-http/rustls-webpki-roots", "twilight-gateway-queue/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
-simd-json = ["dep-simd-json", "value-trait"]
 zlib-simd = ["flate2/zlib-ng-compat"]
 # if the `zlib` feature is enabled anywhere in the dependency tree it will
 # always use stock zlib instead of zlib-ng.

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -153,9 +153,6 @@
     clippy::used_underscore_binding
 )]
 
-#[cfg(feature = "simd-json")]
-extern crate dep_simd_json as simd_json;
-
 pub mod cluster;
 pub mod shard;
 

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -31,11 +31,8 @@ twilight-validate = { default-features = false, path = "../validate" }
 
 # Optional dependencies.
 brotli = { default-features = false, features = ["std"], optional = true, version = "3.0.0" }
-dep-simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, package = "simd-json", version = "0.4" }
+simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.4" }
 tracing = { default-features = false, features = ["std", "attributes"], optional = true, version = "0.1" }
-
-# `value-trait` updated its MSRV in a minor release, so use previous versions.
-value-trait = { default-features = false, optional = true, version = ">=0.2, <0.2.11" }
 
 [features]
 default = ["decompression", "rustls-native-roots", "tracing"]
@@ -43,7 +40,6 @@ decompression = ["brotli"]
 native = ["hyper-tls"]
 rustls-native-roots = ["hyper-rustls/native-tokio"]
 rustls-webpki-roots = ["hyper-rustls/webpki-tokio"]
-simd-json = ["dep-simd-json", "value-trait"]
 trust-dns = ["hyper-trust-dns"]
 
 [dev-dependencies]

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -135,9 +135,6 @@
     clippy::unnecessary_wraps
 )]
 
-#[cfg(feature = "simd-json")]
-extern crate dep_simd_json as simd_json;
-
 pub mod api_error;
 pub mod client;
 pub mod error;


### PR DESCRIPTION
After updating our MSRV to 1.60, this dependency restriction is no longer required.

This reverts commit 0d41c21c3e8795012195c6767d11b9964eb5880d.
