### PR TITLE
fix(http)!: `CreateMessage` take a boolean option for `fail_if_not_exists`

### DIFF
--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -214,6 +214,8 @@ impl<'a> CreateMessage<'a> {
     }
 
     /// Whether to fail sending if the reply no longer exists.
+    ///
+    /// Defaults to [`true`].
     pub const fn fail_if_not_exists(mut self, fail_if_not_exists: bool) -> Self {
         // Clippy recommends using `Option::map_or_else` which is not `const`.
         #[allow(clippy::option_if_let_else)]

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -214,12 +214,12 @@ impl<'a> CreateMessage<'a> {
     }
 
     /// Whether to fail sending if the reply no longer exists.
-    pub const fn fail_if_not_exists(mut self) -> Self {
+    pub const fn fail_if_not_exists(mut self, fail_if_not_exists: bool) -> Self {
         // Clippy recommends using `Option::map_or_else` which is not `const`.
         #[allow(clippy::option_if_let_else)]
         let reference = if let Some(reference) = self.fields.message_reference {
             MessageReference {
-                fail_if_not_exists: Some(true),
+                fail_if_not_exists: Some(fail_if_not_exists),
                 ..reference
             }
         } else {
@@ -227,7 +227,7 @@ impl<'a> CreateMessage<'a> {
                 channel_id: None,
                 guild_id: None,
                 message_id: None,
-                fail_if_not_exists: Some(true),
+                fail_if_not_exists: Some(fail_if_not_exists),
             }
         };
 


### PR DESCRIPTION
Currently it is not possible to set the `fail_if_not_exists` property to `false`. This changes that by adding a boolean option to `fail_if_not_exists` so the user can indicate whether to fail or not.

Closes: #1676