### PR TITLE
refactor: Use identifier in format

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ async fn handle_event(
                 .await?;
         }
         Event::ShardConnected(_) => {
-            println!("Connected on shard {}", shard_id);
+            println!("Connected on shard {shard_id}");
         }
         // Other events here...
         _ => {}

--- a/cache/in-memory/src/iter.rs
+++ b/cache/in-memory/src/iter.rs
@@ -98,7 +98,7 @@ impl<K: Eq + Hash, V> Deref for IterReference<'_, K, V> {
 ///     .filter(|user| user.name.starts_with("twi"))
 ///     .count();
 ///
-/// println!("'twi' users: {}", count);
+/// println!("'twi' users: {count}");
 /// ```
 ///
 /// # Potential inefficiency
@@ -233,7 +233,7 @@ impl<'a> InMemoryCacheIter<'a> {
 ///     .filter(|member| member.pending())
 ///     .count();
 ///
-/// println!("pending users: {}", count);
+/// println!("pending users: {count}");
 /// ```
 pub struct ResourceIter<'a, K, V> {
     iter: Iter<'a, K, V>,
@@ -275,11 +275,7 @@ impl<'a, K: Eq + Hash, V> Iterator for ResourceIter<'a, K, V> {
 ///
 /// for message_id in message_ids {
 ///     if let Some(message) = cache.message(message_id) {
-///         println!(
-///             "message {} content: {}",
-///             message_id,
-///             message.content(),
-///         );
+///         println!("message {message_id} content: {}", message.content());
 ///     }
 /// }
 /// # Some(()) }

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -384,7 +384,7 @@ impl InMemoryCache {
     ///
     /// // later on...
     /// let guilds = cache.stats().guilds();
-    /// println!("guild count: {}", guilds);
+    /// println!("guild count: {guilds}");
     /// ```
     pub const fn stats(&self) -> InMemoryCacheStats<'_> {
         InMemoryCacheStats::new(self)
@@ -418,7 +418,7 @@ impl InMemoryCache {
     /// let user_id = Id::new(5);
     ///
     /// let permissions = cache.permissions().in_channel(user_id, channel_id)?;
-    /// println!("member has these permissions: {:?}", permissions);
+    /// println!("member has these permissions: {permissions:?}");
     /// # Ok(()) }
     /// ```
     #[cfg(feature = "permission-calculator")]

--- a/cache/in-memory/src/permission.rs
+++ b/cache/in-memory/src/permission.rs
@@ -324,12 +324,7 @@ impl<'a> InMemoryCachePermissions<'a> {
     /// let user_id = Id::new(5);
     ///
     /// let permissions = cache.permissions().in_channel(user_id, channel_id)?;
-    /// println!(
-    ///     "User {} in channel {} has permissions {:?}",
-    ///     user_id,
-    ///     channel_id,
-    ///     permissions,
-    /// );
+    /// println!("User {user_id} in channel {channel_id} has permissions {permissions:?}");
     /// # Ok(()) }
     /// ```
     ///
@@ -411,12 +406,7 @@ impl<'a> InMemoryCachePermissions<'a> {
     /// let user_id = Id::new(5);
     ///
     /// let permissions = cache.permissions().root(user_id, guild_id)?;
-    /// println!(
-    ///     "User {} in guild {} has permissions {:?}",
-    ///     user_id,
-    ///     guild_id,
-    ///     permissions,
-    /// );
+    /// println!("User {user_id} in guild {guild_id} has permissions {permissions:?}");
     /// # Ok(()) }
     /// ```
     ///

--- a/embed-builder/src/image_source.rs
+++ b/embed-builder/src/image_source.rs
@@ -161,7 +161,7 @@ impl ImageSource {
             });
         }
 
-        Ok(Self(format!("attachment://{}", filename)))
+        Ok(Self(format!("attachment://{filename}")))
     }
 
     /// Create a URL image source.

--- a/examples/gateway-cluster.rs
+++ b/examples/gateway-cluster.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     });
 
     while let Some((id, event)) = events.next().await {
-        println!("Shard: {}, Event: {:?}", id, event.kind());
+        println!("Shard: {id}, Event: {:?}", event.kind());
     }
 
     Ok(())

--- a/examples/gateway-intents.rs
+++ b/examples/gateway-intents.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     println!("Created shard");
 
     while let Some(event) = events.next().await {
-        println!("Event: {:?}", event);
+        println!("Event: {event:?}");
     }
 
     Ok(())

--- a/examples/gateway-shard.rs
+++ b/examples/gateway-shard.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     println!("Created shard");
 
     while let Some(event) = events.next().await {
-        println!("Event: {:?}", event);
+        println!("Event: {event:?}");
     }
 
     Ok(())

--- a/examples/http-allowed-mentions.rs
+++ b/examples/http-allowed-mentions.rs
@@ -29,8 +29,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     client
         .create_message(channel_id)
         .content(&format!(
-            "<@{}> you are not allowed to ping @everyone!",
-            user_id
+            "<@{user_id}> you are not allowed to ping @everyone!"
         ))?
         .allowed_mentions(Some(&allowed_mentions))
         .exec()

--- a/examples/http-get-message.rs
+++ b/examples/http-get-message.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     future::join_all((1u8..=10).map(|x| {
         client
             .create_message(channel_id)
-            .content(&format!("Ping #{}", x))
+            .content(&format!("Ping #{x}"))
             .expect("content not a valid length")
             .exec()
     }))

--- a/examples/http-proxy.rs
+++ b/examples/http-proxy.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     future::join_all((1u8..=10).map(|x| {
         client
             .create_message(channel_id)
-            .content(&format!("Ping #{}", x))
+            .content(&format!("Ping #{x}"))
             .expect("content not a valid length")
             .exec()
     }))

--- a/examples/lavalink-basic-bot.rs
+++ b/examples/lavalink-basic-bot.rs
@@ -33,7 +33,7 @@ fn spawn(
 ) {
     tokio::spawn(async move {
         if let Err(why) = fut.await {
-            tracing::debug!("handler error: {:?}", why);
+            tracing::debug!("handler error: {why:?}");
         }
     });
 }
@@ -128,7 +128,7 @@ async fn join(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
     state
         .http
         .create_message(msg.channel_id)
-        .content(&format!("Joined <#{}>!", channel_id))?
+        .content(&format!("Joined <#{channel_id}>!"))?
         .exec()
         .await?;
 
@@ -237,7 +237,7 @@ async fn pause(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + 
     state
         .http
         .create_message(msg.channel_id)
-        .content(&format!("{} the track", action))?
+        .content(&format!("{action} the track"))?
         .exec()
         .await?;
 
@@ -273,7 +273,7 @@ async fn seek(msg: Message, state: State) -> Result<(), Box<dyn Error + Send + S
     state
         .http
         .create_message(msg.channel_id)
-        .content(&format!("Seeked to {}s", position))?
+        .content(&format!("Seeked to {position}s"))?
         .exec()
         .await?;
 
@@ -341,7 +341,7 @@ async fn volume(msg: Message, state: State) -> Result<(), Box<dyn Error + Send +
     state
         .http
         .create_message(msg.channel_id)
-        .content(&format!("Set the volume to {}", volume))?
+        .content(&format!("Set the volume to {volume}"))?
         .exec()
         .await?;
 

--- a/examples/model-webhook-slash.rs
+++ b/examples/model-webhook-slash.rs
@@ -144,7 +144,7 @@ async fn debug(i: Interaction) -> Result<InteractionResponse, GenericError> {
     Ok(InteractionResponse {
         kind: InteractionResponseType::ChannelMessageWithSource,
         data: Some(InteractionResponseData {
-            content: Some(format!("```rust\n{:?}\n```", i)),
+            content: Some(format!("```rust\n{i:?}\n```")),
             ..Default::default()
         }),
     })

--- a/gateway-queue/src/day_limiter.rs
+++ b/gateway-queue/src/day_limiter.rs
@@ -105,7 +105,7 @@ impl DayLimiter {
                     let last_check = Instant::now();
                     let next_reset = Duration::from_millis(info.session_start_limit.remaining);
 
-                    tracing::info!("next session start limit reset in: {:.2?}", next_reset);
+                    tracing::info!("next session start limit reset in: {next_reset:.2?}");
 
                     let total = info.session_start_limit.total;
                     let remaining = info.session_start_limit.remaining;

--- a/gateway-queue/src/large_bot_queue.rs
+++ b/gateway-queue/src/large_bot_queue.rs
@@ -70,7 +70,7 @@ async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
     const DUR: Duration = Duration::from_secs(6);
     while let Some(req) = rx.recv().await {
         if let Err(source) = req.send(()) {
-            tracing::warn!("skipping, send failed with: {:?}", source);
+            tracing::warn!("skipping, send failed with: {source:?}");
         }
         sleep(DUR).await;
     }
@@ -88,7 +88,7 @@ impl Queue for LargeBotQueue {
         Box::pin(async move {
             self.limiter.get().await;
             if let Err(source) = self.buckets[bucket].send(tx) {
-                tracing::warn!("skipping, send failed with: {:?}", source);
+                tracing::warn!("skipping, send failed with: {source:?}");
                 return;
             }
 

--- a/gateway-queue/src/lib.rs
+++ b/gateway-queue/src/lib.rs
@@ -132,7 +132,7 @@ async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
     const DUR: Duration = Duration::from_secs(6);
     while let Some(req) = rx.recv().await {
         if let Err(source) = req.send(()) {
-            tracing::warn!("skipping, send failed: {:?}", source);
+            tracing::warn!("skipping, send failed: {source:?}");
         }
         sleep(DUR).await;
     }
@@ -147,11 +147,11 @@ impl Queue for LocalQueue {
             let (tx, rx) = oneshot::channel();
 
             if let Err(source) = self.0.send(tx) {
-                tracing::warn!("skipping, send failed: {:?}", source);
+                tracing::warn!("skipping, send failed: {source:?}");
                 return;
             }
 
-            tracing::info!("shard {}/{} waiting for allowance", id, total);
+            tracing::info!("shard {id}/{total} waiting for allowance");
 
             let _ = rx.await;
         })

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -252,9 +252,9 @@ impl Cluster {
     ///
     /// while let Some((shard_id, event)) = events.next().await {
     ///     match event {
-    ///         Event::MessageCreate(_) => println!("Shard {} got a new message", shard_id),
-    ///         Event::MessageDelete(_) => println!("Shard {} got a deleted message", shard_id),
-    ///         Event::MessageUpdate(_) => println!("Shard {} got an updated message", shard_id),
+    ///         Event::MessageCreate(_) => println!("Shard {shard_id} got a new message"),
+    ///         Event::MessageDelete(_) => println!("Shard {shard_id} got a deleted message"),
+    ///         Event::MessageUpdate(_) => println!("Shard {shard_id} got an updated message"),
     ///         // No other events will come in through the stream.
     ///         _ => {},
     ///     }
@@ -348,9 +348,9 @@ impl Cluster {
     ///
     /// while let Some((shard_id, event)) = events.next().await {
     ///     match event {
-    ///         Event::MessageCreate(_) => println!("Shard {} got a new message", shard_id),
-    ///         Event::MessageDelete(_) => println!("Shard {} got a deleted message", shard_id),
-    ///         Event::MessageUpdate(_) => println!("Shard {} got an updated message", shard_id),
+    ///         Event::MessageCreate(_) => println!("Shard {shard_id} got a new message"),
+    ///         Event::MessageDelete(_) => println!("Shard {shard_id} got a deleted message"),
+    ///         Event::MessageUpdate(_) => println!("Shard {shard_id} got an updated message"),
     ///         // No other events will come in through the stream.
     ///         _ => {},
     ///     }
@@ -449,8 +449,7 @@ impl Cluster {
     ///
     /// for (shard_id, info) in cluster.info() {
     ///     println!(
-    ///         "Shard {} is {} with an average latency of {:?}",
-    ///         shard_id,
+    ///         "Shard {shard_id} is {} with an average latency of {:?}",
     ///         info.stage(),
     ///         info.latency().average(),
     ///     );

--- a/gateway/src/cluster/mod.rs
+++ b/gateway/src/cluster/mod.rs
@@ -31,20 +31,20 @@
 //! async fn handle_event(cluster: Arc<Cluster>, shard_id: u64, event: Event) {
 //!     match event {
 //!         Event::ShardConnected { .. } => {
-//!             println!("Shard {} is now connected", shard_id);
+//!             println!("Shard {shard_id} is now connected");
 //!         },
 //!         Event::ShardDisconnected { .. } => {
-//!             println!("Shard {} is now disconnected", shard_id);
+//!             println!("Shard {shard_id} is now disconnected");
 //!         },
 //!         Event::MessageCreate(msg) if msg.content == "!latency" => {
 //!             if let Some(shard) = cluster.shard(shard_id) {
 //!                 if let Ok(info) = shard.info() {
-//!                     println!("Shard {}'s latency is {:?}", shard_id, info.latency());
+//!                     println!("Shard {shard_id}'s latency is {:?}", info.latency());
 //!                 }
 //!             }
 //!         },
 //!         Event::MessageCreate(msg) if msg.content == "!shutdown" => {
-//!             println!("Got a shutdown request from shard {}", shard_id);
+//!             println!("Got a shutdown request from shard {shard_id}");
 //!
 //!             cluster.down();
 //!         },

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -275,15 +275,9 @@ impl ShardBuilder {
     #[must_use = "has no effect if not built"]
     pub fn large_threshold(mut self, large_threshold: u64) -> Self {
         match large_threshold {
-            0..=49 => panic!(
-                "provided large threshold value {} is fewer than 50",
-                large_threshold
-            ),
+            0..=49 => panic!("provided large threshold value {large_threshold} is fewer than 50",),
             50..=250 => (),
-            251.. => panic!(
-                "provided large threshold value {} is more than 250",
-                large_threshold
-            ),
+            251.. => panic!("provided large threshold value {large_threshold} is more than 250",),
         }
 
         self.large_threshold = large_threshold;

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -275,9 +275,9 @@ impl ShardBuilder {
     #[must_use = "has no effect if not built"]
     pub fn large_threshold(mut self, large_threshold: u64) -> Self {
         match large_threshold {
-            0..=49 => panic!("provided large threshold value {large_threshold} is fewer than 50",),
+            0..=49 => panic!("provided large threshold value {large_threshold} is fewer than 50"),
             50..=250 => (),
-            251.. => panic!("provided large threshold value {large_threshold} is more than 250",),
+            251.. => panic!("provided large threshold value {large_threshold} is more than 250"),
         }
 
         self.large_threshold = large_threshold;

--- a/gateway/src/shard/processor/heartbeat.rs
+++ b/gateway/src/shard/processor/heartbeat.rs
@@ -112,7 +112,7 @@ impl Heartbeats {
             let millis = if let Ok(millis) = dur.as_millis().try_into() {
                 millis
             } else {
-                tracing::error!("duration millis is more than u64: {:?}", dur);
+                tracing::error!("duration millis is more than u64: {dur:?}");
 
                 return;
             };
@@ -197,7 +197,7 @@ impl Heartbeater {
 
     pub async fn run(self) {
         if let Err(source) = self.try_run().await {
-            tracing::warn!("Error sending heartbeat: {:?}", source);
+            tracing::warn!("Error sending heartbeat: {source:?}");
         }
     }
 

--- a/gateway/src/shard/processor/impl.rs
+++ b/gateway/src/shard/processor/impl.rs
@@ -382,7 +382,7 @@ impl ShardProcessor {
     pub async fn run(mut self) {
         loop {
             if let Err(source) = self.next_payload().await {
-                tracing::warn!("{}", source);
+                tracing::warn!("{source}");
 
                 self.emit_disconnected(None, None).await;
 

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -268,8 +268,7 @@ fn available_commands_per_interval(heartbeat_interval: u64) -> u8 {
 
         tracing::warn!(
             %heartbeats,
-            "heartbeats > u8 max; defaulting to allotting {}",
-            ALLOT_ON_FAIL,
+            "heartbeats > u8 max; defaulting to allotting {ALLOT_ON_FAIL}",
         );
 
         ALLOT_ON_FAIL

--- a/gateway/src/shard/processor/socket_forwarder.rs
+++ b/gateway/src/shard/processor/socket_forwarder.rs
@@ -53,10 +53,10 @@ impl SocketForwarder {
                 // `rx` future finished first.
                 Either::Left((Either::Left((maybe_msg, _)), _)) => {
                     if let Some(msg) = maybe_msg {
-                        tracing::trace!("sending message: {}", msg);
+                        tracing::trace!("sending message: {msg}");
 
                         if let Err(source) = self.stream.send(msg).await {
-                            tracing::warn!("sending failed: {}", source);
+                            tracing::warn!("sending failed: {source}");
 
                             break;
                         }
@@ -76,7 +76,7 @@ impl SocketForwarder {
                         }
                     }
                     Some(Err(source)) => {
-                        tracing::warn!("socket errored: {}", source);
+                        tracing::warn!("socket errored: {source}");
 
                         break;
                     }

--- a/http-ratelimiting/src/in_memory/bucket.rs
+++ b/http-ratelimiting/src/in_memory/bucket.rs
@@ -229,7 +229,7 @@ impl BucketQueueTask {
                 continue;
             };
 
-            tracing::debug!(parent: &span, "starting to wait for response headers",);
+            tracing::debug!(parent: &span, "starting to wait for response headers");
 
             match timeout(Self::WAIT, ticket_headers).await {
                 Ok(Ok(Some(headers))) => self.handle_headers(&headers).await,

--- a/http-ratelimiting/src/in_memory/mod.rs
+++ b/http-ratelimiting/src/in_memory/mod.rs
@@ -79,17 +79,17 @@ impl InMemoryRatelimiter {
 
         match buckets.entry(path.clone()) {
             Entry::Occupied(bucket) => {
-                tracing::debug!("got existing bucket: {:?}", path);
+                tracing::debug!("got existing bucket: {path:?}");
 
                 let bucket = bucket.into_mut();
                 bucket.queue.push(tx);
 
-                tracing::debug!("added request into bucket queue: {:?}", path);
+                tracing::debug!("added request into bucket queue: {path:?}");
 
                 (Arc::clone(bucket), false)
             }
             Entry::Vacant(entry) => {
-                tracing::debug!("making new bucket for path: {:?}", path);
+                tracing::debug!("making new bucket for path: {path:?}");
 
                 let bucket = Bucket::new(path);
                 bucket.queue.push(tx);
@@ -139,7 +139,7 @@ impl Ratelimiter for InMemoryRatelimiter {
     }
 
     fn ticket(&self, path: Path) -> GetTicketFuture {
-        tracing::debug!("getting bucket for path: {:?}", path);
+        tracing::debug!("getting bucket for path: {path:?}");
 
         let (tx, rx) = ticket::channel();
         let (bucket, fresh) = self.entry(path.clone(), tx);

--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -129,7 +129,7 @@ use twilight_validate::{
 /// use twilight_http::Client;
 ///
 /// let bearer = env::var("BEARER_TOKEN")?;
-/// let token = format!("Bearer {}", bearer);
+/// let token = format!("Bearer {bearer}");
 ///
 /// let client = Client::new(token);
 /// # Ok(()) }
@@ -2183,7 +2183,7 @@ impl Client {
     /// let id = Id::new(123);
     /// let sticker = client.sticker(id).exec().await?.model().await?;
     ///
-    /// println!("{:#?}", sticker);
+    /// println!("{sticker:#?}");
     /// # Ok(()) }
     /// ```
     pub const fn sticker(&self, sticker_id: Id<StickerMarker>) -> GetSticker<'_> {
@@ -2258,7 +2258,7 @@ impl Client {
     ///     .model()
     ///     .await?;
     ///
-    /// println!("{:#?}", sticker);
+    /// println!("{sticker:#?}");
     /// # Ok(()) }
     /// ```
     pub const fn guild_sticker(
@@ -2295,7 +2295,7 @@ impl Client {
     ///     .model()
     ///     .await?;
     ///
-    /// println!("{:#?}", sticker);
+    /// println!("{sticker:#?}");
     /// # Ok(()) }
     /// ```
     pub fn create_guild_sticker<'a>(
@@ -2331,7 +2331,7 @@ impl Client {
     ///     .model()
     ///     .await?;
     ///
-    /// println!("{:#?}", sticker);
+    /// println!("{sticker:#?}");
     /// # Ok(()) }
     /// ```
     pub const fn update_guild_sticker(
@@ -2410,8 +2410,8 @@ impl Client {
         let protocol = if self.use_http { "http" } else { "https" };
         let host = self.proxy.as_deref().unwrap_or("discord.com");
 
-        let url = format!("{}://{}/api/v{}/{}", protocol, host, API_VERSION, path);
-        tracing::debug!("URL: {:?}", url);
+        let url = format!("{protocol}://{host}/api/v{API_VERSION}/{path}");
+        tracing::debug!("URL: {url:?}");
 
         let mut builder = hyper::Request::builder().method(method.to_http()).uri(&url);
 

--- a/http/src/request/attachment.rs
+++ b/http/src/request/attachment.rs
@@ -100,7 +100,7 @@ const ASCII_NUMBER: u8 = 0x30;
 /// Extend the buffer with the digits of the integer `id`.
 ///
 /// The reason for this is to get around a allocation by for example using
-/// `format!("files[{}]", id)`.
+/// `format!("files[{id}]")`.
 fn push_digits(mut id: u64, buf: &mut Vec<u8>) {
     // The largest 64 bit integer is 20 digits.
     let mut inner_buf = [0_u8; 20];

--- a/http/src/request/guild/get_audit_log.rs
+++ b/http/src/request/guild/get_audit_log.rs
@@ -49,7 +49,7 @@ struct GetAuditLogFields {
 ///     println!("  Changes:");
 ///
 ///     for change in entry.changes {
-///         println!("{:?}", change);
+///         println!("{change:?}");
 ///     }
 /// }
 /// # Ok(()) }

--- a/http/src/request/guild/sticker/create_guild_sticker.rs
+++ b/http/src/request/guild/sticker/create_guild_sticker.rs
@@ -50,7 +50,7 @@ struct CreateGuildStickerFields<'a> {
 ///     .model()
 ///     .await?;
 ///
-/// println!("{:#?}", sticker);
+/// println!("{sticker:#?}");
 /// # Ok(()) }
 /// ```
 pub struct CreateGuildSticker<'a> {

--- a/http/src/request/guild/sticker/get_guild_sticker.rs
+++ b/http/src/request/guild/sticker/get_guild_sticker.rs
@@ -34,7 +34,7 @@ use twilight_model::{
 ///     .model()
 ///     .await?;
 ///
-/// println!("{:#?}", sticker);
+/// println!("{sticker:#?}");
 /// # Ok(()) }
 /// ```
 pub struct GetGuildSticker<'a> {

--- a/http/src/request/guild/sticker/update_guild_sticker.rs
+++ b/http/src/request/guild/sticker/update_guild_sticker.rs
@@ -50,7 +50,7 @@ struct UpdateGuildStickerFields<'a> {
 ///     .model()
 ///     .await?;
 ///
-/// println!("{:#?}", sticker);
+/// println!("{sticker:#?}");
 /// # Ok(()) }
 /// ```
 pub struct UpdateGuildSticker<'a> {

--- a/http/src/request/multipart.rs
+++ b/http/src/request/multipart.rs
@@ -156,7 +156,6 @@ mod tests {
         \r\n\
         file_value\r\n\
         --{boundary}--",
-            boundary = boundary,
         );
 
         let buffer = form.build();

--- a/http/src/response/future.rs
+++ b/http/src/response/future.rs
@@ -131,7 +131,7 @@ impl InFlight {
                 }
                 #[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
                 Err(source) => {
-                    tracing::warn!("header parsing failed: {:?}; {:?}", source, resp);
+                    tracing::warn!("header parsing failed: {source:?}; {resp:?}");
 
                     let _res = tx.headers(None);
                 }
@@ -158,7 +158,7 @@ impl InFlight {
 
         match status {
             HyperStatusCode::TOO_MANY_REQUESTS => {
-                tracing::warn!("429 response: {:?}", resp)
+                tracing::warn!("429 response: {resp:?}")
             }
             HyperStatusCode::SERVICE_UNAVAILABLE => {
                 return InnerPoll::Ready(Err(Error {

--- a/http/src/response/mod.rs
+++ b/http/src/response/mod.rs
@@ -288,7 +288,7 @@ impl<T> Response<T> {
     /// let response = client.current_user().exec().await?;
     /// let text = response.text().await?;
     ///
-    /// println!("body: {}", text);
+    /// println!("body: {text}");
     /// # Ok(()) }
     /// ```
     ///
@@ -454,7 +454,7 @@ impl Response<MemberListBody> {
 /// let mut headers = response.headers();
 ///
 /// while let Some((name, value)) = headers.next() {
-///     println!("{}: {}", name, String::from_utf8_lossy(value));
+///     println!("{name}: {}", String::from_utf8_lossy(value));
 /// }
 /// # Ok(()) }
 /// ```
@@ -504,7 +504,7 @@ impl<'a> Iterator for HeaderIter<'a> {
 /// let response = client.message(channel_id, message_id).exec().await?;
 /// let bytes = response.bytes().await?;
 ///
-/// println!("bytes of the body: {:?}", bytes);
+/// println!("bytes of the body: {bytes:?}");
 /// # Ok(()) }
 /// ```
 ///
@@ -768,7 +768,7 @@ impl Future for MemberListFuture {
 /// let response = client.message(channel_id, message_id).exec().await?;
 /// let text = response.text().await?;
 ///
-/// println!("body: {}", text);
+/// println!("body: {text}");
 /// # Ok(()) }
 /// ```
 ///

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -2838,11 +2838,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/members/{user_id}",
-                guild_id = GUILD_ID,
-                user_id = USER_ID
-            )
+            format!("guilds/{GUILD_ID}/members/{USER_ID}")
         );
     }
 
@@ -2854,11 +2850,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/members/{user_id}",
-                guild_id = GUILD_ID,
-                user_id = USER_ID
-            )
+            format!("guilds/{GUILD_ID}/members/{USER_ID}")
         );
     }
 
@@ -2870,11 +2862,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/members/{user_id}",
-                guild_id = GUILD_ID,
-                user_id = USER_ID
-            )
+            format!("guilds/{GUILD_ID}/members/{USER_ID}")
         );
     }
 
@@ -2886,11 +2874,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/members/{user_id}",
-                guild_id = GUILD_ID,
-                user_id = USER_ID
-            )
+            format!("guilds/{GUILD_ID}/members/{USER_ID}")
         );
     }
 
@@ -2903,12 +2887,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/members/{user_id}/roles/{role_id}",
-                guild_id = GUILD_ID,
-                role_id = ROLE_ID,
-                user_id = USER_ID
-            )
+            format!("guilds/{GUILD_ID}/members/{USER_ID}/roles/{ROLE_ID}")
         );
     }
 
@@ -2921,12 +2900,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/members/{user_id}/roles/{role_id}",
-                guild_id = GUILD_ID,
-                role_id = ROLE_ID,
-                user_id = USER_ID
-            )
+            format!("guilds/{GUILD_ID}/members/{USER_ID}/roles/{ROLE_ID}")
         );
     }
 
@@ -2938,11 +2912,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/thread-members/{user_id}",
-                channel_id = CHANNEL_ID,
-                user_id = USER_ID
-            )
+            format!("channels/{CHANNEL_ID}/thread-members/{USER_ID}")
         );
     }
 
@@ -2954,11 +2924,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/thread-members/{user_id}",
-                channel_id = CHANNEL_ID,
-                user_id = USER_ID
-            )
+            format!("channels/{CHANNEL_ID}/thread-members/{USER_ID}")
         );
     }
 
@@ -2970,57 +2936,38 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/thread-members/{user_id}",
-                channel_id = CHANNEL_ID,
-                user_id = USER_ID
-            )
+            format!("channels/{CHANNEL_ID}/thread-members/{USER_ID}")
         );
     }
 
     #[test]
     fn test_create_channel() {
         let route = Route::CreateChannel { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/channels", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/channels"));
     }
 
     #[test]
     fn test_get_channels() {
         let route = Route::GetChannels { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/channels", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/channels"));
     }
 
     #[test]
     fn test_update_guild_channels() {
         let route = Route::UpdateGuildChannels { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/channels", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/channels"));
     }
 
     #[test]
     fn test_create_emoji() {
         let route = Route::CreateEmoji { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/emojis", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/emojis"));
     }
 
     #[test]
     fn test_get_emojis() {
         let route = Route::GetEmojis { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/emojis", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/emojis"));
     }
 
     #[test]
@@ -3030,10 +2977,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/commands",
-                application_id = APPLICATION_ID
-            )
+            format!("applications/{APPLICATION_ID}/commands")
         );
     }
 
@@ -3044,10 +2988,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/commands",
-                application_id = APPLICATION_ID
-            )
+            format!("applications/{APPLICATION_ID}/commands")
         );
     }
 
@@ -3058,10 +2999,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/commands",
-                application_id = APPLICATION_ID
-            )
+            format!("applications/{APPLICATION_ID}/commands")
         );
     }
 
@@ -3079,11 +3017,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/guilds/{guild_id}/commands",
-                application_id = APPLICATION_ID,
-                guild_id = GUILD_ID
-            )
+            format!("applications/{APPLICATION_ID}/guilds/{GUILD_ID}/commands")
         );
     }
 
@@ -3095,11 +3029,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/guilds/{guild_id}/commands",
-                application_id = APPLICATION_ID,
-                guild_id = GUILD_ID
-            )
+            format!("applications/{APPLICATION_ID}/guilds/{GUILD_ID}/commands")
         );
     }
 
@@ -3111,11 +3041,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/guilds/{guild_id}/commands",
-                application_id = APPLICATION_ID,
-                guild_id = GUILD_ID
-            )
+            format!("applications/{APPLICATION_ID}/guilds/{GUILD_ID}/commands")
         );
     }
 
