### PR TITLE
refactor(gateway): allow `ptr_arg` lint on conditional

### DIFF
--- a/gateway/src/shard/processor/compression/mod.rs
+++ b/gateway/src/shard/processor/compression/mod.rs
@@ -153,7 +153,7 @@ impl Compression {
 /// with a value of `zlib-stream`.
 #[cfg_attr(
     not(any(feature = "zlib-stock", feature = "zlib-simd")),
-    allow(unused_variables)
+    allow(clippy::ptr_arg, unused_variables)
 )]
 pub fn add_url_feature(buf: &mut String) {
     #[cfg(any(feature = "zlib-stock", feature = "zlib-simd"))]


### PR DESCRIPTION
Allow the `clippy::ptr_arg` lint on `compression::add_url_feature`, which conditionally uses the provided `&mut String`. Clippy recommends making this take `&mut str` where zlib is disabled since it's not used, but because we'll always be passing an allocated string in anyway this isn't worth breaking the function up to fix.