### PR TITLE
refactor(http): nits in the `request` module

### DIFF
--- a/http/src/request/guild/update_guild_welcome_screen.rs
+++ b/http/src/request/guild/update_guild_welcome_screen.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, Request, TryIntoRequest},
+    request::{Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -17,7 +17,7 @@ struct UpdateGuildWelcomeScreenFields<'a> {
     description: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
-    #[serde(skip_serializing_if = "request::slice_is_empty")]
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
     welcome_channels: &'a [WelcomeScreenChannel],
 }
 

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -31,7 +31,7 @@ pub use twilight_http_ratelimiting::request::Method;
 use crate::error::{Error, ErrorType};
 use hyper::header::{HeaderName, HeaderValue};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
-use serde::{Serialize, Serializer};
+use serde::Serialize;
 use std::iter;
 
 /// Name of the audit log reason header.
@@ -45,17 +45,8 @@ const REASON_HEADER_NAME: &str = "x-audit-log-reason";
 /// When the request field is `None` a field can skip serialization, while if a
 /// `NullableField` is provided with `None` within it then it will serialize as
 /// null. This mechanism is primarily used in patch requests.
+#[derive(Serialize)]
 struct NullableField<T>(Option<T>);
-
-impl<T: Serialize> Serialize for NullableField<T> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        if let Some(inner) = self.0.as_ref() {
-            serializer.serialize_some(inner)
-        } else {
-            serializer.serialize_none()
-        }
-    }
-}
 
 fn audit_header(reason: &str) -> Result<impl Iterator<Item = (HeaderName, HeaderValue)>, Error> {
     let header_name = HeaderName::from_static(REASON_HEADER_NAME);

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -57,14 +57,12 @@ impl<T: Serialize> Serialize for NullableField<T> {
     }
 }
 
-pub(crate) fn audit_header(
-    reason: &str,
-) -> Result<impl Iterator<Item = (HeaderName, HeaderValue)>, Error> {
+fn audit_header(reason: &str) -> Result<impl Iterator<Item = (HeaderName, HeaderValue)>, Error> {
     let header_name = HeaderName::from_static(REASON_HEADER_NAME);
     let encoded_reason = utf8_percent_encode(reason, NON_ALPHANUMERIC).to_string();
     let header_value = HeaderValue::from_str(&encoded_reason).map_err(|e| Error {
         kind: ErrorType::CreatingHeader {
-            name: encoded_reason.clone(),
+            name: encoded_reason,
         },
         source: Some(Box::new(e)),
     })?;

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -71,7 +71,3 @@ pub(crate) fn audit_header(
 
     Ok(iter::once((header_name, header_value)))
 }
-
-const fn slice_is_empty<T>(slice: &[T]) -> bool {
-    slice.is_empty()
-}


### PR DESCRIPTION
- refactor(http): remove `request::slice_is_empty()`
- refactor(http): clean up `request::audit_header`
- refactor(http): derive `Serialize` on `NullableField`
