### PR TITLE
feat(gateway)!: turn `twilight_http` optional

### DIFF
--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -59,3 +59,7 @@ rustls-native-roots = ["dep:rustls-tls", "dep:rustls-native-certs", "twilight-ht
 rustls-webpki-roots = ["dep:rustls-tls", "dep:webpki-roots", "twilight-http?/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
 zlib-simd = ["dep:flate2", "flate2?/zlib-ng"]
 zlib-stock = ["dep:flate2", "flate2?/zlib"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -54,9 +54,9 @@ tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log
 
 [features]
 default = ["rustls-native-roots", "twilight-http", "zlib-stock"]
-native = ["dep:native-tls", "twilight-http?/native", "tokio-tungstenite/native-tls"]
-rustls-native-roots = ["dep:rustls-tls", "dep:rustls-native-certs", "twilight-http?/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]
-rustls-webpki-roots = ["dep:rustls-tls", "dep:webpki-roots", "twilight-http?/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
+native = ["dep:native-tls", "tokio-tungstenite/native-tls"]
+rustls-native-roots = ["dep:rustls-tls", "dep:rustls-native-certs", "tokio-tungstenite/rustls-tls-native-roots"]
+rustls-webpki-roots = ["dep:rustls-tls", "dep:webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
 zlib-simd = ["dep:flate2", "flate2?/zlib-ng"]
 zlib-stock = ["dep:flate2", "flate2?/zlib"]
 

--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -25,7 +25,6 @@ tokio = { default-features = false, features = ["net", "rt", "sync", "time"], ve
 tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.17" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-gateway-queue = { default-features = false, path = "../twilight-gateway-queue", version = "0.13.0" }
-twilight-http = { default-features = false, path = "../twilight-http", version = "0.13.0" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.13.2" }
 
 # Optional
@@ -35,6 +34,7 @@ twilight-model = { default-features = false, path = "../twilight-model", version
 # https://github.com/alexcrichton/flate2-rs/issues/217
 flate2 = { default-features = false, optional = true, version = "1.0.24" }
 metrics = { default-features = false, optional = true, version = ">=0.18, <0.20" }
+twilight-http = { default-features = false, optional = true, path = "../twilight-http", version = "0.13.0" }
 simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = ">=0.4, <0.7" }
 
 # TLS libraries
@@ -53,9 +53,9 @@ tokio = { default-features = false, features = ["macros", "rt-multi-thread"], ve
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log"], version = "0.3" }
 
 [features]
-default = ["rustls-native-roots", "zlib-stock"]
-native = ["dep:native-tls", "twilight-http/native", "tokio-tungstenite/native-tls"]
-rustls-native-roots = ["dep:rustls-tls", "dep:rustls-native-certs", "twilight-http/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]
-rustls-webpki-roots = ["dep:rustls-tls", "dep:webpki-roots", "twilight-http/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
+default = ["rustls-native-roots", "twilight-http", "zlib-stock"]
+native = ["dep:native-tls", "twilight-http?/native", "tokio-tungstenite/native-tls"]
+rustls-native-roots = ["dep:rustls-tls", "dep:rustls-native-certs", "twilight-http?/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]
+rustls-webpki-roots = ["dep:rustls-tls", "dep:webpki-roots", "twilight-http?/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
 zlib-simd = ["dep:flate2", "flate2?/zlib-ng"]
 zlib-stock = ["dep:flate2", "flate2?/zlib"]

--- a/twilight-gateway/README.md
+++ b/twilight-gateway/README.md
@@ -24,6 +24,7 @@ Using the `stream` module, shards can be easily managed in groups.
   * `rustls-native-roots` (*default*): [`rustls`] using native root certificates
   * `rustls-webpki-roots`: [`rustls`] using [`webpki-roots`] for root
     certificates, useful for `scratch` containers
+* `twilight-http` (*default*): enable the `stream::start_recommended` function
 * Zlib (mutually exclusive)
   * `zlib-stock` (*default*): [`flate2`]'s stock zlib implementation
   * `zlib-ng`: use [`zlib-ng`] for zlib, may have better performance

--- a/twilight-gateway/src/lib.rs
+++ b/twilight-gateway/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(
     clippy::all,
     clippy::missing_const_for_fn,

--- a/twilight-gateway/src/stream.rs
+++ b/twilight-gateway/src/stream.rs
@@ -16,14 +16,18 @@ use crate::{
 use futures_util::stream::{FuturesUnordered, Stream, StreamExt};
 use std::{
     cell::RefCell,
-    error::Error,
-    fmt::{Display, Formatter, Result as FmtResult},
     future::Future,
     ops::{Bound, Deref, DerefMut, Range, RangeBounds},
     pin::Pin,
     rc::Rc,
     task::{Context, Poll},
 };
+#[cfg(feature = "twilight-http")]
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+#[cfg(feature = "twilight-http")]
 use twilight_http::Client;
 use twilight_model::gateway::event::Event;
 
@@ -33,6 +37,7 @@ type FutureList<'a, Item> =
 
 /// Failure when fetching the recommended number of shards to use from Discord's
 /// REST API.
+#[cfg(feature = "twilight-http")]
 #[derive(Debug)]
 pub struct StartRecommendedError {
     /// Type of error.
@@ -41,6 +46,7 @@ pub struct StartRecommendedError {
     pub(crate) source: Option<Box<dyn Error + Send + Sync>>,
 }
 
+#[cfg(feature = "twilight-http")]
 impl Display for StartRecommendedError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self.kind {
@@ -52,6 +58,7 @@ impl Display for StartRecommendedError {
     }
 }
 
+#[cfg(feature = "twilight-http")]
 impl Error for StartRecommendedError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         self.source
@@ -61,6 +68,7 @@ impl Error for StartRecommendedError {
 }
 
 /// Type of [`StartRecommendedError`] that occurred.
+#[cfg(feature = "twilight-http")]
 #[derive(Debug)]
 pub enum StartRecommendedErrorType {
     /// Received gateway event failed to be deserialized.
@@ -465,6 +473,7 @@ pub fn start_range<F: Fn(ShardId) -> Config>(
 /// # Panics
 ///
 /// Panics if loading TLS certificates fails.
+#[cfg(feature = "twilight-http")]
 #[track_caller]
 pub async fn start_recommended<F: Fn(ShardId) -> Config>(
     client: &Client,


### PR DESCRIPTION
Allows projects not using Discord's HTTP API to opt out of building `twilight_http`. Can be useful for gateway proxies.

HTTP allows the gateway to retrieve Discord's recommended shard count (exposed in the `twilight_gateway::stream::start_recommended` function).

The last commit in this PR ([fff53e1](https://github.com/twilight-rs/twilight/pull/1760/commits/fff53e17d06286afcae6b5d880bbecb495c31941)) makes the TLS features, combined with `twilight_http`, no build `twilight_http` with the same TLS variants. This allows projects requiring WSS but not HTTPS; HTTP could in this case be proxied by, for example, twilight-http-proxy.