### PR TITLE
feat(model): add command data guild_id field

### DIFF
--- a/cache/in-memory/src/event/interaction.rs
+++ b/cache/in-memory/src/event/interaction.rs
@@ -102,6 +102,7 @@ mod tests {
                 application_id: Id::new(1),
                 channel_id: Id::new(2),
                 data: CommandData {
+                    guild_id: None,
                     id: Id::new(5),
                     name: "command name".into(),
                     kind: CommandType::ChatInput, // This isn't actually a valid command, so just mark it as a slash command.

--- a/model/src/application/interaction/application_command/data.rs
+++ b/model/src/application/interaction/application_command/data.rs
@@ -4,7 +4,7 @@ use crate::{
         interaction::application_command::{CommandDataOption, CommandInteractionDataResolved},
     },
     id::{
-        marker::{CommandMarker, GenericMarker},
+        marker::{CommandMarker, GenericMarker, GuildMarker},
         Id,
     },
 };
@@ -18,6 +18,9 @@ use serde::{Deserialize, Serialize};
 /// [Discord Docs/Interaction Object]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-data-structure
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CommandData {
+    /// ID of the guild the command is registered to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guild_id: Option<Id<GuildMarker>>,
     /// ID of the command.
     pub id: Id<CommandMarker>,
     /// Name of the command.

--- a/model/src/application/interaction/application_command/mod.rs
+++ b/model/src/application/interaction/application_command/mod.rs
@@ -118,6 +118,7 @@ mod tests {
             application_id: Id::<ApplicationMarker>::new(1),
             channel_id: Id::<ChannelMarker>::new(1),
             data: CommandData {
+                guild_id: None,
                 id: Id::new(3),
                 name: "search".to_owned(),
                 kind: CommandType::ChatInput,

--- a/model/src/application/interaction/application_command/option.rs
+++ b/model/src/application/interaction/application_command/option.rs
@@ -354,6 +354,7 @@ mod tests {
     #[test]
     fn no_options() {
         let value = CommandData {
+            guild_id: Some(Id::new(2)),
             id: Id::new(1),
             name: "permissions".to_owned(),
             kind: CommandType::ChatInput,
@@ -366,8 +367,12 @@ mod tests {
             &[
                 Token::Struct {
                     name: "CommandData",
-                    len: 3,
+                    len: 4,
                 },
+                Token::Str("guild_id"),
+                Token::Some,
+                Token::NewtypeStruct { name: "Id" },
+                Token::Str("2"),
                 Token::Str("id"),
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("1"),
@@ -383,6 +388,7 @@ mod tests {
     #[test]
     fn subcommand_without_option() {
         let value = CommandData {
+            guild_id: None,
             id: Id::new(1),
             name: "photo".to_owned(),
             kind: CommandType::ChatInput,

--- a/model/src/application/interaction/mod.rs
+++ b/model/src/application/interaction/mod.rs
@@ -486,6 +486,7 @@ mod tests {
             application_id: Id::new(100),
             channel_id: Id::new(200),
             data: CommandData {
+                guild_id: None,
                 id: Id::new(300),
                 name: "command name".into(),
                 kind: CommandType::ChatInput,


### PR DESCRIPTION
Add the `CommandData::guild_id` field, which denotes the ID of the guild the command is registered in.

Closes #1716.