### PR TITLE
docs(model): modal submits valid for `DeferredUpdateMessage` and `UpdateMessage`

### DIFF
--- a/model/src/http/interaction.rs
+++ b/model/src/http/interaction.rs
@@ -92,11 +92,11 @@ pub enum InteractionResponseType {
     /// Acknowledges a component interaction, allowing for the message to be
     /// edited later.
     ///
-    /// This is only valid for components.
+    /// This is only valid for components and modal submits.
     DeferredUpdateMessage = 6,
     /// Acknowledges a component interaction and edits the message.
     ///
-    /// This is only valid for components.
+    /// This is only valid for components and modal submits.
     UpdateMessage = 7,
     /// Respond to an autocomplete interaction with suggested choices.
     ApplicationCommandAutocompleteResult = 8,


### PR DESCRIPTION
I've done some testing and `Interaction::ModalSubmit` seems to be allowed to be responded to with these types, `DeferredChannelMessageWithSource` is still allowed but it creates another deferred message that replies to the bot's original message.