### PR TITLE
fix(http)!: imaga Data URIs need to be a string

### DIFF
--- a/http/src/client/mod.rs
+++ b/http/src/client/mod.rs
@@ -686,7 +686,7 @@ impl Client {
         &'a self,
         guild_id: Id<GuildMarker>,
         name: &'a str,
-        image: &'a [u8],
+        image: &'a str,
     ) -> CreateEmoji<'a> {
         CreateEmoji::new(self, guild_id, name, image)
     }

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -18,7 +18,7 @@ use twilight_validate::request::{
 #[derive(Serialize)]
 struct CreateWebhookFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<&'a [u8]>,
+    avatar: Option<&'a str>,
     name: &'a str,
 }
 
@@ -72,7 +72,7 @@ impl<'a> CreateWebhook<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn avatar(mut self, avatar: &'a [u8]) -> Self {
+    pub const fn avatar(mut self, avatar: &'a str) -> Self {
         self.fields.avatar = Some(avatar);
 
         self

--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -118,3 +118,37 @@ impl TryIntoRequest for CreateWebhook<'_> {
         Ok(request.build())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn test_create_webhook() -> Result<(), Box<dyn Error>> {
+        const CHANNEL_ID: Id<ChannelMarker> = Id::new(1);
+
+        let client = Client::new("token".into());
+
+        {
+            let expected = r#"{"name":"Spidey Bot"}"#;
+            let actual =
+                CreateWebhook::new(&client, CHANNEL_ID, "Spidey Bot")?.try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"avatar":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI","name":"Spidey Bot"}"#;
+            let actual = CreateWebhook::new(&client, CHANNEL_ID, "Spidey Bot")?
+            .avatar(
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI",
+            )
+                .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        Ok(())
+    }
+}

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -131,3 +131,70 @@ impl TryIntoRequest for UpdateWebhook<'_> {
         Ok(request.build())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn test_update_webhook() -> Result<(), Box<dyn Error>> {
+        const WEBHOOK_ID: Id<WebhookMarker> = Id::new(1);
+        const CHANNEL_ID: Id<ChannelMarker> = Id::new(2);
+
+        let client = Client::new("token".into());
+
+        {
+            let expected = r#"{}"#;
+            let actual = UpdateWebhook::new(&client, WEBHOOK_ID).try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"avatar":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI"}"#;
+            let actual = UpdateWebhook::new(&client, WEBHOOK_ID)
+            .avatar(Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI"))
+                .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+
+            let expected = r#"{"avatar":null}"#;
+            let actual = UpdateWebhook::new(&client, WEBHOOK_ID)
+                .avatar(None)
+                .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"channel_id":"2"}"#;
+            let actual = UpdateWebhook::new(&client, WEBHOOK_ID)
+                .channel_id(CHANNEL_ID)
+                .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"name":"Captain Hook"}"#;
+            let actual = UpdateWebhook::new(&client, WEBHOOK_ID)
+                .name(Some("Captain Hook"))?
+                .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"avatar":null,"channel_id":"2","name":"Captain Hook"}"#;
+            let actual = UpdateWebhook::new(&client, WEBHOOK_ID)
+                .avatar(None)
+                .channel_id(CHANNEL_ID)
+                .name(Some("Captain Hook"))?
+                .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+        Ok(())
+    }
+}

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -21,7 +21,7 @@ use twilight_validate::request::{
 #[derive(Serialize)]
 struct UpdateWebhookFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<NullableField<&'a [u8]>>,
+    avatar: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     channel_id: Option<Id<ChannelMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -59,7 +59,7 @@ impl<'a> UpdateWebhook<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn avatar(mut self, avatar: Option<&'a [u8]>) -> Self {
+    pub const fn avatar(mut self, avatar: Option<&'a str>) -> Self {
         self.fields.avatar = Some(NullableField(avatar));
 
         self

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -103,3 +103,60 @@ impl TryIntoRequest for UpdateWebhookWithToken<'_> {
         Ok(request.build())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn test_update_webhook_with_token() -> Result<(), Box<dyn Error>> {
+        const WEBHOOK_ID: Id<WebhookMarker> = Id::new(1);
+
+        let client = Client::new("token".into());
+
+        {
+            let expected = r#"{}"#;
+            let actual =
+                UpdateWebhookWithToken::new(&client, WEBHOOK_ID, "token").try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"avatar":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI"}"#;
+            let actual = UpdateWebhookWithToken::new(&client, WEBHOOK_ID, "token")
+            .avatar(Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI"))
+                .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+
+            let expected = r#"{"avatar":null}"#;
+            let actual = UpdateWebhookWithToken::new(&client, WEBHOOK_ID, "token")
+                .avatar(None)
+                .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"name":"Captain Hook"}"#;
+            let actual = UpdateWebhookWithToken::new(&client, WEBHOOK_ID, "token")
+                .name(Some("Captain Hook"))?
+                .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"avatar":null,"name":"Captain Hook"}"#;
+            let actual = UpdateWebhookWithToken::new(&client, WEBHOOK_ID, "token")
+                .avatar(None)
+                .name(Some("Captain Hook"))?
+                .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+        Ok(())
+    }
+}

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -15,7 +15,7 @@ use twilight_validate::request::{webhook_username as validate_webhook_username, 
 #[derive(Serialize)]
 struct UpdateWebhookWithTokenFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<NullableField<&'a [u8]>>,
+    avatar: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<NullableField<&'a str>>,
 }
@@ -53,7 +53,7 @@ impl<'a> UpdateWebhookWithToken<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn avatar(mut self, avatar: Option<&'a [u8]>) -> Self {
+    pub const fn avatar(mut self, avatar: Option<&'a str>) -> Self {
         self.fields.avatar = Some(NullableField(avatar));
 
         self

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -110,7 +110,7 @@ struct CreateGuildFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     explicit_content_filter: Option<ExplicitContentFilter>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<&'a [u8]>,
+    icon: Option<&'a str>,
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     roles: Option<Vec<RoleFields>>,
@@ -371,7 +371,7 @@ impl<'a> CreateGuild<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub fn icon(mut self, icon: &'a [u8]) -> Self {
+    pub fn icon(mut self, icon: &'a str) -> Self {
         self.fields.icon.replace(icon);
 
         self

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -108,3 +108,45 @@ impl TryIntoRequest for CreateEmoji<'_> {
         Ok(request.build())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn test_create_emoji() -> Result<(), Box<dyn Error>> {
+        const GUILD_ID: Id<GuildMarker> = Id::new(1);
+        const ROLE_ID: Id<RoleMarker> = Id::new(2);
+
+        let client = Client::new("token".into());
+
+        {
+            let expected = r#"{"image":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI","name":"square"}"#;
+            let actual = CreateEmoji::new(
+                &client,
+                GUILD_ID,
+                "square",
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI",
+            )
+            .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"image":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI","name":"square","roles":["2"]}"#;
+            let actual = CreateEmoji::new(
+                &client,
+                GUILD_ID,
+                "square",
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI",
+            )
+            .roles(&[ROLE_ID])
+            .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+        Ok(())
+    }
+}

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -17,7 +17,7 @@ use twilight_validate::request::{audit_reason as validate_audit_reason, Validati
 
 #[derive(Serialize)]
 struct CreateEmojiFields<'a> {
-    image: &'a [u8],
+    image: &'a str,
     name: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     roles: Option<&'a [Id<RoleMarker>]>,
@@ -43,7 +43,7 @@ impl<'a> CreateEmoji<'a> {
         http: &'a Client,
         guild_id: Id<GuildMarker>,
         name: &'a str,
-        image: &'a [u8],
+        image: &'a str,
     ) -> Self {
         Self {
             fields: CreateEmojiFields {

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -37,7 +37,7 @@ struct UpdateGuildFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     features: Option<&'a [&'a str]>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<NullableField<&'a [u8]>>,
+    icon: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -180,7 +180,7 @@ impl<'a> UpdateGuild<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn icon(mut self, icon: Option<&'a [u8]>) -> Self {
+    pub const fn icon(mut self, icon: Option<&'a str>) -> Self {
         self.fields.icon = Some(NullableField(icon));
 
         self

--- a/http/src/request/scheduled_event/create_guild_scheduled_event/external.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/external.rs
@@ -68,7 +68,7 @@ impl<'a> CreateGuildExternalScheduledEvent<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn image(mut self, image: &'a [u8]) -> Self {
+    pub const fn image(mut self, image: &'a str) -> Self {
         self.0.fields.image = Some(image);
 
         self

--- a/http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
@@ -40,7 +40,7 @@ struct CreateGuildScheduledEventFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     entity_type: Option<EntityType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    image: Option<&'a [u8]>,
+    image: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/http/src/request/scheduled_event/create_guild_scheduled_event/stage_instance.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/stage_instance.rs
@@ -62,7 +62,7 @@ impl<'a> CreateGuildStageInstanceScheduledEvent<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn image(mut self, image: &'a [u8]) -> Self {
+    pub const fn image(mut self, image: &'a str) -> Self {
         self.0.fields.image = Some(image);
 
         self

--- a/http/src/request/scheduled_event/create_guild_scheduled_event/voice.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/voice.rs
@@ -62,7 +62,7 @@ impl<'a> CreateGuildVoiceScheduledEvent<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn image(mut self, image: &'a [u8]) -> Self {
+    pub const fn image(mut self, image: &'a str) -> Self {
         self.0.fields.image = Some(image);
 
         self

--- a/http/src/request/scheduled_event/update_guild_scheduled_event.rs
+++ b/http/src/request/scheduled_event/update_guild_scheduled_event.rs
@@ -32,7 +32,7 @@ struct UpdateGuildScheduledEventFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     entity_type: Option<EntityType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    image: Option<NullableField<&'a [u8]>>,
+    image: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -153,7 +153,7 @@ impl<'a> UpdateGuildScheduledEvent<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn image(mut self, image: Option<&'a [u8]>) -> Self {
+    pub const fn image(mut self, image: Option<&'a str>) -> Self {
         self.fields.image = Some(NullableField(image));
 
         self

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -12,7 +12,7 @@ use twilight_validate::request::{guild_name as validate_guild_name, ValidationEr
 #[derive(Serialize)]
 struct CreateGuildFromTemplateFields<'a> {
     name: &'a str,
-    icon: Option<&'a [u8]>,
+    icon: Option<&'a str>,
 }
 
 /// Create a new guild based on a template.
@@ -54,7 +54,7 @@ impl<'a> CreateGuildFromTemplate<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn icon(mut self, icon: &'a [u8]) -> Self {
+    pub const fn icon(mut self, icon: &'a str) -> Self {
         self.fields.icon = Some(icon);
 
         self

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -84,3 +84,32 @@ impl TryIntoRequest for CreateGuildFromTemplate<'_> {
         Ok(request.build())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn test_create_guild_from_template() -> Result<(), Box<dyn Error>> {
+        let client = Client::new("token".into());
+
+        {
+            let expected = r#"{"name":"New Guild","icon":null}"#;
+            let actual =
+                CreateGuildFromTemplate::new(&client, "code", "New Guild")?.try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"name":"New Guild","icon":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI"}"#;
+            let actual = CreateGuildFromTemplate::new(&client, "code", "New Guild")?
+            .icon("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI")
+            .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+        Ok(())
+    }
+}

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -109,3 +109,52 @@ impl TryIntoRequest for UpdateCurrentUser<'_> {
         Ok(request.build())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn test_clear_attachment() -> Result<(), Box<dyn Error>> {
+        let client = Client::new("token".into());
+
+        {
+            let expected = r#"{}"#;
+            let actual = UpdateCurrentUser::new(&client).try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"avatar":null}"#;
+            let actual = UpdateCurrentUser::new(&client)
+                .avatar(None)
+                .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+
+            let expected = r#"{"avatar":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI"}"#;
+            let actual = UpdateCurrentUser::new(&client).avatar(Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI")).try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"username":"other side"}"#;
+            let actual = UpdateCurrentUser::new(&client)
+                .username("other side")?
+                .try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+
+        {
+            let expected = r#"{"avatar":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI","username":"other side"}"#;
+            let actual = UpdateCurrentUser::new(&client).avatar(Some("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI")).username("other side")?.try_into_request()?;
+
+            assert_eq!(Some(expected.as_bytes()), actual.body());
+        }
+        Ok(())
+    }
+}

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -14,7 +14,7 @@ use twilight_validate::request::{
 #[derive(Serialize)]
 struct UpdateCurrentUserFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    avatar: Option<NullableField<&'a [u8]>>,
+    avatar: Option<NullableField<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     username: Option<&'a str>,
 }
@@ -49,7 +49,7 @@ impl<'a> UpdateCurrentUser<'a> {
     /// and `{data}` is the base64-encoded image. See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn avatar(mut self, avatar: Option<&'a [u8]>) -> Self {
+    pub const fn avatar(mut self, avatar: Option<&'a str>) -> Self {
         self.fields.avatar = Some(NullableField(avatar));
 
         self


### PR DESCRIPTION
Discord expects that Data URIs get send as a string therefore we should take a &str accordingly.