@@ -3126,10 +3052,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/templates/{template_code}",
-                template_code = TEMPLATE_CODE
-            )
+            format!("guilds/templates/{TEMPLATE_CODE}")
         );
     }
 
@@ -3140,47 +3063,32 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/templates/{template_code}",
-                template_code = TEMPLATE_CODE
-            )
+            format!("guilds/templates/{TEMPLATE_CODE}")
         );
     }
 
     #[test]
     fn test_create_guild_integration() {
         let route = Route::CreateGuildIntegration { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/integrations", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/integrations"));
     }
 
     #[test]
     fn test_get_guild_integrations() {
         let route = Route::GetGuildIntegrations { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/integrations", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/integrations"));
     }
 
     #[test]
     fn test_create_guild_sticker() {
         let route = Route::CreateGuildSticker { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/stickers", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/stickers"));
     }
 
     #[test]
     fn test_get_guild_stickers() {
         let route = Route::GetGuildStickers { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/stickers", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/stickers"));
     }
 
     #[test]
@@ -3188,10 +3096,7 @@ mod tests {
         let route = Route::CreateInvite {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("channels/{channel_id}/invites", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("channels/{CHANNEL_ID}/invites"));
     }
 
     #[test]
@@ -3199,10 +3104,7 @@ mod tests {
         let route = Route::GetChannelInvites {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("channels/{channel_id}/invites", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("channels/{CHANNEL_ID}/invites"));
     }
 
     #[test]
@@ -3210,10 +3112,7 @@ mod tests {
         let route = Route::CreateMessage {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("channels/{channel_id}/messages", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("channels/{CHANNEL_ID}/messages"));
     }
 
     #[test]
@@ -3239,12 +3138,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/messages/{message_id}/reactions/{emoji}/@me",
-                channel_id = CHANNEL_ID,
-                emoji = emoji,
-                message_id = MESSAGE_ID
-            )
+            format!("channels/{CHANNEL_ID}/messages/{MESSAGE_ID}/reactions/{emoji}/@me")
         );
     }
 
