### PR TITLE
fix: pin dashmap version

### DIFF
--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.10.2"
 
 [dependencies]
 bitflags = { default-features = false, version = "1" }
-dashmap = { default-features = false, version = "5.1" }
+dashmap = { default-features = false, version = ">= 5.1, < 5.3" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 twilight-model = { default-features = false, path = "../../model" }
 

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/twilight-rs/twilight.git"
 version = "0.10.2"
 
 [dependencies]
-dashmap = { default-features = false, version = "5.1" }
+dashmap = { default-features = false, version = ">= 5.1, < 5.3" }
 futures-util = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3" }
 http = { default-features = false, version = "0.2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }

--- a/standby/Cargo.toml
+++ b/standby/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.57"
 version = "0.10.0"
 
 [dependencies]
-dashmap = { default-features = false, version = "5.1" }
+dashmap = { default-features = false, version = ">= 5.1, < 5.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 tokio = { default-features = false, features = ["sync"], version = "1.0" }
 twilight-model = { default-features = false, path = "../model" }


### PR DESCRIPTION
[`dashmap` v5.3.0](https://github.com/xacrimon/dashmap/releases/tag/v5.3.0) introduced a MSRV breaking change which makes the CI fails ([example](https://github.com/twilight-rs/twilight/runs/6241189438)). This pins the dashmap version to any semver version below `5.3` to fix the CI while waiting to bump the MSRV.

See also https://github.com/twilight-rs/twilight/pull/1699