### PR TITLE
feat(model): add `MANAGE_EVENTS` permission flag

### DIFF
--- a/model/src/guild/permissions.rs
+++ b/model/src/guild/permissions.rs
@@ -40,6 +40,8 @@ bitflags! {
         const MANAGE_EMOJIS_AND_STICKERS = 1 << 30;
         const USE_SLASH_COMMANDS = 1 << 31;
         const REQUEST_TO_SPEAK = 1 << 32;
+        /// Allows for creating, editing, and deleting scheduled events.
+        const MANAGE_EVENTS = 1 << 33;
         /// Allows for deleting and archiving threads, and viewing all private threads.
         const MANAGE_THREADS = 1 << 34;
         /// Allows for creating public threads.


### PR DESCRIPTION
This adds the `MANAGE_EVENTS` permission flag (1 << 33).

Reference: https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags