### PR TITLE
docs(gateway-queue): fix the sharding for very large bots hyperlink

### DIFF
--- a/gateway-queue/README.md
+++ b/gateway-queue/README.md
@@ -41,6 +41,7 @@ create sessions.
 The `twilight-http` feature brings in support for [`LargeBotQueue`].
 
 This is enabled by default.
+
 [Sharding for Very Large Bots]: https://discord.com/developers/docs/topics/gateway#sharding-for-very-large-bots
 
 <!-- cargo-sync-readme end -->

--- a/gateway-queue/src/lib.rs
+++ b/gateway-queue/src/lib.rs
@@ -39,6 +39,7 @@
 //! The `twilight-http` feature brings in support for [`LargeBotQueue`].
 //!
 //! This is enabled by default.
+//!
 //! [Sharding for Very Large Bots]: https://discord.com/developers/docs/topics/gateway#sharding-for-very-large-bots
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]


### PR DESCRIPTION
EOF links in markdown require a blankline separating them from the rest of the file. Add one for it to properly link
