### PR TITLE
ci: add dependabot monitoring of github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
Monitoring github actions' versions is tedious task that's better left to be automated.
Note that rust dependencies are *excluded* and are left for us humans to monitor.
