### PR TITLE
fix(cache): correct `channel_messages` max len

### DIFF
--- a/cache/in-memory/src/event/message.rs
+++ b/cache/in-memory/src/event/message.rs
@@ -28,7 +28,7 @@ impl UpdateCache for MessageCreate {
         // requested then we pop a message ID out. Once we have the popped ID we
         // can remove it from the message cache. This prevents the cache from
         // filling up with old messages that aren't in any channel cache.
-        if channel_messages.len() > cache.config.message_cache_size() {
+        if channel_messages.len() >= cache.config.message_cache_size() {
             if let Some(popped_id) = channel_messages.pop_back() {
                 cache.messages.remove(&popped_id);
             }
@@ -145,7 +145,7 @@ mod tests {
         let joined_at = Timestamp::from_secs(1_632_072_645).expect("non zero");
         let cache = InMemoryCache::builder()
             .resource_types(ResourceType::MESSAGE | ResourceType::MEMBER | ResourceType::USER)
-            .message_cache_size(1)
+            .message_cache_size(2)
             .build();
 
         let avatar = ImageHash::parse(b"e91c75bc7656063cc745f4e79d0b7664")?;


### PR DESCRIPTION
A cache configured with `message_cache_size(1)` could fit up to two messages instead of one.

This corrects it to fit upto the configured value.

Closes #1696
