### PR TITLE
docs(model): expand `Attachment` documentation

### DIFF
--- a/model/src/http/attachment.rs
+++ b/model/src/http/attachment.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 /// description for screen readers:
 ///
 /// ```
-/// use twilight_model::http::Attachment;
+/// use twilight_model::http::attachment::Attachment;
 ///
 /// let filename = "twilight_sparkle.json".to_owned();
 /// let file_content = br#"{
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 ///     "cutie_mark": "sparkles",
 ///     "name": "Twilight Sparkle"
 /// }"#.to_vec();
+/// let id = 1;
 ///
 /// let mut attachment = Attachment::from_bytes(filename, file_content, id);
 /// attachment.description("Raw data about Twilight Sparkle".to_owned());
@@ -52,7 +53,7 @@ impl Attachment {
     /// Create an attachment with a grocery list named "grocerylist.txt":
     ///
     /// ```
-    /// use twilight_model::http::attachment;
+    /// use twilight_model::http::attachment::Attachment;
     ///
     /// let filename = "grocerylist.txt".to_owned();
     /// let file_content = b"Apples\nGrapes\nLemonade".to_vec();

--- a/model/src/http/attachment.rs
+++ b/model/src/http/attachment.rs
@@ -15,6 +15,7 @@ pub struct Attachment {
 
 impl Attachment {
     /// Create a attachment from a filename and bytes.
+    /// The id field is placeholder that can be any u64 value, such as 0,1,2...
     pub const fn from_bytes(filename: String, file: Vec<u8>, id: u64) -> Self {
         Self {
             description: None,
@@ -23,6 +24,35 @@ impl Attachment {
             id,
         }
     }
+    
+    # Examples
+    ///
+    /// ```no_run
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use twilight_http::Client;
+    /// use twilight_model::http::attachment;
+    ///
+    /// let client = Client::new("my token".to_owned());
+    /// let mut attachments: Vec<Attachment> = vec![];
+    ///
+    /// let grocery_list: &str = "Apples/nGrapes/nLemonade";
+    /// let message_content = format!("Here is the grocery list!");
+    ///         
+    /// attachments.push(Attachment::from_bytes(
+    ///    "grocerylist.txt".to_owned(),
+    ///    Vec::from(grocery_list),
+    ///    0
+    /// ));
+    ///
+    /// http.create_message(package)
+    ///    .content(&message_content)?
+    ///    .attachments(&attachments)
+    ///    .exec()
+    ///    .await?;
+    ///
+    ///
+    /// # Ok(()) }
+    /// ```
 
     /// Set the description of a attachment, this is used for alt-text
     /// on Discords end.

--- a/model/src/http/attachment.rs
+++ b/model/src/http/attachment.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Attachment for when creating and updating messages.
+/// The id field is placeholder that can be any u64 value, such as 0,1,2...
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Attachment {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -15,7 +16,6 @@ pub struct Attachment {
 
 impl Attachment {
     /// Create a attachment from a filename and bytes.
-    /// The id field is placeholder that can be any u64 value, such as 0,1,2...
     pub const fn from_bytes(filename: String, file: Vec<u8>, id: u64) -> Self {
         Self {
             description: None,
@@ -25,7 +25,7 @@ impl Attachment {
         }
     }
     
-     /// # Examples
+    /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/model/src/http/attachment.rs
+++ b/model/src/http/attachment.rs
@@ -25,7 +25,7 @@ impl Attachment {
         }
     }
     
-    # Examples
+     /// # Examples
     ///
     /// ```no_run
     /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/model/src/http/attachment.rs
+++ b/model/src/http/attachment.rs
@@ -2,48 +2,62 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Attachment for when creating and updating messages.
+/// Attachments used in messages.
 ///
-/// `id` can be any placeholder value. If attaching multiple files to the
-/// message, each must be unique.
+/// # Examples
+///
+/// Create an attachment of a short JSON blob describing a cat with a
+/// description for screen readers:
+///
+/// ```
+/// use twilight_model::http::Attachment;
+///
+/// let filename = "twilight_sparkle.json".to_owned();
+/// let file_content = br#"{
+///     "best_friend": "Spike",
+///     "cutie_mark": "sparkles",
+///     "name": "Twilight Sparkle"
+/// }"#.to_vec();
+///
+/// let mut attachment = Attachment::from_bytes(filename, file_content, id);
+/// attachment.description("Raw data about Twilight Sparkle".to_owned());
+/// ```
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Attachment {
+    /// Description of the attachment, useful for screen readers and users
+    /// requiring alt text.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Content of the file.
     #[serde(skip)]
     pub file: Vec<u8>,
+    /// Name of the file.
+    ///
+    /// Examples may be "twilight_sparkle.png", "cat.jpg", or "logs.txt".
     pub filename: String,
+    /// Unique ID of the attachment in the message.
+    ///
+    /// All attachment IDs in a message must be unique, but may be any value of
+    /// no particular format; for example, IDs of 0, 100, the current timestamp,
+    /// and so on are all valid.
     pub id: u64,
 }
 
 impl Attachment {
-    /// Create a attachment from a filename and bytes.
+    /// Create an attachment from a filename and bytes.
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use twilight_http::Client;
+    /// Create an attachment with a grocery list named "grocerylist.txt":
+    ///
+    /// ```
     /// use twilight_model::http::attachment;
     ///
-    /// let client = Client::new("my token".to_owned());
+    /// let filename = "grocerylist.txt".to_owned();
+    /// let file_content = b"Apples\nGrapes\nLemonade".to_vec();
+    /// let id = 1;
     ///
-    /// let grocery_list: &str = "Apples/nGrapes/nLemonade";
-    /// let message_content = "Here is the grocery list!".into();
-    /// let attachments = Vec::from([Attachment::from_bytes(
-    ///    "grocerylist.txt".to_owned(),
-    ///    Vec::from(grocery_list),
-    ///    0
-    /// )]);
-    ///
-    /// http.create_message(package)
-    ///    .content(&message_content)?
-    ///    .attachments(&attachments)
-    ///    .exec()
-    ///    .await?;
-    ///
-    ///
-    /// # Ok(()) }
+    /// let attachment = Attachment::from_bytes(filename, file_content, id);
     /// ```
     pub const fn from_bytes(filename: String, file: Vec<u8>, id: u64) -> Self {
         Self {
@@ -54,8 +68,10 @@ impl Attachment {
         }
     }
 
-    /// Set the description of a attachment, this is used for alt-text
-    /// on Discords end.
+    /// Set the description of the attachment.
+    ///
+    /// Attachment descriptions are useful for those requiring screen readers
+    /// and are displayed as alt text.
     pub fn description(&mut self, description: String) {
         self.description = Some(description);
     }

--- a/model/src/http/attachment.rs
+++ b/model/src/http/attachment.rs
@@ -37,9 +37,10 @@ pub struct Attachment {
     pub filename: String,
     /// Unique ID of the attachment in the message.
     ///
-    /// All attachment IDs in a message must be unique, but may be any value of
-    /// no particular format; for example, IDs of 0, 100, the current timestamp,
-    /// and so on are all valid.
+    /// While attachment IDs can be the same as attachments in other messages,
+    /// they must be unique within the same message. Attachment IDs don't need
+    /// to be in any particular format; for example, IDs of 0, 100, the current
+    /// timestamp, and so on are all valid.
     pub id: u64,
 }
 

--- a/model/src/http/attachment.rs
+++ b/model/src/http/attachment.rs
@@ -3,7 +3,9 @@
 use serde::{Deserialize, Serialize};
 
 /// Attachment for when creating and updating messages.
-/// The id field is placeholder that can be any u64 value, such as 0,1,2...
+///
+/// `id` can be any placeholder value. If attaching multiple files to the
+/// message, each must be unique.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Attachment {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -16,15 +18,7 @@ pub struct Attachment {
 
 impl Attachment {
     /// Create a attachment from a filename and bytes.
-    pub const fn from_bytes(filename: String, file: Vec<u8>, id: u64) -> Self {
-        Self {
-            description: None,
-            file,
-            filename,
-            id,
-        }
-    }
-    
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -33,16 +27,14 @@ impl Attachment {
     /// use twilight_model::http::attachment;
     ///
     /// let client = Client::new("my token".to_owned());
-    /// let mut attachments: Vec<Attachment> = vec![];
     ///
     /// let grocery_list: &str = "Apples/nGrapes/nLemonade";
-    /// let message_content = format!("Here is the grocery list!");
-    ///         
-    /// attachments.push(Attachment::from_bytes(
+    /// let message_content = "Here is the grocery list!".into();
+    /// let attachments = Vec::from([Attachment::from_bytes(
     ///    "grocerylist.txt".to_owned(),
     ///    Vec::from(grocery_list),
     ///    0
-    /// ));
+    /// )]);
     ///
     /// http.create_message(package)
     ///    .content(&message_content)?
@@ -53,6 +45,14 @@ impl Attachment {
     ///
     /// # Ok(()) }
     /// ```
+    pub const fn from_bytes(filename: String, file: Vec<u8>, id: u64) -> Self {
+        Self {
+            description: None,
+            file,
+            filename,
+            id,
+        }
+    }
 
     /// Set the description of a attachment, this is used for alt-text
     /// on Discords end.


### PR DESCRIPTION
Add example and clarify the purpose of the id field on Attachment.