### PR TITLE
refactor(http-ratelimiting): cleanup `InMemory::entry`

### DIFF
--- a/http-ratelimiting/src/headers.rs
+++ b/http-ratelimiting/src/headers.rs
@@ -549,9 +549,13 @@ impl RatelimitHeaders {
 /// Parse a value as a boolean.
 fn header_bool(name: HeaderName, value: &[u8]) -> Result<bool, HeaderParsingError> {
     let text = header_str(name, value)?;
-    
+
     let end = text.parse().map_err(|source| HeaderParsingError {
-        kind: HeaderParsingErrorType::Parsing { kind: HeaderType::Bool, name, value: text.to_owned() },
+        kind: HeaderParsingErrorType::Parsing {
+            kind: HeaderType::Bool,
+            name,
+            value: text.to_owned(),
+        },
         source: Some(Box::new(source)),
     })?;
 

--- a/http-ratelimiting/src/headers.rs
+++ b/http-ratelimiting/src/headers.rs
@@ -195,6 +195,8 @@ impl Display for HeaderName {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum HeaderType {
+    /// Type of header value is a bool.
+    Bool,
     /// Type of header value is a float.
     Float,
     /// Type of header value is an integer.
@@ -207,6 +209,7 @@ impl HeaderType {
     /// Name of the type of header.
     const fn name(self) -> &'static str {
         match self {
+            Self::Bool => "bool",
             Self::Float => "float",
             Self::Integer => "integer",
             Self::String => "string",
@@ -473,7 +476,7 @@ impl RatelimitHeaders {
                     bucket.replace(header_str(HeaderName::Bucket, value)?);
                 }
                 HeaderName::GLOBAL => {
-                    global = header_bool(value);
+                    global = header_bool(HeaderName::Global, value)?;
                 }
                 HeaderName::LIMIT => {
                     limit.replace(header_int(HeaderName::Limit, value)?);
@@ -544,14 +547,20 @@ impl RatelimitHeaders {
 }
 
 /// Parse a value as a boolean.
-fn header_bool(value: &[u8]) -> bool {
-    value == b"true"
+fn header_bool(name: HeaderName, value: &[u8]) -> Result<bool, HeaderParsingError> {
+    let text = header_str(name, value)?;
+    
+    let end = text.parse().map_err(|source| HeaderParsingError {
+        kind: HeaderParsingErrorType::Parsing { kind: HeaderType::Bool, name: name, value: text.to_owned() },
+        source: Some(Box::new(source)),
+    })?;
+
+    Ok(end)
 }
 
 /// Parse a value expected to be a float.
 fn header_float(name: HeaderName, value: &[u8]) -> Result<f64, HeaderParsingError> {
-    let text = str::from_utf8(value)
-        .map_err(|source| HeaderParsingError::not_utf8(name, value.to_owned(), source))?;
+    let text = header_str(name, value)?;
 
     let end = text.parse().map_err(|source| HeaderParsingError {
         kind: HeaderParsingErrorType::Parsing {
@@ -567,8 +576,7 @@ fn header_float(name: HeaderName, value: &[u8]) -> Result<f64, HeaderParsingErro
 
 /// Parse a value expected to be an integer.
 fn header_int(name: HeaderName, value: &[u8]) -> Result<u64, HeaderParsingError> {
-    let text = str::from_utf8(value)
-        .map_err(|source| HeaderParsingError::not_utf8(name, value.to_owned(), source))?;
+    let text = header_str(name, value)?;
 
     let end = text.parse().map_err(|source| HeaderParsingError {
         kind: HeaderParsingErrorType::Parsing {
@@ -782,6 +790,7 @@ mod tests {
 
     #[test]
     fn test_type() {
+        assert_eq!("bool", HeaderType::Bool.name());
         assert_eq!("float", HeaderType::Float.name());
         assert_eq!("integer", HeaderType::Integer.name());
         assert_eq!("string", HeaderType::String.name());

--- a/http-ratelimiting/src/headers.rs
+++ b/http-ratelimiting/src/headers.rs
@@ -551,7 +551,7 @@ fn header_bool(name: HeaderName, value: &[u8]) -> Result<bool, HeaderParsingErro
     let text = header_str(name, value)?;
     
     let end = text.parse().map_err(|source| HeaderParsingError {
-        kind: HeaderParsingErrorType::Parsing { kind: HeaderType::Bool, name: name, value: text.to_owned() },
+        kind: HeaderParsingErrorType::Parsing { kind: HeaderType::Bool, name, value: text.to_owned() },
         source: Some(Box::new(source)),
     })?;
 

--- a/http-ratelimiting/src/in_memory/mod.rs
+++ b/http-ratelimiting/src/in_memory/mod.rs
@@ -146,6 +146,7 @@ impl Ratelimiter for InMemoryRatelimiter {
         tracing::debug!("getting bucket for path: {:?}", path);
 
         let (tx, rx) = ticket::channel();
+
         if let Some(bucket) = self.entry(path.clone(), tx) {
             tokio::spawn(
                 BucketQueueTask::new(

--- a/http-ratelimiting/src/in_memory/mod.rs
+++ b/http-ratelimiting/src/in_memory/mod.rs
@@ -72,7 +72,7 @@ impl InMemoryRatelimiter {
         Self::default()
     }
 
-    /// Enqueue the [`TicketNotifier`] to its [`Bucket`].
+    /// Enqueue the [`TicketNotifier`] to the [`Path`]'s [`Bucket`].
     ///
     /// Returns the new [`Bucket`] if none existed.
     fn entry(&self, path: Path, tx: TicketNotifier) -> Option<Arc<Bucket>> {

--- a/http-ratelimiting/src/in_memory/mod.rs
+++ b/http-ratelimiting/src/in_memory/mod.rs
@@ -73,7 +73,7 @@ impl InMemoryRatelimiter {
     }
 
     /// Enqueue the [`TicketNotifier`] to its [`Bucket`].
-    /// 
+    ///
     /// Returns the new [`Bucket`] if none existed.
     fn entry(&self, path: Path, tx: TicketNotifier) -> Option<Arc<Bucket>> {
         let mut buckets = self.buckets.lock().expect("buckets poisoned");
@@ -146,7 +146,7 @@ impl Ratelimiter for InMemoryRatelimiter {
         tracing::debug!("getting bucket for path: {:?}", path);
 
         let (tx, rx) = ticket::channel();
-        if let Some(bucket) =  self.entry(path.clone(), tx) {
+        if let Some(bucket) = self.entry(path.clone(), tx) {
             tokio::spawn(
                 BucketQueueTask::new(
                     bucket,

--- a/http-ratelimiting/src/in_memory/mod.rs
+++ b/http-ratelimiting/src/in_memory/mod.rs
@@ -83,8 +83,7 @@ impl InMemoryRatelimiter {
                 #[cfg(feature = "tracing")]
                 tracing::debug!("got existing bucket: {:?}", path);
 
-                let bucket = bucket.into_mut();
-                bucket.queue.push(tx);
+                bucket.get().queue.push(tx);
 
                 #[cfg(feature = "tracing")]
                 tracing::debug!("added request into bucket queue: {:?}", path);


### PR DESCRIPTION
See individual commit messages for more info.

This could be split into two PRs, but the changes are so small that it felt needless.
I hope to rework and document `http-ratelimiting` further to increase its maintainability.
