### PR TITLE
refactor(model): rework optional member deserialization

### DIFF
--- a/model/src/gateway/payload/incoming/thread_members_update.rs
+++ b/model/src/gateway/payload/incoming/thread_members_update.rs
@@ -214,7 +214,7 @@ mod tests {
                 Token::Str("member"),
                 Token::Some,
                 Token::Struct {
-                    name: "MemberIntermediary",
+                    name: "Member",
                     len: 11,
                 },
                 Token::Str("avatar"),


### PR DESCRIPTION
Removed the `OptionalMemberDeserializer` that took an arbitrary guild_id before being replaced with the proper one, if available.
Also now correctly skips optional `Reaction` fields on serialization.
