### PR TITLE
refactor: `#[must_use]` on builders, not methods

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -46,6 +46,7 @@ use crate::shard::tls::TlsContainer;
 ///
 /// [`large_threshold`]: Self::large_threshold
 // Remember to sync this with the custom Debug implementation.
+#[must_use = "has no effect if not built"]
 pub struct ClusterBuilder {
     queue: Arc<dyn Queue>,
     resume_sessions: HashMap<u64, ResumeSession>,
@@ -154,7 +155,6 @@ impl ClusterBuilder {
     ///
     /// [`EventTypeFlags::SHARD_PAYLOAD`]: crate::EventTypeFlags::SHARD_PAYLOAD
     #[allow(clippy::missing_const_for_fn)]
-    #[must_use = "has no effect if not built"]
     pub fn event_types(mut self, event_types: EventTypeFlags) -> Self {
         self.shard = self.shard.event_types(event_types);
 
@@ -164,7 +164,6 @@ impl ClusterBuilder {
     /// Set the URL that will be used to connect to the gateway.
     ///
     /// Default is to fetch it from the HTTP API.
-    #[must_use = "has no effect if not built"]
     pub fn gateway_url(mut self, gateway_url: String) -> Self {
         self.shard = self.shard.gateway_url(gateway_url);
 
@@ -178,7 +177,6 @@ impl ClusterBuilder {
     /// information.
     ///
     /// Defaults to a new, default HTTP client is used.
-    #[must_use = "has no effect if not built"]
     pub fn http_client(mut self, http_client: Arc<Client>) -> Self {
         self.shard = self.shard.http_client(http_client);
 
@@ -208,7 +206,6 @@ impl ClusterBuilder {
     /// # Ok(()) }
     /// ```
     #[allow(clippy::missing_const_for_fn)]
-    #[must_use = "has no effect if not built"]
     pub fn identify_properties(mut self, identify_properties: IdentifyProperties) -> Self {
         self.shard = self.shard.identify_properties(identify_properties);
 
@@ -223,7 +220,6 @@ impl ClusterBuilder {
     /// # Panics
     ///
     /// Panics if the provided value is below 50 or above 250.
-    #[must_use = "has no effect if not built"]
     pub fn large_threshold(mut self, large_threshold: u64) -> Self {
         self.shard = self.shard.large_threshold(large_threshold);
 
@@ -233,7 +229,6 @@ impl ClusterBuilder {
     /// Set the presence to use when identifying with the gateway.
     ///
     /// Refer to the shard's [`ShardBuilder::presence`] for more information.
-    #[must_use = "has no effect if not built"]
     pub fn presence(mut self, presence: UpdatePresencePayload) -> Self {
         self.shard = self.shard.presence(presence);
 
@@ -247,7 +242,6 @@ impl ClusterBuilder {
     ///
     /// Defaults to being enabled.
     #[allow(clippy::missing_const_for_fn)]
-    #[must_use = "has no effect if not built"]
     pub fn ratelimit_payloads(mut self, ratelimit_payloads: bool) -> Self {
         self.shard = self.shard.ratelimit_payloads(ratelimit_payloads);
 
@@ -261,7 +255,6 @@ impl ClusterBuilder {
     /// by [`presence`], even if the provided closure returns [`None`].
     ///
     /// [`presence`]: Self::presence
-    #[must_use = "has no effect if not built"]
     pub fn shard_presence<F>(mut self, shard_presence: F) -> Self
     where
         F: Fn(u64) -> Option<UpdatePresencePayload> + Send + Sync + 'static,
@@ -299,7 +292,6 @@ impl ClusterBuilder {
     /// # Ok(()) }
     /// ```
     #[allow(clippy::missing_const_for_fn)]
-    #[must_use = "has no effect if not built"]
     pub fn shard_scheme(mut self, scheme: ShardScheme) -> Self {
         self.shard_scheme = Some(scheme);
 
@@ -314,7 +306,6 @@ impl ClusterBuilder {
     /// Refer to the [`queue`] module for more information.
     ///
     /// [`queue`]: crate::queue
-    #[must_use = "has no effect if not built"]
     pub fn queue(mut self, queue: Arc<dyn Queue>) -> Self {
         self.queue = Arc::clone(&queue);
         self.shard = self.shard.queue(queue);
@@ -331,7 +322,6 @@ impl ClusterBuilder {
     /// to resume. If their sessions are invalid they will have to re-identify
     /// to initialize a new session.
     #[allow(clippy::missing_const_for_fn)]
-    #[must_use = "has no effect if not built"]
     pub fn resume_sessions(mut self, resume_sessions: HashMap<u64, ResumeSession>) -> Self {
         self.resume_sessions = resume_sessions;
         self

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -96,6 +96,7 @@ pub enum ShardIdErrorType {
 /// [`large_threshold`]: Self::large_threshold
 /// [`shard`]: Self::shard
 #[derive(Debug)]
+#[must_use = "has no effect if not built"]
 pub struct ShardBuilder {
     event_types: EventTypeFlags,
     pub(crate) gateway_url: Option<Box<str>>,
@@ -203,7 +204,6 @@ impl ShardBuilder {
     /// [`EventTypeFlags::SHARD_PAYLOAD`] is enabled.
     ///
     /// [`EventTypeFlags::SHARD_PAYLOAD`]: crate::EventTypeFlags::SHARD_PAYLOAD
-    #[must_use = "has no effect if not built"]
     pub const fn event_types(mut self, event_types: EventTypeFlags) -> Self {
         self.event_types = event_types;
 
@@ -213,7 +213,6 @@ impl ShardBuilder {
     /// Set the URL used for connecting to Discord's gateway
     ///
     /// Default is to fetch it from the HTTP API.
-    #[must_use = "has no effect if not built"]
     pub fn gateway_url(mut self, gateway_url: String) -> Self {
         self.gateway_url = Some(gateway_url.into_boxed_str());
 
@@ -225,7 +224,6 @@ impl ShardBuilder {
     ///
     /// Default is a new, unconfigured instance of an HTTP client.
     #[allow(clippy::missing_const_for_fn)]
-    #[must_use = "has no effect if not built"]
     pub fn http_client(mut self, http_client: Arc<Client>) -> Self {
         self.http_client = http_client;
 
@@ -255,7 +253,6 @@ impl ShardBuilder {
     /// # Ok(()) }
     /// ```
     #[allow(clippy::missing_const_for_fn)]
-    #[must_use = "has no effect if not built"]
     pub fn identify_properties(mut self, identify_properties: IdentifyProperties) -> Self {
         self.identify_properties = Some(identify_properties);
 
@@ -277,7 +274,6 @@ impl ShardBuilder {
     ///
     /// Panics if the provided value is below 50 or above 250.
     #[allow(clippy::missing_const_for_fn)]
-    #[must_use = "has no effect if not built"]
     pub fn large_threshold(mut self, large_threshold: u64) -> Self {
         match large_threshold {
             0..=49 => panic!("provided large threshold value {large_threshold} is fewer than 50"),
@@ -324,7 +320,6 @@ impl ShardBuilder {
     /// # Ok(()) }
     ///
     /// ```
-    #[must_use = "has no effect if not built"]
     pub fn presence(mut self, presence: UpdatePresencePayload) -> Self {
         self.presence.replace(presence);
 
@@ -342,7 +337,6 @@ impl ShardBuilder {
     ///
     /// [`Cluster`]: crate::cluster::Cluster
     /// [`queue`]: crate::queue
-    #[must_use = "has no effect if not built"]
     pub fn queue(mut self, queue: Arc<dyn Queue>) -> Self {
         self.queue = queue;
 
@@ -356,7 +350,6 @@ impl ShardBuilder {
     ///
     /// Defaults to being enabled.
     #[allow(clippy::missing_const_for_fn)]
-    #[must_use = "has no effect if not built"]
     pub fn ratelimit_payloads(mut self, ratelimit_payloads: bool) -> Self {
         self.ratelimit_payloads = ratelimit_payloads;
 

--- a/http/src/client/builder.rs
+++ b/http/src/client/builder.rs
@@ -9,6 +9,7 @@ use twilight_model::channel::message::allowed_mentions::AllowedMentions;
 
 #[derive(Debug)]
 /// A builder for [`Client`].
+#[must_use = "has no effect if not built into a Client"]
 pub struct ClientBuilder {
     pub(crate) default_allowed_mentions: Option<AllowedMentions>,
     pub(crate) proxy: Option<Box<str>>,
@@ -53,7 +54,6 @@ impl ClientBuilder {
 
     /// Set the default allowed mentions setting to use on all messages sent through the HTTP
     /// client.
-    #[must_use = "has no effect if not built into a Client"]
     pub fn default_allowed_mentions(mut self, allowed_mentions: AllowedMentions) -> Self {
         self.default_allowed_mentions.replace(allowed_mentions);
 
@@ -80,7 +80,6 @@ impl ClientBuilder {
     /// ```
     ///
     /// [twilight's HTTP proxy server]: https://github.com/twilight-rs/http-proxy
-    #[must_use = "has no effect if not built into a Client"]
     pub fn proxy(mut self, proxy_url: String, use_http: bool) -> Self {
         self.proxy.replace(proxy_url.into_boxed_str());
         self.use_http = use_http;
@@ -96,7 +95,6 @@ impl ClientBuilder {
     /// If this method is not called at all then a default [`InMemoryRatelimiter`] will be
     /// created by [`ClientBuilder::build`].
     #[allow(clippy::missing_const_for_fn)]
-    #[must_use = "has no effect if not built into a Client"]
     pub fn ratelimiter(mut self, ratelimiter: Option<Box<dyn Ratelimiter>>) -> Self {
         self.ratelimiter = ratelimiter;
 
@@ -106,7 +104,6 @@ impl ClientBuilder {
     /// Set the timeout for HTTP requests.
     ///
     /// The default is 10 seconds.
-    #[must_use = "has no effect if not built into a Client"]
     pub const fn timeout(mut self, duration: Duration) -> Self {
         self.timeout = duration;
 
@@ -114,7 +111,6 @@ impl ClientBuilder {
     }
 
     /// Set a group headers which are sent in every request.
-    #[must_use = "has no effect if not built into a Client"]
     pub fn default_headers(mut self, headers: HeaderMap) -> Self {
         self.default_headers.replace(headers);
 
@@ -128,7 +124,6 @@ impl ClientBuilder {
     /// will not process future requests.
     ///
     /// Defaults to true.
-    #[must_use = "has no effect if not built into a Client"]
     pub const fn remember_invalid_token(mut self, remember: bool) -> Self {
         self.remember_invalid_token = remember;
 
@@ -136,7 +131,6 @@ impl ClientBuilder {
     }
 
     /// Set the token to use for HTTP requests.
-    #[must_use = "has no effect if not built into a Client"]
     pub fn token(mut self, mut token: String) -> Self {
         let is_bot = token.starts_with("Bot ");
         let is_bearer = token.starts_with("Bearer ");

--- a/http/src/request/base.rs
+++ b/http/src/request/base.rs
@@ -25,11 +25,11 @@ use serde::Serialize;
 /// }).body(body).build();
 /// ```
 #[derive(Debug)]
+#[must_use = "request has not been fully built"]
 pub struct RequestBuilder(Request);
 
 impl RequestBuilder {
     /// Create a new request builder.
-    #[must_use = "request has not been fully built"]
     pub fn new(route: &Route<'_>) -> Self {
         Self(Request::from_route(route))
     }
@@ -63,7 +63,6 @@ impl RequestBuilder {
     /// ).build();
     /// # Ok(()) }
     /// ```
-    #[must_use = "request has not been fully built"]
     pub const fn raw(method: Method, ratelimit_path: Path, path_and_query: String) -> Self {
         Self(Request {
             body: None,
@@ -84,7 +83,6 @@ impl RequestBuilder {
     }
 
     /// Set the contents of the body.
-    #[must_use = "request has not been fully built"]
     pub fn body(mut self, body: Vec<u8>) -> Self {
         self.0.body = Some(body);
 
@@ -93,7 +91,6 @@ impl RequestBuilder {
 
     /// Set the multipart form.
     #[allow(clippy::missing_const_for_fn)]
-    #[must_use = "request has not been fully built"]
     pub fn form(mut self, form: Form) -> Self {
         self.0.form = Some(form);
 
@@ -101,7 +98,6 @@ impl RequestBuilder {
     }
 
     /// Set the headers to add.
-    #[must_use = "request has not been fully built"]
     pub fn headers(mut self, iter: impl Iterator<Item = (HeaderName, HeaderValue)>) -> Self {
         self.0.headers.replace(iter.collect());
 
@@ -116,7 +112,6 @@ impl RequestBuilder {
     /// serialized as JSON.
     ///
     /// [`ErrorType::Json`]: crate::error::ErrorType::Json
-    #[must_use = "request has not been fully built"]
     pub fn json(self, to: &impl Serialize) -> Result<Self, Error> {
         let bytes = crate::json::to_vec(to).map_err(Error::json)?;
 
@@ -127,7 +122,6 @@ impl RequestBuilder {
     /// is set.
     ///
     /// This is primarily useful for executing webhooks.
-    #[must_use = "request has not been fully built"]
     pub const fn use_authorization_token(mut self, use_authorization_token: bool) -> Self {
         self.0.use_authorization_token = use_authorization_token;
 

--- a/http/src/request/multipart.rs
+++ b/http/src/request/multipart.rs
@@ -1,6 +1,7 @@
 use rand::{distributions::Alphanumeric, Rng};
 
 #[derive(Clone, Debug)]
+#[must_use = "has no effect if not built into a Form"]
 pub struct Form {
     boundary: [u8; 15],
     buffer: Vec<u8>,
@@ -38,7 +39,6 @@ impl Form {
         content_type
     }
 
-    #[must_use = "has no effect if not built into a Form"]
     pub fn part(mut self, name: &[u8], value: &[u8]) -> Self {
         // Write the Content-Disposition header.
         self.buffer.extend(Self::NEWLINE);
@@ -58,7 +58,6 @@ impl Form {
         self
     }
 
-    #[must_use = "has no effect if not built into a Form"]
     pub fn file_part(mut self, name: &[u8], filename: &[u8], value: &[u8]) -> Self {
         // Write the Content-Disposition header.
         self.buffer.extend(Self::NEWLINE);
@@ -86,7 +85,6 @@ impl Form {
         self.buffer.len() + Self::BOUNDARY_TERMINATOR.len()
     }
 
-    #[must_use = "has no effect if not built into a Form"]
     pub fn json_part(mut self, name: &[u8], value: &[u8]) -> Self {
         // Write the Content-Disposition header.
         self.buffer.extend(Self::NEWLINE);

--- a/model/src/channel/message/allowed_mentions/builder.rs
+++ b/model/src/channel/message/allowed_mentions/builder.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[must_use = "has no effect if not built into an AllowedMentions"]
 pub struct AllowedMentionsBuilder(AllowedMentions);
 
 impl AllowedMentionsBuilder {
@@ -21,7 +22,6 @@ impl AllowedMentionsBuilder {
     }
 
     /// Allow parsing of `@everyone`.
-    #[must_use = "has no effect if not built into an AllowedMentions"]
     pub fn everyone(mut self) -> Self {
         self.0.parse.push(ParseTypes::Everyone);
 
@@ -29,7 +29,6 @@ impl AllowedMentionsBuilder {
     }
 
     /// When replying, whether to mention the target user.
-    #[must_use = "has no effect if not built into an AllowedMentions"]
     pub const fn replied_user(mut self) -> Self {
         self.0.replied_user = true;
 
@@ -37,7 +36,6 @@ impl AllowedMentionsBuilder {
     }
 
     /// Allow parsing of all roles.
-    #[must_use = "has no effect if not built into an AllowedMentions"]
     pub fn roles(mut self) -> Self {
         self.0.parse.push(ParseTypes::Roles);
 
@@ -50,7 +48,6 @@ impl AllowedMentionsBuilder {
     /// specific role ids.
     ///
     /// [`roles`]: Self::roles
-    #[must_use = "has no effect if not built into an AllowedMentions"]
     pub fn role_ids(mut self, role_ids: impl IntoIterator<Item = Id<RoleMarker>>) -> Self {
         self.0.roles.extend(role_ids);
 
@@ -58,7 +55,6 @@ impl AllowedMentionsBuilder {
     }
 
     /// Allow parsing of all users.
-    #[must_use = "has no effect if not built into an AllowedMentions"]
     pub fn users(mut self) -> Self {
         self.0.parse.push(ParseTypes::Users);
 
@@ -71,7 +67,6 @@ impl AllowedMentionsBuilder {
     /// specific user ids.
     ///
     /// [`users`]: Self::users
-    #[must_use = "has no effect if not built into an AllowedMentions"]
     pub fn user_ids(mut self, user_ids: impl IntoIterator<Item = Id<UserMarker>>) -> Self {
         self.0.users.extend(user_ids);
 


### PR DESCRIPTION
Conservative first change for our `#[must_use]` policy.
