### PR TITLE
fix(gateway)!: remove duplicate `EventTypeFlags` value

### DIFF
--- a/gateway/src/event.rs
+++ b/gateway/src/event.rs
@@ -17,7 +17,7 @@ bitflags! {
         /// Channel has been updated.
         const CHANNEL_UPDATE = 1 << 5;
         /// A command's permissions has been updated.
-        const COMMAND_PERMISSIONS_UPDATE = 1 << 69;
+        const COMMAND_PERMISSIONS_UPDATE = 1 << 70;
         /// Heartbeat has been created.
         const GATEWAY_HEARTBEAT = 1 << 6;
         /// Heartbeat has been acknowledged.


### PR DESCRIPTION
`COMMAND_PERMISSIONS_UPDATE` was accidentally duplicated, this PR fixes that.