@@ -3259,40 +3153,26 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/messages/{message_id}/reactions/{emoji}/@me",
-                channel_id = CHANNEL_ID,
-                emoji = emoji,
-                message_id = MESSAGE_ID
-            )
+            format!("channels/{CHANNEL_ID}/messages/{MESSAGE_ID}/reactions/{emoji}/@me")
         );
     }
 
     #[test]
     fn test_create_role() {
         let route = Route::CreateRole { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/roles", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/roles"));
     }
 
     #[test]
     fn test_get_guild_roles() {
         let route = Route::GetGuildRoles { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/roles", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/roles"));
     }
 
     #[test]
     fn test_update_role_positions() {
         let route = Route::UpdateRolePositions { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/roles", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/roles"));
     }
 
     #[test]
@@ -3304,19 +3184,13 @@ mod tests {
     #[test]
     fn test_create_template() {
         let route = Route::CreateTemplate { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/templates", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/templates"));
     }
 
     #[test]
     fn test_get_templates() {
         let route = Route::GetTemplates { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/templates", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/templates"));
     }
 
     #[test]
@@ -3324,10 +3198,7 @@ mod tests {
         let route = Route::CreateThread {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("channels/{channel_id}/threads", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("channels/{CHANNEL_ID}/threads"));
     }
 
     #[test]
@@ -3338,11 +3209,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/messages/{message_id}/threads",
-                channel_id = CHANNEL_ID,
-                message_id = MESSAGE_ID
-            )
+            format!("channels/{CHANNEL_ID}/messages/{MESSAGE_ID}/threads")
         );
     }
 
