### PR TITLE
Use zlib-ng directly instead of through zlib-sys

### DIFF
--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -34,7 +34,7 @@ leaky-bucket-lite = { default-features = false, features = ["tokio"], version = 
 # from the C-backed backend zlib, When you give it the sync argument
 # it does not seem to update the total_in of the function to have an offset
 # https://github.com/alexcrichton/flate2-rs/issues/217
-flate2 = { default-features = false, optional = true, version = "1.0" }
+flate2 = { default-features = false, optional = true, version = "1.0.24" }
 metrics = { default-features = false, optional = true, version = "0.18" }
 simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.4" }
 
@@ -55,8 +55,5 @@ default = ["rustls-native-roots", "zlib-stock"]
 native = ["dep:native-tls", "twilight-http/native", "twilight-gateway-queue/native", "tokio-tungstenite/native-tls"]
 rustls-native-roots = ["dep:rustls-tls", "dep:rustls-native-certs", "twilight-http/rustls-native-roots", "twilight-gateway-queue/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]
 rustls-webpki-roots = ["dep:rustls-tls", "dep:webpki-roots", "twilight-http/rustls-webpki-roots", "twilight-gateway-queue/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
-zlib-simd = ["dep:flate2", "flate2?/zlib-ng-compat"]
-# if the `zlib` feature is enabled anywhere in the dependency tree it will
-# always use stock zlib instead of zlib-ng.
-# https://github.com/rust-lang/libz-sys/blob/main/README.md#zlib-ng
+zlib-simd = ["dep:flate2", "flate2?/zlib-ng"]
 zlib-stock = ["dep:flate2", "flate2?/zlib"]

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -92,7 +92,7 @@ This should be preferred over `rustls-native-roots` in Docker containers based o
 zlib compression is enabled with one of the two `zlib` features described below.
 
 There are 2 zlib features `zlib-stock` and `zlib-simd`, if both are enabled it
-will use `zlib-stock`.
+will use `zlib-simd`.
 
 `zlib-stock` is enabled by default.
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -96,8 +96,8 @@ will use `zlib-stock`.
 
 `zlib-stock` is enabled by default.
 
-Enabling **only** `zlib-simd` will make the library use [`zlib-ng`] which is a modern
-fork of zlib that is faster and more effective, but it needs `cmake` to compile.
+Enabling `zlib-simd` will make the library use [`zlib-ng`] which is a modern
+fork of zlib that is faster and more efficient, but it needs `cmake` to compile.
 
 ### Metrics
 


### PR DESCRIPTION
This means that it is no longer nessesary to make sure that zlib-stock
is anywhere in the dependency to make sure it is used instead of
zlib-ng.

For more information see: https://internals.rust-lang.org/t/psa-flate2-now-supports-zlib-ng-natively-via-libz-ng-sys/16706