### PR TITLE
refactor(http): rename `NullableField` to `Nullable`

### DIFF
--- a/http/src/request/application/interaction/create_followup.rs
+++ b/http/src/request/application/interaction/create_followup.rs
@@ -3,7 +3,7 @@ use crate::{
     error::Error as HttpError,
     request::{
         attachment::{AttachmentManager, PartialAttachment},
-        NullableField, Request, TryIntoRequest,
+        Nullable, Request, TryIntoRequest,
     },
     response::ResponseFuture,
     routing::Route,
@@ -27,7 +27,7 @@ use twilight_validate::message::{
 #[derive(Serialize)]
 struct CreateFollowupFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    allowed_mentions: Option<NullableField<&'a AllowedMentions>>,
+    allowed_mentions: Option<Nullable<&'a AllowedMentions>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     attachments: Option<Vec<PartialAttachment<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -110,7 +110,7 @@ impl<'a> CreateFollowup<'a> {
     /// Unless otherwise called, the request will use the client's default
     /// allowed mentions. Set to `None` to ignore this default.
     pub const fn allowed_mentions(mut self, allowed_mentions: Option<&'a AllowedMentions>) -> Self {
-        self.fields.allowed_mentions = Some(NullableField(allowed_mentions));
+        self.fields.allowed_mentions = Some(Nullable(allowed_mentions));
 
         self
     }
@@ -272,7 +272,7 @@ impl TryIntoRequest for CreateFollowup<'_> {
         // Set the default allowed mentions if required.
         if self.fields.allowed_mentions.is_none() {
             if let Some(allowed_mentions) = self.http.default_allowed_mentions() {
-                self.fields.allowed_mentions = Some(NullableField(Some(allowed_mentions)));
+                self.fields.allowed_mentions = Some(Nullable(Some(allowed_mentions)));
             }
         }
 

--- a/http/src/request/application/interaction/update_followup.rs
+++ b/http/src/request/application/interaction/update_followup.rs
@@ -5,7 +5,7 @@ use crate::{
     error::Error as HttpError,
     request::{
         attachment::{AttachmentManager, PartialAttachment},
-        NullableField, Request, TryIntoRequest,
+        Nullable, Request, TryIntoRequest,
     },
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
@@ -28,16 +28,16 @@ use twilight_validate::message::{
 #[derive(Serialize)]
 struct UpdateFollowupFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    allowed_mentions: Option<NullableField<&'a AllowedMentions>>,
+    allowed_mentions: Option<Nullable<&'a AllowedMentions>>,
     /// List of attachments to keep, and new attachments to add.
     #[serde(skip_serializing_if = "Option::is_none")]
-    attachments: Option<NullableField<Vec<PartialAttachment<'a>>>>,
+    attachments: Option<Nullable<Vec<PartialAttachment<'a>>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    components: Option<NullableField<&'a [Component]>>,
+    components: Option<Nullable<&'a [Component]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<NullableField<&'a str>>,
+    content: Option<Nullable<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    embeds: Option<NullableField<&'a [Embed]>>,
+    embeds: Option<Nullable<&'a [Embed]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payload_json: Option<&'a [u8]>,
 }
@@ -121,7 +121,7 @@ impl<'a> UpdateFollowup<'a> {
     /// Unless otherwise called, the request will use the client's default
     /// allowed mentions. Set to `None` to ignore this default.
     pub const fn allowed_mentions(mut self, allowed_mentions: Option<&'a AllowedMentions>) -> Self {
-        self.fields.allowed_mentions = Some(NullableField(allowed_mentions));
+        self.fields.allowed_mentions = Some(Nullable(allowed_mentions));
 
         self
     }
@@ -172,7 +172,7 @@ impl<'a> UpdateFollowup<'a> {
             validate_components(components)?;
         }
 
-        self.fields.components = Some(NullableField(components));
+        self.fields.components = Some(Nullable(components));
 
         Ok(self)
     }
@@ -197,7 +197,7 @@ impl<'a> UpdateFollowup<'a> {
             validate_content(content_ref)?;
         }
 
-        self.fields.content = Some(NullableField(content));
+        self.fields.content = Some(Nullable(content));
 
         Ok(self)
     }
@@ -268,7 +268,7 @@ impl<'a> UpdateFollowup<'a> {
             validate_embeds(embeds)?;
         }
 
-        self.fields.embeds = Some(NullableField(embeds));
+        self.fields.embeds = Some(Nullable(embeds));
 
         Ok(self)
     }
@@ -287,7 +287,7 @@ impl<'a> UpdateFollowup<'a> {
 
         // Set an empty list. This will be overwritten in `TryIntoRequest` if
         // the actual list is not empty.
-        self.fields.attachments = Some(NullableField(Some(Vec::new())));
+        self.fields.attachments = Some(Nullable(Some(Vec::new())));
 
         self
     }
@@ -336,7 +336,7 @@ impl TryIntoRequest for UpdateFollowup<'_> {
         // Set the default allowed mentions if required.
         if self.fields.allowed_mentions.is_none() {
             if let Some(allowed_mentions) = self.http.default_allowed_mentions() {
-                self.fields.allowed_mentions = Some(NullableField(Some(allowed_mentions)));
+                self.fields.allowed_mentions = Some(Nullable(Some(allowed_mentions)));
             }
         }
 
@@ -346,7 +346,7 @@ impl TryIntoRequest for UpdateFollowup<'_> {
             let form = if let Some(payload_json) = self.fields.payload_json {
                 self.attachment_manager.build_form(payload_json)
             } else {
-                self.fields.attachments = Some(NullableField(Some(
+                self.fields.attachments = Some(Nullable(Some(
                     self.attachment_manager.get_partial_attachments(),
                 )));
 

--- a/http/src/request/application/interaction/update_response.rs
+++ b/http/src/request/application/interaction/update_response.rs
@@ -5,7 +5,7 @@ use crate::{
     error::Error as HttpError,
     request::{
         attachment::{AttachmentManager, PartialAttachment},
-        NullableField, Request, TryIntoRequest,
+        Nullable, Request, TryIntoRequest,
     },
     response::ResponseFuture,
     routing::Route,
@@ -28,16 +28,16 @@ use twilight_validate::message::{
 #[derive(Serialize)]
 struct UpdateResponseFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    allowed_mentions: Option<NullableField<&'a AllowedMentions>>,
+    allowed_mentions: Option<Nullable<&'a AllowedMentions>>,
     /// List of attachments to keep, and new attachments to add.
     #[serde(skip_serializing_if = "Option::is_none")]
-    attachments: Option<NullableField<Vec<PartialAttachment<'a>>>>,
+    attachments: Option<Nullable<Vec<PartialAttachment<'a>>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    components: Option<NullableField<&'a [Component]>>,
+    components: Option<Nullable<&'a [Component]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<NullableField<&'a str>>,
+    content: Option<Nullable<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    embeds: Option<NullableField<&'a [Embed]>>,
+    embeds: Option<Nullable<&'a [Embed]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payload_json: Option<&'a [u8]>,
 }
@@ -118,7 +118,7 @@ impl<'a> UpdateResponse<'a> {
     /// If not called, the request will use the client's default allowed
     /// mentions.
     pub const fn allowed_mentions(mut self, allowed_mentions: Option<&'a AllowedMentions>) -> Self {
-        self.fields.allowed_mentions = Some(NullableField(allowed_mentions));
+        self.fields.allowed_mentions = Some(Nullable(allowed_mentions));
 
         self
     }
@@ -169,7 +169,7 @@ impl<'a> UpdateResponse<'a> {
             validate_components(components)?;
         }
 
-        self.fields.components = Some(NullableField(components));
+        self.fields.components = Some(Nullable(components));
 
         Ok(self)
     }
@@ -194,7 +194,7 @@ impl<'a> UpdateResponse<'a> {
             validate_content(content_ref)?;
         }
 
-        self.fields.content = Some(NullableField(content));
+        self.fields.content = Some(Nullable(content));
 
         Ok(self)
     }
@@ -264,7 +264,7 @@ impl<'a> UpdateResponse<'a> {
             validate_embeds(embeds)?;
         }
 
-        self.fields.embeds = Some(NullableField(embeds));
+        self.fields.embeds = Some(Nullable(embeds));
 
         Ok(self)
     }
@@ -283,7 +283,7 @@ impl<'a> UpdateResponse<'a> {
 
         // Set an empty list. This will be overwritten in `TryIntoRequest` if
         // the actual list is not empty.
-        self.fields.attachments = Some(NullableField(Some(Vec::new())));
+        self.fields.attachments = Some(Nullable(Some(Vec::new())));
 
         self
     }
@@ -330,7 +330,7 @@ impl TryIntoRequest for UpdateResponse<'_> {
         // Set the default allowed mentions if required.
         if self.fields.allowed_mentions.is_none() {
             if let Some(allowed_mentions) = self.http.default_allowed_mentions() {
-                self.fields.allowed_mentions = Some(NullableField(Some(allowed_mentions)));
+                self.fields.allowed_mentions = Some(Nullable(Some(allowed_mentions)));
             }
         }
 
@@ -340,7 +340,7 @@ impl TryIntoRequest for UpdateResponse<'_> {
             let form = if let Some(payload_json) = self.fields.payload_json {
                 self.attachment_manager.build_form(payload_json)
             } else {
-                self.fields.attachments = Some(NullableField(Some(
+                self.fields.attachments = Some(Nullable(Some(
                     self.attachment_manager.get_partial_attachments(),
                 )));
 

--- a/http/src/request/channel/message/create_message.rs
+++ b/http/src/request/channel/message/create_message.rs
@@ -3,7 +3,7 @@ use crate::{
     error::Error as HttpError,
     request::{
         attachment::{AttachmentManager, PartialAttachment},
-        NullableField, Request, TryIntoRequest,
+        Nullable, Request, TryIntoRequest,
     },
     response::ResponseFuture,
     routing::Route,
@@ -31,7 +31,7 @@ use twilight_validate::message::{
 #[derive(Serialize)]
 pub(crate) struct CreateMessageFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    allowed_mentions: Option<NullableField<&'a AllowedMentions>>,
+    allowed_mentions: Option<Nullable<&'a AllowedMentions>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     attachments: Option<Vec<PartialAttachment<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -117,7 +117,7 @@ impl<'a> CreateMessage<'a> {
     /// Unless otherwise called, the request will use the client's default
     /// allowed mentions. Set to `None` to ignore this default.
     pub const fn allowed_mentions(mut self, allowed_mentions: Option<&'a AllowedMentions>) -> Self {
-        self.fields.allowed_mentions = Some(NullableField(allowed_mentions));
+        self.fields.allowed_mentions = Some(Nullable(allowed_mentions));
 
         self
     }
@@ -347,7 +347,7 @@ impl TryIntoRequest for CreateMessage<'_> {
         // Set the default allowed mentions if required.
         if self.fields.allowed_mentions.is_none() {
             if let Some(allowed_mentions) = self.http.default_allowed_mentions() {
-                self.fields.allowed_mentions = Some(NullableField(Some(allowed_mentions)));
+                self.fields.allowed_mentions = Some(Nullable(Some(allowed_mentions)));
             }
         }
 

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -3,7 +3,7 @@ use crate::{
     error::Error as HttpError,
     request::{
         attachment::{AttachmentManager, PartialAttachment},
-        NullableField, Request, TryIntoRequest,
+        Nullable, Request, TryIntoRequest,
     },
     response::ResponseFuture,
     routing::Route,
@@ -30,16 +30,16 @@ use twilight_validate::message::{
 #[derive(Serialize)]
 struct UpdateMessageFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    allowed_mentions: Option<NullableField<&'a AllowedMentions>>,
+    allowed_mentions: Option<Nullable<&'a AllowedMentions>>,
     /// List of attachments to keep, and new attachments to add.
     #[serde(skip_serializing_if = "Option::is_none")]
-    attachments: Option<NullableField<Vec<PartialAttachment<'a>>>>,
+    attachments: Option<Nullable<Vec<PartialAttachment<'a>>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    components: Option<NullableField<&'a [Component]>>,
+    components: Option<Nullable<&'a [Component]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<NullableField<&'a str>>,
+    content: Option<Nullable<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    embeds: Option<NullableField<&'a [Embed]>>,
+    embeds: Option<Nullable<&'a [Embed]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<MessageFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -126,7 +126,7 @@ impl<'a> UpdateMessage<'a> {
     /// If not called, the request will use the client's default allowed
     /// mentions.
     pub const fn allowed_mentions(mut self, allowed_mentions: Option<&'a AllowedMentions>) -> Self {
-        self.fields.allowed_mentions = Some(NullableField(allowed_mentions));
+        self.fields.allowed_mentions = Some(Nullable(allowed_mentions));
 
         self
     }
@@ -177,7 +177,7 @@ impl<'a> UpdateMessage<'a> {
             validate_components(components)?;
         }
 
-        self.fields.components = Some(NullableField(components));
+        self.fields.components = Some(Nullable(components));
 
         Ok(self)
     }
@@ -203,7 +203,7 @@ impl<'a> UpdateMessage<'a> {
             validate_content(content_ref)?;
         }
 
-        self.fields.content = Some(NullableField(content));
+        self.fields.content = Some(Nullable(content));
 
         Ok(self)
     }
@@ -241,7 +241,7 @@ impl<'a> UpdateMessage<'a> {
             validate_embeds(embeds)?;
         }
 
-        self.fields.embeds = Some(NullableField(embeds));
+        self.fields.embeds = Some(Nullable(embeds));
 
         Ok(self)
     }
@@ -271,7 +271,7 @@ impl<'a> UpdateMessage<'a> {
 
         // Set an empty list. This will be overwritten in `TryIntoRequest` if
         // the actual list is not empty.
-        self.fields.attachments = Some(NullableField(Some(Vec::new())));
+        self.fields.attachments = Some(Nullable(Some(Vec::new())));
 
         self
     }
@@ -317,7 +317,7 @@ impl TryIntoRequest for UpdateMessage<'_> {
         // Set the default allowed mentions if required.
         if self.fields.allowed_mentions.is_none() {
             if let Some(allowed_mentions) = self.http.default_allowed_mentions() {
-                self.fields.allowed_mentions = Some(NullableField(Some(allowed_mentions)));
+                self.fields.allowed_mentions = Some(Nullable(Some(allowed_mentions)));
             }
         }
 
@@ -327,7 +327,7 @@ impl TryIntoRequest for UpdateMessage<'_> {
             let form = if let Some(payload_json) = self.fields.payload_json {
                 self.attachment_manager.build_form(payload_json)
             } else {
-                self.fields.attachments = Some(NullableField(Some(
+                self.fields.attachments = Some(Nullable(Some(
                     self.attachment_manager.get_partial_attachments(),
                 )));
 

--- a/http/src/request/channel/update_channel.rs
+++ b/http/src/request/channel/update_channel.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, NullableField, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -26,7 +26,7 @@ struct UpdateChannelFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     nsfw: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    parent_id: Option<NullableField<Id<ChannelMarker>>>,
+    parent_id: Option<Nullable<Id<ChannelMarker>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     permission_overwrites: Option<&'a [PermissionOverwrite]>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -111,7 +111,7 @@ impl<'a> UpdateChannel<'a> {
     /// If this is specified, and the parent ID is a `ChannelType::CategoryChannel`, move this
     /// channel to a child of the category channel.
     pub const fn parent_id(mut self, parent_id: Option<Id<ChannelMarker>>) -> Self {
-        self.fields.parent_id = Some(NullableField(parent_id));
+        self.fields.parent_id = Some(Nullable(parent_id));
 
         self
     }

--- a/http/src/request/channel/webhook/execute_webhook.rs
+++ b/http/src/request/channel/webhook/execute_webhook.rs
@@ -4,7 +4,7 @@ use crate::{
     request::{
         attachment::{AttachmentManager, PartialAttachment},
         channel::webhook::ExecuteWebhookAndWait,
-        NullableField, Request, TryIntoRequest,
+        Nullable, Request, TryIntoRequest,
     },
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
@@ -34,7 +34,7 @@ use twilight_validate::{
 #[derive(Serialize)]
 pub(crate) struct ExecuteWebhookFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    allowed_mentions: Option<NullableField<&'a AllowedMentions>>,
+    allowed_mentions: Option<Nullable<&'a AllowedMentions>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     attachments: Option<Vec<PartialAttachment<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -125,7 +125,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// Unless otherwise called, the request will use the client's default
     /// allowed mentions. Set to `None` to ignore this default.
     pub const fn allowed_mentions(mut self, allowed_mentions: Option<&'a AllowedMentions>) -> Self {
-        self.fields.allowed_mentions = Some(NullableField(allowed_mentions));
+        self.fields.allowed_mentions = Some(Nullable(allowed_mentions));
 
         self
     }
@@ -377,7 +377,7 @@ impl TryIntoRequest for ExecuteWebhook<'_> {
         // Set the default allowed mentions if required.
         if self.fields.allowed_mentions.is_none() {
             if let Some(allowed_mentions) = self.http.default_allowed_mentions() {
-                self.fields.allowed_mentions = Some(NullableField(Some(allowed_mentions)));
+                self.fields.allowed_mentions = Some(Nullable(Some(allowed_mentions)));
             }
         }
 

--- a/http/src/request/channel/webhook/update_webhook.rs
+++ b/http/src/request/channel/webhook/update_webhook.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, NullableField, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -24,11 +24,11 @@ struct UpdateWebhookFields<'a> {
         serialize_with = "request::serialize_optional_nullable_image",
         skip_serializing_if = "Option::is_none"
     )]
-    avatar: Option<NullableField<&'a [u8]>>,
+    avatar: Option<Nullable<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     channel_id: Option<Id<ChannelMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<NullableField<&'a str>>,
+    name: Option<Nullable<&'a str>>,
 }
 
 /// Update a webhook by ID.
@@ -63,7 +63,7 @@ impl<'a> UpdateWebhook<'a> {
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
     pub const fn avatar(mut self, avatar: Option<&'a [u8]>) -> Self {
-        self.fields.avatar = Some(NullableField(avatar));
+        self.fields.avatar = Some(Nullable(avatar));
 
         self
     }
@@ -88,7 +88,7 @@ impl<'a> UpdateWebhook<'a> {
             validate_webhook_username(name)?;
         }
 
-        self.fields.name = Some(NullableField(name));
+        self.fields.name = Some(Nullable(name));
 
         Ok(self)
     }

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -5,7 +5,7 @@ use crate::{
     error::Error as HttpError,
     request::{
         attachment::{AttachmentManager, PartialAttachment},
-        NullableField, Request, TryIntoRequest,
+        Nullable, Request, TryIntoRequest,
     },
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
@@ -28,16 +28,16 @@ use twilight_validate::message::{
 #[derive(Serialize)]
 struct UpdateWebhookMessageFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    allowed_mentions: Option<NullableField<&'a AllowedMentions>>,
+    allowed_mentions: Option<Nullable<&'a AllowedMentions>>,
     /// List of attachments to keep, and new attachments to add.
     #[serde(skip_serializing_if = "Option::is_none")]
-    attachments: Option<NullableField<Vec<PartialAttachment<'a>>>>,
+    attachments: Option<Nullable<Vec<PartialAttachment<'a>>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    components: Option<NullableField<&'a [Component]>>,
+    components: Option<Nullable<&'a [Component]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<NullableField<&'a str>>,
+    content: Option<Nullable<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    embeds: Option<NullableField<&'a [Embed]>>,
+    embeds: Option<Nullable<&'a [Embed]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payload_json: Option<&'a [u8]>,
 }
@@ -118,7 +118,7 @@ impl<'a> UpdateWebhookMessage<'a> {
     /// Unless otherwise called, the request will use the client's default
     /// allowed mentions. Set to `None` to ignore this default.
     pub const fn allowed_mentions(mut self, allowed_mentions: Option<&'a AllowedMentions>) -> Self {
-        self.fields.allowed_mentions = Some(NullableField(allowed_mentions));
+        self.fields.allowed_mentions = Some(Nullable(allowed_mentions));
 
         self
     }
@@ -171,7 +171,7 @@ impl<'a> UpdateWebhookMessage<'a> {
             validate_components(components)?;
         }
 
-        self.fields.components = Some(NullableField(components));
+        self.fields.components = Some(Nullable(components));
 
         Ok(self)
     }
@@ -196,7 +196,7 @@ impl<'a> UpdateWebhookMessage<'a> {
             validate_content(content_ref)?;
         }
 
-        self.fields.content = Some(NullableField(content));
+        self.fields.content = Some(Nullable(content));
 
         Ok(self)
     }
@@ -266,7 +266,7 @@ impl<'a> UpdateWebhookMessage<'a> {
             validate_embeds(embeds)?;
         }
 
-        self.fields.embeds = Some(NullableField(embeds));
+        self.fields.embeds = Some(Nullable(embeds));
 
         Ok(self)
     }
@@ -284,7 +284,7 @@ impl<'a> UpdateWebhookMessage<'a> {
 
         // Set an empty list. This will be overwritten in `TryIntoRequest` if
         // the actual list is not empty.
-        self.fields.attachments = Some(NullableField(Some(Vec::new())));
+        self.fields.attachments = Some(Nullable(Some(Vec::new())));
 
         self
     }
@@ -342,7 +342,7 @@ impl TryIntoRequest for UpdateWebhookMessage<'_> {
         // Set the default allowed mentions if required.
         if self.fields.allowed_mentions.is_none() {
             if let Some(allowed_mentions) = self.http.default_allowed_mentions() {
-                self.fields.allowed_mentions = Some(NullableField(Some(allowed_mentions)));
+                self.fields.allowed_mentions = Some(Nullable(Some(allowed_mentions)));
             }
         }
 
@@ -352,7 +352,7 @@ impl TryIntoRequest for UpdateWebhookMessage<'_> {
             let form = if let Some(payload_json) = self.fields.payload_json {
                 self.attachment_manager.build_form(payload_json)
             } else {
-                self.fields.attachments = Some(NullableField(Some(
+                self.fields.attachments = Some(Nullable(Some(
                     self.attachment_manager.get_partial_attachments(),
                 )));
 
@@ -377,7 +377,7 @@ mod tests {
     use super::{UpdateWebhookMessage, UpdateWebhookMessageFields};
     use crate::{
         client::Client,
-        request::{NullableField, Request, TryIntoRequest},
+        request::{Nullable, Request, TryIntoRequest},
         routing::Route,
     };
     use twilight_model::id::Id;
@@ -398,7 +398,7 @@ mod tests {
             allowed_mentions: None,
             attachments: None,
             components: None,
-            content: Some(NullableField(Some("test"))),
+            content: Some(Nullable(Some("test"))),
             embeds: None,
             payload_json: None,
         };

--- a/http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{NullableField, Request, TryIntoRequest},
+    request::{Nullable, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -18,9 +18,9 @@ struct UpdateWebhookWithTokenFields<'a> {
         serialize_with = "crate::request::serialize_optional_nullable_image",
         skip_serializing_if = "Option::is_none"
     )]
-    avatar: Option<NullableField<&'a [u8]>>,
+    avatar: Option<Nullable<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<NullableField<&'a str>>,
+    name: Option<Nullable<&'a str>>,
 }
 
 /// Update a webhook, with a token, by ID.
@@ -57,7 +57,7 @@ impl<'a> UpdateWebhookWithToken<'a> {
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
     pub const fn avatar(mut self, avatar: Option<&'a [u8]>) -> Self {
-        self.fields.avatar = Some(NullableField(avatar));
+        self.fields.avatar = Some(Nullable(avatar));
 
         self
     }
@@ -75,7 +75,7 @@ impl<'a> UpdateWebhookWithToken<'a> {
             validate_webhook_username(name)?;
         }
 
-        self.fields.name = Some(NullableField(name));
+        self.fields.name = Some(Nullable(name));
 
         Ok(self)
     }

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, NullableField, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
     response::{marker::MemberBody, ResponseFuture},
     routing::Route,
 };
@@ -23,15 +23,15 @@ use twilight_validate::request::{
 struct UpdateGuildMemberFields<'a> {
     #[allow(clippy::option_option)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    channel_id: Option<NullableField<Id<ChannelMarker>>>,
+    channel_id: Option<Nullable<Id<ChannelMarker>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    communication_disabled_until: Option<NullableField<Timestamp>>,
+    communication_disabled_until: Option<Nullable<Timestamp>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     deaf: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     mute: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    nick: Option<NullableField<&'a str>>,
+    nick: Option<Nullable<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     roles: Option<&'a [Id<RoleMarker>]>,
 }
@@ -74,7 +74,7 @@ impl<'a> UpdateGuildMember<'a> {
 
     /// Move the member to a different voice channel.
     pub const fn channel_id(mut self, channel_id: Option<Id<ChannelMarker>>) -> Self {
-        self.fields.channel_id = Some(NullableField(channel_id));
+        self.fields.channel_id = Some(Nullable(channel_id));
 
         self
     }
@@ -103,7 +103,7 @@ impl<'a> UpdateGuildMember<'a> {
             validate_communication_disabled_until(timestamp)?;
         }
 
-        self.fields.communication_disabled_until = Some(NullableField(timestamp));
+        self.fields.communication_disabled_until = Some(Nullable(timestamp));
 
         Ok(self)
     }
@@ -137,7 +137,7 @@ impl<'a> UpdateGuildMember<'a> {
             validate_nickname(nick)?;
         }
 
-        self.fields.nick = Some(NullableField(nick));
+        self.fields.nick = Some(Nullable(nick));
 
         Ok(self)
     }
@@ -198,7 +198,7 @@ impl TryIntoRequest for UpdateGuildMember<'_> {
 mod tests {
     use super::{UpdateGuildMember, UpdateGuildMemberFields};
     use crate::{
-        request::{NullableField, Request, TryIntoRequest},
+        request::{Nullable, Request, TryIntoRequest},
         routing::Route,
         Client,
     };
@@ -250,7 +250,7 @@ mod tests {
             communication_disabled_until: None,
             deaf: None,
             mute: None,
-            nick: Some(NullableField(None)),
+            nick: Some(Nullable(None)),
             roles: None,
         };
         let route = Route::UpdateMember {
@@ -275,7 +275,7 @@ mod tests {
             communication_disabled_until: None,
             deaf: None,
             mute: None,
-            nick: Some(NullableField(Some("foo"))),
+            nick: Some(Nullable(Some("foo"))),
             roles: None,
         };
         let route = Route::UpdateMember {

--- a/http/src/request/guild/role/update_role.rs
+++ b/http/src/request/guild/role/update_role.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, NullableField, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -18,7 +18,7 @@ use twilight_validate::request::{audit_reason as validate_audit_reason, Validati
 #[derive(Serialize)]
 struct UpdateRoleFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    color: Option<NullableField<u32>>,
+    color: Option<Nullable<u32>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -26,7 +26,7 @@ struct UpdateRoleFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     mentionable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<NullableField<&'a str>>,
+    name: Option<Nullable<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     permissions: Option<Permissions>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -68,7 +68,7 @@ impl<'a> UpdateRole<'a> {
 
     /// Set the color of the role.
     pub const fn color(mut self, color: Option<u32>) -> Self {
-        self.fields.color = Some(NullableField(color));
+        self.fields.color = Some(Nullable(color));
 
         self
     }
@@ -102,7 +102,7 @@ impl<'a> UpdateRole<'a> {
 
     /// Set the name of the role.
     pub const fn name(mut self, name: Option<&'a str>) -> Self {
-        self.fields.name = Some(NullableField(name));
+        self.fields.name = Some(Nullable(name));
 
         self
     }

--- a/http/src/request/guild/update_guild.rs
+++ b/http/src/request/guild/update_guild.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, NullableField, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -23,42 +23,42 @@ use twilight_validate::request::{
 #[derive(Serialize)]
 struct UpdateGuildFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    afk_channel_id: Option<NullableField<Id<ChannelMarker>>>,
+    afk_channel_id: Option<Nullable<Id<ChannelMarker>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     afk_timeout: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    banner: Option<NullableField<&'a str>>,
+    banner: Option<Nullable<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_message_notifications: Option<NullableField<DefaultMessageNotificationLevel>>,
+    default_message_notifications: Option<Nullable<DefaultMessageNotificationLevel>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discovery_splash: Option<NullableField<&'a str>>,
+    discovery_splash: Option<Nullable<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    explicit_content_filter: Option<NullableField<ExplicitContentFilter>>,
+    explicit_content_filter: Option<Nullable<ExplicitContentFilter>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     features: Option<&'a [&'a str]>,
     #[serde(
         serialize_with = "request::serialize_optional_nullable_image",
         skip_serializing_if = "Option::is_none"
     )]
-    icon: Option<NullableField<&'a [u8]>>,
+    icon: Option<Nullable<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     owner_id: Option<Id<UserMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    splash: Option<NullableField<&'a str>>,
+    splash: Option<Nullable<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    system_channel_id: Option<NullableField<Id<ChannelMarker>>>,
+    system_channel_id: Option<Nullable<Id<ChannelMarker>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    system_channel_flags: Option<NullableField<SystemChannelFlags>>,
+    system_channel_flags: Option<Nullable<SystemChannelFlags>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    verification_level: Option<NullableField<VerificationLevel>>,
+    verification_level: Option<Nullable<VerificationLevel>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    rules_channel_id: Option<NullableField<Id<ChannelMarker>>>,
+    rules_channel_id: Option<Nullable<Id<ChannelMarker>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    public_updates_channel_id: Option<NullableField<Id<ChannelMarker>>>,
+    public_updates_channel_id: Option<Nullable<Id<ChannelMarker>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    preferred_locale: Option<NullableField<&'a str>>,
+    preferred_locale: Option<Nullable<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     premium_progress_bar_enabled: Option<bool>,
 }
@@ -107,7 +107,7 @@ impl<'a> UpdateGuild<'a> {
 
     /// Set the voice channel where AFK voice users are sent.
     pub const fn afk_channel_id(mut self, afk_channel_id: Option<Id<ChannelMarker>>) -> Self {
-        self.fields.afk_channel_id = Some(NullableField(afk_channel_id));
+        self.fields.afk_channel_id = Some(Nullable(afk_channel_id));
 
         self
     }
@@ -126,7 +126,7 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// The server must have the `BANNER` feature.
     pub const fn banner(mut self, banner: Option<&'a str>) -> Self {
-        self.fields.banner = Some(NullableField(banner));
+        self.fields.banner = Some(Nullable(banner));
 
         self
     }
@@ -139,8 +139,7 @@ impl<'a> UpdateGuild<'a> {
         mut self,
         default_message_notifications: Option<DefaultMessageNotificationLevel>,
     ) -> Self {
-        self.fields.default_message_notifications =
-            Some(NullableField(default_message_notifications));
+        self.fields.default_message_notifications = Some(Nullable(default_message_notifications));
 
         self
     }
@@ -149,7 +148,7 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// Requires the guild to have the `DISCOVERABLE` feature enabled.
     pub const fn discovery_splash(mut self, discovery_splash: Option<&'a str>) -> Self {
-        self.fields.discovery_splash = Some(NullableField(discovery_splash));
+        self.fields.discovery_splash = Some(Nullable(discovery_splash));
 
         self
     }
@@ -159,7 +158,7 @@ impl<'a> UpdateGuild<'a> {
         mut self,
         explicit_content_filter: Option<ExplicitContentFilter>,
     ) -> Self {
-        self.fields.explicit_content_filter = Some(NullableField(explicit_content_filter));
+        self.fields.explicit_content_filter = Some(Nullable(explicit_content_filter));
 
         self
     }
@@ -184,7 +183,7 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
     pub const fn icon(mut self, icon: Option<&'a [u8]>) -> Self {
-        self.fields.icon = Some(NullableField(icon));
+        self.fields.icon = Some(Nullable(icon));
 
         self
     }
@@ -221,14 +220,14 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// Requires the guild to have the `INVITE_SPLASH` feature enabled.
     pub const fn splash(mut self, splash: Option<&'a str>) -> Self {
-        self.fields.splash = Some(NullableField(splash));
+        self.fields.splash = Some(Nullable(splash));
 
         self
     }
 
     /// Set the channel where events such as welcome messages are posted.
     pub const fn system_channel(mut self, system_channel_id: Option<Id<ChannelMarker>>) -> Self {
-        self.fields.system_channel_id = Some(NullableField(system_channel_id));
+        self.fields.system_channel_id = Some(Nullable(system_channel_id));
 
         self
     }
@@ -238,7 +237,7 @@ impl<'a> UpdateGuild<'a> {
         mut self,
         system_channel_flags: Option<SystemChannelFlags>,
     ) -> Self {
-        self.fields.system_channel_flags = Some(NullableField(system_channel_flags));
+        self.fields.system_channel_flags = Some(Nullable(system_channel_flags));
 
         self
     }
@@ -249,7 +248,7 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// [Discord Docs/Modify Guild]: https://discord.com/developers/docs/resources/guild#modify-guild
     pub const fn rules_channel(mut self, rules_channel_id: Option<Id<ChannelMarker>>) -> Self {
-        self.fields.rules_channel_id = Some(NullableField(rules_channel_id));
+        self.fields.rules_channel_id = Some(Nullable(rules_channel_id));
 
         self
     }
@@ -261,7 +260,7 @@ impl<'a> UpdateGuild<'a> {
         mut self,
         public_updates_channel_id: Option<Id<ChannelMarker>>,
     ) -> Self {
-        self.fields.public_updates_channel_id = Some(NullableField(public_updates_channel_id));
+        self.fields.public_updates_channel_id = Some(Nullable(public_updates_channel_id));
 
         self
     }
@@ -270,7 +269,7 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// Defaults to `en-US`. Requires the guild to be `PUBLIC`.
     pub const fn preferred_locale(mut self, preferred_locale: Option<&'a str>) -> Self {
-        self.fields.preferred_locale = Some(NullableField(preferred_locale));
+        self.fields.preferred_locale = Some(Nullable(preferred_locale));
 
         self
     }
@@ -284,7 +283,7 @@ impl<'a> UpdateGuild<'a> {
         mut self,
         verification_level: Option<VerificationLevel>,
     ) -> Self {
-        self.fields.verification_level = Some(NullableField(verification_level));
+        self.fields.verification_level = Some(Nullable(verification_level));
 
         self
     }

--- a/http/src/request/guild/update_guild_widget.rs
+++ b/http/src/request/guild/update_guild_widget.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{NullableField, Request, TryIntoRequest},
+    request::{Nullable, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -17,7 +17,7 @@ use twilight_model::{
 #[derive(Serialize)]
 struct UpdateGuildWidgetFields {
     #[serde(skip_serializing_if = "Option::is_none")]
-    channel_id: Option<NullableField<Id<ChannelMarker>>>,
+    channel_id: Option<Nullable<Id<ChannelMarker>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
 }
@@ -44,7 +44,7 @@ impl<'a> UpdateGuildWidget<'a> {
 
     /// Set which channel to display on the widget.
     pub const fn channel_id(mut self, channel_id: Option<Id<ChannelMarker>>) -> Self {
-        self.fields.channel_id = Some(NullableField(channel_id));
+        self.fields.channel_id = Some(Nullable(channel_id));
 
         self
     }

--- a/http/src/request/guild/user/update_current_user_voice_state.rs
+++ b/http/src/request/guild/user/update_current_user_voice_state.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{NullableField, Request, TryIntoRequest},
+    request::{Nullable, Request, TryIntoRequest},
     response::{marker::EmptyBody, ResponseFuture},
     routing::Route,
 };
@@ -17,7 +17,7 @@ struct UpdateCurrentUserVoiceStateFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     suppress: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    request_to_speak_timestamp: Option<NullableField<&'a str>>,
+    request_to_speak_timestamp: Option<Nullable<&'a str>>,
 }
 
 /// Update the current user's voice state.
@@ -55,10 +55,10 @@ impl<'a> UpdateCurrentUserVoiceState<'a> {
     /// future time.
     pub const fn request_to_speak_timestamp(mut self, request_to_speak_timestamp: &'a str) -> Self {
         if request_to_speak_timestamp.is_empty() {
-            self.fields.request_to_speak_timestamp = Some(NullableField(None));
+            self.fields.request_to_speak_timestamp = Some(Nullable(None));
         } else {
             self.fields.request_to_speak_timestamp =
-                Some(NullableField(Some(request_to_speak_timestamp)));
+                Some(Nullable(Some(request_to_speak_timestamp)));
         }
 
         self

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -37,12 +37,12 @@ use std::iter;
 /// Name of the audit log reason header.
 const REASON_HEADER_NAME: &str = "x-audit-log-reason";
 
-/// Field that either serializes to null or a value.
+/// Value that either serializes to null or a value.
 ///
 /// This is particularly useful when combined with an `Option` by allowing three
 /// states via `Option<Nullable<T>>`: undefined, null, and T.
 ///
-/// When the request field is `None` a field can skip serialization, while if
+/// When the request value is `None` it can skip serialization, while if
 /// `Nullable` is provided with `None` within it then it will serialize as
 /// null. This mechanism is primarily used in patch requests.
 #[derive(Serialize)]

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -37,7 +37,7 @@ use std::iter;
 /// Name of the audit log reason header.
 const REASON_HEADER_NAME: &str = "x-audit-log-reason";
 
-/// Value that either serializes to null or a value.
+/// Type that either serializes to null or a value.
 ///
 /// This is particularly useful when combined with an `Option` by allowing three
 /// states via `Option<Nullable<T>>`: undefined, null, and T.

--- a/http/src/request/scheduled_event/update_guild_scheduled_event.rs
+++ b/http/src/request/scheduled_event/update_guild_scheduled_event.rs
@@ -2,7 +2,7 @@ use super::EntityMetadataFields;
 use crate::{
     client::Client,
     error::Error,
-    request::{AuditLogReason, NullableField, Request, RequestBuilder, TryIntoRequest},
+    request::{AuditLogReason, Nullable, Request, RequestBuilder, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -24,9 +24,9 @@ use twilight_validate::request::{
 #[derive(Serialize)]
 struct UpdateGuildScheduledEventFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    channel_id: Option<NullableField<Id<ChannelMarker>>>,
+    channel_id: Option<Nullable<Id<ChannelMarker>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<NullableField<&'a str>>,
+    description: Option<Nullable<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     entity_metadata: Option<EntityMetadataFields<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -35,13 +35,13 @@ struct UpdateGuildScheduledEventFields<'a> {
         serialize_with = "crate::request::serialize_optional_nullable_image",
         skip_serializing_if = "Option::is_none"
     )]
-    image: Option<NullableField<&'a [u8]>>,
+    image: Option<Nullable<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     privacy_level: Option<PrivacyLevel>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    scheduled_end_time: Option<NullableField<&'a Timestamp>>,
+    scheduled_end_time: Option<Nullable<&'a Timestamp>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     scheduled_start_time: Option<&'a Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -108,7 +108,7 @@ impl<'a> UpdateGuildScheduledEvent<'a> {
             }
         }
 
-        self.fields.channel_id = Some(NullableField(Some(channel_id)));
+        self.fields.channel_id = Some(Nullable(Some(channel_id)));
 
         self
     }
@@ -128,7 +128,7 @@ impl<'a> UpdateGuildScheduledEvent<'a> {
             validate_scheduled_event_description(description)?;
         }
 
-        self.fields.description = Some(NullableField(description));
+        self.fields.description = Some(Nullable(description));
 
         Ok(self)
     }
@@ -157,7 +157,7 @@ impl<'a> UpdateGuildScheduledEvent<'a> {
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
     pub const fn image(mut self, image: Option<&'a [u8]>) -> Self {
-        self.fields.image = Some(NullableField(image));
+        self.fields.image = Some(Nullable(image));
 
         self
     }
@@ -194,7 +194,7 @@ impl<'a> UpdateGuildScheduledEvent<'a> {
     ///
     /// Required for external events.
     pub const fn scheduled_end_time(mut self, scheduled_end_time: Option<&'a Timestamp>) -> Self {
-        self.fields.scheduled_end_time = Some(NullableField(scheduled_end_time));
+        self.fields.scheduled_end_time = Some(Nullable(scheduled_end_time));
 
         self
     }

--- a/http/src/request/user/update_current_user.rs
+++ b/http/src/request/user/update_current_user.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error as HttpError,
-    request::{self, AuditLogReason, NullableField, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -17,7 +17,7 @@ struct UpdateCurrentUserFields<'a> {
         serialize_with = "request::serialize_optional_nullable_image",
         skip_serializing_if = "Option::is_none"
     )]
-    avatar: Option<NullableField<&'a [u8]>>,
+    avatar: Option<Nullable<&'a [u8]>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     username: Option<&'a str>,
 }
@@ -53,7 +53,7 @@ impl<'a> UpdateCurrentUser<'a> {
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
     pub const fn avatar(mut self, avatar: Option<&'a [u8]>) -> Self {
-        self.fields.avatar = Some(NullableField(avatar));
+        self.fields.avatar = Some(Nullable(avatar));
 
         self
     }


### PR DESCRIPTION
Shorter to write and the type is generic; not just for fields.