@@ -3351,10 +3218,7 @@ mod tests {
         let route = Route::CreateTypingTrigger {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("channels/{channel_id}/typing", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("channels/{CHANNEL_ID}/typing"));
     }
 
     #[test]
@@ -3362,10 +3226,7 @@ mod tests {
         let route = Route::CreateWebhook {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("channels/{channel_id}/webhooks", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("channels/{CHANNEL_ID}/webhooks"));
     }
 
     #[test]
@@ -3373,10 +3234,7 @@ mod tests {
         let route = Route::GetChannelWebhooks {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("channels/{channel_id}/webhooks", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("channels/{CHANNEL_ID}/webhooks"));
     }
 
     #[test]
@@ -3387,11 +3245,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/messages/{message_id}/crosspost",
-                channel_id = CHANNEL_ID,
-                message_id = MESSAGE_ID
-            )
+            format!("channels/{CHANNEL_ID}/messages/{MESSAGE_ID}/crosspost")
         );
     }
 
@@ -3403,11 +3257,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/bans/{user_id}",
-                guild_id = GUILD_ID,
-                user_id = USER_ID
-            )
+            format!("guilds/{GUILD_ID}/bans/{USER_ID}")
         );
     }
 
@@ -3419,11 +3269,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/bans/{user_id}",
-                guild_id = GUILD_ID,
-                user_id = USER_ID
-            )
+            format!("guilds/{GUILD_ID}/bans/{USER_ID}")
         );
     }
 
@@ -3432,10 +3278,7 @@ mod tests {
         let route = Route::DeleteChannel {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("channels/{channel_id}", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("channels/{CHANNEL_ID}"));
     }
 
     #[test]
@@ -3443,10 +3286,7 @@ mod tests {
         let route = Route::GetChannel {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("channels/{channel_id}", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("channels/{CHANNEL_ID}"));
     }
 
     #[test]
@@ -3454,10 +3294,7 @@ mod tests {
         let route = Route::UpdateChannel {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("channels/{channel_id}", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("channels/{CHANNEL_ID}"));
     }
 
     #[test]
@@ -3468,11 +3305,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/emojis/{emoji_id}",
-                emoji_id = EMOJI_ID,
-                guild_id = GUILD_ID
-            )
+            format!("guilds/{GUILD_ID}/emojis/{EMOJI_ID}")
         );
     }
 
@@ -3484,11 +3317,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/emojis/{emoji_id}",
-                emoji_id = EMOJI_ID,
-                guild_id = GUILD_ID
-            )
+            format!("guilds/{GUILD_ID}/emojis/{EMOJI_ID}")
         );
     }
 
@@ -3500,11 +3329,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/emojis/{emoji_id}",
-                emoji_id = EMOJI_ID,
-                guild_id = GUILD_ID
-            )
+            format!("guilds/{GUILD_ID}/emojis/{EMOJI_ID}")
         );
     }
 
@@ -3516,11 +3341,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/commands/{command_id}",
-                application_id = APPLICATION_ID,
-                command_id = COMMAND_ID
-            )
+            format!("applications/{APPLICATION_ID}/commands/{COMMAND_ID}")
         );
     }
 
@@ -3532,11 +3353,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/commands/{command_id}",
-                application_id = APPLICATION_ID,
-                command_id = COMMAND_ID
-            )
+            format!("applications/{APPLICATION_ID}/commands/{COMMAND_ID}")
         );
     }
 
@@ -3548,30 +3365,20 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/commands/{command_id}",
-                application_id = APPLICATION_ID,
-                command_id = COMMAND_ID
-            )
+            format!("applications/{APPLICATION_ID}/commands/{COMMAND_ID}")
         );
     }
 
     #[test]
     fn test_delete_guild() {
         let route = Route::DeleteGuild { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}"));
     }
 
     #[test]
     fn test_update_guild() {
         let route = Route::UpdateGuild { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}"));
     }
 
     #[test]
@@ -3583,12 +3390,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/guilds/{guild_id}/commands/{command_id}",
-                application_id = APPLICATION_ID,
-                command_id = COMMAND_ID,
-                guild_id = GUILD_ID
-            )
+            format!("applications/{APPLICATION_ID}/guilds/{GUILD_ID}/commands/{COMMAND_ID}")
         );
     }
 
@@ -3601,12 +3403,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/guilds/{guild_id}/commands/{command_id}",
-                application_id = APPLICATION_ID,
-                command_id = COMMAND_ID,
-                guild_id = GUILD_ID
-            )
+            format!("applications/{APPLICATION_ID}/guilds/{GUILD_ID}/commands/{COMMAND_ID}")
         );
     }
 
@@ -3619,12 +3416,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/guilds/{guild_id}/commands/{command_id}",
-                application_id = APPLICATION_ID,
-                command_id = COMMAND_ID,
-                guild_id = GUILD_ID
-            )
+            format!("applications/{APPLICATION_ID}/guilds/{GUILD_ID}/commands/{COMMAND_ID}")
         );
     }
 
@@ -3636,11 +3428,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/integrations/{integration_id}",
-                guild_id = GUILD_ID,
-                integration_id = INTEGRATION_ID
-            )
+            format!("guilds/{GUILD_ID}/integrations/{INTEGRATION_ID}")
         );
     }
 
