### PR TITLE
fix(http): backport #1744 string image serializers

### DIFF
--- a/http/src/request/channel/webhook/create_webhook.rs
+++ b/http/src/request/channel/webhook/create_webhook.rs
@@ -1,3 +1,6 @@
+// clippy: due to the image serializer, which has a signature required by serde
+#![allow(clippy::ref_option_ref)]
+
 use crate::{
     client::Client,
     error::Error,
@@ -17,7 +20,10 @@ use twilight_validate::request::{
 
 #[derive(Serialize)]
 struct CreateWebhookFields<'a> {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        serialize_with = "request::serialize_optional_image",
+        skip_serializing_if = "Option::is_none"
+    )]
     avatar: Option<&'a [u8]>,
     name: &'a str,
 }

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -20,7 +20,10 @@ use twilight_validate::request::{
 
 #[derive(Serialize)]
 struct UpdateWebhookFields<'a> {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        serialize_with = "request::serialize_optional_nullable_image",
+        skip_serializing_if = "Option::is_none"
+    )]
     avatar: Option<NullableField<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     channel_id: Option<Id<ChannelMarker>>,

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -14,7 +14,10 @@ use twilight_validate::request::{webhook_username as validate_webhook_username, 
 
 #[derive(Serialize)]
 struct UpdateWebhookWithTokenFields<'a> {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        serialize_with = "crate::request::serialize_optional_nullable_image",
+        skip_serializing_if = "Option::is_none"
+    )]
     avatar: Option<NullableField<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<NullableField<&'a str>>,

--- a/http/src/request/guild/create_guild/mod.rs
+++ b/http/src/request/guild/create_guild/mod.rs
@@ -1,3 +1,6 @@
+// clippy: due to the image serializer, which has a signature required by serde
+#![allow(clippy::ref_option_ref)]
+
 use crate::{
     client::Client,
     error::Error as HttpError,
@@ -109,7 +112,10 @@ struct CreateGuildFields<'a> {
     default_message_notifications: Option<DefaultMessageNotificationLevel>,
     #[serde(skip_serializing_if = "Option::is_none")]
     explicit_content_filter: Option<ExplicitContentFilter>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        serialize_with = "crate::request::serialize_optional_image",
+        skip_serializing_if = "Option::is_none"
+    )]
     icon: Option<&'a [u8]>,
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/http/src/request/guild/emoji/create_emoji.rs
+++ b/http/src/request/guild/emoji/create_emoji.rs
@@ -17,6 +17,7 @@ use twilight_validate::request::{audit_reason as validate_audit_reason, Validati
 
 #[derive(Serialize)]
 struct CreateEmojiFields<'a> {
+    #[serde(serialize_with = "request::serialize_image")]
     image: &'a [u8],
     name: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -36,7 +36,10 @@ struct UpdateGuildFields<'a> {
     explicit_content_filter: Option<NullableField<ExplicitContentFilter>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     features: Option<&'a [&'a str]>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        serialize_with = "request::serialize_optional_nullable_image",
+        skip_serializing_if = "Option::is_none"
+    )]
     icon: Option<NullableField<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -31,7 +31,7 @@ pub use twilight_http_ratelimiting::request::Method;
 use crate::error::{Error, ErrorType};
 use hyper::header::{HeaderName, HeaderValue};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 use std::iter;
 
 /// Name of the audit log reason header.
@@ -59,4 +59,103 @@ fn audit_header(reason: &str) -> Result<impl Iterator<Item = (HeaderName, Header
     })?;
 
     Ok(iter::once((header_name, header_value)))
