### PR TITLE
Add method to retrieve token of interaction

### DIFF
--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -87,6 +87,17 @@ impl Interaction {
         }
     }
 
+    /// Return the token of the inner interaction.
+    pub fn token(&self) -> &str {
+        match self {
+            Interaction::Ping(ping) => &ping.token,
+            Interaction::ApplicationCommand(command) => &command.token,
+            Interaction::ApplicationCommandAutocomplete(command) => &command.token,
+            Interaction::MessageComponent(component) => &component.token,
+            Interaction::ModalSubmit(modal) => &modal.token,
+        }
+    }
+
     /// Type of interaction.
     pub const fn kind(&self) -> InteractionType {
         match self {

--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -87,17 +87,6 @@ impl Interaction {
         }
     }
 
-    /// Return the token of the inner interaction.
-    pub fn token(&self) -> &str {
-        match self {
-            Self::Ping(ping) => &ping.token,
-            Self::ApplicationCommand(command) => &command.token,
-            Self::ApplicationCommandAutocomplete(command) => &command.token,
-            Self::MessageComponent(component) => &component.token,
-            Self::ModalSubmit(modal) => &modal.token,
-        }
-    }
-
     /// Type of interaction.
     pub const fn kind(&self) -> InteractionType {
         match self {
@@ -108,6 +97,17 @@ impl Interaction {
             }
             Interaction::MessageComponent(_) => InteractionType::MessageComponent,
             Interaction::ModalSubmit(_) => InteractionType::ModalSubmit,
+        }
+    }
+
+    /// Token of the interaction.
+    pub fn token(&self) -> &str {
+        match self {
+            Self::Ping(ping) => &ping.token,
+            Self::ApplicationCommand(command) => &command.token,
+            Self::ApplicationCommandAutocomplete(command) => &command.token,
+            Self::MessageComponent(component) => &component.token,
+            Self::ModalSubmit(modal) => &modal.token,
         }
     }
 }

--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -90,11 +90,11 @@ impl Interaction {
     /// Return the token of the inner interaction.
     pub fn token(&self) -> &str {
         match self {
-            Interaction::Ping(ping) => &ping.token,
-            Interaction::ApplicationCommand(command) => &command.token,
-            Interaction::ApplicationCommandAutocomplete(command) => &command.token,
-            Interaction::MessageComponent(component) => &component.token,
-            Interaction::ModalSubmit(modal) => &modal.token,
+            Self::Ping(ping) => &ping.token,
+            Self::ApplicationCommand(command) => &command.token,
+            Self::ApplicationCommandAutocomplete(command) => &command.token,
+            Self::MessageComponent(component) => &component.token,
+            Self::ModalSubmit(modal) => &modal.token,
         }
     }
 


### PR DESCRIPTION
All variants of `Interaction` contain a token and most methods only require a reference to it, so this method would be very convenient and be used frequently

There's the possible overhead of unnecessary matches on the 5 variants of `Interaction` but i'd assume it's very very tiny

This also can't be `const` because of the coercion from `String` to `&str`