@@ -3652,11 +3440,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/integrations/{integration_id}",
-                guild_id = GUILD_ID,
-                integration_id = INTEGRATION_ID
-            )
+            format!("guilds/{GUILD_ID}/integrations/{INTEGRATION_ID}")
         );
     }
 
@@ -3668,11 +3452,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "webhooks/{application_id}/{interaction_token}/messages/@original",
-                application_id = APPLICATION_ID,
-                interaction_token = INTERACTION_TOKEN
-            )
+            format!("webhooks/{APPLICATION_ID}/{INTERACTION_TOKEN}/messages/@original")
         );
     }
 
@@ -3684,11 +3464,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "webhooks/{application_id}/{interaction_token}/messages/@original",
-                application_id = APPLICATION_ID,
-                interaction_token = INTERACTION_TOKEN
-            )
+            format!("webhooks/{APPLICATION_ID}/{INTERACTION_TOKEN}/messages/@original")
         );
     }
 
@@ -3700,18 +3476,14 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "webhooks/{application_id}/{interaction_token}/messages/@original",
-                application_id = APPLICATION_ID,
-                interaction_token = INTERACTION_TOKEN
-            )
+            format!("webhooks/{APPLICATION_ID}/{INTERACTION_TOKEN}/messages/@original")
         );
     }
 
     #[test]
     fn test_delete_invite() {
         let route = Route::DeleteInvite { code: CODE };
-        assert_eq!(route.to_string(), format!("invites/{code}", code = CODE));
+        assert_eq!(route.to_string(), format!("invites/{CODE}"))
     }
 
     #[test]
@@ -3722,11 +3494,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/messages/{message_id}/reactions",
-                channel_id = CHANNEL_ID,
-                message_id = MESSAGE_ID
-            )
+            format!("channels/{CHANNEL_ID}/messages/{MESSAGE_ID}/reactions")
         );
     }
 
@@ -3741,12 +3509,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/messages/{message_id}/reactions/{emoji}",
-                channel_id = CHANNEL_ID,
-                emoji = emoji,
-                message_id = MESSAGE_ID
-            )
+            format!("channels/{CHANNEL_ID}/messages/{MESSAGE_ID}/reactions/{emoji}")
         );
     }
 
@@ -3758,11 +3521,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/messages/{message_id}",
-                channel_id = CHANNEL_ID,
-                message_id = MESSAGE_ID
-            )
+            format!("channels/{CHANNEL_ID}/messages/{MESSAGE_ID}")
         );
     }
 
@@ -3774,11 +3533,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/messages/{message_id}",
-                channel_id = CHANNEL_ID,
-                message_id = MESSAGE_ID
-            )
+            format!("channels/{CHANNEL_ID}/messages/{MESSAGE_ID}")
         );
     }
 
@@ -3790,11 +3545,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/messages/{message_id}",
-                channel_id = CHANNEL_ID,
-                message_id = MESSAGE_ID
-            )
+            format!("channels/{CHANNEL_ID}/messages/{MESSAGE_ID}")
         );
     }
 
@@ -3805,10 +3556,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/messages/bulk-delete",
-                channel_id = CHANNEL_ID
-            )
+            format!("channels/{CHANNEL_ID}/messages/bulk-delete")
         );
     }
 
@@ -3820,11 +3568,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/permissions/{target_id}",
-                channel_id = CHANNEL_ID,
-                target_id = ROLE_ID
-            )
+            format!("channels/{CHANNEL_ID}/permissions/{ROLE_ID}")
         );
     }
 
@@ -3836,11 +3580,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/permissions/{target_id}",
-                channel_id = CHANNEL_ID,
-                target_id = USER_ID
-            )
+            format!("channels/{CHANNEL_ID}/permissions/{USER_ID}")
         );
     }
 
@@ -3856,13 +3596,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/messages/{message_id}/reactions/{emoji}/{user_id}",
-                channel_id = CHANNEL_ID,
-                emoji = emoji,
-                message_id = MESSAGE_ID,
-                user_id = USER_ID
-            )
+            format!("channels/{CHANNEL_ID}/messages/{MESSAGE_ID}/reactions/{emoji}/{USER_ID}")
         );
     }
 
@@ -3874,11 +3608,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/roles/{role_id}",
-                guild_id = GUILD_ID,
-                role_id = ROLE_ID
-            )
+            format!("guilds/{GUILD_ID}/roles/{ROLE_ID}")
         );
     }
 
@@ -3890,11 +3620,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/roles/{role_id}",
-                guild_id = GUILD_ID,
-                role_id = ROLE_ID
-            )
+            format!("guilds/{GUILD_ID}/roles/{ROLE_ID}")
         );
     }
 
@@ -3903,10 +3629,7 @@ mod tests {
         let route = Route::DeleteStageInstance {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("stage-instances/{channel_id}", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("stage-instances/{CHANNEL_ID}"));
     }
 
     #[test]
@@ -3914,10 +3637,7 @@ mod tests {
         let route = Route::GetStageInstance {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("stage-instances/{channel_id}", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("stage-instances/{CHANNEL_ID}"));
     }
 
     #[test]
@@ -3925,10 +3645,7 @@ mod tests {
         let route = Route::UpdateStageInstance {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("stage-instances/{channel_id}", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("stage-instances/{CHANNEL_ID}"));
     }
 
     #[test]
@@ -3939,11 +3656,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/templates/{template_code}",
-                guild_id = GUILD_ID,
-                template_code = TEMPLATE_CODE
-            )
+            format!("guilds/{GUILD_ID}/templates/{TEMPLATE_CODE}")
         );
     }
 
@@ -3955,11 +3668,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/templates/{template_code}",
-                guild_id = GUILD_ID,
-                template_code = TEMPLATE_CODE
-            )
+            format!("guilds/{GUILD_ID}/templates/{TEMPLATE_CODE}")
         );
     }
 
@@ -3971,11 +3680,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/templates/{template_code}",
-                guild_id = GUILD_ID,
-                template_code = TEMPLATE_CODE
-            )
+            format!("guilds/{GUILD_ID}/templates/{TEMPLATE_CODE}")
         );
     }
 
@@ -3986,7 +3691,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!("channels/{channel_id}/followers", channel_id = CHANNEL_ID)
+            format!("channels/{CHANNEL_ID}/followers")
         );
     }
 
@@ -3995,17 +3700,14 @@ mod tests {
         let route = Route::GetActiveThreads { guild_id: GUILD_ID };
         assert_eq!(
             route.to_string(),
-            format!("guilds/{guild_id}/threads/active", guild_id = GUILD_ID)
+            format!("guilds/{GUILD_ID}/threads/active")
         );
     }
 
     #[test]
     fn test_get_bans() {
         let route = Route::GetBans { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/bans", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/bans"));
     }
 
     #[test]
@@ -4016,10 +3718,7 @@ mod tests {
             guild_id: GUILD_ID,
             limit: None,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/bans?", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/bans?"));
 
         let route = Route::GetBansWithParameters {
             after: Some(USER_ID),
@@ -4029,11 +3728,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/bans?after={after}",
-                after = USER_ID,
-                guild_id = GUILD_ID
-            )
+            format!("guilds/{GUILD_ID}/bans?after={USER_ID}")
         );
 
         let route = Route::GetBansWithParameters {
@@ -4044,11 +3739,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/bans?&before={before}",
-                before = USER_ID,
-                guild_id = GUILD_ID
-            )
+            format!("guilds/{GUILD_ID}/bans?&before={USER_ID}")
         );
 
         let route = Route::GetBansWithParameters {
@@ -4059,11 +3750,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/bans?&limit={limit}",
-                guild_id = GUILD_ID,
-                limit = 100,
-            )
+            format!("guilds/{GUILD_ID}/bans?&limit={limit}", limit = 100)
         );
 
         let route = Route::GetBansWithParameters {
@@ -4075,10 +3762,8 @@ mod tests {
         assert_eq!(
             route.to_string(),
             format!(
-                "guilds/{guild_id}/bans?after={after}&before={before}&limit={limit}",
-                after = USER_ID,
+                "guilds/{GUILD_ID}/bans?after={USER_ID}&before={before}&limit={limit}",
                 before = USER_ID + 100,
-                guild_id = GUILD_ID,
                 limit = 25,
             )
         );
@@ -4100,10 +3785,7 @@ mod tests {
         assert_eq!(
             route.to_string(),
             format!(
-                "applications/{application_id}/guilds/{guild_id}/commands/{command_id}/permissions",
-                application_id = APPLICATION_ID,
-                command_id = COMMAND_ID,
-                guild_id = GUILD_ID
+                "applications/{APPLICATION_ID}/guilds/{GUILD_ID}/commands/{COMMAND_ID}/permissions"
             )
         );
     }
@@ -4118,10 +3800,7 @@ mod tests {
         assert_eq!(
             route.to_string(),
             format!(
-                "applications/{application_id}/guilds/{guild_id}/commands/{command_id}/permissions",
-                application_id = APPLICATION_ID,
-                command_id = COMMAND_ID,
-                guild_id = GUILD_ID
+                "applications/{APPLICATION_ID}/guilds/{GUILD_ID}/commands/{COMMAND_ID}/permissions"
             )
         );
     }
@@ -4143,7 +3822,7 @@ mod tests {
         let route = Route::GetCurrentUserGuildMember { guild_id: GUILD_ID };
         assert_eq!(
             route.to_string(),
-            format!("users/@me/guilds/{guild_id}/member", guild_id = GUILD_ID)
+            format!("users/@me/guilds/{GUILD_ID}/member")
         )
     }
 
@@ -4167,30 +3846,20 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/guilds/{guild_id}/commands/permissions",
-                application_id = APPLICATION_ID,
-                guild_id = GUILD_ID
-            )
+            format!("applications/{APPLICATION_ID}/guilds/{GUILD_ID}/commands/permissions")
         );
     }
 
     #[test]
     fn test_get_guild_invites() {
         let route = Route::GetGuildInvites { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/invites", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/invites"));
     }
 
     #[test]
     fn test_get_guild_preview() {
         let route = Route::GetGuildPreview { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/preview", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/preview"));
     }
 
     #[test]
