### PR TITLE
docs(http, model): auto archives not boost locked

### DIFF
--- a/http/src/request/channel/thread/create_thread.rs
+++ b/http/src/request/channel/thread/create_thread.rs
@@ -27,15 +27,10 @@ struct CreateThreadFields<'a> {
 
 /// Start a thread that is not connected to a message.
 ///
-/// Values of [`ThreeDays`] and [`Week`] require the guild to be boosted.  The
-/// guild's features will indicate if a guild is able to use these settings.
-///
 /// To make a [`GuildPrivateThread`], the guild must also have the
 /// `PRIVATE_THREADS` feature.
 ///
 /// [`GuildPrivateThread`]: twilight_model::channel::ChannelType::GuildPrivateThread
-/// [`ThreeDays`]: twilight_model::channel::thread::AutoArchiveDuration::ThreeDays
-/// [`Week`]: twilight_model::channel::thread::AutoArchiveDuration::Week
 #[must_use = "requests must be configured and executed"]
 pub struct CreateThread<'a> {
     channel_id: Id<ChannelMarker>,
@@ -68,12 +63,8 @@ impl<'a> CreateThread<'a> {
 
     /// Set the thread's auto archive duration.
     ///
-    /// Values of [`ThreeDays`] and [`Week`] require the guild to be boosted.
-    /// The guild's features will indicate if a guild is able to use these
-    /// settings.
-    ///
-    /// [`ThreeDays`]: twilight_model::channel::thread::AutoArchiveDuration::ThreeDays
-    /// [`Week`]: twilight_model::channel::thread::AutoArchiveDuration::Week
+    /// Automatic archive durations are not locked behind the guild's boost
+    /// level.
     pub const fn auto_archive_duration(
         mut self,
         auto_archive_duration: AutoArchiveDuration,

--- a/http/src/request/channel/thread/create_thread_from_message.rs
+++ b/http/src/request/channel/thread/create_thread_from_message.rs
@@ -71,12 +71,8 @@ impl<'a> CreateThreadFromMessage<'a> {
 
     /// Set the thread's auto archive duration.
     ///
-    /// Values of [`ThreeDays`] and [`Week`] require the guild to be boosted.
-    /// The guild's features will indicate if a guild is able to use these
-    /// settings.
-    ///
-    /// [`ThreeDays`]: twilight_model::channel::thread::AutoArchiveDuration::ThreeDays
-    /// [`Week`]: twilight_model::channel::thread::AutoArchiveDuration::Week
+    /// Automatic archive durations are not locked behind the guild's boost
+    /// level.
     pub const fn auto_archive_duration(
         mut self,
         auto_archive_duration: AutoArchiveDuration,

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -77,7 +77,11 @@ pub struct Channel {
     /// Bitrate setting of audio channels.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bitrate: Option<u64>,
-    /// Default duration before the channel's threads archive.
+    /// Default duration without messages before the channel's threads
+    /// automatically archive.
+    ///
+    /// Automatic archive durations are not locked behind the guild's boost
+    /// level.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_auto_archive_duration: Option<AutoArchiveDuration>,
     /// ID of the guild the channel is in.

--- a/model/src/channel/thread/metadata.rs
+++ b/model/src/channel/thread/metadata.rs
@@ -7,6 +7,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ThreadMetadata {
     pub archived: bool,
+    /// Duration without messages before the thread automatically archives.
+    ///
+    /// Automatic archive durations are not locked behind the guild's boost
+    /// level.
     pub auto_archive_duration: AutoArchiveDuration,
     pub archive_timestamp: Timestamp,
     /// When the thread was created at.


### PR DESCRIPTION
Document that thread automatic archive durations are no longer boost locked, where 3-day and 7-day durations were previously locked behind guild boosting.

Closes #1713.