+}
+
+/// Serialize image data as a string.
+///
+/// Part of a backported fix for #1744. Remove after 0.11.x.
+#[allow(clippy::ref_option_ref)]
+fn serialize_image<S: Serializer>(data: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&String::from_utf8_lossy(data))
+}
+
+/// Serialize optional image data as a string.
+///
+/// Part of a backported fix for #1744. Remove after 0.11.x.
+#[allow(clippy::ref_option_ref)]
+fn serialize_optional_image<S: Serializer>(
+    maybe_data: &Option<&[u8]>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    if let Some(data) = maybe_data {
+        serializer.serialize_some(&String::from_utf8_lossy(data))
+    } else {
+        serializer.serialize_none()
+    }
+}
+
+/// Serialize optional and image data as a string.
+///
+/// Part of a backported fix for #1744. Remove after 0.11.x.
+#[allow(clippy::ref_option_ref)]
+fn serialize_optional_nullable_image<S: Serializer>(
+    maybe_data: &Option<NullableField<&[u8]>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    if let Some(data) = maybe_data.as_ref().and_then(|field| field.0) {
+        serializer.serialize_some(&String::from_utf8_lossy(data))
+    } else {
+        serializer.serialize_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Serializer;
+    use std::io::Cursor;
+
+    use crate::request::NullableField;
+
+    #[test]
+    fn test_serialize_image() {
+        let mut buf = Cursor::new(Vec::new());
+        let mut serializer = Serializer::new(&mut buf);
+        super::serialize_image(b"test", &mut serializer).unwrap();
+        assert_eq!(br#""test""#, buf.into_inner().as_slice());
+    }
+
+    #[test]
+    fn test_serialize_optional_image_some() {
+        let mut buf = Cursor::new(Vec::new());
+        let mut serializer = Serializer::new(&mut buf);
+        super::serialize_optional_image(&Some(b"test"), &mut serializer).unwrap();
+        assert_eq!(br#""test""#, buf.into_inner().as_slice());
+    }
+
+    #[test]
+    fn test_serialize_optional_image_none() {
+        let mut buf = Cursor::new(Vec::new());
+        let mut serializer = Serializer::new(&mut buf);
+        super::serialize_optional_image(&None, &mut serializer).unwrap();
+        assert_eq!(b"null", buf.into_inner().as_slice());
+    }
+
+    #[test]
+    fn test_serialize_optional_nullable_image_none() {
+        let mut buf = Cursor::new(Vec::new());
+        let mut serializer = Serializer::new(&mut buf);
+        super::serialize_optional_nullable_image(&None, &mut serializer).unwrap();
+        assert_eq!(b"null", buf.into_inner().as_slice());
+    }
+
+    #[test]
+    fn test_serialize_optional_nullable_image_some_null() {
+        let mut buf = Cursor::new(Vec::new());
+        let mut serializer = Serializer::new(&mut buf);
+        super::serialize_optional_nullable_image(&Some(NullableField(None)), &mut serializer)
+            .unwrap();
+        assert_eq!(b"null", buf.into_inner().as_slice());
+    }
+
+    #[test]
+    fn test_serialize_optional_nullable_image_some_value() {
+        let mut buf = Cursor::new(Vec::new());
+        let mut serializer = Serializer::new(&mut buf);
+        super::serialize_optional_nullable_image(
+            &Some(NullableField(Some(b"test"))),
+            &mut serializer,
+        )
+        .unwrap();
+        assert_eq!(br#""test""#, buf.into_inner().as_slice());
+    }
 }

--- a/http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
+++ b/http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
@@ -1,3 +1,6 @@
+// clippy: due to the image serializer, which has a signature required by serde
+#![allow(clippy::ref_option_ref)]
+
 mod external;
 mod stage_instance;
 mod voice;
@@ -39,7 +42,10 @@ struct CreateGuildScheduledEventFields<'a> {
     entity_metadata: Option<EntityMetadataFields<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     entity_type: Option<EntityType>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        serialize_with = "crate::request::serialize_optional_image",
+        skip_serializing_if = "Option::is_none"
+    )]
     image: Option<&'a [u8]>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,

--- a/http/src/request/scheduled_event/update_guild_scheduled_event.rs
+++ b/http/src/request/scheduled_event/update_guild_scheduled_event.rs
@@ -31,7 +31,10 @@ struct UpdateGuildScheduledEventFields<'a> {
     entity_metadata: Option<EntityMetadataFields<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     entity_type: Option<EntityType>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        serialize_with = "crate::request::serialize_optional_nullable_image",
+        skip_serializing_if = "Option::is_none"
+    )]
     image: Option<NullableField<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,

--- a/http/src/request/template/create_guild_from_template.rs
+++ b/http/src/request/template/create_guild_from_template.rs
@@ -1,3 +1,6 @@
+// clippy: due to the image serializer, which has a signature required by serde
+#![allow(clippy::ref_option_ref)]
+
 use crate::{
     client::Client,
     error::Error as HttpError,
@@ -12,6 +15,7 @@ use twilight_validate::request::{guild_name as validate_guild_name, ValidationEr
 #[derive(Serialize)]
 struct CreateGuildFromTemplateFields<'a> {
     name: &'a str,
+    #[serde(serialize_with = "crate::request::serialize_optional_image")]
     icon: Option<&'a [u8]>,
 }
 

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -13,7 +13,10 @@ use twilight_validate::request::{
 
 #[derive(Serialize)]
 struct UpdateCurrentUserFields<'a> {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        serialize_with = "request::serialize_optional_nullable_image",
+        skip_serializing_if = "Option::is_none"
+    )]
     avatar: Option<NullableField<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     username: Option<&'a str>,


### PR DESCRIPTION
Backport the fixes from #1744 to serialize image data as strings. We can achieve this by still accepting bytes, but serializing them as strings.

Relates to #1744.