@@ -4201,11 +3870,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/stickers/{sticker_id}",
-                guild_id = GUILD_ID,
-                sticker_id = STICKER_ID
-            )
+            format!("guilds/{GUILD_ID}/stickers/{STICKER_ID}")
         );
     }
 
@@ -4217,11 +3882,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/stickers/{sticker_id}",
-                guild_id = GUILD_ID,
-                sticker_id = STICKER_ID
-            )
+            format!("guilds/{GUILD_ID}/stickers/{STICKER_ID}")
         );
     }
 
@@ -4233,30 +3894,20 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/stickers/{sticker_id}",
-                guild_id = GUILD_ID,
-                sticker_id = STICKER_ID
-            )
+            format!("guilds/{GUILD_ID}/stickers/{STICKER_ID}")
         );
     }
 
     #[test]
     fn test_get_guild_vanity_url() {
         let route = Route::GetGuildVanityUrl { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/vanity-url", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/vanity-url"));
     }
 
     #[test]
     fn test_get_guild_voice_regions() {
         let route = Route::GetGuildVoiceRegions { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/regions", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/regions"));
     }
 
     #[test]
@@ -4264,7 +3915,7 @@ mod tests {
         let route = Route::GetGuildWelcomeScreen { guild_id: GUILD_ID };
         assert_eq!(
             route.to_string(),
-            format!("guilds/{guild_id}/welcome-screen", guild_id = GUILD_ID)
+            format!("guilds/{GUILD_ID}/welcome-screen")
         );
     }
 
@@ -4273,35 +3924,26 @@ mod tests {
         let route = Route::UpdateGuildWelcomeScreen { guild_id: GUILD_ID };
         assert_eq!(
             route.to_string(),
-            format!("guilds/{guild_id}/welcome-screen", guild_id = GUILD_ID)
+            format!("guilds/{GUILD_ID}/welcome-screen")
         );
     }
 
     #[test]
     fn test_get_guild_webhooks() {
         let route = Route::GetGuildWebhooks { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/webhooks", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/webhooks"));
     }
 
     #[test]
     fn test_get_guild_widget() {
         let route = Route::GetGuildWidget { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/widget", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/widget"));
     }
 
     #[test]
     fn test_update_guild_widget() {
         let route = Route::UpdateGuildWidget { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/widget", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/widget"));
     }
 
     #[test]
@@ -4316,10 +3958,7 @@ mod tests {
         let route = Route::GetPins {
             channel_id: CHANNEL_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("channels/{channel_id}/pins", channel_id = CHANNEL_ID)
-        );
+        assert_eq!(route.to_string(), format!("channels/{CHANNEL_ID}/pins"));
     }
 
     #[test]
@@ -4327,10 +3966,7 @@ mod tests {
         let route = Route::GetSticker {
             sticker_id: STICKER_ID,
         };
-        assert_eq!(
-            route.to_string(),
-            format!("stickers/{sticker_id}", sticker_id = STICKER_ID)
-        );
+        assert_eq!(route.to_string(), format!("stickers/{STICKER_ID}"));
     }
 
     #[test]
@@ -4340,10 +3976,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/thread-members",
-                channel_id = CHANNEL_ID
-            )
+            format!("channels/{CHANNEL_ID}/thread-members")
         );
     }
 
@@ -4356,10 +3989,7 @@ mod tests {
     #[test]
     fn test_get_user() {
         let route = Route::GetUser { user_id: USER_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("users/{user_id}", user_id = USER_ID)
-        );
+        assert_eq!(route.to_string(), format!("users/{USER_ID}"));
     }
 
     #[test]
@@ -4376,11 +4006,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "interactions/{interaction_id}/{interaction_token}/callback",
-                interaction_id = INTERACTION_ID,
-                interaction_token = INTERACTION_TOKEN
-            )
+            format!("interactions/{INTERACTION_ID}/{INTERACTION_TOKEN}/callback")
         );
     }
 
@@ -4391,10 +4017,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/thread-members/@me",
-                channel_id = CHANNEL_ID
-            )
+            format!("channels/{CHANNEL_ID}/thread-members/@me")
         );
     }
 
@@ -4405,20 +4028,14 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/thread-members/@me",
-                channel_id = CHANNEL_ID
-            )
+            format!("channels/{CHANNEL_ID}/thread-members/@me")
         );
     }
 
     #[test]
     fn test_leave_guild() {
         let route = Route::LeaveGuild { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("users/@me/guilds/{guild_id}", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("users/@me/guilds/{GUILD_ID}"));
     }
 
     #[test]
@@ -4429,11 +4046,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/pins/{message_id}",
-                channel_id = CHANNEL_ID,
-                message_id = MESSAGE_ID
-            )
+            format!("channels/{CHANNEL_ID}/pins/{MESSAGE_ID}")
         );
     }
 
@@ -4445,11 +4058,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "channels/{channel_id}/pins/{message_id}",
-                channel_id = CHANNEL_ID,
-                message_id = MESSAGE_ID
-            )
+            format!("channels/{CHANNEL_ID}/pins/{MESSAGE_ID}")
         );
     }
 
@@ -4461,21 +4070,14 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/integrations/{integration_id}/sync",
-                guild_id = GUILD_ID,
-                integration_id = INTEGRATION_ID
-            )
+            format!("guilds/{GUILD_ID}/integrations/{INTEGRATION_ID}/sync")
         );
     }
 
     #[test]
     fn test_update_current_member() {
         let route = Route::UpdateCurrentMember { guild_id: GUILD_ID };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/members/@me", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/members/@me"));
     }
 
     #[test]
@@ -4483,7 +4085,7 @@ mod tests {
         let route = Route::UpdateCurrentUserVoiceState { guild_id: GUILD_ID };
         assert_eq!(
             route.to_string(),
-            format!("guilds/{guild_id}/voice-states/@me", guild_id = GUILD_ID)
+            format!("guilds/{GUILD_ID}/voice-states/@me")
         );
     }
 
@@ -4492,7 +4094,7 @@ mod tests {
         let route = Route::UpdateNickname { guild_id: GUILD_ID };
         assert_eq!(
             route.to_string(),
-            format!("guilds/{guild_id}/members/@me/nick", guild_id = GUILD_ID)
+            format!("guilds/{GUILD_ID}/members/@me/nick")
         );
     }
 
@@ -4504,11 +4106,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/voice-states/{user_id}",
-                guild_id = GUILD_ID,
-                user_id = USER_ID
-            )
+            format!("guilds/{GUILD_ID}/voice-states/{USER_ID}")
         );
     }
 
@@ -4521,11 +4119,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/bans/{user_id}?",
-                guild_id = GUILD_ID,
-                user_id = USER_ID
-            )
+            format!("guilds/{GUILD_ID}/bans/{USER_ID}?")
         );
 
         route = Route::CreateBan {
@@ -4535,11 +4129,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/bans/{user_id}?delete_message_days=3",
-                guild_id = GUILD_ID,
-                user_id = USER_ID
-            )
+            format!("guilds/{GUILD_ID}/bans/{USER_ID}?delete_message_days=3")
         );
     }
 
@@ -4551,10 +4141,7 @@ mod tests {
             guild_id: GUILD_ID,
             include_roles: &[],
         };
-        assert_eq!(
-            route.to_string(),
-            format!("guilds/{guild_id}/prune?", guild_id = GUILD_ID)
-        );
+        assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/prune?"));
     }
 
     #[test]
@@ -4567,10 +4154,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/prune?compute_prune_count=true",
-                guild_id = GUILD_ID
-            )
+            format!("guilds/{GUILD_ID}/prune?compute_prune_count=true")
         );
     }
 
@@ -4584,10 +4168,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/prune?compute_prune_count=false",
-                guild_id = GUILD_ID
-            )
+            format!("guilds/{GUILD_ID}/prune?compute_prune_count=false")
         );
     }
 
@@ -4601,7 +4182,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!("guilds/{guild_id}/prune?&days=4", guild_id = GUILD_ID)
+            format!("guilds/{GUILD_ID}/prune?&days=4")
         );
     }
 
@@ -4617,10 +4198,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/prune?&include_roles=1",
-                guild_id = GUILD_ID
-            )
+            format!("guilds/{GUILD_ID}/prune?&include_roles=1")
         );
     }
 
@@ -4636,10 +4214,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/prune?&include_roles=1,2",
-                guild_id = GUILD_ID
-            )
+            format!("guilds/{GUILD_ID}/prune?&include_roles=1,2")
         );
     }
 
@@ -4655,10 +4230,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/prune?compute_prune_count=true&days=4&include_roles=1,2",
-                guild_id = GUILD_ID
-            )
+            format!("guilds/{GUILD_ID}/prune?compute_prune_count=true&days=4&include_roles=1,2")
         );
     }
 
@@ -4671,7 +4243,7 @@ mod tests {
 
         assert_eq!(
             route.to_string(),
-            format!("guilds/{guild_id}/scheduled-events?", guild_id = GUILD_ID)
+            format!("guilds/{GUILD_ID}/scheduled-events?")
         );
 
         let route = Route::GetGuildScheduledEvents {
@@ -4681,10 +4253,7 @@ mod tests {
 
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/scheduled-events?with_user_count=true",
-                guild_id = GUILD_ID
-            )
+            format!("guilds/{GUILD_ID}/scheduled-events?with_user_count=true")
         );
     }
 
@@ -4694,7 +4263,7 @@ mod tests {
 
         assert_eq!(
             route.to_string(),
-            format!("guilds/{guild_id}/scheduled-events", guild_id = GUILD_ID)
+            format!("guilds/{GUILD_ID}/scheduled-events")
         );
     }
 
