### PR TITLE
feat(model): add `From` implementation for `Component` variants

### DIFF
--- a/model/src/application/component/action_row.rs
+++ b/model/src/application/component/action_row.rs
@@ -11,6 +11,12 @@ pub struct ActionRow {
     pub components: Vec<Component>,
 }
 
+impl From<ActionRow> for Component {
+    fn from(action_row: ActionRow) -> Self {
+        Self::ActionRow(action_row)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -19,4 +25,6 @@ mod tests {
 
     assert_fields!(ActionRow: components);
     assert_impl_all!(ActionRow: Clone, Debug, Eq, Hash, PartialEq, Send, Sync);
+
+    assert_impl_all!(Component: From<ActionRow>);
 }

--- a/model/src/application/component/button.rs
+++ b/model/src/application/component/button.rs
@@ -1,6 +1,8 @@
 use crate::channel::ReactionType;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
+use super::Component;
+
 /// Clickable interactive components that render on messages.
 ///
 /// See [Discord Docs/Message Components].
@@ -66,6 +68,12 @@ pub enum ButtonStyle {
     Link = 5,
 }
 
+impl From<Button> for Component {
+    fn from(button: Button) -> Self {
+        Self::Button(button)
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -96,6 +104,8 @@ mod tests {
     const_assert_eq!(3, ButtonStyle::Success as u8);
     const_assert_eq!(4, ButtonStyle::Danger as u8);
     const_assert_eq!(5, ButtonStyle::Link as u8);
+
+    assert_impl_all!(Component: From<Button>);
 
     #[test]
     fn test_button_style() {

--- a/model/src/application/component/mod.rs
+++ b/model/src/application/component/mod.rs
@@ -73,6 +73,30 @@ impl Component {
     }
 }
 
+impl From<ActionRow> for Component {
+    fn from(action_row: ActionRow) -> Self {
+        Self::ActionRow(action_row)
+    }
+}
+
+impl From<Button> for Component {
+    fn from(button: Button) -> Self {
+        Self::Button(button)
+    }
+}
+
+impl From<SelectMenu> for Component {
+    fn from(select_menu: SelectMenu) -> Self {
+        Self::SelectMenu(select_menu)
+    }
+}
+
+impl From<TextInput> for Component {
+    fn from(text_input: TextInput) -> Self {
+        Self::TextInput(text_input)
+    }
+}
+
 impl<'de> Deserialize<'de> for Component {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         deserializer.deserialize_any(ComponentVisitor)

--- a/model/src/application/component/mod.rs
+++ b/model/src/application/component/mod.rs
@@ -73,30 +73,6 @@ impl Component {
     }
 }
 
-impl From<ActionRow> for Component {
-    fn from(action_row: ActionRow) -> Self {
-        Self::ActionRow(action_row)
-    }
-}
-
-impl From<Button> for Component {
-    fn from(button: Button) -> Self {
-        Self::Button(button)
-    }
-}
-
-impl From<SelectMenu> for Component {
-    fn from(select_menu: SelectMenu) -> Self {
-        Self::SelectMenu(select_menu)
-    }
-}
-
-impl From<TextInput> for Component {
-    fn from(text_input: TextInput) -> Self {
-        Self::TextInput(text_input)
-    }
-}
-
 impl<'de> Deserialize<'de> for Component {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         deserializer.deserialize_any(ComponentVisitor)

--- a/model/src/application/component/select_menu.rs
+++ b/model/src/application/component/select_menu.rs
@@ -1,6 +1,8 @@
 use crate::channel::ReactionType;
 use serde::{Deserialize, Serialize};
 
+use super::Component;
+
 /// Dropdown-style interactive components that render on messages.
 ///
 /// Refer to [Discord Docs/Message Components] for additional information.
@@ -45,6 +47,12 @@ pub struct SelectMenuOption {
     pub value: String,
 }
 
+impl From<SelectMenu> for Component {
+    fn from(select_menu: SelectMenu) -> Self {
+        Self::SelectMenu(select_menu)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -73,4 +81,6 @@ mod tests {
         Sync
     );
     assert_fields!(SelectMenuOption: default, description, emoji, label, value);
+
+    assert_impl_all!(Component: From<SelectMenu>);
 }

--- a/model/src/application/component/text_input.rs
+++ b/model/src/application/component/text_input.rs
@@ -1,5 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
+use super::Component;
+
 /// Modal component to prompt users for a text input.
 ///
 /// Refer to [Discord Docs/Input Text] for additional information.
@@ -25,6 +27,12 @@ pub struct TextInput {
     pub style: TextInputStyle,
     /// Pre-filled value for input text.
     pub value: Option<String>,
+}
+
+impl From<TextInput> for Component {
+    fn from(text_input: TextInput) -> Self {
+        Self::TextInput(text_input)
+    }
 }
 
 /// Style of an [`TextInput`].
@@ -73,6 +81,8 @@ mod tests {
     );
     const_assert_eq!(1, TextInputStyle::Short as u8);
     const_assert_eq!(2, TextInputStyle::Paragraph as u8);
+
+    assert_impl_all!(Component: From<TextInput>);
 
     #[test]
     fn test_text_input_style() {


### PR DESCRIPTION
In order to make it easier to construct components a `From<ActionRow> for Component` is useful.
This PR would make it possible to do:
```rs
let action_row = ActionRow {
    components: Vec::from(
        Button {
            ..
        }.into()
    )
}
```
Instead of
```rs
let action_row = ActionRow {
    components: Vec::from(
        Component::Button(Button {
            ..
        })
    )
}
```