### PR TITLE
refactor(http-ratelimiting): use `instrument` for spans

### DIFF
--- a/http-ratelimiting/Cargo.toml
+++ b/http-ratelimiting/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.10.1"
 futures-util = { version = "0.3", default-features = false }
 http = { version = "0.2", default-features = false }
 tokio = { version = "1", default-features = false, features = ["rt", "sync", "time"] }
-tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
+tracing = { default-features = false, features = ["std", "attributes"], version = "0.1.23" }
 
 [dev-dependencies]
 criterion = { default-features = false, version = "0.3" }


### PR DESCRIPTION
Improves readability as each tracing call uses the same parent span.