@@ -4708,11 +4277,7 @@ mod tests {
 
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/scheduled-events/{scheduled_event_id}",
-                guild_id = GUILD_ID,
-                scheduled_event_id = SCHEDULED_EVENT_ID
-            )
+            format!("guilds/{GUILD_ID}/scheduled-events/{SCHEDULED_EVENT_ID}")
         );
 
         let route = Route::GetGuildScheduledEvent {
@@ -4723,11 +4288,7 @@ mod tests {
 
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/scheduled-events/{scheduled_event_id}?with_user_count=true",
-                guild_id = GUILD_ID,
-                scheduled_event_id = SCHEDULED_EVENT_ID
-            )
+            format!("guilds/{GUILD_ID}/scheduled-events/{SCHEDULED_EVENT_ID}?with_user_count=true")
         );
     }
 
@@ -4740,11 +4301,7 @@ mod tests {
 
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/scheduled-events/{scheduled_event_id}",
-                guild_id = GUILD_ID,
-                scheduled_event_id = SCHEDULED_EVENT_ID
-            )
+            format!("guilds/{GUILD_ID}/scheduled-events/{SCHEDULED_EVENT_ID}")
         );
     }
 
@@ -4757,11 +4314,7 @@ mod tests {
 
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/scheduled-events/{scheduled_event_id}",
-                guild_id = GUILD_ID,
-                scheduled_event_id = SCHEDULED_EVENT_ID
-            )
+            format!("guilds/{GUILD_ID}/scheduled-events/{SCHEDULED_EVENT_ID}")
         );
     }
 
@@ -4779,10 +4332,7 @@ mod tests {
         assert_eq!(
             route.to_string(),
             format!(
-                "guilds/{guild_id}/scheduled-events/{scheduled_event_id}/users?&before={user_id}&with_member=true",
-                guild_id = GUILD_ID,
-                scheduled_event_id = SCHEDULED_EVENT_ID,
-                user_id = USER_ID,
+                "guilds/{GUILD_ID}/scheduled-events/{SCHEDULED_EVENT_ID}/users?&before={USER_ID}&with_member=true"
             )
         );
 
@@ -4798,10 +4348,7 @@ mod tests {
         assert_eq!(
             route.to_string(),
             format!(
-                "guilds/{guild_id}/scheduled-events/{scheduled_event_id}/users?after={user_id}&limit=101",
-                guild_id = GUILD_ID,
-                scheduled_event_id = SCHEDULED_EVENT_ID,
-                user_id = USER_ID,
+                "guilds/{GUILD_ID}/scheduled-events/{SCHEDULED_EVENT_ID}/users?after={USER_ID}&limit=101"
             )
         );
 
@@ -4817,11 +4364,7 @@ mod tests {
         assert_eq!(
             route.to_string(),
             format!(
-                "guilds/{guild_id}/scheduled-events/{scheduled_event_id}/users?after={after}&before={before}&limit=99",
-                after = USER_ID,
-                before = USER_ID,
-                guild_id = GUILD_ID,
-                scheduled_event_id = SCHEDULED_EVENT_ID,
+                "guilds/{GUILD_ID}/scheduled-events/{SCHEDULED_EVENT_ID}/users?after={USER_ID}&before={USER_ID}&limit=99"
             )
         );
     }
@@ -4836,10 +4379,7 @@ mod tests {
 
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/members/search?query=foo%20bar&limit=99",
-                guild_id = GUILD_ID,
-            )
+            format!("guilds/{GUILD_ID}/members/search?query=foo%20bar&limit=99")
         );
 
         let route = Route::SearchGuildMembers {
@@ -4850,10 +4390,7 @@ mod tests {
 
         assert_eq!(
             route.to_string(),
-            format!(
-                "guilds/{guild_id}/members/search?query=foo%2Fbar&limit=99",
-                guild_id = GUILD_ID,
-            )
+            format!("guilds/{GUILD_ID}/members/search?query=foo%2Fbar&limit=99")
         );
     }
 }

--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -171,7 +171,7 @@ impl Lavalink {
     ///
     /// [crate documentation]: crate#examples
     pub async fn process(&self, event: &Event) -> Result<(), ClientError> {
-        tracing::trace!("processing event: {:?}", event);
+        tracing::trace!("processing event: {event:?}");
 
         let guild_id = match event {
             Event::Ready(e) => {
@@ -186,7 +186,7 @@ impl Lavalink {
                     self.server_updates.insert(guild_id, e.clone().into());
                     guild_id
                 } else {
-                    tracing::trace!("event has no guild ID: {:?}", e);
+                    tracing::trace!("event has no guild ID: {e:?}");
                     return Ok(());
                 }
             }
@@ -211,18 +211,14 @@ impl Lavalink {
                     }
                     guild_id
                 } else {
-                    tracing::trace!("event has no guild ID: {:?}", e);
+                    tracing::trace!("event has no guild ID: {e:?}");
                     return Ok(());
                 }
             }
             _ => return Ok(()),
         };
 
-        tracing::debug!(
-            "got voice server/state update for {:?}: {:?}",
-            guild_id,
-            event
-        );
+        tracing::debug!("got voice server/state update for {guild_id:?}: {event:?}");
 
         let update = {
             let server = self.server_updates.get(&guild_id);
@@ -232,25 +228,20 @@ impl Lavalink {
                     let server = server.value();
                     let session = session.value();
                     tracing::debug!(
-                        "got both halves for {}: {:?}; Session ID: {:?}",
-                        guild_id,
-                        server,
-                        session,
+                        "got both halves for {guild_id}: {server:?}; Session ID: {session:?}",
                     );
                     VoiceUpdate::new(guild_id, session.as_ref(), server.clone())
                 }
                 (Some(server), None) => {
                     tracing::debug!(
-                        "guild {} is now waiting for other half; got: {:?}",
-                        guild_id,
+                        "guild {guild_id} is now waiting for other half; got: {:?}",
                         server.value()
                     );
                     return Ok(());
                 }
                 (None, Some(session)) => {
                     tracing::debug!(
-                        "guild {} is now waiting for other half; got session ID: {:?}",
-                        guild_id,
+                        "guild {guild_id} is now waiting for other half; got session ID: {:?}",
                         session.value()
                     );
                     return Ok(());
@@ -259,18 +250,18 @@ impl Lavalink {
             }
         };
 
-        tracing::debug!("getting player for guild {}", guild_id);
+        tracing::debug!("getting player for guild {guild_id}");
 
         let player = self.player(guild_id).await?;
 
-        tracing::debug!("sending voice update for guild {}: {:?}", guild_id, update);
+        tracing::debug!("sending voice update for guild {guild_id}: {update:?}");
 
         player.send(update).map_err(|source| ClientError {
             kind: ClientErrorType::SendingVoiceUpdate,
             source: Some(Box::new(source)),
         })?;
 
-        tracing::debug!("sent voice update for guild {}", guild_id);
+        tracing::debug!("sent voice update for guild {guild_id}");
 
         Ok(())
     }

--- a/lavalink/src/http.rs
+++ b/lavalink/src/http.rs
@@ -254,7 +254,7 @@ pub fn load_track(
 ) -> Result<Request<&'static [u8]>, HttpError> {
     let identifier =
         percent_encoding::percent_encode(identifier.as_ref().as_bytes(), NON_ALPHANUMERIC);
-    let url = format!("http://{}/loadtracks?identifier={}", address, identifier);
+    let url = format!("http://{address}/loadtracks?identifier={identifier}");
 
     let mut req = Request::get(url);
 
@@ -272,7 +272,7 @@ pub fn get_route_planner(
     address: SocketAddr,
     authorization: impl AsRef<str>,
 ) -> Result<Request<&'static [u8]>, HttpError> {
-    let mut req = Request::get(format!("{}/routeplanner/status", address));
+    let mut req = Request::get(format!("{address}/routeplanner/status"));
 
     let auth_value = HeaderValue::from_str(authorization.as_ref())?;
     req = req.header(AUTHORIZATION, auth_value);

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -490,9 +490,8 @@ impl Connection {
                 outgoing = self.node_from.recv() => {
                     if let Some(outgoing) = outgoing {
                         tracing::debug!(
-                            "forwarding event to {}: {:?}",
+                            "forwarding event to {}: {outgoing:?}",
                             self.config.address,
-                            outgoing
                         );
 
                         let payload = serde_json::to_string(&outgoing).map_err(|source| NodeError {
@@ -515,9 +514,8 @@ impl Connection {
 
     async fn incoming(&mut self, incoming: Message) -> Result<bool, NodeError> {
         tracing::debug!(
-            "received message from {}: {:?}",
+            "received message from {}: {incoming:?}",
             self.config.address,
-            incoming
         );
 
         let text = match incoming {
@@ -538,7 +536,7 @@ impl Connection {
             }
             Message::Text(text) => text,
             other => {
-                tracing::debug!("got pong or bytes payload: {:?}", other);
+                tracing::debug!("got pong or bytes payload: {other:?}");
 
                 return Ok(true);
             }
@@ -547,7 +545,7 @@ impl Connection {
         let event = if let Ok(event) = serde_json::from_str(&text) {
             event
         } else {
-            tracing::warn!("unknown message from lavalink node: {}", text);
+            tracing::warn!("unknown message from lavalink node: {text}");
 
             return Ok(true);
         };
@@ -572,9 +570,8 @@ impl Connection {
             player
         } else {
             tracing::warn!(
-                "invalid player update for guild {}: {:?}",
+                "invalid player update for guild {}: {update:?}",
                 update.guild_id,
-                update,
             );
 
             return Ok(());
@@ -661,7 +658,7 @@ async fn backoff(
         match tokio_tungstenite::connect_async(req).await {
             Ok((stream, res)) => return Ok((stream, res)),
             Err(source) => {
-                tracing::warn!("failed to connect to node {}: {:?}", source, config.address);
+                tracing::warn!("failed to connect to node {source}: {:?}", config.address);
 
                 if matches!(&source, TungsteniteError::Http(resp) if resp.status() == StatusCode::UNAUTHORIZED)
                 {
@@ -684,8 +681,7 @@ async fn backoff(
                 }
 
                 tracing::debug!(
-                    "waiting {} seconds before attempting to connect to node {} again",
-                    seconds,
+                    "waiting {seconds} seconds before attempting to connect to node {} again",
                     config.address,
                 );
                 tokio_time::sleep(Duration::from_secs(seconds)).await;

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -143,11 +143,7 @@ impl Player {
     }
 
     fn _send(&self, event: OutgoingEvent) -> Result<(), NodeSenderError> {
-        tracing::debug!(
-            "sending event on guild player {}: {:?}",
-            self.guild_id,
-            event
-        );
+        tracing::debug!("sending event on guild player {}: {event:?}", self.guild_id,);
 
         match &event {
             OutgoingEvent::Pause(event) => self.paused.store(event.pause, Ordering::Release),

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -143,7 +143,7 @@ impl Player {
     }
 
     fn _send(&self, event: OutgoingEvent) -> Result<(), NodeSenderError> {
-        tracing::debug!("sending event on guild player {}: {event:?}", self.guild_id,);
+        tracing::debug!("sending event on guild player {}: {event:?}", self.guild_id);
 
         match &event {
             OutgoingEvent::Pause(event) => self.paused.store(event.pause, Ordering::Release),

--- a/mention/benches/fmt.rs
+++ b/mention/benches/fmt.rs
@@ -7,7 +7,7 @@ use twilight_model::id::{
 };
 
 fn format_id<T: Display>(input: &mut String, formatter: &T) {
-    input.write_fmt(format_args!("{}", formatter)).unwrap();
+    input.write_fmt(format_args!("{formatter}")).unwrap();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/model/src/application/command/option.rs
+++ b/model/src/application/command/option.rs
@@ -239,7 +239,7 @@ impl<'de> Visitor<'de> for OptionVisitor {
                 Err(why) => {
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!("ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {why:?}");
 
                     continue;
                 }

--- a/model/src/application/component/mod.rs
+++ b/model/src/application/component/mod.rs
@@ -151,7 +151,7 @@ impl<'de> Visitor<'de> for ComponentVisitor {
                     // Encountered when we run into an unknown key.
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!("ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {why:?}");
 
                     continue;
                 }

--- a/model/src/application/interaction/application_command/option.rs
+++ b/model/src/application/interaction/application_command/option.rs
@@ -129,7 +129,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         Err(why) => {
                             map.next_value::<IgnoredAny>()?;
 
-                            tracing::trace!("ran into an unknown key: {:?}", why);
+                            tracing::trace!("ran into an unknown key: {why:?}");
 
                             continue;
                         }

--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -180,7 +180,7 @@ impl<'de> Visitor<'de> for InteractionVisitor {
                     // Encountered when we run into an unknown key.
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!("ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {why:?}");
 
                     continue;
                 }

--- a/model/src/channel/reaction.rs
+++ b/model/src/channel/reaction.rs
@@ -68,7 +68,7 @@ impl<'de> Visitor<'de> for ReactionVisitor {
                     // Encountered when we run into an unknown key.
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!("ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {why:?}");
 
                     continue;
                 }

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -344,7 +344,7 @@ impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
                         Err(why) => {
                             map.next_value::<IgnoredAny>()?;
 
-                            tracing::trace!("ran into an unknown key: {:?}", why);
+                            tracing::trace!("ran into an unknown key: {why:?}");
 
                             continue;
                         }

--- a/model/src/gateway/payload/incoming/member_chunk.rs
+++ b/model/src/gateway/payload/incoming/member_chunk.rs
@@ -74,7 +74,7 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
                     // Encountered when we run into an unknown key.
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!("ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {why:?}");
 
                     continue;
                 }

--- a/model/src/gateway/payload/incoming/typing_start.rs
+++ b/model/src/gateway/payload/incoming/typing_start.rs
@@ -66,7 +66,7 @@ impl<'de> Visitor<'de> for TypingStartVisitor {
                     // Encountered when we run into an unknown key.
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!("ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {why:?}");
 
                     continue;
                 }

--- a/model/src/gateway/presence/activity_button.rs
+++ b/model/src/gateway/presence/activity_button.rs
@@ -141,7 +141,7 @@ impl<'de> Visitor<'de> for ActivityButtonVisitor {
                     // Encountered when we run into an unknown key.
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!("ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {why:?}");
 
                     continue;
                 }

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -261,7 +261,7 @@ impl<'de> Deserialize<'de> for Guild {
                             // Encountered when we run into an unknown key.
                             map.next_value::<IgnoredAny>()?;
 
-                            tracing::trace!("ran into an unknown key: {:?}", why);
+                            tracing::trace!("ran into an unknown key: {why:?}");
 
                             continue;
                         }

--- a/model/src/id/mod.rs
+++ b/model/src/id/mod.rs
@@ -99,7 +99,7 @@ impl<T> Id<T> {
     ///
     /// const ID: Id<GenericMarker> = Id::new(123);
     ///
-    /// println!("id: {}", ID);
+    /// println!("id: {ID}");
     /// ```
     ///
     /// # Panics
@@ -506,7 +506,7 @@ mod tests {
     fn test_debug() {
         let id = Id::<RoleMarker>::new(114_941_315_417_899_012);
 
-        assert_eq!("Id<RoleMarker>(114941315417899012)", format!("{:?}", id));
+        assert_eq!("Id<RoleMarker>(114941315417899012)", format!("{id:?}"));
     }
 
     /// Test that display formatting an ID formats the value.

--- a/model/src/user/mod.rs
+++ b/model/src/user/mod.rs
@@ -62,7 +62,7 @@ pub(crate) mod discriminator {
 ///
 /// This may be preferable to use instead of using `format!` to avoid a String
 /// allocation, and may also be preferable to use rather than defining your own
-/// implementations via `format_args!("{:04}", discriminator)`.
+/// implementations via `format_args!("{discriminator:04}")`.
 ///
 /// # Examples
 ///

--- a/model/src/voice/voice_state.rs
+++ b/model/src/voice/voice_state.rs
@@ -106,7 +106,7 @@ impl<'de> Visitor<'de> for VoiceStateVisitor {
                     // Encountered when we run into an unknown key.
                     map.next_value::<IgnoredAny>()?;
 
-                    tracing::trace!("ran into an unknown key: {:?}", why);
+                    tracing::trace!("ran into an unknown key: {why:?}");
 
                     continue;
                 }

--- a/twilight/src/lib.rs
+++ b/twilight/src/lib.rs
@@ -183,7 +183,7 @@
 //!                 .await?;
 //!         }
 //!         Event::ShardConnected(_) => {
-//!             println!("Connected on shard {}", shard_id);
+//!             println!("Connected on shard {shard_id}");
 //!         }
 //!         // Other events here...
 //!         _ => {}

--- a/util/src/builder/embed/image_source.rs
+++ b/util/src/builder/embed/image_source.rs
@@ -159,7 +159,7 @@ impl ImageSource {
             });
         }
 
-        Ok(Self(format!("attachment://{}", filename)))
+        Ok(Self(format!("attachment://{filename}")))
     }
 
     /// Create a URL image source.

--- a/validate/src/request.rs
+++ b/validate/src/request.rs
@@ -1061,8 +1061,7 @@ mod tests {
         assert_eq!(expected, actual.to_string());
 
         let expected = format!(
-            "provided username length is 200, but it must be at least {} and at most {}",
-            USERNAME_LIMIT_MIN, USERNAME_LIMIT_MAX
+            "provided username length is 200, but it must be at least {USERNAME_LIMIT_MIN} and at most {USERNAME_LIMIT_MAX}",
         );
         let actual = ValidationError {
             kind: ValidationErrorType::Username {

--- a/validate/src/request.rs
+++ b/validate/src/request.rs
@@ -1048,8 +1048,8 @@ mod tests {
     #[test]
     fn test_username_variants() {
         let expected = format!(
-            "provided username length is 200, but it must be at least {USERNAME_LIMIT_MIN} and at most {USERNAME_LIMIT_MAX}, and \
-            cannot contain :"
+            "provided username length is 200, but it must be at least {USERNAME_LIMIT_MIN} and at \
+            most {USERNAME_LIMIT_MAX}, and cannot contain :"
         );
         let actual = ValidationError {
             kind: ValidationErrorType::Username {
@@ -1060,7 +1060,8 @@ mod tests {
         assert_eq!(expected, actual.to_string());
 
         let expected = format!(
-            "provided username length is 200, but it must be at least {USERNAME_LIMIT_MIN} and at most {USERNAME_LIMIT_MAX}",
+            "provided username length is 200, but it must be at least {USERNAME_LIMIT_MIN} and at \
+            most {USERNAME_LIMIT_MAX}",
         );
         let actual = ValidationError {
             kind: ValidationErrorType::Username {

--- a/validate/src/request.rs
+++ b/validate/src/request.rs
@@ -1048,9 +1048,8 @@ mod tests {
     #[test]
     fn test_username_variants() {
         let expected = format!(
-            "provided username length is 200, but it must be at least {} and at most {}, and \
-            cannot contain :",
-            USERNAME_LIMIT_MIN, USERNAME_LIMIT_MAX
+            "provided username length is 200, but it must be at least {USERNAME_LIMIT_MIN} and at most {USERNAME_LIMIT_MAX}, and \
+            cannot contain :"
         );
         let actual = ValidationError {
             kind: ValidationErrorType::Username {


### PR DESCRIPTION
This feature was stabilized in 1.58: use it everywhere.
<https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html#captured-identifiers-in-format-strings>
