### PR TITLE
refactor: remove `test_` prexif from tests

### DIFF
--- a/cache/in-memory/src/config.rs
+++ b/cache/in-memory/src/config.rs
@@ -97,7 +97,7 @@ mod tests {
     assert_fields!(Config: resource_types, message_cache_size);
 
     #[test]
-    fn test_defaults() {
+    fn defaults() {
         let conf = Config {
             resource_types: ResourceType::all(),
             message_cache_size: 100,

--- a/cache/in-memory/src/event/channel.rs
+++ b/cache/in-memory/src/event/channel.rs
@@ -89,7 +89,7 @@ mod tests {
     use twilight_model::gateway::event::Event;
 
     #[test]
-    fn test_channel_delete_guild() {
+    fn channel_delete_guild() {
         let cache = InMemoryCache::new();
         let (guild_id, channel_id, channel) = test::guild_channel_text();
 
@@ -107,7 +107,7 @@ mod tests {
     }
 
     #[test]
-    fn test_channel_update_guild() {
+    fn channel_update_guild() {
         let cache = InMemoryCache::new();
         let (guild_id, channel_id, channel) = test::guild_channel_text();
 

--- a/cache/in-memory/src/event/emoji.rs
+++ b/cache/in-memory/src/event/emoji.rs
@@ -80,7 +80,7 @@ mod tests {
     };
 
     #[test]
-    fn test_cache_emoji() {
+    fn cache_emoji() {
         let cache = InMemoryCache::new();
 
         // The user to do some of the inserts
@@ -146,7 +146,7 @@ mod tests {
     }
 
     #[test]
-    fn test_emoji_removal() {
+    fn emoji_removal() {
         let cache = InMemoryCache::new();
 
         let guild_id = Id::new(1);

--- a/cache/in-memory/src/event/guild.rs
+++ b/cache/in-memory/src/event/guild.rs
@@ -299,7 +299,7 @@ mod tests {
     };
 
     #[test]
-    fn test_guild_create_channels_have_guild_ids() -> Result<(), TimestampParseError> {
+    fn guild_create_channels_have_guild_ids() -> Result<(), TimestampParseError> {
         const DATETIME: &str = "2021-09-19T14:17:32.000000+00:00";
 
         let timestamp = Timestamp::from_str(DATETIME)?;
@@ -446,7 +446,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_update() {
+    fn guild_update() {
         let cache = InMemoryCache::new();
         let guild = test::guild(Id::new(1), None);
 
@@ -497,7 +497,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_member_count() {
+    fn guild_member_count() {
         let user_id = Id::new(2);
         let guild_id = Id::new(1);
         let cache = InMemoryCache::new();
@@ -516,7 +516,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_members_size_after_unavailable() {
+    fn guild_members_size_after_unavailable() {
         let user_id = Id::new(2);
         let guild_id = Id::new(1);
         let cache = InMemoryCache::new();

--- a/cache/in-memory/src/event/interaction.rs
+++ b/cache/in-memory/src/event/interaction.rs
@@ -89,7 +89,7 @@ mod tests {
     };
 
     #[test]
-    fn test_interaction_create() -> Result<(), ImageHashParseError> {
+    fn interaction_create() -> Result<(), ImageHashParseError> {
         let timestamp = Timestamp::from_secs(1_632_072_645).expect("non zero");
         // let avatar1 = ImageHash::parse(b"1ef6bca4fddaa303a9cd32dd70fb395d")?;
         let avatar2 = ImageHash::parse(b"3a43231a99f4dfcf0fd94d1d8defd301")?;

--- a/cache/in-memory/src/event/member.rs
+++ b/cache/in-memory/src/event/member.rs
@@ -200,7 +200,7 @@ mod tests {
     use crate::test;
 
     #[test]
-    fn test_cache_guild_member() {
+    fn cache_guild_member() {
         let cache = InMemoryCache::new();
 
         // Single inserts
@@ -257,7 +257,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_user_guild_state() {
+    fn cache_user_guild_state() {
         let user_id = Id::new(2);
         let cache = InMemoryCache::new();
         cache.cache_user(Cow::Owned(test::user(user_id)), Some(Id::new(1)));

--- a/cache/in-memory/src/event/message.rs
+++ b/cache/in-memory/src/event/message.rs
@@ -140,7 +140,7 @@ mod tests {
     };
 
     #[test]
-    fn test_message_create() -> Result<(), ImageHashParseError> {
+    fn message_create() -> Result<(), ImageHashParseError> {
         let joined_at = Timestamp::from_secs(1_632_072_645).expect("non zero");
         let cache = InMemoryCache::builder()
             .resource_types(ResourceType::MESSAGE | ResourceType::MEMBER | ResourceType::USER)

--- a/cache/in-memory/src/event/mod.rs
+++ b/cache/in-memory/src/event/mod.rs
@@ -104,7 +104,7 @@ mod tests {
     /// panic or do anything funny. This is the only synchronous mutex that we
     /// might have trouble with across await points if we're not careful.
     #[test]
-    fn test_current_user_retrieval() {
+    fn current_user_retrieval() {
         let cache = InMemoryCache::new();
         assert!(cache.current_user().is_none());
         cache.cache_current_user(test::current_user(1));

--- a/cache/in-memory/src/event/presence.rs
+++ b/cache/in-memory/src/event/presence.rs
@@ -48,7 +48,7 @@ mod tests {
     };
 
     #[test]
-    fn test_presence_update() {
+    fn presence_update() {
         let cache = InMemoryCache::new();
 
         let guild_id = Id::new(1);

--- a/cache/in-memory/src/event/reaction.rs
+++ b/cache/in-memory/src/event/reaction.rs
@@ -129,7 +129,7 @@ mod tests {
     };
 
     #[test]
-    fn test_reaction_add() {
+    fn reaction_add() {
         let cache = test::cache_with_message_and_reactions();
         let msg = cache.message(Id::new(4)).unwrap();
 
@@ -151,7 +151,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reaction_remove() {
+    fn reaction_remove() {
         let cache = test::cache_with_message_and_reactions();
         cache.update(&ReactionRemove(Reaction {
             channel_id: Id::new(2),
@@ -184,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reaction_remove_all() {
+    fn reaction_remove_all() {
         let cache = test::cache_with_message_and_reactions();
         cache.update(&ReactionRemoveAll {
             channel_id: Id::new(2),
@@ -198,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reaction_remove_emoji() {
+    fn reaction_remove_emoji() {
         let cache = test::cache_with_message_and_reactions();
         cache.update(&ReactionRemoveEmoji {
             channel_id: Id::new(2),

--- a/cache/in-memory/src/event/role.rs
+++ b/cache/in-memory/src/event/role.rs
@@ -75,7 +75,7 @@ mod tests {
     use crate::test;
 
     #[test]
-    fn test_insert_role_on_event() {
+    fn insert_role_on_event() {
         let cache = InMemoryCache::new();
 
         cache.update(&RoleCreate {
@@ -92,7 +92,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_role() {
+    fn cache_role() {
         let cache = InMemoryCache::new();
 
         // Single inserts

--- a/cache/in-memory/src/event/stage_instance.rs
+++ b/cache/in-memory/src/event/stage_instance.rs
@@ -80,7 +80,7 @@ mod tests {
     use twilight_model::{channel::stage_instance::PrivacyLevel, id::Id};
 
     #[test]
-    fn test_stage_channels() {
+    fn stage_channels() {
         let cache = InMemoryCache::new();
 
         let stage_instance = StageInstance {

--- a/cache/in-memory/src/event/sticker.rs
+++ b/cache/in-memory/src/event/sticker.rs
@@ -102,7 +102,7 @@ mod tests {
     /// sticker cache by testing their identity, and that the map of a guild's
     /// sticker associated IDs contains all stickers.
     #[test]
-    fn test_cache_stickers() {
+    fn cache_stickers() {
         let cache = cache_with_stickers();
         assert_eq!(cache.stickers.len(), 2);
         let one = test::sticker(STICKER_ONE_ID, GUILD_ID);
@@ -135,7 +135,7 @@ mod tests {
     /// cached and a new list of stickers with only "foo" is cached, then "bar"
     /// will be removed.
     #[test]
-    fn test_cache_stickers_removal() {
+    fn cache_stickers_removal() {
         let cache = cache_with_stickers();
         let one = test::sticker(STICKER_ONE_ID, GUILD_ID);
         cache.cache_stickers(GUILD_ID, Vec::from([one]));

--- a/cache/in-memory/src/event/voice_state.rs
+++ b/cache/in-memory/src/event/voice_state.rs
@@ -103,7 +103,7 @@ mod tests {
     };
 
     #[test]
-    fn test_voice_state_inserts_and_removes() {
+    fn voice_state_inserts_and_removes() {
         let cache = InMemoryCache::new();
 
         // Note: Channel ids are `<guildid><idx>` where idx is the index of the channel id
@@ -240,7 +240,7 @@ mod tests {
     }
 
     #[test]
-    fn test_voice_states() {
+    fn voice_states() {
         let cache = InMemoryCache::new();
         cache.cache_voice_state(test::voice_state(Id::new(1), Some(Id::new(2)), Id::new(3)));
         cache.cache_voice_state(test::voice_state(Id::new(1), Some(Id::new(2)), Id::new(4)));
@@ -253,7 +253,7 @@ mod tests {
     }
 
     #[test]
-    fn test_voice_states_with_no_cached_guilds() {
+    fn voice_states_with_no_cached_guilds() {
         let cache = InMemoryCache::builder()
             .resource_types(ResourceType::VOICE_STATE)
             .build();
@@ -279,7 +279,7 @@ mod tests {
     }
 
     #[test]
-    fn test_voice_states_members() -> Result<(), ImageHashParseError> {
+    fn voice_states_members() -> Result<(), ImageHashParseError> {
         let joined_at = Timestamp::from_secs(1_632_072_645).expect("non zero");
         use twilight_model::{guild::member::Member, user::User};
 
@@ -352,7 +352,7 @@ mod tests {
     /// Assert that the a cached variant of the voice state is correctly
     /// inserted.
     #[test]
-    fn test_uses_cached_variant() {
+    fn uses_cached_variant() {
         const CHANNEL_ID: Id<ChannelMarker> = Id::new(2);
         const GUILD_ID: Id<GuildMarker> = Id::new(1);
         const USER_ID: Id<UserMarker> = Id::new(3);

--- a/cache/in-memory/src/iter.rs
+++ b/cache/in-memory/src/iter.rs
@@ -333,7 +333,7 @@ mod tests {
     assert_impl_all!(ResourceIter<'_, Id<UserMarker>, User>: Iterator, Send, Sync);
 
     #[test]
-    fn test_iter() {
+    fn iter() {
         let guild_id = Id::new(1);
         let users = &[
             (Id::new(2), Some(guild_id)),

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -915,7 +915,7 @@ mod tests {
     };
 
     #[test]
-    fn test_syntax_update() {
+    fn syntax_update() {
         let cache = InMemoryCache::new();
         cache.update(&RoleDelete {
             guild_id: Id::new(1),
@@ -924,7 +924,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear() {
+    fn clear() {
         let cache = InMemoryCache::new();
         cache.cache_emoji(Id::new(1), test::emoji(Id::new(3), None));
         cache.cache_member(Id::new(2), test::member(Id::new(4), Id::new(2)));
@@ -934,7 +934,7 @@ mod tests {
     }
 
     #[test]
-    fn test_highest_role() {
+    fn highest_role() {
         let joined_at = Timestamp::from_secs(1_632_072_645).expect("non zero");
         let cache = InMemoryCache::new();
         let guild_id = Id::new(1);

--- a/cache/in-memory/src/model/emoji.rs
+++ b/cache/in-memory/src/model/emoji.rs
@@ -133,7 +133,7 @@ mod tests {
     );
 
     #[test]
-    fn test_eq_emoji() {
+    fn eq_emoji() {
         let emoji = Emoji {
             id: Id::new(123),
             animated: true,

--- a/cache/in-memory/src/model/member.rs
+++ b/cache/in-memory/src/model/member.rs
@@ -298,7 +298,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eq_member() {
+    fn eq_member() {
         let joined_at = Timestamp::from_secs(1_632_072_645).expect("non zero");
 
         let member = Member {
@@ -319,7 +319,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eq_partial_member() {
+    fn eq_partial_member() {
         let joined_at = Timestamp::from_secs(1_632_072_645).expect("non zero");
 
         let member = PartialMember {

--- a/cache/in-memory/src/model/mod.rs
+++ b/cache/in-memory/src/model/mod.rs
@@ -17,7 +17,7 @@ pub use self::{
 #[cfg(tests)]
 mod tests {
     #[test]
-    fn test_reexports() {
+    fn reexports() {
         use super::{CachedEmoji, CachedGuild, CachedMember, CachedPresence, CachedVoiceState};
     }
 }

--- a/cache/in-memory/src/model/sticker.rs
+++ b/cache/in-memory/src/model/sticker.rs
@@ -184,7 +184,7 @@ mod tests {
     );
 
     #[test]
-    fn test_eq_sticker() -> Result<(), ImageHashParseError> {
+    fn eq_sticker() -> Result<(), ImageHashParseError> {
         let avatar = ImageHash::parse(b"5bf451026c107906b4dccea015320222")?;
 
         let sticker = Sticker {

--- a/cache/in-memory/src/model/voice_state.rs
+++ b/cache/in-memory/src/model/voice_state.rs
@@ -203,7 +203,7 @@ mod tests {
     const USER_ID: Id<UserMarker> = Id::new(3);
 
     #[test]
-    fn test_eq() {
+    fn eq() {
         let voice_state = test::voice_state(GUILD_ID, Some(CHANNEL_ID), USER_ID);
         let cached = CachedVoiceState::from_model(CHANNEL_ID, GUILD_ID, voice_state.clone());
 
@@ -211,7 +211,7 @@ mod tests {
     }
 
     #[test]
-    fn test_getters() {
+    fn getters() {
         let voice_state = test::voice_state(GUILD_ID, Some(CHANNEL_ID), USER_ID);
         let cached = CachedVoiceState::from_model(CHANNEL_ID, GUILD_ID, voice_state.clone());
 

--- a/cache/in-memory/src/permission.rs
+++ b/cache/in-memory/src/permission.rs
@@ -861,7 +861,7 @@ mod tests {
     ///
     /// [`root`]: super::InMemoryCachePermissions::root
     #[test]
-    fn test_root_errors() {
+    fn root_errors() {
         let cache = InMemoryCache::new();
         let permissions = cache.permissions();
         assert!(matches!(
@@ -887,7 +887,7 @@ mod tests {
     ///
     /// [`root`]: super::InMemoryCachePermissions::root
     #[test]
-    fn test_root() -> Result<(), Box<dyn Error>> {
+    fn root() -> Result<(), Box<dyn Error>> {
         let joined_at = Timestamp::from_str("2021-09-19T14:17:32.000000+00:00")?;
 
         let cache = InMemoryCache::new();
@@ -932,7 +932,7 @@ mod tests {
     ///
     /// [`in_channel`]: super::InMemoryCachePermissions::in_channel
     #[test]
-    fn test_in_channel() -> Result<(), Box<dyn Error>> {
+    fn in_channel() -> Result<(), Box<dyn Error>> {
         let cache = InMemoryCache::new();
         let permissions = cache.permissions();
 
@@ -994,7 +994,7 @@ mod tests {
     /// [`in_channel`]: super::InMemoryCachePermissions::in_channel
     /// [`root`]: super::InMemoryCachePermissions::root
     #[test]
-    fn test_owner() -> Result<(), Box<dyn Error>> {
+    fn owner() -> Result<(), Box<dyn Error>> {
         let cache = InMemoryCache::new();
         let permissions = cache.permissions();
         cache.update(&GuildCreate(base_guild()));
@@ -1021,7 +1021,7 @@ mod tests {
     /// [`in_channel`]: super::InMemoryCachePermissions::in_channel
     /// [`root`]: super::InMemoryCachePermissions::root
     #[test]
-    fn test_member_communication_disabled() -> Result<(), Box<dyn Error>> {
+    fn member_communication_disabled() -> Result<(), Box<dyn Error>> {
         fn acceptable_time(in_future: bool) -> Result<Timestamp, Box<dyn Error>> {
             const TIME_RANGE: Duration = Duration::from_secs(60);
 

--- a/embed-builder/src/author.rs
+++ b/embed-builder/src/author.rs
@@ -87,7 +87,7 @@ mod tests {
     assert_impl_all!(EmbedAuthor: From<EmbedAuthorBuilder>);
 
     #[test]
-    fn test_name_empty() {
+    fn name_empty() {
         let builder = EmbedBuilder::new().author(EmbedAuthorBuilder::new("".to_owned()));
 
         assert!(matches!(
@@ -97,7 +97,7 @@ mod tests {
     }
 
     #[test]
-    fn test_name_too_long() {
+    fn name_too_long() {
         let builder = EmbedBuilder::new().author(EmbedAuthorBuilder::new("a".repeat(256)));
         assert!(builder.build().is_ok());
 
@@ -109,7 +109,7 @@ mod tests {
     }
 
     #[test]
-    fn test_builder() {
+    fn builder() {
         let expected = EmbedAuthor {
             icon_url: Some("https://example.com/1.png".to_owned()),
             name: "an author".to_owned(),

--- a/embed-builder/src/builder.rs
+++ b/embed-builder/src/builder.rs
@@ -782,7 +782,7 @@ mod tests {
     assert_impl_all!(Embed: TryFrom<EmbedBuilder>);
 
     #[test]
-    fn test_color_error() {
+    fn color_error() {
         assert!(matches!(
             EmbedBuilder::new().color(0).build().unwrap_err().kind(),
             EmbedErrorType::ColorZero
@@ -795,7 +795,7 @@ mod tests {
     }
 
     #[test]
-    fn test_description_error() {
+    fn description_error() {
         assert!(matches!(
             EmbedBuilder::new().description("").build().unwrap_err().kind(),
             EmbedErrorType::DescriptionEmpty { description }
@@ -810,7 +810,7 @@ mod tests {
     }
 
     #[test]
-    fn test_title_error() {
+    fn title_error() {
         assert!(matches!(
             EmbedBuilder::new().title("").build().unwrap_err().kind(),
             EmbedErrorType::TitleEmpty { title }
@@ -825,7 +825,7 @@ mod tests {
     }
 
     #[test]
-    fn test_builder() {
+    fn builder() {
         let footer_image = ImageSource::url(
             "https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png",
         )

--- a/embed-builder/src/field.rs
+++ b/embed-builder/src/field.rs
@@ -85,7 +85,7 @@ mod tests {
     assert_impl_all!(EmbedField: From<EmbedFieldBuilder>);
 
     #[test]
-    fn test_new_errors() {
+    fn new_errors() {
         assert!(matches!(
             EmbedBuilder::new().field(EmbedFieldBuilder::new("", "a")).build().unwrap_err().kind(),
             EmbedErrorType::FieldNameEmpty { name, value }
@@ -109,7 +109,7 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_inline() {
+    fn builder_inline() {
         let expected = EmbedField {
             inline: true,
             name: "name".to_owned(),
@@ -121,7 +121,7 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_no_inline() {
+    fn builder_no_inline() {
         let expected = EmbedField {
             inline: false,
             name: "name".to_owned(),

--- a/embed-builder/src/footer.rs
+++ b/embed-builder/src/footer.rs
@@ -82,7 +82,7 @@ mod tests {
     assert_impl_all!(EmbedFooter: From<EmbedFooterBuilder>);
 
     #[test]
-    fn test_text() {
+    fn text() {
         assert!(matches!(
             EmbedBuilder::new().footer(EmbedFooterBuilder::new("")).build().unwrap_err().kind(),
             EmbedErrorType::FooterTextEmpty { text }
@@ -105,7 +105,7 @@ mod tests {
     }
 
     #[test]
-    fn test_builder() {
+    fn builder() {
         let expected = EmbedFooter {
             icon_url: Some("https://example.com/1.png".to_owned()),
             proxy_icon_url: None,

--- a/embed-builder/src/image_source.rs
+++ b/embed-builder/src/image_source.rs
@@ -207,7 +207,7 @@ mod tests {
     assert_impl_all!(ImageSource: Clone, Debug, Eq, PartialEq, Send, Sync);
 
     #[test]
-    fn test_attachment() -> Result<(), Box<dyn Error>> {
+    fn attachment() -> Result<(), Box<dyn Error>> {
         assert!(matches!(
             ImageSource::attachment("abc").unwrap_err().kind(),
             ImageSourceAttachmentErrorType::ExtensionMissing
@@ -225,7 +225,7 @@ mod tests {
     }
 
     #[test]
-    fn test_url() -> Result<(), Box<dyn Error>> {
+    fn url() -> Result<(), Box<dyn Error>> {
         assert!(matches!(
             ImageSource::url("ftp://example.com/foo").unwrap_err().kind(),
             ImageSourceUrlErrorType::ProtocolUnsupported { url }

--- a/gateway/src/cluster/scheme.rs
+++ b/gateway/src/cluster/scheme.rs
@@ -349,7 +349,7 @@ mod tests {
     );
 
     #[test]
-    fn test_scheme() -> Result<(), Box<dyn Error>> {
+    fn scheme() -> Result<(), Box<dyn Error>> {
         assert_eq!(
             ShardScheme::Range {
                 from: 0,
@@ -363,7 +363,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scheme_from() {
+    fn scheme_from() {
         assert_eq!(
             18,
             ShardScheme::Bucket {
@@ -385,7 +385,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scheme_total() {
+    fn scheme_total() {
         assert_eq!(
             160,
             ShardScheme::Bucket {
@@ -407,7 +407,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scheme_to() {
+    fn scheme_to() {
         assert_eq!(
             317,
             ShardScheme::Bucket {
@@ -442,7 +442,7 @@ mod tests {
     ///
     /// [`BucketTooLarge`]: super::ShardSchemeRangeError::BucketTooLarge
     #[test]
-    fn test_scheme_bucket_larger_than_concurrency() {
+    fn scheme_bucket_larger_than_concurrency() {
         assert!(matches!(
             ShardScheme::try_from((25, 16, 320)).unwrap_err(),
             ShardSchemeRangeError {

--- a/gateway/src/shard/emitter.rs
+++ b/gateway/src/shard/emitter.rs
@@ -160,7 +160,7 @@ mod tests {
     use crate::{Event, EventTypeFlags};
 
     #[test]
-    fn test_bytes_send() {
+    fn bytes_send() {
         let (emitter, mut rx) = Emitter::new(EventTypeFlags::SHARD_PAYLOAD);
         emitter.bytes(&[1]);
 
@@ -169,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    fn test_event_sends_to_rx() {
+    fn event_sends_to_rx() {
         let (emitter, mut rx) = Emitter::new(EventTypeFlags::default());
         emitter.event(Event::GatewayReconnect);
 

--- a/gateway/src/shard/processor/compression/inflater.rs
+++ b/gateway/src/shard/processor/compression/inflater.rs
@@ -204,7 +204,7 @@ mod tests {
     const SHARD: [u64; 2] = [2, 5];
 
     #[test]
-    fn test_inflater() -> Result<(), Box<dyn Error>> {
+    fn inflater() -> Result<(), Box<dyn Error>> {
         let mut inflater = Inflater::new(SHARD);
         inflater.extend(&MESSAGE[0..MESSAGE.len() - 2]);
         assert_eq!(None, inflater.msg()?);

--- a/gateway/src/shard/processor/compression/mod.rs
+++ b/gateway/src/shard/processor/compression/mod.rs
@@ -163,7 +163,7 @@ pub fn add_url_feature(buf: &mut String) {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn test_add_url_features() {
+    fn add_url_features() {
         let mut buf = String::new();
         super::add_url_feature(&mut buf);
 

--- a/gateway/src/shard/processor/session.rs
+++ b/gateway/src/shard/processor/session.rs
@@ -280,7 +280,7 @@ fn available_commands_per_interval(heartbeat_interval: u64) -> u8 {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn test_heartbeats_per_reset() {
+    fn heartbeats_per_reset() {
         assert_eq!(118, super::available_commands_per_interval(60_000));
         assert_eq!(116, super::available_commands_per_interval(42_500));
         assert_eq!(116, super::available_commands_per_interval(30_000));

--- a/gateway/src/shard/stage.rs
+++ b/gateway/src/shard/stage.rs
@@ -160,7 +160,7 @@ mod tests {
     );
 
     #[test]
-    fn test_conversion() -> Result<(), Box<dyn Error>> {
+    fn conversion() -> Result<(), Box<dyn Error>> {
         assert_eq!(Stage::Connected, Stage::try_from(0)?);
         assert_eq!(Stage::Disconnected, Stage::try_from(1)?);
         assert_eq!(Stage::Handshaking, Stage::try_from(2)?);
@@ -172,7 +172,7 @@ mod tests {
     }
 
     #[test]
-    fn test_formatting() {
+    fn formatting() {
         assert_eq!("Connected", Stage::Connected.to_string());
         assert_eq!("Disconnected", Stage::Disconnected.to_string());
         assert_eq!("Handshaking", Stage::Handshaking.to_string());

--- a/http-ratelimiting/src/headers.rs
+++ b/http-ratelimiting/src/headers.rs
@@ -646,7 +646,7 @@ mod tests {
     assert_impl_all!(RatelimitHeaders: Clone, Debug, Send, Sync);
 
     #[test]
-    fn test_global() -> Result<(), Box<dyn Error>> {
+    fn global() -> Result<(), Box<dyn Error>> {
         let map = {
             let mut map = HeaderMap::new();
             map.insert(
@@ -669,7 +669,7 @@ mod tests {
     }
 
     #[test]
-    fn test_global_with_scope() -> Result<(), Box<dyn Error>> {
+    fn global_with_scope() -> Result<(), Box<dyn Error>> {
         let map = {
             let mut map = HeaderMap::new();
             map.insert(
@@ -705,7 +705,7 @@ mod tests {
     }
 
     #[test]
-    fn test_present() -> Result<(), Box<dyn Error>> {
+    fn present() -> Result<(), Box<dyn Error>> {
         let map = {
             let mut map = HeaderMap::new();
             map.insert(
@@ -773,7 +773,7 @@ mod tests {
     }
 
     #[test]
-    fn test_name() {
+    fn name() {
         assert_eq!("x-ratelimit-bucket", HeaderName::BUCKET);
         assert_eq!("x-ratelimit-global", HeaderName::GLOBAL);
         assert_eq!("x-ratelimit-limit", HeaderName::LIMIT);
@@ -793,7 +793,7 @@ mod tests {
     }
 
     #[test]
-    fn test_type() {
+    fn type() {
         assert_eq!("bool", HeaderType::Bool.name());
         assert_eq!("float", HeaderType::Float.name());
         assert_eq!("integer", HeaderType::Integer.name());

--- a/http-ratelimiting/src/headers.rs
+++ b/http-ratelimiting/src/headers.rs
@@ -793,7 +793,7 @@ mod tests {
     }
 
     #[test]
-    fn type() {
+    fn type_name() {
         assert_eq!("bool", HeaderType::Bool.name());
         assert_eq!("float", HeaderType::Float.name());
         assert_eq!("integer", HeaderType::Integer.name());

--- a/http-ratelimiting/src/request.rs
+++ b/http-ratelimiting/src/request.rs
@@ -461,7 +461,7 @@ mod tests {
     assert_impl_all!(Path: Clone, Debug, Eq, Hash, PartialEq, Send, Sync);
 
     #[test]
-    fn test_prefix_unimportant() -> Result<(), Box<dyn Error>> {
+    fn prefix_unimportant() -> Result<(), Box<dyn Error>> {
         assert_eq!(Path::Guilds, Path::from_str("guilds")?);
         assert_eq!(Path::Guilds, Path::from_str("/guilds")?);
 
@@ -469,7 +469,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_str() -> Result<(), Box<dyn Error>> {
+    fn from_str() -> Result<(), Box<dyn Error>> {
         assert_eq!(Path::ChannelsId(123), Path::from_str("/channels/123")?);
         assert_eq!(Path::WebhooksId(123), Path::from_str("/webhooks/123")?);
         assert_eq!(Path::InvitesCode, Path::from_str("/invites/abc")?);
@@ -478,7 +478,7 @@ mod tests {
     }
 
     #[test]
-    fn test_message_id() -> Result<(), Box<dyn Error>> {
+    fn message_id() -> Result<(), Box<dyn Error>> {
         assert!(matches!(
             Path::from_str("channels/123/messages/456")
                 .unwrap_err()
@@ -496,7 +496,7 @@ mod tests {
     assert_impl_all!(Method: Clone, Copy, Debug, Eq, PartialEq);
 
     #[test]
-    fn test_method_conversions() {
+    fn method_conversions() {
         assert_eq!(HttpMethod::DELETE, Method::Delete.to_http());
         assert_eq!(HttpMethod::GET, Method::Get.to_http());
         assert_eq!(HttpMethod::PATCH, Method::Patch.to_http());

--- a/http/src/api_error.rs
+++ b/http/src/api_error.rs
@@ -136,7 +136,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_api_error_deser() {
+    fn api_error_deser() {
         let expected = GeneralApiError {
             code: 10001,
             message: "Unknown account".to_owned(),
@@ -159,7 +159,7 @@ mod tests {
     }
 
     #[test]
-    fn test_api_error_message() {
+    fn api_error_message() {
         let expected = ApiError::Message(MessageApiError {
             embed: Some(
                 [
@@ -195,7 +195,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ratelimited_api_error() {
+    fn ratelimited_api_error() {
         let expected = RatelimitedApiError {
             global: true,
             message: "You are being rate limited.".to_owned(),
@@ -228,7 +228,7 @@ mod tests {
     ///
     /// [#1302]: https://github.com/twilight-rs/twilight/issues/1302
     #[test]
-    fn test_api_error_variant_ratelimited() {
+    fn api_error_variant_ratelimited() {
         let expected = ApiError::Ratelimited(RatelimitedApiError {
             global: false,
             message: "You are being rate limited.".to_owned(),

--- a/http/src/request/application/command/mod.rs
+++ b/http/src/request/application/command/mod.rs
@@ -74,7 +74,7 @@ mod tests {
     /// `Command` or a type is changed then the destructure of it and creation
     /// of `CommandBorrowed` will fail.
     #[test]
-    fn test_command_borrowed_from_command() {
+    fn command_borrowed_from_command() {
         let command = Command {
             application_id: Some(Id::new(1)),
             default_member_permissions: Some(Permissions::ADMINISTRATOR),

--- a/http/src/request/application/interaction/create_followup.rs
+++ b/http/src/request/application/interaction/create_followup.rs
@@ -308,7 +308,7 @@ mod tests {
     use twilight_model::id::Id;
 
     #[test]
-    fn test_create_followup_message() -> Result<(), Box<dyn Error>> {
+    fn create_followup_message() -> Result<(), Box<dyn Error>> {
         let application_id = Id::new(1);
         let token = "foo".to_owned();
 

--- a/http/src/request/application/interaction/create_response.rs
+++ b/http/src/request/application/interaction/create_response.rs
@@ -92,7 +92,7 @@ mod tests {
     };
 
     #[test]
-    fn test_interaction_callback() -> Result<(), Box<dyn Error>> {
+    fn interaction_callback() -> Result<(), Box<dyn Error>> {
         let application_id = Id::new(1);
         let interaction_id = Id::new(2);
         let token = "foo".to_owned().into_boxed_str();

--- a/http/src/request/application/interaction/delete_followup.rs
+++ b/http/src/request/application/interaction/delete_followup.rs
@@ -91,7 +91,7 @@ mod tests {
     use twilight_model::id::Id;
 
     #[test]
-    fn test_request() -> Result<(), Box<dyn Error>> {
+    fn request() -> Result<(), Box<dyn Error>> {
         let client = Client::new("token".to_owned());
 
         let builder = DeleteFollowup::new(&client, Id::new(1), "token", Id::new(2));

--- a/http/src/request/application/interaction/delete_response.rs
+++ b/http/src/request/application/interaction/delete_response.rs
@@ -81,7 +81,7 @@ mod tests {
     use twilight_model::id::Id;
 
     #[test]
-    fn test_delete_followup_message() -> Result<(), Box<dyn Error>> {
+    fn delete_followup_message() -> Result<(), Box<dyn Error>> {
         let application_id = Id::new(1);
         let token = "foo".to_owned();
 

--- a/http/src/request/application/interaction/get_followup.rs
+++ b/http/src/request/application/interaction/get_followup.rs
@@ -102,7 +102,7 @@ mod tests {
     assert_impl_all!(GetFollowup<'_>: Send, Sync);
 
     #[test]
-    fn test_request() -> Result<(), Box<dyn Error>> {
+    fn request() -> Result<(), Box<dyn Error>> {
         const APPLICATION_ID: Id<ApplicationMarker> = Id::new(1);
         const MESSAGE_ID: Id<MessageMarker> = Id::new(2);
         const TOKEN: &str = "token";

--- a/http/src/request/application/interaction/get_response.rs
+++ b/http/src/request/application/interaction/get_response.rs
@@ -84,7 +84,7 @@ mod tests {
     use twilight_model::id::Id;
 
     #[test]
-    fn test_delete_followup_message() -> Result<(), Box<dyn Error>> {
+    fn delete_followup_message() -> Result<(), Box<dyn Error>> {
         let application_id = Id::new(1);
         let token = "foo".to_owned();
 

--- a/http/src/request/application/interaction/update_followup.rs
+++ b/http/src/request/application/interaction/update_followup.rs
@@ -374,7 +374,7 @@ mod tests {
     use twilight_model::id::Id;
 
     #[test]
-    fn test_update_followup_message() -> Result<(), Box<dyn Error>> {
+    fn update_followup_message() -> Result<(), Box<dyn Error>> {
         let application_id = Id::new(1);
         let message_id = Id::new(2);
         let token = "foo".to_owned();

--- a/http/src/request/application/interaction/update_response.rs
+++ b/http/src/request/application/interaction/update_response.rs
@@ -368,7 +368,7 @@ mod tests {
     use twilight_model::id::Id;
 
     #[test]
-    fn test_delete_followup_message() -> Result<(), Box<dyn Error>> {
+    fn delete_followup_message() -> Result<(), Box<dyn Error>> {
         let application_id = Id::new(1);
         let token = "foo".to_owned();
 

--- a/http/src/request/attachment.rs
+++ b/http/src/request/attachment.rs
@@ -139,7 +139,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_push_digits() {
+    fn push_digits() {
         let min_d = b"0";
         let max_d = b"18446744073709551615";
 
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn test_num_digits() {
+    fn num_digits() {
         assert_eq!(1, num_digits(0));
         assert_eq!(1, num_digits(1));
         assert_eq!(2, num_digits(10));

--- a/http/src/request/attachment.rs
+++ b/http/src/request/attachment.rs
@@ -139,7 +139,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn push_digits() {
+    fn push_digits_limits() {
         let min_d = b"0";
         let max_d = b"18446744073709551615";
 
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn num_digits() {
+    fn num_digits_count() {
         assert_eq!(1, num_digits(0));
         assert_eq!(1, num_digits(1));
         assert_eq!(2, num_digits(10));

--- a/http/src/request/audit_reason.rs
+++ b/http/src/request/audit_reason.rs
@@ -79,7 +79,7 @@ mod private {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::AuditLogReason;
     use crate::request::{
         channel::{

--- a/http/src/request/channel/invite/create_invite.rs
+++ b/http/src/request/channel/invite/create_invite.rs
@@ -258,7 +258,7 @@ mod tests {
     use twilight_model::id::Id;
 
     #[test]
-    fn test_max_age() -> Result<(), Box<dyn Error>> {
+    fn max_age() -> Result<(), Box<dyn Error>> {
         let client = Client::new("foo".to_owned());
         let mut builder = CreateInvite::new(&client, Id::new(1)).max_age(0)?;
         assert_eq!(Some(0), builder.fields.max_age);
@@ -270,7 +270,7 @@ mod tests {
     }
 
     #[test]
-    fn test_max_uses() -> Result<(), Box<dyn Error>> {
+    fn max_uses() -> Result<(), Box<dyn Error>> {
         let client = Client::new("foo".to_owned());
         let mut builder = CreateInvite::new(&client, Id::new(1)).max_uses(0)?;
         assert_eq!(Some(0), builder.fields.max_uses);

--- a/http/src/request/channel/message/update_message.rs
+++ b/http/src/request/channel/message/update_message.rs
@@ -353,7 +353,7 @@ mod tests {
     use std::error::Error;
 
     #[test]
-    fn test_clear_attachment() -> Result<(), Box<dyn Error>> {
+    fn clear_attachment() -> Result<(), Box<dyn Error>> {
         const CHANNEL_ID: Id<ChannelMarker> = Id::new(1);
         const MESSAGE_ID: Id<MessageMarker> = Id::new(2);
 

--- a/http/src/request/channel/reaction/create_reaction.rs
+++ b/http/src/request/channel/reaction/create_reaction.rs
@@ -96,7 +96,7 @@ mod tests {
     use twilight_model::id::Id;
 
     #[test]
-    fn test_request() -> Result<(), Box<dyn Error>> {
+    fn request() -> Result<(), Box<dyn Error>> {
         let client = Client::new("foo".to_owned());
 
         let emoji = RequestReactionType::Unicode { name: "🌃" };

--- a/http/src/request/channel/reaction/mod.rs
+++ b/http/src/request/channel/reaction/mod.rs
@@ -106,7 +106,7 @@ mod tests {
     assert_impl_all!(RequestReactionType<'_>: Clone, Copy, Debug, Display, Eq, Hash, PartialEq, Send, Sync);
 
     #[test]
-    fn test_display_custom_with_name() {
+    fn display_custom_with_name() {
         let reaction = RequestReactionType::Custom {
             id: Id::new(123),
             name: Some("foo"),
@@ -116,7 +116,7 @@ mod tests {
     }
 
     #[test]
-    fn test_display_custom_without_name() {
+    fn display_custom_without_name() {
         let reaction = RequestReactionType::Custom {
             id: Id::new(123),
             name: None,
@@ -128,7 +128,7 @@ mod tests {
     /// Test that unicode reactions format with percent encoding.
     // We can't use the actual flag here
     #[test]
-    fn test_display_unicode() {
+    fn display_unicode() {
         let reaction = RequestReactionType::Unicode {
             // Rainbow flag 🏳️‍🌈
             name: "🏳️‍🌈",

--- a/http/src/request/channel/thread/update_thread.rs
+++ b/http/src/request/channel/thread/update_thread.rs
@@ -205,7 +205,7 @@ mod tests {
     use twilight_model::id::Id;
 
     #[test]
-    fn test_request() -> Result<(), Box<dyn Error>> {
+    fn request() -> Result<(), Box<dyn Error>> {
         let client = Client::new("token".to_string());
         let channel_id = Id::new(123);
 

--- a/http/src/request/channel/update_channel_permission.rs
+++ b/http/src/request/channel/update_channel_permission.rs
@@ -131,7 +131,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_request() {
+    fn request() {
         let permission_overwrite = PermissionOverwrite {
             allow: None,
             deny: Some(Permissions::SEND_MESSAGES),

--- a/http/src/request/channel/webhook/delete_webhook_message.rs
+++ b/http/src/request/channel/webhook/delete_webhook_message.rs
@@ -117,7 +117,7 @@ mod tests {
     use twilight_model::id::Id;
 
     #[test]
-    fn test_request() {
+    fn request() {
         let client = Client::new("token".to_owned());
         let builder = DeleteWebhookMessage::new(&client, Id::new(1), "token", Id::new(2));
         let actual = builder

--- a/http/src/request/channel/webhook/update_webhook_message.rs
+++ b/http/src/request/channel/webhook/update_webhook_message.rs
@@ -383,7 +383,7 @@ mod tests {
     use twilight_model::id::Id;
 
     #[test]
-    fn test_request() {
+    fn request() {
         let client = Client::new("token".to_owned());
         let builder = UpdateWebhookMessage::new(&client, Id::new(1), "token", Id::new(2))
             .content(Some("test"))

--- a/http/src/request/guild/ban/create_ban.rs
+++ b/http/src/request/guild/ban/create_ban.rs
@@ -146,7 +146,7 @@ mod tests {
     };
 
     #[test]
-    fn test_request() -> Result<(), Box<dyn Error>> {
+    fn request() -> Result<(), Box<dyn Error>> {
         const GUILD_ID: Id<GuildMarker> = Id::new(1);
         const REASON: &str = "spam";
         const USER_ID: Id<UserMarker> = Id::new(2);

--- a/http/src/request/guild/create_guild/builder.rs
+++ b/http/src/request/guild/create_guild/builder.rs
@@ -787,7 +787,7 @@ mod tests {
     }
 
     #[test]
-    fn test_role_fields() {
+    fn role_fields() {
         assert!(matches!(
             RoleFieldsBuilder::new("role".to_owned())
                 .color(123_123_123)
@@ -821,7 +821,7 @@ mod tests {
     }
 
     #[test]
-    fn test_voice_fields() {
+    fn voice_fields() {
         assert!(matches!(
             VoiceFieldsBuilder::new("".to_owned()).unwrap_err().kind(),
             VoiceFieldsErrorType::NameTooShort { name }
@@ -860,7 +860,7 @@ mod tests {
     }
 
     #[test]
-    fn test_text_fields() {
+    fn text_fields() {
         assert!(matches!(
             TextFieldsBuilder::new("".to_owned()).unwrap_err().kind(),
             TextFieldsErrorType::NameTooShort { name }
@@ -895,7 +895,7 @@ mod tests {
     }
 
     #[test]
-    fn test_category_fields() {
+    fn category_fields() {
         assert!(matches!(
             CategoryFieldsBuilder::new("".to_owned()).unwrap_err().kind(),
             CategoryFieldsErrorType::NameTooShort { name }
@@ -956,7 +956,7 @@ mod tests {
     }
 
     #[test]
-    fn test_channels() {
+    fn channels() {
         let channels = GuildChannelFieldsBuilder::new()
             .add_text(text())
             .add_voice(voice());

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -91,7 +91,7 @@ impl TryIntoRequest for GetGuildPruneCount<'_> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::GetGuildPruneCount;
     use crate::Client;
     use twilight_model::id::Id;

--- a/http/src/request/guild/get_guild_prune_count.rs
+++ b/http/src/request/guild/get_guild_prune_count.rs
@@ -97,7 +97,7 @@ mod test {
     use twilight_model::id::Id;
 
     #[test]
-    fn test_days() {
+    fn days() {
         fn days_valid(days: u16) -> bool {
             let client = Client::new("".to_owned());
             let count = GetGuildPruneCount::new(&client, Id::new(1));

--- a/http/src/request/guild/member/update_guild_member.rs
+++ b/http/src/request/guild/member/update_guild_member.rs
@@ -212,7 +212,7 @@ mod tests {
     const USER_ID: Id<UserMarker> = Id::new(1);
 
     #[test]
-    fn test_request() -> Result<(), Box<dyn Error>> {
+    fn request() -> Result<(), Box<dyn Error>> {
         let client = Client::new("foo".to_owned());
         let builder = UpdateGuildMember::new(&client, GUILD_ID, USER_ID)
             .deaf(true)
@@ -240,7 +240,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nick_set_null() -> Result<(), Box<dyn Error>> {
+    fn nick_set_null() -> Result<(), Box<dyn Error>> {
         let client = Client::new("foo".to_owned());
         let builder = UpdateGuildMember::new(&client, GUILD_ID, USER_ID).nick(None)?;
         let actual = builder.try_into_request()?;
@@ -265,7 +265,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nick_set_value() -> Result<(), Box<dyn Error>> {
+    fn nick_set_value() -> Result<(), Box<dyn Error>> {
         let client = Client::new("foo".to_owned());
         let builder = UpdateGuildMember::new(&client, GUILD_ID, USER_ID).nick(Some("foo"))?;
         let actual = builder.try_into_request()?;

--- a/http/src/request/mod.rs
+++ b/http/src/request/mod.rs
@@ -107,7 +107,7 @@ mod tests {
     use crate::request::Nullable;
 
     #[test]
-    fn test_serialize_image() {
+    fn serialize_image() {
         let mut buf = Cursor::new(Vec::new());
         let mut serializer = Serializer::new(&mut buf);
         super::serialize_image(b"test", &mut serializer).unwrap();
@@ -115,7 +115,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_optional_image_some() {
+    fn serialize_optional_image_some() {
         let mut buf = Cursor::new(Vec::new());
         let mut serializer = Serializer::new(&mut buf);
         super::serialize_optional_image(&Some(b"test"), &mut serializer).unwrap();
@@ -123,7 +123,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_optional_image_none() {
+    fn serialize_optional_image_none() {
         let mut buf = Cursor::new(Vec::new());
         let mut serializer = Serializer::new(&mut buf);
         super::serialize_optional_image(&None, &mut serializer).unwrap();
@@ -131,7 +131,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_optional_nullable_image_none() {
+    fn serialize_optional_nullable_image_none() {
         let mut buf = Cursor::new(Vec::new());
         let mut serializer = Serializer::new(&mut buf);
         super::serialize_optional_nullable_image(&None, &mut serializer).unwrap();
@@ -139,7 +139,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_optional_nullable_image_some_null() {
+    fn serialize_optional_nullable_image_some_null() {
         let mut buf = Cursor::new(Vec::new());
         let mut serializer = Serializer::new(&mut buf);
         super::serialize_optional_nullable_image(&Some(Nullable(None)), &mut serializer).unwrap();
@@ -147,7 +147,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_optional_nullable_image_some_value() {
+    fn serialize_optional_nullable_image_some_value() {
         let mut buf = Cursor::new(Vec::new());
         let mut serializer = Serializer::new(&mut buf);
         super::serialize_optional_nullable_image(&Some(Nullable(Some(b"test"))), &mut serializer)

--- a/http/src/request/multipart.rs
+++ b/http/src/request/multipart.rs
@@ -145,7 +145,7 @@ mod tests {
     use std::str;
 
     #[test]
-    fn test_form_builder() {
+    fn form_builder() {
         let form = Form::new()
             .json_part(b"payload_json", b"json_value")
             .file_part(b"files[0]", b"filename.jpg", b"file_value");

--- a/http/src/request/try_into_request.rs
+++ b/http/src/request/try_into_request.rs
@@ -330,7 +330,7 @@ mod tests {
     assert_obj_safe!(TryIntoRequest);
 
     #[test]
-    fn test_conversion() -> Result<(), Box<dyn Error>> {
+    fn conversion() -> Result<(), Box<dyn Error>> {
         let client = Client::new("token".to_owned());
         let channel_id = Id::new(1);
         let builder = client.create_message(channel_id).content("test")?;

--- a/http/src/response/status_code.rs
+++ b/http/src/response/status_code.rs
@@ -125,7 +125,7 @@ mod tests {
     );
 
     #[test]
-    fn test_eq_with_integer() {
+    fn eq_with_integer() {
         assert_eq!(200_u16, StatusCode::new(200));
         assert_eq!(StatusCode::new(404), 404_u16);
     }
@@ -136,14 +136,14 @@ mod tests {
     /// the same value (as if it were hardcoded), and that it's instead
     /// returning the provided value.
     #[test]
-    fn test_get() {
+    fn get() {
         assert_eq!(200, StatusCode::new(200).get());
         assert_eq!(403, StatusCode::new(403).get());
         assert_eq!(404, StatusCode::new(404).get());
     }
 
     #[test]
-    fn test_ranges() {
+    fn ranges() {
         assert!(StatusCode::new(100).is_informational());
         assert!(StatusCode::new(199).is_informational());
         assert!(StatusCode::new(200).is_success());

--- a/http/src/routing.rs
+++ b/http/src/routing.rs
@@ -2776,7 +2776,7 @@ mod tests {
 
     /// Test a route for each method.
     #[test]
-    fn test_methods() {
+    fn methods() {
         assert_eq!(
             Method::Delete,
             Route::DeleteInvite {
@@ -2837,7 +2837,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_public_archived_threads() {
+    fn get_public_archived_threads() {
         let route = Route::GetPublicArchivedThreads {
             channel_id: 1,
             before: Some("2021-01-01T00:00:00Z"),
@@ -2851,7 +2851,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_webhook_message_thread_id() {
+    fn update_webhook_message_thread_id() {
         let route = Route::UpdateWebhookMessage {
             message_id: 1,
             thread_id: Some(2),
@@ -2863,7 +2863,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_guild_member() {
+    fn add_guild_member() {
         let route = Route::AddGuildMember {
             guild_id: GUILD_ID,
             user_id: USER_ID,
@@ -2875,7 +2875,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_member() {
+    fn get_member() {
         let route = Route::GetMember {
             guild_id: GUILD_ID,
             user_id: USER_ID,
@@ -2887,7 +2887,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_member() {
+    fn remove_member() {
         let route = Route::RemoveMember {
             guild_id: GUILD_ID,
             user_id: USER_ID,
@@ -2899,7 +2899,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_member() {
+    fn update_member() {
         let route = Route::UpdateMember {
             guild_id: GUILD_ID,
             user_id: USER_ID,
@@ -2911,7 +2911,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_member_role() {
+    fn add_member_role() {
         let route = Route::AddMemberRole {
             guild_id: GUILD_ID,
             role_id: ROLE_ID,
@@ -2924,7 +2924,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_member_role() {
+    fn remove_member_role() {
         let route = Route::RemoveMemberRole {
             guild_id: GUILD_ID,
             role_id: ROLE_ID,
@@ -2937,7 +2937,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_thread_member() {
+    fn add_thread_member() {
         let route = Route::AddThreadMember {
             channel_id: CHANNEL_ID,
             user_id: USER_ID,
@@ -2949,7 +2949,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_thread_member() {
+    fn get_thread_member() {
         let route = Route::GetThreadMember {
             channel_id: CHANNEL_ID,
             user_id: USER_ID,
@@ -2961,7 +2961,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_thread_member() {
+    fn remove_thread_member() {
         let route = Route::RemoveThreadMember {
             channel_id: CHANNEL_ID,
             user_id: USER_ID,
@@ -2973,37 +2973,37 @@ mod tests {
     }
 
     #[test]
-    fn test_create_channel() {
+    fn create_channel() {
         let route = Route::CreateChannel { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/channels"));
     }
 
     #[test]
-    fn test_get_channels() {
+    fn get_channels() {
         let route = Route::GetChannels { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/channels"));
     }
 
     #[test]
-    fn test_update_guild_channels() {
+    fn update_guild_channels() {
         let route = Route::UpdateGuildChannels { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/channels"));
     }
 
     #[test]
-    fn test_create_emoji() {
+    fn create_emoji() {
         let route = Route::CreateEmoji { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/emojis"));
     }
 
     #[test]
-    fn test_get_emojis() {
+    fn get_emojis() {
         let route = Route::GetEmojis { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/emojis"));
     }
 
     #[test]
-    fn test_create_global_command() {
+    fn create_global_command() {
         let route = Route::CreateGlobalCommand {
             application_id: APPLICATION_ID,
         };
@@ -3014,7 +3014,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_global_commands() {
+    fn get_global_commands() {
         let route = Route::GetGlobalCommands {
             application_id: APPLICATION_ID,
             with_localizations: Some(true),
@@ -3038,7 +3038,7 @@ mod tests {
     }
 
     #[test]
-    fn test_set_global_commands() {
+    fn set_global_commands() {
         let route = Route::SetGlobalCommands {
             application_id: APPLICATION_ID,
         };
@@ -3049,13 +3049,13 @@ mod tests {
     }
 
     #[test]
-    fn test_create_guild() {
+    fn create_guild() {
         let route = Route::CreateGuild;
         assert_eq!(route.to_string(), "guilds");
     }
 
     #[test]
-    fn test_create_guild_command() {
+    fn create_guild_command() {
         let route = Route::CreateGuildCommand {
             application_id: APPLICATION_ID,
             guild_id: GUILD_ID,
@@ -3067,7 +3067,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_guild_commands() {
+    fn get_guild_commands() {
         let route = Route::GetGuildCommands {
             application_id: APPLICATION_ID,
             guild_id: GUILD_ID,
@@ -3094,7 +3094,7 @@ mod tests {
     }
 
     #[test]
-    fn test_set_guild_commands() {
+    fn set_guild_commands() {
         let route = Route::SetGuildCommands {
             application_id: APPLICATION_ID,
             guild_id: GUILD_ID,
@@ -3106,7 +3106,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_guild_from_template() {
+    fn create_guild_from_template() {
         let route = Route::CreateGuildFromTemplate {
             template_code: TEMPLATE_CODE,
         };
@@ -3117,7 +3117,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_template() {
+    fn get_template() {
         let route = Route::GetTemplate {
             template_code: TEMPLATE_CODE,
         };
@@ -3128,31 +3128,31 @@ mod tests {
     }
 
     #[test]
-    fn test_create_guild_integration() {
+    fn create_guild_integration() {
         let route = Route::CreateGuildIntegration { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/integrations"));
     }
 
     #[test]
-    fn test_get_guild_integrations() {
+    fn get_guild_integrations() {
         let route = Route::GetGuildIntegrations { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/integrations"));
     }
 
     #[test]
-    fn test_create_guild_sticker() {
+    fn create_guild_sticker() {
         let route = Route::CreateGuildSticker { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/stickers"));
     }
 
     #[test]
-    fn test_get_guild_stickers() {
+    fn get_guild_stickers() {
         let route = Route::GetGuildStickers { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/stickers"));
     }
 
     #[test]
-    fn test_create_invite() {
+    fn create_invite() {
         let route = Route::CreateInvite {
             channel_id: CHANNEL_ID,
         };
@@ -3160,7 +3160,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_channel_invites() {
+    fn get_channel_invites() {
         let route = Route::GetChannelInvites {
             channel_id: CHANNEL_ID,
         };
@@ -3168,7 +3168,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_message() {
+    fn create_message() {
         let route = Route::CreateMessage {
             channel_id: CHANNEL_ID,
         };
@@ -3176,19 +3176,19 @@ mod tests {
     }
 
     #[test]
-    fn test_create_private_channel() {
+    fn create_private_channel() {
         let route = Route::CreatePrivateChannel;
         assert_eq!(route.to_string(), "users/@me/channels");
     }
 
     #[test]
-    fn test_get_user_private_channels() {
+    fn get_user_private_channels() {
         let route = Route::GetUserPrivateChannels;
         assert_eq!(route.to_string(), "users/@me/channels");
     }
 
     #[test]
-    fn test_create_reaction() {
+    fn create_reaction() {
         let emoji = emoji();
 
         let route = Route::CreateReaction {
@@ -3203,7 +3203,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_reaction_current_user() {
+    fn delete_reaction_current_user() {
         let emoji = emoji();
 
         let route = Route::DeleteReactionCurrentUser {
@@ -3218,43 +3218,43 @@ mod tests {
     }
 
     #[test]
-    fn test_create_role() {
+    fn create_role() {
         let route = Route::CreateRole { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/roles"));
     }
 
     #[test]
-    fn test_get_guild_roles() {
+    fn get_guild_roles() {
         let route = Route::GetGuildRoles { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/roles"));
     }
 
     #[test]
-    fn test_update_role_positions() {
+    fn update_role_positions() {
         let route = Route::UpdateRolePositions { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/roles"));
     }
 
     #[test]
-    fn test_create_stage_instance() {
+    fn create_stage_instance() {
         let route = Route::CreateStageInstance;
         assert_eq!(route.to_string(), "stage-instances");
     }
 
     #[test]
-    fn test_create_template() {
+    fn create_template() {
         let route = Route::CreateTemplate { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/templates"));
     }
 
     #[test]
-    fn test_get_templates() {
+    fn get_templates() {
         let route = Route::GetTemplates { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/templates"));
     }
 
     #[test]
-    fn test_create_thread() {
+    fn create_thread() {
         let route = Route::CreateThread {
             channel_id: CHANNEL_ID,
         };
@@ -3262,7 +3262,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_thread_from_message() {
+    fn create_thread_from_message() {
         let route = Route::CreateThreadFromMessage {
             channel_id: CHANNEL_ID,
             message_id: MESSAGE_ID,
@@ -3274,7 +3274,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_typing_trigger() {
+    fn create_typing_trigger() {
         let route = Route::CreateTypingTrigger {
             channel_id: CHANNEL_ID,
         };
@@ -3282,7 +3282,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_webhook() {
+    fn create_webhook() {
         let route = Route::CreateWebhook {
             channel_id: CHANNEL_ID,
         };
@@ -3290,7 +3290,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_channel_webhooks() {
+    fn get_channel_webhooks() {
         let route = Route::GetChannelWebhooks {
             channel_id: CHANNEL_ID,
         };
@@ -3298,7 +3298,7 @@ mod tests {
     }
 
     #[test]
-    fn test_crosspost_message() {
+    fn crosspost_message() {
         let route = Route::CrosspostMessage {
             channel_id: CHANNEL_ID,
             message_id: MESSAGE_ID,
@@ -3310,7 +3310,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_ban() {
+    fn delete_ban() {
         let route = Route::DeleteBan {
             guild_id: GUILD_ID,
             user_id: USER_ID,
@@ -3322,7 +3322,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_ban() {
+    fn get_ban() {
         let route = Route::GetBan {
             guild_id: GUILD_ID,
             user_id: USER_ID,
@@ -3334,7 +3334,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_channel() {
+    fn delete_channel() {
         let route = Route::DeleteChannel {
             channel_id: CHANNEL_ID,
         };
@@ -3342,7 +3342,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_channel() {
+    fn get_channel() {
         let route = Route::GetChannel {
             channel_id: CHANNEL_ID,
         };
@@ -3350,7 +3350,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_channel() {
+    fn update_channel() {
         let route = Route::UpdateChannel {
             channel_id: CHANNEL_ID,
         };
@@ -3358,7 +3358,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_emoji() {
+    fn delete_emoji() {
         let route = Route::DeleteEmoji {
             emoji_id: EMOJI_ID,
             guild_id: GUILD_ID,
@@ -3370,7 +3370,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_emoji() {
+    fn get_emoji() {
         let route = Route::GetEmoji {
             emoji_id: EMOJI_ID,
             guild_id: GUILD_ID,
@@ -3382,7 +3382,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_emoji() {
+    fn update_emoji() {
         let route = Route::UpdateEmoji {
             emoji_id: EMOJI_ID,
             guild_id: GUILD_ID,
@@ -3394,7 +3394,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_global_command() {
+    fn delete_global_command() {
         let route = Route::DeleteGlobalCommand {
             application_id: APPLICATION_ID,
             command_id: COMMAND_ID,
@@ -3406,7 +3406,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_global_command() {
+    fn get_global_command() {
         let route = Route::GetGlobalCommand {
             application_id: APPLICATION_ID,
             command_id: COMMAND_ID,
@@ -3418,7 +3418,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_global_command() {
+    fn update_global_command() {
         let route = Route::UpdateGlobalCommand {
             application_id: APPLICATION_ID,
             command_id: COMMAND_ID,
@@ -3430,19 +3430,19 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_guild() {
+    fn delete_guild() {
         let route = Route::DeleteGuild { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}"));
     }
 
     #[test]
-    fn test_update_guild() {
+    fn update_guild() {
         let route = Route::UpdateGuild { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}"));
     }
 
     #[test]
-    fn test_delete_guild_command() {
+    fn delete_guild_command() {
         let route = Route::DeleteGuildCommand {
             application_id: APPLICATION_ID,
             command_id: COMMAND_ID,
@@ -3455,7 +3455,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_guild_command() {
+    fn get_guild_command() {
         let route = Route::GetGuildCommand {
             application_id: APPLICATION_ID,
             command_id: COMMAND_ID,
@@ -3468,7 +3468,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_guild_command() {
+    fn update_guild_command() {
         let route = Route::UpdateGuildCommand {
             application_id: APPLICATION_ID,
             command_id: COMMAND_ID,
@@ -3481,7 +3481,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_guild_integration() {
+    fn delete_guild_integration() {
         let route = Route::DeleteGuildIntegration {
             guild_id: GUILD_ID,
             integration_id: INTEGRATION_ID,
@@ -3493,7 +3493,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_guild_integration() {
+    fn update_guild_integration() {
         let route = Route::UpdateGuildIntegration {
             guild_id: GUILD_ID,
             integration_id: INTEGRATION_ID,
@@ -3505,7 +3505,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_interaction_original() {
+    fn delete_interaction_original() {
         let route = Route::DeleteInteractionOriginal {
             application_id: APPLICATION_ID,
             interaction_token: INTERACTION_TOKEN,
@@ -3517,7 +3517,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_interaction_original() {
+    fn get_interaction_original() {
         let route = Route::GetInteractionOriginal {
             application_id: APPLICATION_ID,
             interaction_token: INTERACTION_TOKEN,
@@ -3529,7 +3529,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_interaction_original() {
+    fn update_interaction_original() {
         let route = Route::UpdateInteractionOriginal {
             application_id: APPLICATION_ID,
             interaction_token: INTERACTION_TOKEN,
@@ -3541,13 +3541,13 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_invite() {
+    fn delete_invite() {
         let route = Route::DeleteInvite { code: CODE };
         assert_eq!(route.to_string(), format!("invites/{CODE}"))
     }
 
     #[test]
-    fn test_delete_message_reactions() {
+    fn delete_message_reactions() {
         let route = Route::DeleteMessageReactions {
             channel_id: CHANNEL_ID,
             message_id: MESSAGE_ID,
@@ -3559,7 +3559,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_message_specific_reaction() {
+    fn delete_message_specific_reaction() {
         let emoji = emoji();
 
         let route = Route::DeleteMessageSpecificReaction {
@@ -3574,7 +3574,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_message() {
+    fn delete_message() {
         let route = Route::DeleteMessage {
             channel_id: CHANNEL_ID,
             message_id: MESSAGE_ID,
@@ -3586,7 +3586,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_message() {
+    fn get_message() {
         let route = Route::GetMessage {
             channel_id: CHANNEL_ID,
             message_id: MESSAGE_ID,
@@ -3598,7 +3598,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_message() {
+    fn update_message() {
         let route = Route::UpdateMessage {
             channel_id: CHANNEL_ID,
             message_id: MESSAGE_ID,
@@ -3610,7 +3610,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_messages() {
+    fn delete_messages() {
         let route = Route::DeleteMessages {
             channel_id: CHANNEL_ID,
         };
@@ -3621,7 +3621,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_permission_overwrite() {
+    fn delete_permission_overwrite() {
         let route = Route::DeletePermissionOverwrite {
             channel_id: CHANNEL_ID,
             target_id: ROLE_ID,
@@ -3633,7 +3633,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_permission_overwrite() {
+    fn update_permission_overwrite() {
         let route = Route::UpdatePermissionOverwrite {
             channel_id: CHANNEL_ID,
             target_id: USER_ID,
@@ -3645,7 +3645,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_reaction() {
+    fn delete_reaction() {
         let emoji = emoji();
 
         let route = Route::DeleteReaction {
@@ -3661,7 +3661,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_role() {
+    fn delete_role() {
         let route = Route::DeleteRole {
             guild_id: GUILD_ID,
             role_id: ROLE_ID,
@@ -3673,7 +3673,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_role() {
+    fn update_role() {
         let route = Route::UpdateRole {
             guild_id: GUILD_ID,
             role_id: ROLE_ID,
@@ -3685,7 +3685,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_stage_instance() {
+    fn delete_stage_instance() {
         let route = Route::DeleteStageInstance {
             channel_id: CHANNEL_ID,
         };
@@ -3693,7 +3693,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_stage_instance() {
+    fn get_stage_instance() {
         let route = Route::GetStageInstance {
             channel_id: CHANNEL_ID,
         };
@@ -3701,7 +3701,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_stage_instance() {
+    fn update_stage_instance() {
         let route = Route::UpdateStageInstance {
             channel_id: CHANNEL_ID,
         };
@@ -3709,7 +3709,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_template() {
+    fn delete_template() {
         let route = Route::DeleteTemplate {
             guild_id: GUILD_ID,
             template_code: TEMPLATE_CODE,
@@ -3721,7 +3721,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sync_template() {
+    fn sync_template() {
         let route = Route::SyncTemplate {
             guild_id: GUILD_ID,
             template_code: TEMPLATE_CODE,
@@ -3733,7 +3733,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_template() {
+    fn update_template() {
         let route = Route::UpdateTemplate {
             guild_id: GUILD_ID,
             template_code: TEMPLATE_CODE,
@@ -3745,7 +3745,7 @@ mod tests {
     }
 
     #[test]
-    fn test_follow_news_channel() {
+    fn follow_news_channel() {
         let route = Route::FollowNewsChannel {
             channel_id: CHANNEL_ID,
         };
@@ -3756,7 +3756,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_active_threads() {
+    fn get_active_threads() {
         let route = Route::GetActiveThreads { guild_id: GUILD_ID };
         assert_eq!(
             route.to_string(),
@@ -3765,13 +3765,13 @@ mod tests {
     }
 
     #[test]
-    fn test_get_bans() {
+    fn get_bans() {
         let route = Route::GetBans { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/bans"));
     }
 
     #[test]
-    fn test_get_bans_with_parameters() {
+    fn get_bans_with_parameters() {
         let route = Route::GetBansWithParameters {
             after: None,
             before: None,
@@ -3830,13 +3830,13 @@ mod tests {
     }
 
     #[test]
-    fn test_get_gateway_bot() {
+    fn get_gateway_bot() {
         let route = Route::GetGatewayBot;
         assert_eq!(route.to_string(), "gateway/bot");
     }
 
     #[test]
-    fn test_get_command_permissions() {
+    fn get_command_permissions() {
         let route = Route::GetCommandPermissions {
             application_id: APPLICATION_ID,
             command_id: COMMAND_ID,
@@ -3851,7 +3851,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_command_permissions() {
+    fn update_command_permissions() {
         let route = Route::UpdateCommandPermissions {
             application_id: APPLICATION_ID,
             command_id: COMMAND_ID,
@@ -3866,19 +3866,19 @@ mod tests {
     }
 
     #[test]
-    fn test_get_current_user_application_info() {
+    fn get_current_user_application_info() {
         let route = Route::GetCurrentUserApplicationInfo;
         assert_eq!(route.to_string(), "oauth2/applications/@me");
     }
 
     #[test]
-    fn test_get_current_user() {
+    fn get_current_user() {
         let route = Route::GetCurrentUser;
         assert_eq!(route.to_string(), "users/@me");
     }
 
     #[test]
-    fn test_get_current_user_guild_member() {
+    fn get_current_user_guild_member() {
         let route = Route::GetCurrentUserGuildMember { guild_id: GUILD_ID };
         assert_eq!(
             route.to_string(),
@@ -3887,19 +3887,19 @@ mod tests {
     }
 
     #[test]
-    fn test_update_current_user() {
+    fn update_current_user() {
         let route = Route::UpdateCurrentUser;
         assert_eq!(route.to_string(), "users/@me");
     }
 
     #[test]
-    fn test_get_gateway() {
+    fn get_gateway() {
         let route = Route::GetGateway;
         assert_eq!(route.to_string(), "gateway");
     }
 
     #[test]
-    fn test_get_guild_command_permissions() {
+    fn get_guild_command_permissions() {
         let route = Route::GetGuildCommandPermissions {
             application_id: APPLICATION_ID,
             guild_id: GUILD_ID,
@@ -3911,19 +3911,19 @@ mod tests {
     }
 
     #[test]
-    fn test_get_guild_invites() {
+    fn get_guild_invites() {
         let route = Route::GetGuildInvites { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/invites"));
     }
 
     #[test]
-    fn test_get_guild_preview() {
+    fn get_guild_preview() {
         let route = Route::GetGuildPreview { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/preview"));
     }
 
     #[test]
-    fn test_get_guild_sticker() {
+    fn get_guild_sticker() {
         let route = Route::GetGuildSticker {
             guild_id: GUILD_ID,
             sticker_id: STICKER_ID,
@@ -3935,7 +3935,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_guild_sticker() {
+    fn delete_guild_sticker() {
         let route = Route::DeleteGuildSticker {
             guild_id: GUILD_ID,
             sticker_id: STICKER_ID,
@@ -3947,7 +3947,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_guild_sticker() {
+    fn update_guild_sticker() {
         let route = Route::UpdateGuildSticker {
             guild_id: GUILD_ID,
             sticker_id: STICKER_ID,
@@ -3959,19 +3959,19 @@ mod tests {
     }
 
     #[test]
-    fn test_get_guild_vanity_url() {
+    fn get_guild_vanity_url() {
         let route = Route::GetGuildVanityUrl { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/vanity-url"));
     }
 
     #[test]
-    fn test_get_guild_voice_regions() {
+    fn get_guild_voice_regions() {
         let route = Route::GetGuildVoiceRegions { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/regions"));
     }
 
     #[test]
-    fn test_get_guild_welcome_screen() {
+    fn get_guild_welcome_screen() {
         let route = Route::GetGuildWelcomeScreen { guild_id: GUILD_ID };
         assert_eq!(
             route.to_string(),
@@ -3980,7 +3980,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_guild_welcome_screen() {
+    fn update_guild_welcome_screen() {
         let route = Route::UpdateGuildWelcomeScreen { guild_id: GUILD_ID };
         assert_eq!(
             route.to_string(),
@@ -3989,32 +3989,32 @@ mod tests {
     }
 
     #[test]
-    fn test_get_guild_webhooks() {
+    fn get_guild_webhooks() {
         let route = Route::GetGuildWebhooks { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/webhooks"));
     }
 
     #[test]
-    fn test_get_guild_widget() {
+    fn get_guild_widget() {
         let route = Route::GetGuildWidget { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/widget"));
     }
 
     #[test]
-    fn test_update_guild_widget() {
+    fn update_guild_widget() {
         let route = Route::UpdateGuildWidget { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/widget"));
     }
 
     #[test]
-    fn test_get_nitro_sticker_packs() {
+    fn get_nitro_sticker_packs() {
         let route = Route::GetNitroStickerPacks;
 
         assert_eq!(route.to_string(), "sticker-packs");
     }
 
     #[test]
-    fn test_get_pins() {
+    fn get_pins() {
         let route = Route::GetPins {
             channel_id: CHANNEL_ID,
         };
@@ -4022,7 +4022,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_sticker() {
+    fn get_sticker() {
         let route = Route::GetSticker {
             sticker_id: STICKER_ID,
         };
@@ -4030,7 +4030,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_thread_members() {
+    fn get_thread_members() {
         let route = Route::GetThreadMembers {
             channel_id: CHANNEL_ID,
         };
@@ -4041,25 +4041,25 @@ mod tests {
     }
 
     #[test]
-    fn test_get_user_connections() {
+    fn get_user_connections() {
         let route = Route::GetUserConnections;
         assert_eq!(route.to_string(), "users/@me/connections");
     }
 
     #[test]
-    fn test_get_user() {
+    fn get_user() {
         let route = Route::GetUser { user_id: USER_ID };
         assert_eq!(route.to_string(), format!("users/{USER_ID}"));
     }
 
     #[test]
-    fn test_get_voice_regions() {
+    fn get_voice_regions() {
         let route = Route::GetVoiceRegions;
         assert_eq!(route.to_string(), "voice/regions");
     }
 
     #[test]
-    fn test_interaction_callback() {
+    fn interaction_callback() {
         let route = Route::InteractionCallback {
             interaction_id: INTERACTION_ID,
             interaction_token: INTERACTION_TOKEN,
@@ -4071,7 +4071,7 @@ mod tests {
     }
 
     #[test]
-    fn test_join_thread() {
+    fn join_thread() {
         let route = Route::JoinThread {
             channel_id: CHANNEL_ID,
         };
@@ -4082,7 +4082,7 @@ mod tests {
     }
 
     #[test]
-    fn test_leave_thread() {
+    fn leave_thread() {
         let route = Route::LeaveThread {
             channel_id: CHANNEL_ID,
         };
@@ -4093,13 +4093,13 @@ mod tests {
     }
 
     #[test]
-    fn test_leave_guild() {
+    fn leave_guild() {
         let route = Route::LeaveGuild { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("users/@me/guilds/{GUILD_ID}"));
     }
 
     #[test]
-    fn test_pin_message() {
+    fn pin_message() {
         let route = Route::PinMessage {
             channel_id: CHANNEL_ID,
             message_id: MESSAGE_ID,
@@ -4111,7 +4111,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unpin_message() {
+    fn unpin_message() {
         let route = Route::UnpinMessage {
             channel_id: CHANNEL_ID,
             message_id: MESSAGE_ID,
@@ -4123,7 +4123,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sync_guild_integration() {
+    fn sync_guild_integration() {
         let route = Route::SyncGuildIntegration {
             guild_id: GUILD_ID,
             integration_id: INTEGRATION_ID,
@@ -4135,13 +4135,13 @@ mod tests {
     }
 
     #[test]
-    fn test_update_current_member() {
+    fn update_current_member() {
         let route = Route::UpdateCurrentMember { guild_id: GUILD_ID };
         assert_eq!(route.to_string(), format!("guilds/{GUILD_ID}/members/@me"));
     }
 
     #[test]
-    fn test_update_current_user_voice_state() {
+    fn update_current_user_voice_state() {
         let route = Route::UpdateCurrentUserVoiceState { guild_id: GUILD_ID };
         assert_eq!(
             route.to_string(),
@@ -4150,7 +4150,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_nickname() {
+    fn update_nickname() {
         let route = Route::UpdateNickname { guild_id: GUILD_ID };
         assert_eq!(
             route.to_string(),
@@ -4159,7 +4159,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_user_voice_state() {
+    fn update_user_voice_state() {
         let route = Route::UpdateUserVoiceState {
             guild_id: GUILD_ID,
             user_id: USER_ID,
@@ -4171,7 +4171,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_ban() {
+    fn create_ban() {
         let mut route = Route::CreateBan {
             guild_id: GUILD_ID,
             delete_message_days: None,
@@ -4194,7 +4194,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_guild_prune_none() {
+    fn create_guild_prune_none() {
         let route = Route::CreateGuildPrune {
             compute_prune_count: None,
             days: None,
@@ -4205,7 +4205,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_guild_prune_compute_prune_count_true() {
+    fn create_guild_prune_compute_prune_count_true() {
         let route = Route::CreateGuildPrune {
             compute_prune_count: Some(true),
             days: None,
@@ -4219,7 +4219,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_guild_prune_compute_prune_count_false() {
+    fn create_guild_prune_compute_prune_count_false() {
         let route = Route::CreateGuildPrune {
             compute_prune_count: Some(false),
             days: None,
@@ -4233,7 +4233,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_guild_prune_days() {
+    fn create_guild_prune_days() {
         let route = Route::CreateGuildPrune {
             compute_prune_count: None,
             days: Some(4),
@@ -4247,7 +4247,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_guild_prune_include_one_role() {
+    fn create_guild_prune_include_one_role() {
         let include_roles = [Id::new(1)];
 
         let route = Route::CreateGuildPrune {
@@ -4263,7 +4263,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_guild_prune_include_two_roles() {
+    fn create_guild_prune_include_two_roles() {
         let include_roles = [Id::new(1), Id::new(2)];
 
         let route = Route::CreateGuildPrune {
@@ -4279,7 +4279,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_guild_prune_all() {
+    fn create_guild_prune_all() {
         let include_roles = [Id::new(1), Id::new(2)];
 
         let route = Route::CreateGuildPrune {
@@ -4295,7 +4295,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_guild_scheduled_events() {
+    fn get_guild_scheduled_events() {
         let route = Route::GetGuildScheduledEvents {
             guild_id: GUILD_ID,
             with_user_count: false,
@@ -4318,7 +4318,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_guild_scheduled_event() {
+    fn create_guild_scheduled_event() {
         let route = Route::CreateGuildScheduledEvent { guild_id: GUILD_ID };
 
         assert_eq!(
@@ -4328,7 +4328,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_guild_scheduled_event() {
+    fn get_guild_scheduled_event() {
         let route = Route::GetGuildScheduledEvent {
             guild_id: GUILD_ID,
             scheduled_event_id: SCHEDULED_EVENT_ID,
@@ -4353,7 +4353,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_guild_scheduled_event() {
+    fn update_guild_scheduled_event() {
         let route = Route::UpdateGuildScheduledEvent {
             guild_id: GUILD_ID,
             scheduled_event_id: SCHEDULED_EVENT_ID,
@@ -4366,7 +4366,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_guild_scheduled_event() {
+    fn delete_guild_scheduled_event() {
         let route = Route::DeleteGuildScheduledEvent {
             guild_id: GUILD_ID,
             scheduled_event_id: SCHEDULED_EVENT_ID,
@@ -4379,7 +4379,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_guild_scheduled_event_users() {
+    fn get_guild_scheduled_event_users() {
         let route = Route::GetGuildScheduledEventUsers {
             after: None,
             before: Some(USER_ID),
@@ -4430,7 +4430,7 @@ mod tests {
     }
 
     #[test]
-    fn test_search_guild_members() {
+    fn search_guild_members() {
         let route = Route::SearchGuildMembers {
             guild_id: GUILD_ID,
             limit: Some(99),

--- a/mention/src/fmt.rs
+++ b/mention/src/fmt.rs
@@ -233,7 +233,7 @@ mod tests {
     assert_impl_all!(&'static User: Mention<Id<UserMarker>>);
 
     #[test]
-    fn test_mention_format_channel_id() {
+    fn mention_format_channel_id() {
         assert_eq!(
             "<#123>",
             Id::<ChannelMarker>::new(123).mention().to_string()
@@ -241,7 +241,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mention_format_emoji_id() {
+    fn mention_format_emoji_id() {
         assert_eq!(
             "<:emoji:123>",
             Id::<EmojiMarker>::new(123).mention().to_string()
@@ -249,13 +249,13 @@ mod tests {
     }
 
     #[test]
-    fn test_mention_format_role_id() {
+    fn mention_format_role_id() {
         assert_eq!("<@&123>", Id::<RoleMarker>::new(123).mention().to_string());
     }
 
     /// Test that a timestamp with a style displays correctly.
     #[test]
-    fn test_mention_format_timestamp_styled() {
+    fn mention_format_timestamp_styled() {
         let timestamp = Timestamp::new(1_624_047_064, Some(TimestampStyle::RelativeTime));
 
         assert_eq!("<t:1624047064:R>", timestamp.mention().to_string());
@@ -263,14 +263,14 @@ mod tests {
 
     /// Test that a timestamp without a style displays correctly.
     #[test]
-    fn test_mention_format_timestamp_unstyled() {
+    fn mention_format_timestamp_unstyled() {
         let timestamp = Timestamp::new(1_624_047_064, None);
 
         assert_eq!("<t:1624047064>", timestamp.mention().to_string());
     }
 
     #[test]
-    fn test_mention_format_user_id() {
+    fn mention_format_user_id() {
         assert_eq!("<@123>", Id::<UserMarker>::new(123).mention().to_string());
     }
 }

--- a/mention/src/parse/error.rs
+++ b/mention/src/parse/error.rs
@@ -186,7 +186,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_display() {
+    fn display() {
         let mut expected = "id portion ('abcd') of mention is not a u64";
         assert_eq!(
             expected,

--- a/mention/src/parse/impl.rs
+++ b/mention/src/parse/impl.rs
@@ -375,7 +375,7 @@ mod tests {
     assert_impl_all!(Id<UserMarker>: ParseMention, Sealed);
 
     #[test]
-    fn test_sigils() {
+    fn sigils() {
         assert_eq!(&["#"], Id::<ChannelMarker>::SIGILS);
         assert_eq!(&[":"], Id::<EmojiMarker>::SIGILS);
         assert_eq!(&["#", ":", "@&", "@", "t:"], MentionType::SIGILS);
@@ -384,7 +384,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_channel_id() {
+    fn parse_channel_id() {
         assert_eq!(Id::<ChannelMarker>::new(123), Id::parse("<#123>").unwrap());
         assert_eq!(
             &ParseMentionErrorType::Sigil {
@@ -396,7 +396,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_emoji_id() {
+    fn parse_emoji_id() {
         assert_eq!(
             Id::<EmojiMarker>::new(123),
             Id::parse("<:name:123>").unwrap()
@@ -411,7 +411,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_mention_type() {
+    fn parse_mention_type() {
         assert_eq!(
             MentionType::Channel(Id::new(123)),
             MentionType::parse("<#123>").unwrap()
@@ -438,7 +438,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_role_id() {
+    fn parse_role_id() {
         assert_eq!(Id::<RoleMarker>::new(123), Id::parse("<@&123>").unwrap());
         assert_eq!(
             &ParseMentionErrorType::Sigil {
@@ -450,7 +450,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_timestamp() -> Result<(), ParseMentionError<'static>> {
+    fn parse_timestamp() -> Result<(), ParseMentionError<'static>> {
         assert_eq!(Timestamp::new(123, None), Timestamp::parse("<t:123>")?);
         assert_eq!(
             Timestamp::new(123, Some(TimestampStyle::RelativeTime)),
@@ -465,7 +465,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_user_id() {
+    fn parse_user_id() {
         assert_eq!(Id::<UserMarker>::new(123), Id::parse("<@123>").unwrap());
         assert_eq!(
             &ParseMentionErrorType::IdNotU64 { found: "&123" },
@@ -474,7 +474,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_id_wrong_sigil() {
+    fn parse_id_wrong_sigil() {
         assert_eq!(
             &ParseMentionErrorType::Sigil {
                 expected: &["@"],

--- a/mention/src/parse/iter.rs
+++ b/mention/src/parse/iter.rs
@@ -128,14 +128,14 @@ mod tests {
     );
 
     #[test]
-    fn test_iter_channel_id() {
+    fn iter_channel_id() {
         let mut iter = Id::<ChannelMarker>::iter("<#123>");
         assert_eq!(Id::new(123), iter.next().unwrap().0);
         assert!(iter.next().is_none());
     }
 
     #[test]
-    fn test_iter_multiple_ids() {
+    fn iter_multiple_ids() {
         let buf = "one <@123>two<#456><@789> ----";
         let mut iter = Id::<UserMarker>::iter(buf);
         assert_eq!(Id::new(123), iter.next().unwrap().0);
@@ -147,7 +147,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_emoji_ids() {
+    fn iter_emoji_ids() {
         let mut iter = Id::<EmojiMarker>::iter("some <:name:123> emojis <:emoji:456>");
         assert_eq!(Id::new(123), iter.next().unwrap().0);
         assert_eq!(Id::new(456), iter.next().unwrap().0);
@@ -155,7 +155,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_mention_type() {
+    fn iter_mention_type() {
         let mut iter = MentionType::iter("<#12><:name:34><@&56><@78>");
         assert_eq!(MentionType::Channel(Id::new(12)), iter.next().unwrap().0);
         assert_eq!(MentionType::Emoji(Id::new(34)), iter.next().unwrap().0);
@@ -165,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_mention_type_with_timestamp() {
+    fn iter_mention_type_with_timestamp() {
         let mut iter = MentionType::iter("<#12> <t:34> <t:56:d>");
         assert_eq!(MentionType::Channel(Id::new(12)), iter.next().unwrap().0);
         assert_eq!(
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_role_ids() {
+    fn iter_role_ids() {
         let mut iter = Id::<RoleMarker>::iter("some <@&123> roles <@&456>");
         assert_eq!(Id::new(123), iter.next().unwrap().0);
         assert_eq!(Id::new(456), iter.next().unwrap().0);
@@ -188,7 +188,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_timestamps() {
+    fn iter_timestamps() {
         let mut iter = Timestamp::iter("some <t:123> roles <t:456:t>");
         assert_eq!(Timestamp::new(123, None), iter.next().unwrap().0);
         assert_eq!(
@@ -199,7 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_user_ids() {
+    fn iter_user_ids() {
         let mut iter = Id::<UserMarker>::iter("some <@123>users<@456>");
         assert_eq!(Id::new(123), iter.next().unwrap().0);
         assert_eq!(Id::new(456), iter.next().unwrap().0);
@@ -207,7 +207,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_no_id() {
+    fn iter_no_id() {
         let mention = "this is not <# actually a mention";
         let mut iter = Id::<ChannelMarker>::iter(mention);
 
@@ -215,7 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_ignores_other_types() {
+    fn iter_ignores_other_types() {
         let mention = "<#123> <:name:456> <@&789>";
         let mut iter = Id::<UserMarker>::iter(mention);
 
@@ -223,7 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_as_str() {
+    fn iter_as_str() {
         let buf = "a buf";
         let mut iter = Id::<RoleMarker>::iter(buf);
         assert_eq!(buf, iter.as_str());

--- a/mention/src/timestamp.rs
+++ b/mention/src/timestamp.rs
@@ -314,7 +314,7 @@ mod tests {
 
     /// Test the corresponding style modifiers.
     #[test]
-    fn test_timestamp_style_modifiers() {
+    fn timestamp_style_modifiers() {
         assert_eq!("F", TimestampStyle::LongDateTime.style());
         assert_eq!("D", TimestampStyle::LongDate.style());
         assert_eq!("T", TimestampStyle::LongTime.style());
@@ -326,7 +326,7 @@ mod tests {
 
     /// Test that style modifiers correctly parse from their string slice variants.
     #[test]
-    fn test_timestamp_style_try_from() -> Result<(), TimestampStyleConversionError> {
+    fn timestamp_style_try_from() -> Result<(), TimestampStyleConversionError> {
         assert_eq!(TimestampStyle::try_from("F")?, TimestampStyle::LongDateTime);
         assert_eq!(TimestampStyle::try_from("D")?, TimestampStyle::LongDate);
         assert_eq!(TimestampStyle::try_from("T")?, TimestampStyle::LongTime);
@@ -344,7 +344,7 @@ mod tests {
     /// Test that timestamps are correctly compared based on their inner unix
     /// timestamp value.
     #[test]
-    fn test_timestamp_cmp() {
+    fn timestamp_cmp() {
         // Assert that a higher timestamp is greater than a lesser timestamp.
         assert!(TIMESTAMP_NEW > TIMESTAMP_OLD);
 
@@ -359,7 +359,7 @@ mod tests {
 
     /// Test that whether a timestamp has a style incurs no effect on results.
     #[test]
-    fn test_timestamp_cmp_styles() {
+    fn timestamp_cmp_styles() {
         // Assert that a higher timestamp is greater than a lesser timestamp
         // regardless of style combinations.
         assert!(TIMESTAMP_NEW_STYLED > TIMESTAMP_OLD);

--- a/model/src/application/command/command_type.rs
+++ b/model/src/application/command/command_type.rs
@@ -49,14 +49,14 @@ mod tests {
     );
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&CommandType::ChatInput, &[Token::U8(1)]);
         serde_test::assert_tokens(&CommandType::User, &[Token::U8(2)]);
         serde_test::assert_tokens(&CommandType::Message, &[Token::U8(3)]);
     }
 
     #[test]
-    fn test_kinds() {
+    fn kinds() {
         assert_eq!("ChatInput", CommandType::ChatInput.kind());
         assert_eq!("User", CommandType::User.kind());
         assert_eq!("Message", CommandType::Message.kind());

--- a/model/src/application/command/option.rs
+++ b/model/src/application/command/option.rs
@@ -775,7 +775,7 @@ mod tests {
     /// missing during deserialization that the field is defaulted instead of
     /// returning a missing field error.
     #[test]
-    fn test_issue_1150() {
+    fn issue_1150() {
         let value = CommandOption::SubCommand(OptionsCommandOptionData {
             description: "ponyville".to_owned(),
             description_localizations: None,
@@ -1184,7 +1184,7 @@ mod tests {
     }
 
     #[test]
-    fn test_number() {
+    fn number() {
         const NUMBER_1: Number = Number(12.34_f64);
         const NUMBER_2: Number = Number(12.34_f64);
 

--- a/model/src/application/command/permissions.rs
+++ b/model/src/application/command/permissions.rs
@@ -107,7 +107,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_command_permissions() {
+    fn command_permissions() {
         let value = CommandPermissions {
             id: CommandPermissionsType::Role(Id::new(100)),
             permission: true,

--- a/model/src/application/component/button.rs
+++ b/model/src/application/component/button.rs
@@ -98,7 +98,7 @@ mod tests {
     const_assert_eq!(5, ButtonStyle::Link as u8);
 
     #[test]
-    fn test_button_style() {
+    fn button_style() {
         serde_test::assert_tokens(&ButtonStyle::Primary, &[Token::U8(1)]);
         serde_test::assert_tokens(&ButtonStyle::Secondary, &[Token::U8(2)]);
         serde_test::assert_tokens(&ButtonStyle::Success, &[Token::U8(3)]);

--- a/model/src/application/component/kind.rs
+++ b/model/src/application/component/kind.rs
@@ -87,14 +87,14 @@ mod tests {
     const_assert_eq!(3, ComponentType::SelectMenu as u8);
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&ComponentType::ActionRow, &[Token::U8(1)]);
         serde_test::assert_tokens(&ComponentType::Button, &[Token::U8(2)]);
         serde_test::assert_tokens(&ComponentType::SelectMenu, &[Token::U8(3)]);
     }
 
     #[test]
-    fn test_names() {
+    fn names() {
         assert_eq!("ActionRow", ComponentType::ActionRow.name());
         assert_eq!("Button", ComponentType::Button.name());
         assert_eq!("SelectMenu", ComponentType::SelectMenu.name());

--- a/model/src/application/component/mod.rs
+++ b/model/src/application/component/mod.rs
@@ -567,7 +567,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_component_full() {
+    fn component_full() {
         let component = Component::ActionRow(ActionRow {
             components: Vec::from([
                 Component::Button(Button {
@@ -668,7 +668,7 @@ mod tests {
     }
 
     #[test]
-    fn test_action_row() {
+    fn action_row() {
         let value = Component::ActionRow(ActionRow {
             components: Vec::from([Component::Button(Button {
                 custom_id: Some("button-1".to_owned()),
@@ -713,7 +713,7 @@ mod tests {
     }
 
     #[test]
-    fn test_button() {
+    fn button() {
         // Free Palestine.
         //
         // Palestinian Flag.
@@ -765,7 +765,7 @@ mod tests {
     }
 
     #[test]
-    fn test_text_input() {
+    fn text_input() {
         let value = Component::TextInput(TextInput {
             custom_id: "test".to_owned(),
             label: "The label".to_owned(),

--- a/model/src/application/component/text_input.rs
+++ b/model/src/application/component/text_input.rs
@@ -75,7 +75,7 @@ mod tests {
     const_assert_eq!(2, TextInputStyle::Paragraph as u8);
 
     #[test]
-    fn test_text_input_style() {
+    fn text_input_style() {
         serde_test::assert_tokens(&TextInputStyle::Short, &[Token::U8(1)]);
         serde_test::assert_tokens(&TextInputStyle::Paragraph, &[Token::U8(2)]);
     }

--- a/model/src/application/interaction/application_command/mod.rs
+++ b/model/src/application/interaction/application_command/mod.rs
@@ -111,7 +111,7 @@ mod tests {
     const USER_ID: Id<UserMarker> = Id::new(7);
 
     #[test]
-    fn test_author_id() -> Result<(), TimestampParseError> {
+    fn author_id() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2020-02-02T02:02:02.020000+00:00")?;
 
         let in_guild = ApplicationCommand {

--- a/model/src/application/interaction/application_command_autocomplete/mod.rs
+++ b/model/src/application/interaction/application_command_autocomplete/mod.rs
@@ -104,7 +104,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_autocomplete() -> Result<(), TimestampParseError> {
+    fn autocomplete() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2015-04-26T06:26:56.936000+00:00")?;
 
         let value =
@@ -238,7 +238,7 @@ mod tests {
     const USER_ID: Id<UserMarker> = Id::new(7);
 
     #[test]
-    fn test_author_id() -> Result<(), TimestampParseError> {
+    fn author_id() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2020-02-02T02:02:02.020000+00:00")?;
 
         let in_guild = ApplicationCommandAutocomplete {

--- a/model/src/application/interaction/interaction_type.rs
+++ b/model/src/application/interaction/interaction_type.rs
@@ -87,7 +87,7 @@ mod tests {
     const_assert_eq!(5, InteractionType::ModalSubmit as u8);
 
     #[test]
-    fn test_kind() {
+    fn kind() {
         assert_eq!("Ping", InteractionType::Ping.kind());
         assert_eq!(
             "ApplicationCommand",
@@ -102,7 +102,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_from() -> Result<(), UnknownInteractionTypeError> {
+    fn try_from() -> Result<(), UnknownInteractionTypeError> {
         assert_eq!(InteractionType::Ping, InteractionType::try_from(1)?);
         assert_eq!(
             InteractionType::ApplicationCommand,

--- a/model/src/application/interaction/message_component/data.rs
+++ b/model/src/application/interaction/message_component/data.rs
@@ -42,7 +42,7 @@ mod tests {
     );
 
     #[test]
-    fn test_message_component_interaction_data() {
+    fn message_component_interaction_data() {
         let value = MessageComponentInteractionData {
             custom_id: "test".to_owned(),
             component_type: ComponentType::Button,

--- a/model/src/application/interaction/message_component/mod.rs
+++ b/model/src/application/interaction/message_component/mod.rs
@@ -128,7 +128,7 @@ mod tests {
     );
 
     #[test]
-    fn test_author_id() -> Result<(), TimestampParseError> {
+    fn author_id() -> Result<(), TimestampParseError> {
         const USER_ID: Id<UserMarker> = Id::new(7);
 
         let timestamp = Timestamp::from_str("2020-02-02T02:02:02.020000+00:00")?;

--- a/model/src/application/interaction/modal/data.rs
+++ b/model/src/application/interaction/modal/data.rs
@@ -95,7 +95,7 @@ mod tests {
     );
 
     #[test]
-    fn test_modal_data() {
+    fn modal_data() {
         let value = ModalInteractionData {
             custom_id: "test-modal".to_owned(),
             components: Vec::from([ModalInteractionDataActionRow {

--- a/model/src/application/interaction/modal/mod.rs
+++ b/model/src/application/interaction/modal/mod.rs
@@ -138,7 +138,7 @@ mod tests {
     const USER_ID: Id<UserMarker> = Id::new(7);
 
     #[test]
-    fn test_author_id() -> Result<(), TimestampParseError> {
+    fn author_id() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2020-02-02T02:02:02.020000+00:00")?;
 
         let in_guild = ModalSubmitInteraction {

--- a/model/src/channel/attachment.rs
+++ b/model/src/channel/attachment.rs
@@ -62,7 +62,7 @@ mod tests {
     );
 
     #[test]
-    fn test_attachment() {
+    fn attachment() {
         let value = Attachment {
             content_type: Some("image/png".to_owned()),
             ephemeral: false,

--- a/model/src/channel/channel_mention.rs
+++ b/model/src/channel/channel_mention.rs
@@ -23,7 +23,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_channel_mention() {
+    fn channel_mention() {
         let value = ChannelMention {
             guild_id: Id::new(1),
             id: Id::new(2),

--- a/model/src/channel/channel_type.rs
+++ b/model/src/channel/channel_type.rs
@@ -104,7 +104,7 @@ mod tests {
     const_assert!(ChannelType::GuildPrivateThread.is_thread());
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&ChannelType::GuildText, &[Token::U8(0)]);
         serde_test::assert_tokens(&ChannelType::Private, &[Token::U8(1)]);
         serde_test::assert_tokens(&ChannelType::GuildVoice, &[Token::U8(2)]);
@@ -119,7 +119,7 @@ mod tests {
     }
 
     #[test]
-    fn test_names() {
+    fn names() {
         assert_eq!("Group", ChannelType::Group.name());
         assert_eq!("GuildCategory", ChannelType::GuildCategory.name());
         assert_eq!("GuildDirectory", ChannelType::GuildDirectory.name());

--- a/model/src/channel/embed/author.rs
+++ b/model/src/channel/embed/author.rs
@@ -17,7 +17,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_embed_author() {
+    fn embed_author() {
         let value = EmbedAuthor {
             icon_url: Some("https://example.com/1.png".to_owned()),
             name: "test".to_owned(),
@@ -46,7 +46,7 @@ mod tests {
     }
 
     #[test]
-    fn test_embed_author_complete() {
+    fn embed_author_complete() {
         let value = EmbedAuthor {
             icon_url: Some("https://example.com/1.png".to_owned()),
             name: "test".to_owned(),

--- a/model/src/channel/embed/field.rs
+++ b/model/src/channel/embed/field.rs
@@ -14,7 +14,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_embed_field() {
+    fn embed_field() {
         let value = EmbedField {
             inline: true,
             name: "name".to_owned(),

--- a/model/src/channel/embed/footer.rs
+++ b/model/src/channel/embed/footer.rs
@@ -15,7 +15,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_embed_footer_with_icon() {
+    fn embed_footer_with_icon() {
         let value = EmbedFooter {
             icon_url: Some("https://example.com/1.png".to_owned()),
             proxy_icon_url: Some("https://cdn.example.com/1-hash.png".to_owned()),
@@ -43,7 +43,7 @@ mod tests {
     }
 
     #[test]
-    fn test_embed_footer_without_icon() {
+    fn embed_footer_without_icon() {
         let value = EmbedFooter {
             icon_url: None,
             proxy_icon_url: None,

--- a/model/src/channel/embed/image.rs
+++ b/model/src/channel/embed/image.rs
@@ -17,7 +17,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_embed_image() {
+    fn embed_image() {
         let value = EmbedImage {
             height: Some(1440),
             proxy_url: Some("https://cdn.example.com/1-hash.png".to_owned()),

--- a/model/src/channel/embed/mod.rs
+++ b/model/src/channel/embed/mod.rs
@@ -55,7 +55,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_embed() -> Result<(), TimestampParseError> {
+    fn embed() -> Result<(), TimestampParseError> {
         let timestamp = Timestamp::from_str("2021-08-02T16:56:43.772000+00:00")?;
 
         let value = Embed {
@@ -107,7 +107,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_embed_complete() -> Result<(), TimestampParseError> {
+    fn embed_complete() -> Result<(), TimestampParseError> {
         let timestamp = Timestamp::from_str("2021-08-02T16:56:43.772000+00:00")?;
 
         let value = Embed {

--- a/model/src/channel/embed/provider.rs
+++ b/model/src/channel/embed/provider.rs
@@ -14,7 +14,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_embed_provider() {
+    fn embed_provider() {
         let value = EmbedProvider {
             name: Some("Example".to_owned()),
             url: Some("https://example.com".to_owned()),

--- a/model/src/channel/embed/thumbnail.rs
+++ b/model/src/channel/embed/thumbnail.rs
@@ -17,7 +17,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_embed_thumbnail() {
+    fn embed_thumbnail() {
         let value = EmbedThumbnail {
             height: Some(1440),
             proxy_url: Some("https://cdn.example.com/1-hash.png".to_owned()),

--- a/model/src/channel/embed/video.rs
+++ b/model/src/channel/embed/video.rs
@@ -18,7 +18,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_embed_video() {
+    fn embed_video() {
         let value = EmbedVideo {
             height: Some(1440),
             proxy_url: Some("https://proxy.cdn.example.com/1-hash.mp4".to_owned()),

--- a/model/src/channel/followed_channel.rs
+++ b/model/src/channel/followed_channel.rs
@@ -23,7 +23,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_followed_channel() {
+    fn followed_channel() {
         let value = FollowedChannel {
             channel_id: Id::new(1),
             webhook_id: Id::new(2),

--- a/model/src/channel/message/activity.rs
+++ b/model/src/channel/message/activity.rs
@@ -15,7 +15,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_message_activity() {
+    fn message_activity() {
         let value = MessageActivity {
             kind: MessageActivityType::Join,
             party_id: None,
@@ -36,7 +36,7 @@ mod tests {
     }
 
     #[test]
-    fn test_message_activity_complete() {
+    fn message_activity_complete() {
         let value = MessageActivity {
             kind: MessageActivityType::Join,
             party_id: Some("test".to_owned()),

--- a/model/src/channel/message/activity_type.rs
+++ b/model/src/channel/message/activity_type.rs
@@ -15,7 +15,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&MessageActivityType::Join, &[Token::U8(1)]);
         serde_test::assert_tokens(&MessageActivityType::Spectate, &[Token::U8(2)]);
         serde_test::assert_tokens(&MessageActivityType::Listen, &[Token::U8(3)]);

--- a/model/src/channel/message/allowed_mentions/builder.rs
+++ b/model/src/channel/message/allowed_mentions/builder.rs
@@ -128,7 +128,7 @@ mod tests {
     );
 
     #[test]
-    fn test_max_mentioned() {
+    fn max_mentioned() {
         let value = AllowedMentionsBuilder::new()
             .everyone()
             .replied_user()
@@ -148,7 +148,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validation() {
+    fn validation() {
         let value = AllowedMentionsBuilder::new()
             .users()
             .user_ids(vec![Id::new(100), Id::new(200)])

--- a/model/src/channel/message/allowed_mentions/mod.rs
+++ b/model/src/channel/message/allowed_mentions/mod.rs
@@ -47,7 +47,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_minimal() {
+    fn minimal() {
         let value = AllowedMentions {
             parse: Vec::new(),
             users: Vec::new(),
@@ -71,7 +71,7 @@ mod tests {
     }
 
     #[test]
-    fn test_full() {
+    fn full() {
         let value = AllowedMentions {
             parse: vec![ParseTypes::Everyone],
             users: vec![Id::new(100)],

--- a/model/src/channel/message/application.rs
+++ b/model/src/channel/message/application.rs
@@ -21,7 +21,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_message_application() {
+    fn message_application() {
         let value = MessageApplication {
             cover_image: Some(image_hash::COVER),
             description: "a description".to_owned(),

--- a/model/src/channel/message/interaction.rs
+++ b/model/src/channel/message/interaction.rs
@@ -37,7 +37,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_message_interaction() -> Result<(), Box<dyn Error>> {
+    fn message_interaction() -> Result<(), Box<dyn Error>> {
         let joined_at = Timestamp::from_str("2015-04-26T06:26:56.936000+00:00")?;
 
         let value = MessageInteraction {

--- a/model/src/channel/message/kind.rs
+++ b/model/src/channel/message/kind.rs
@@ -72,7 +72,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&MessageType::Regular, &[Token::U8(0)]);
         serde_test::assert_tokens(&MessageType::RecipientAdd, &[Token::U8(1)]);
         serde_test::assert_tokens(&MessageType::RecipientRemove, &[Token::U8(2)]);
@@ -105,7 +105,7 @@ mod tests {
     }
 
     #[test]
-    fn test_conversions() {
+    fn conversions() {
         assert_eq!(MessageType::try_from(0).unwrap(), MessageType::Regular);
         assert_eq!(MessageType::try_from(1).unwrap(), MessageType::RecipientAdd);
         assert_eq!(

--- a/model/src/channel/message/mention.rs
+++ b/model/src/channel/message/mention.rs
@@ -54,7 +54,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_mention_without_member() {
+    fn mention_without_member() {
         let value = Mention {
             avatar: None,
             bot: false,
@@ -93,7 +93,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mention_with_member() -> Result<(), TimestampParseError> {
+    fn mention_with_member() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2015-04-26T06:26:56.936000+00:00")?;
 
         let value = Mention {

--- a/model/src/channel/message/mod.rs
+++ b/model/src/channel/message/mod.rs
@@ -160,7 +160,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_message_deserialization() -> Result<(), TimestampParseError> {
+    fn message_deserialization() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2020-01-01T00:00:00.000000+00:00")?;
         let timestamp = Timestamp::from_micros(1_580_608_922_020_000).expect("non zero");
 
@@ -344,7 +344,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_message_deserialization_complete() -> Result<(), TimestampParseError> {
+    fn message_deserialization_complete() -> Result<(), TimestampParseError> {
         let edited_timestamp = Timestamp::from_str("2021-08-10T12:41:51.602000+00:00")?;
         let joined_at = Timestamp::from_str("2020-01-01T00:00:00.000000+00:00")?;
         let timestamp = Timestamp::from_micros(1_580_608_922_020_000).expect("non zero");

--- a/model/src/channel/message/reaction.rs
+++ b/model/src/channel/message/reaction.rs
@@ -14,7 +14,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_message_reaction_unicode() {
+    fn message_reaction_unicode() {
         let value = MessageReaction {
             count: 7,
             emoji: ReactionType::Unicode {

--- a/model/src/channel/message/reference.rs
+++ b/model/src/channel/message/reference.rs
@@ -23,7 +23,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_minimal() {
+    fn minimal() {
         let value = MessageReference {
             channel_id: Some(Id::new(1)),
             guild_id: None,
@@ -48,7 +48,7 @@ mod tests {
     }
 
     #[test]
-    fn test_complete() {
+    fn complete() {
         let value = MessageReference {
             channel_id: Some(Id::new(1)),
             guild_id: Some(Id::new(2)),

--- a/model/src/channel/message/sticker/format_type.rs
+++ b/model/src/channel/message/sticker/format_type.rs
@@ -63,14 +63,14 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&StickerFormatType::Png, &[Token::U8(1)]);
         serde_test::assert_tokens(&StickerFormatType::Apng, &[Token::U8(2)]);
         serde_test::assert_tokens(&StickerFormatType::Lottie, &[Token::U8(3)]);
     }
 
     #[test]
-    fn test_conversions() {
+    fn conversions() {
         assert_eq!(
             StickerFormatType::try_from(1).unwrap(),
             StickerFormatType::Png

--- a/model/src/channel/message/sticker/kind.rs
+++ b/model/src/channel/message/sticker/kind.rs
@@ -62,13 +62,13 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&StickerType::Standard, &[Token::U8(1)]);
         serde_test::assert_tokens(&StickerType::Guild, &[Token::U8(2)]);
     }
 
     #[test]
-    fn test_conversions() {
+    fn conversions() {
         assert_eq!(StickerType::try_from(1).unwrap(), StickerType::Standard);
         assert_eq!(StickerType::try_from(2).unwrap(), StickerType::Guild);
     }

--- a/model/src/channel/message/sticker/message.rs
+++ b/model/src/channel/message/sticker/message.rs
@@ -34,7 +34,7 @@ mod tests {
     );
 
     #[test]
-    fn test_full() {
+    fn full() {
         let value = MessageSticker {
             format_type: StickerFormatType::Lottie,
             id: Id::new(1),

--- a/model/src/channel/message/sticker/mod.rs
+++ b/model/src/channel/message/sticker/mod.rs
@@ -99,7 +99,7 @@ mod tests {
     );
 
     #[test]
-    fn test_minimal() {
+    fn minimal() {
         let value = Sticker {
             available: false,
             description: Some("foo2".to_owned()),
@@ -142,7 +142,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_full() {
+    fn full() {
         let value = Sticker {
             available: true,
             description: Some("sticker".into()),

--- a/model/src/channel/message/sticker/pack.rs
+++ b/model/src/channel/message/sticker/pack.rs
@@ -61,7 +61,7 @@ mod tests {
     );
 
     #[test]
-    fn test_full() {
+    fn full() {
         let value = StickerPack {
             banner_asset_id: Some(Id::new(761_773_777_976_819_732)),
             cover_sticker_id: Some(Id::new(749_053_689_419_006_003)),

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -186,7 +186,7 @@ mod tests {
     // The deserializer for GuildChannel should skip over fields names that
     // it couldn't deserialize.
     #[test]
-    fn test_guild_channel_unknown_field_deserialization() {
+    fn guild_channel_unknown_field_deserialization() {
         let input = serde_json::json!({
             "type": 0,
             "topic": "a",
@@ -248,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_category_channel_deserialization() {
+    fn guild_category_channel_deserialization() {
         let value = Channel {
             application_id: None,
             bitrate: None,
@@ -295,7 +295,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_news_channel_deserialization() {
+    fn guild_news_channel_deserialization() {
         let value = Channel {
             application_id: None,
             bitrate: None,
@@ -346,7 +346,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_news_thread_deserialization() {
+    fn guild_news_thread_deserialization() {
         let timestamp = Timestamp::from_secs(1_632_074_792).expect("non zero");
         let formatted = timestamp.iso_8601().to_string();
 
@@ -428,7 +428,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_public_thread_deserialization() {
+    fn guild_public_thread_deserialization() {
         let timestamp = Timestamp::from_secs(1_632_074_792).expect("non zero");
 
         let value = Channel {
@@ -509,7 +509,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_private_thread_deserialization() {
+    fn guild_private_thread_deserialization() {
         let timestamp = Timestamp::from_secs(1_632_074_792).expect("non zero");
         let formatted = timestamp.iso_8601().to_string();
 

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -61,7 +61,7 @@ mod tests {
     const_assert_eq!(1, PermissionOverwriteType::Member as u8);
 
     #[test]
-    fn test_overwrite() {
+    fn overwrite() {
         let value = PermissionOverwrite {
             allow: Permissions::CREATE_INVITE,
             deny: Permissions::KICK_MEMBERS,
@@ -91,7 +91,7 @@ mod tests {
     }
 
     #[test]
-    fn test_blank_overwrite() {
+    fn blank_overwrite() {
         // Test integer deser used in guild templates.
         let raw = r#"{
   "allow": "1",
@@ -133,7 +133,7 @@ mod tests {
     }
 
     #[test]
-    fn test_overwrite_type_name() {
+    fn overwrite_type_name() {
         serde_test::assert_tokens(&PermissionOverwriteType::Member, &[Token::U8(1)]);
         serde_test::assert_tokens(&PermissionOverwriteType::Role, &[Token::U8(0)]);
     }

--- a/model/src/channel/reaction.rs
+++ b/model/src/channel/reaction.rs
@@ -176,7 +176,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_reaction_with_member() -> Result<(), TimestampParseError> {
+    fn reaction_with_member() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2020-01-01T00:00:00.000000+00:00")?;
 
         let value = Reaction {
@@ -304,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reaction_without_member() {
+    fn reaction_without_member() {
         let value = Reaction {
             channel_id: Id::new(2),
             emoji: ReactionType::Unicode {

--- a/model/src/channel/reaction_type.rs
+++ b/model/src/channel/reaction_type.rs
@@ -28,7 +28,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_custom() {
+    fn custom() {
         let value = ReactionType::Custom {
             animated: false,
             id: Id::new(1337),
@@ -75,7 +75,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unicode() {
+    fn unicode() {
         let value = ReactionType::Unicode {
             name: "\u{1f643}".to_owned(),
         };

--- a/model/src/channel/stage_instance/mod.rs
+++ b/model/src/channel/stage_instance/mod.rs
@@ -28,7 +28,7 @@ mod test {
     use serde_test::Token;
 
     #[test]
-    fn test_stage_instance() {
+    fn stage_instance() {
         let value = StageInstance {
             channel_id: Id::new(100),
             guild_id: Id::new(200),

--- a/model/src/channel/stage_instance/mod.rs
+++ b/model/src/channel/stage_instance/mod.rs
@@ -22,7 +22,7 @@ pub struct StageInstance {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::{PrivacyLevel, StageInstance};
     use crate::id::Id;
     use serde_test::Token;

--- a/model/src/channel/stage_instance/privacy_level.rs
+++ b/model/src/channel/stage_instance/privacy_level.rs
@@ -14,7 +14,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&PrivacyLevel::GuildOnly, &[Token::U8(2)]);
     }
 }

--- a/model/src/channel/thread/auto_archive_duration.rs
+++ b/model/src/channel/thread/auto_archive_duration.rs
@@ -81,7 +81,7 @@ mod tests {
     ];
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         for (kind, num) in MAP {
             serde_test::assert_tokens(kind, &[Token::U16(*num)]);
             assert_eq!(*kind, AutoArchiveDuration::from(*num));
@@ -90,7 +90,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unknown_conversion() {
+    fn unknown_conversion() {
         assert_eq!(
             AutoArchiveDuration::Unknown { value: 250 },
             AutoArchiveDuration::from(250)
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[test]
-    fn test_std_time_duration() {
+    fn std_time_duration() {
         for (kind, _) in MAP {
             let std_duration = Duration::from(*kind);
             assert_eq!(u64::from(kind.number()) * 60, std_duration.as_secs());

--- a/model/src/channel/thread/member.rs
+++ b/model/src/channel/thread/member.rs
@@ -68,7 +68,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_thread_member() -> Result<(), TimestampParseError> {
+    fn thread_member() -> Result<(), TimestampParseError> {
         const DATETIME: &str = "2021-09-19T14:17:32.000000+00:00";
 
         let join_timestamp = Timestamp::from_str(DATETIME)?;

--- a/model/src/channel/thread/metadata.rs
+++ b/model/src/channel/thread/metadata.rs
@@ -32,7 +32,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_thread_metadata() -> Result<(), TimestampParseError> {
+    fn thread_metadata() -> Result<(), TimestampParseError> {
         const DATETIME: &str = "2021-09-19T14:17:32.000000+00:00";
 
         let timestamp = Timestamp::from_str(DATETIME)?;

--- a/model/src/channel/video_quality_mode.rs
+++ b/model/src/channel/video_quality_mode.rs
@@ -26,13 +26,13 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&VideoQualityMode::Auto, &[Token::U8(1)]);
         serde_test::assert_tokens(&VideoQualityMode::Full, &[Token::U8(2)]);
     }
 
     #[test]
-    fn test_names() {
+    fn names() {
         assert_eq!("Auto", VideoQualityMode::Auto.name());
         assert_eq!("Full", VideoQualityMode::Full.name());
     }

--- a/model/src/channel/webhook/kind.rs
+++ b/model/src/channel/webhook/kind.rs
@@ -21,12 +21,12 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_default() {
+    fn default() {
         assert_eq!(WebhookType::Incoming, WebhookType::default());
     }
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&WebhookType::Incoming, &[Token::U8(1)]);
         serde_test::assert_tokens(&WebhookType::ChannelFollower, &[Token::U8(2)]);
         serde_test::assert_tokens(&WebhookType::Application, &[Token::U8(3)]);

--- a/model/src/channel/webhook/mod.rs
+++ b/model/src/channel/webhook/mod.rs
@@ -79,7 +79,7 @@ mod tests {
     );
 
     #[test]
-    fn test_webhook() {
+    fn webhook() {
         let value = Webhook {
             application_id: Some(Id::new(4)),
             avatar: Some(image_hash::AVATAR),
@@ -134,7 +134,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_webhook_complete() {
+    fn webhook_complete() {
         let value = Webhook {
             application_id: Some(Id::new(4)),
             avatar: Some(image_hash::AVATAR),

--- a/model/src/gateway/close_code.rs
+++ b/model/src/gateway/close_code.rs
@@ -98,7 +98,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&CloseCode::UnknownError, &[Token::U16(4000)]);
         serde_test::assert_tokens(&CloseCode::UnknownOpcode, &[Token::U16(4001)]);
         serde_test::assert_tokens(&CloseCode::DecodeError, &[Token::U16(4002)]);
@@ -116,7 +116,7 @@ mod tests {
     }
 
     #[test]
-    fn test_conversion() {
+    fn conversion() {
         assert_eq!(CloseCode::try_from(4000).unwrap(), CloseCode::UnknownError);
         assert_eq!(CloseCode::try_from(4001).unwrap(), CloseCode::UnknownOpcode);
         assert_eq!(CloseCode::try_from(4002).unwrap(), CloseCode::DecodeError);

--- a/model/src/gateway/connection_info/bot_connection_info.rs
+++ b/model/src/gateway/connection_info/bot_connection_info.rs
@@ -19,7 +19,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_connection_info() {
+    fn connection_info() {
         let value = BotConnectionInfo {
             session_start_limit: SessionStartLimit {
                 max_concurrency: 16,

--- a/model/src/gateway/connection_info/mod.rs
+++ b/model/src/gateway/connection_info/mod.rs
@@ -17,7 +17,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_connection_info() {
+    fn connection_info() {
         let value = ConnectionInfo {
             url: "wss://gateway.discord.gg".to_owned(),
         };

--- a/model/src/gateway/event/dispatch.rs
+++ b/model/src/gateway/event/dispatch.rs
@@ -407,7 +407,7 @@ mod tests {
     use serde_json::Deserializer;
 
     #[test]
-    fn test_gift_code_update() {
+    fn gift_code_update() {
         // Input will be ignored so long as it's valid JSON.
         let input = r#"{
             "a": "b"

--- a/model/src/gateway/event/gateway.rs
+++ b/model/src/gateway/event/gateway.rs
@@ -525,7 +525,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_deserialize_dispatch_role_delete() {
+    fn deserialize_dispatch_role_delete() {
         let input = r#"{
             "d": {
                 "guild_id": "1",
@@ -543,7 +543,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_dispatch_guild_update() {
+    fn deserialize_dispatch_guild_update() {
         let input = format!(
             r#"{{
   "d": {{
@@ -621,7 +621,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_dispatch_guild_update_2() {
+    fn deserialize_dispatch_guild_update_2() {
         let input = format!(
             r#"{{
   "d": {{
@@ -697,7 +697,7 @@ mod tests {
     // Test that events which are not documented to have any data will not fail if
     // they contain it
     #[test]
-    fn test_deserialize_dispatch_resumed() {
+    fn deserialize_dispatch_resumed() {
         let input = r#"{
   "t": "RESUMED",
   "s": 37448,
@@ -717,7 +717,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_heartbeat() {
+    fn deserialize_heartbeat() {
         let input = r#"{
             "t": null,
             "s": null,
@@ -733,7 +733,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_heartbeat_ack() {
+    fn deserialize_heartbeat_ack() {
         let input = r#"{
             "t": null,
             "s": null,
@@ -749,7 +749,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_hello() {
+    fn deserialize_hello() {
         let input = r#"{
             "t": null,
             "s": null,
@@ -770,7 +770,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_invalidate_session() {
+    fn deserialize_invalidate_session() {
         let input = r#"{
             "t": null,
             "s": null,
@@ -786,7 +786,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_reconnect() {
+    fn deserialize_reconnect() {
         let input = r#"{
             "t": null,
             "s": null,
@@ -804,7 +804,7 @@ mod tests {
     /// Test that the deserializer won't mess up on a nested "t" in user input
     /// while searching for the event type.
     #[test]
-    fn test_deserializer_from_json_nested_quotes() {
+    fn deserializer_from_json_nested_quotes() {
         let input = r#"{
             "t": "DOESNT_MATTER",
             "s": 5144,
@@ -823,7 +823,7 @@ mod tests {
     // event types. For example HeartbeatAck
     #[allow(unused)]
     #[test]
-    fn test_deserializer_handles_null_event_types() {
+    fn deserializer_handles_null_event_types() {
         let input = r#"{"t":null,"op":11}"#;
 
         let deserializer = GatewayEventDeserializer::from_json(input).unwrap();
@@ -834,7 +834,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_dispatch() {
+    fn serialize_dispatch() {
         let role_delete = RoleDelete {
             guild_id: Id::new(1),
             role_id: Id::new(2),
@@ -876,7 +876,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_heartbeat() {
+    fn serialize_heartbeat() {
         serde_test::assert_ser_tokens(
             &GatewayEvent::Heartbeat(1024),
             &[
@@ -898,7 +898,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_heartbeat_ack() {
+    fn serialize_heartbeat_ack() {
         serde_test::assert_ser_tokens(
             &GatewayEvent::HeartbeatAck,
             &[
@@ -920,7 +920,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_hello() {
+    fn serialize_hello() {
         serde_test::assert_ser_tokens(
             &GatewayEvent::Hello(41250),
             &[
@@ -948,7 +948,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_invalidate() {
+    fn serialize_invalidate() {
         let value = GatewayEvent::InvalidateSession(true);
 
         serde_test::assert_ser_tokens(
@@ -972,7 +972,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_reconnect() {
+    fn serialize_reconnect() {
         serde_test::assert_ser_tokens(
             &GatewayEvent::Reconnect,
             &[

--- a/model/src/gateway/event/kind.rs
+++ b/model/src/gateway/event/kind.rs
@@ -253,7 +253,7 @@ mod tests {
     }
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         assert_variant(EventType::BanAdd, "GUILD_BAN_ADD");
         assert_variant(EventType::BanRemove, "GUILD_BAN_REMOVE");
         assert_variant(EventType::ChannelCreate, "CHANNEL_CREATE");

--- a/model/src/gateway/event/shard.rs
+++ b/model/src/gateway/event/shard.rs
@@ -114,7 +114,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_connected() {
+    fn connected() {
         let value = Connected {
             heartbeat_interval: 41_250,
             shard_id: 4,
@@ -137,7 +137,7 @@ mod tests {
     }
 
     #[test]
-    fn test_connecting() {
+    fn connecting() {
         let value = Connecting {
             gateway: "https://example.com".to_owned(),
             shard_id: 4,
@@ -160,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    fn test_disconnected() {
+    fn disconnected() {
         let value = Disconnected {
             code: Some(4_000),
             reason: Some("the reason".to_owned()),
@@ -188,7 +188,7 @@ mod tests {
     }
 
     #[test]
-    fn test_identifying() {
+    fn identifying() {
         let value = Identifying {
             shard_id: 4,
             shard_total: 7,
@@ -211,7 +211,7 @@ mod tests {
     }
 
     #[test]
-    fn test_payload() {
+    fn payload() {
         let value = Payload { bytes: vec![1, 2] };
 
         serde_test::assert_tokens(
@@ -232,7 +232,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reconnecting() {
+    fn reconnecting() {
         let value = Reconnecting { shard_id: 4 };
 
         serde_test::assert_tokens(
@@ -250,7 +250,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resuming() {
+    fn resuming() {
         let value = Resuming {
             seq: 100,
             shard_id: 4,
@@ -273,7 +273,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shard_event_try_from_event() {
+    fn shard_event_try_from_event() {
         let connected = Event::ShardConnected(Connected {
             heartbeat_interval: 41_250,
             shard_id: 4,

--- a/model/src/gateway/opcode.rs
+++ b/model/src/gateway/opcode.rs
@@ -38,7 +38,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&OpCode::Event, &[Token::U8(0)]);
         serde_test::assert_tokens(&OpCode::Heartbeat, &[Token::U8(1)]);
         serde_test::assert_tokens(&OpCode::Identify, &[Token::U8(2)]);

--- a/model/src/gateway/payload/incoming/guild_delete.rs
+++ b/model/src/gateway/payload/incoming/guild_delete.rs
@@ -21,7 +21,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_guild_delete_available() {
+    fn guild_delete_available() {
         let expected = GuildDelete {
             id: Id::new(123),
             unavailable: true,
@@ -60,7 +60,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_delete_unavailable() {
+    fn guild_delete_unavailable() {
         let expected = GuildDelete {
             id: Id::new(123),
             unavailable: false,
@@ -99,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_delete_unavailable_null_default() {
+    fn guild_delete_unavailable_null_default() {
         let expected = GuildDelete {
             id: Id::new(123),
             unavailable: false,

--- a/model/src/gateway/payload/incoming/invite_create.rs
+++ b/model/src/gateway/payload/incoming/invite_create.rs
@@ -129,7 +129,7 @@ mod tests {
     );
 
     #[test]
-    fn test_invite_create() {
+    fn invite_create() {
         let created_at = Timestamp::from_secs(1_609_459_200).expect("non zero");
 
         let value = InviteCreate {
@@ -177,7 +177,7 @@ mod tests {
     }
 
     #[test]
-    fn test_partial_user() {
+    fn partial_user() {
         let value = PartialUser {
             avatar: Some(image_hash::AVATAR),
             discriminator: 123,

--- a/model/src/gateway/payload/incoming/member_add.rs
+++ b/model/src/gateway/payload/incoming/member_add.rs
@@ -26,7 +26,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_member_add() {
+    fn member_add() {
         let joined_at = Timestamp::from_secs(1_632_072_645).expect("non zero");
 
         let value = MemberAdd(Member {

--- a/model/src/gateway/payload/incoming/member_chunk.rs
+++ b/model/src/gateway/payload/incoming/member_chunk.rs
@@ -207,7 +207,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_simple_member_chunk() -> Result<(), TimestampParseError> {
+    fn simple_member_chunk() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2020-04-04T04:04:04.000000+00:00")?;
 
         let input = serde_json::json!({

--- a/model/src/gateway/payload/incoming/member_update.rs
+++ b/model/src/gateway/payload/incoming/member_update.rs
@@ -41,7 +41,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_member_update() {
+    fn member_update() {
         let joined_at = Timestamp::from_micros(1_488_234_110_121_000).expect("non zero");
         let communication_disabled_until =
             Timestamp::from_micros(1_641_027_600_000_000).expect("non zero");

--- a/model/src/gateway/payload/incoming/role_delete.rs
+++ b/model/src/gateway/payload/incoming/role_delete.rs
@@ -17,7 +17,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_webhooks_update() {
+    fn webhooks_update() {
         let value = RoleDelete {
             guild_id: Id::new(1),
             role_id: Id::new(2),

--- a/model/src/gateway/payload/incoming/role_update.rs
+++ b/model/src/gateway/payload/incoming/role_update.rs
@@ -17,7 +17,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_role_update() {
+    fn role_update() {
         let value = RoleUpdate {
             guild_id: Id::new(1),
             role: Role {

--- a/model/src/gateway/payload/incoming/thread_members_update.rs
+++ b/model/src/gateway/payload/incoming/thread_members_update.rs
@@ -102,7 +102,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_thread_members_update() {
+    fn thread_members_update() {
         const JOIN_TIMESTAMP: &str = "2015-04-26T06:26:56.936000+00:00";
         const PREMIUM_SINCE: &str = "2021-03-16T14:29:19.046000+00:00";
 

--- a/model/src/gateway/payload/incoming/typing_start.rs
+++ b/model/src/gateway/payload/incoming/typing_start.rs
@@ -164,7 +164,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_typing_start_with_member() -> Result<(), TimestampParseError> {
+    fn typing_start_with_member() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2020-01-01T00:00:00.000000+00:00")?;
 
         let value = TypingStart {
@@ -280,7 +280,7 @@ mod tests {
     }
 
     #[test]
-    fn test_typing_start_without_member() {
+    fn typing_start_without_member() {
         let value = TypingStart {
             channel_id: Id::new(2),
             guild_id: None,

--- a/model/src/gateway/payload/incoming/unavailable_guild.rs
+++ b/model/src/gateway/payload/incoming/unavailable_guild.rs
@@ -13,7 +13,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_unavailable_guild() {
+    fn unavailable_guild() {
         let value = UnavailableGuild { id: Id::new(1) };
 
         serde_test::assert_tokens(

--- a/model/src/gateway/payload/incoming/webhooks_update.rs
+++ b/model/src/gateway/payload/incoming/webhooks_update.rs
@@ -17,7 +17,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_webhooks_update() {
+    fn webhooks_update() {
         let value = WebhooksUpdate {
             channel_id: Id::new(1),
             guild_id: Id::new(2),

--- a/model/src/gateway/presence/activity_assets.rs
+++ b/model/src/gateway/presence/activity_assets.rs
@@ -18,7 +18,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_activity_secrets() {
+    fn activity_secrets() {
         let value = ActivityAssets {
             large_image: Some("large image hash".to_owned()),
             large_text: Some("large image text".to_owned()),

--- a/model/src/gateway/presence/activity_button.rs
+++ b/model/src/gateway/presence/activity_button.rs
@@ -318,7 +318,7 @@ mod tests {
     }
 
     #[test]
-    fn test_activity_button_link() {
+    fn activity_button_link() {
         serde_test::assert_de_tokens(
             &link(),
             &[
@@ -336,12 +336,12 @@ mod tests {
     }
 
     #[test]
-    fn test_activity_button_text() {
+    fn activity_button_text() {
         serde_test::assert_de_tokens(&text(), &[Token::Str("a")]);
     }
 
     #[test]
-    fn test_activity_button_with_url() {
+    fn activity_button_with_url() {
         serde_test::assert_tokens(
             &ActivityButton::Link(link()),
             &[
@@ -359,7 +359,7 @@ mod tests {
     }
 
     #[test]
-    fn test_activity_button_without_url() {
+    fn activity_button_without_url() {
         serde_test::assert_tokens(&ActivityButton::Text(text()), &[Token::Str("a")]);
     }
 }

--- a/model/src/gateway/presence/activity_emoji.rs
+++ b/model/src/gateway/presence/activity_emoji.rs
@@ -15,7 +15,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_activity_emoji() {
+    fn activity_emoji() {
         let value = ActivityEmoji {
             animated: Some(false),
             name: "a".to_owned(),
@@ -40,7 +40,7 @@ mod tests {
     }
 
     #[test]
-    fn test_activity_emoji_complete() {
+    fn activity_emoji_complete() {
         let value = ActivityEmoji {
             animated: Some(false),
             name: "a".to_owned(),

--- a/model/src/gateway/presence/activity_party.rs
+++ b/model/src/gateway/presence/activity_party.rs
@@ -14,7 +14,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_activity_secrets() {
+    fn activity_secrets() {
         let value = ActivityParty {
             id: Some("party id".to_owned()),
             size: Some([2, 6]),

--- a/model/src/gateway/presence/activity_secrets.rs
+++ b/model/src/gateway/presence/activity_secrets.rs
@@ -16,7 +16,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_activity_secrets() {
+    fn activity_secrets() {
         let value = ActivitySecrets {
             join: Some("a".to_owned()),
             match_: Some("b".to_owned()),

--- a/model/src/gateway/presence/activity_timestamps.rs
+++ b/model/src/gateway/presence/activity_timestamps.rs
@@ -14,7 +14,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_empty() {
+    fn empty() {
         let value = ActivityTimestamps {
             end: None,
             start: None,
@@ -33,7 +33,7 @@ mod tests {
     }
 
     #[test]
-    fn test_start() {
+    fn start() {
         let value = ActivityTimestamps {
             end: Some(1),
             start: None,
@@ -55,7 +55,7 @@ mod tests {
     }
 
     #[test]
-    fn test_end() {
+    fn end() {
         let value = ActivityTimestamps {
             end: None,
             start: Some(1),
@@ -77,7 +77,7 @@ mod tests {
     }
 
     #[test]
-    fn test_present() {
+    fn present() {
         let value = ActivityTimestamps {
             end: Some(2),
             start: Some(1),

--- a/model/src/gateway/presence/activity_type.rs
+++ b/model/src/gateway/presence/activity_type.rs
@@ -23,12 +23,12 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_default() {
+    fn default() {
         assert_eq!(ActivityType::Playing, ActivityType::default());
     }
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&ActivityType::Playing, &[Token::U8(0)]);
         serde_test::assert_tokens(&ActivityType::Streaming, &[Token::U8(1)]);
         serde_test::assert_tokens(&ActivityType::Listening, &[Token::U8(2)]);

--- a/model/src/gateway/presence/client_status.rs
+++ b/model/src/gateway/presence/client_status.rs
@@ -17,7 +17,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_mobile_online() {
+    fn mobile_online() {
         let value = ClientStatus {
             desktop: Some(Status::Idle),
             mobile: Some(Status::Online),

--- a/model/src/gateway/presence/mod.rs
+++ b/model/src/gateway/presence/mod.rs
@@ -293,7 +293,7 @@ mod tests {
     //
     // Can't test seeded deserializers with serde_test.
     #[test]
-    fn test_presence_map_guild_id_default() {
+    fn presence_map_guild_id_default() {
         let input = r#"[{
             "user": {
                 "id": "1"

--- a/model/src/gateway/presence/status.rs
+++ b/model/src/gateway/presence/status.rs
@@ -20,7 +20,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(
             &Status::DoNotDisturb,
             &[Token::UnitVariant {

--- a/model/src/gateway/session_start_limit.rs
+++ b/model/src/gateway/session_start_limit.rs
@@ -20,7 +20,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_connection_info() {
+    fn connection_info() {
         let value = SessionStartLimit {
             max_concurrency: 16,
             remaining: 998,

--- a/model/src/guild/audit_log/change.rs
+++ b/model/src/guild/audit_log/change.rs
@@ -904,7 +904,7 @@ mod tests {
     );
 
     #[test]
-    fn test_afk_channel_id() {
+    fn afk_channel_id() {
         let value = AuditLogChange::AfkChannelId {
             new: Some(Id::new(1)),
             old: None,
@@ -931,7 +931,7 @@ mod tests {
     }
 
     #[test]
-    fn test_permissions() {
+    fn permissions() {
         let old: Permissions = Permissions::SEND_MESSAGES;
         let new: Permissions = old | Permissions::EMBED_LINKS;
 

--- a/model/src/guild/audit_log/change_key.rs
+++ b/model/src/guild/audit_log/change_key.rs
@@ -292,7 +292,7 @@ mod tests {
     );
 
     #[test]
-    fn test_name() {
+    fn name() {
         assert_eq!("afk_channel_id", AuditLogChangeKey::AfkChannelId.name());
         assert_eq!("afk_timeout", AuditLogChangeKey::AfkTimeout.name());
         assert_eq!("allow", AuditLogChangeKey::Allow.name());
@@ -393,7 +393,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_serde() {
+    fn serde() {
         serde_test::assert_tokens(
             &AuditLogChangeKey::AfkChannelId,
             &[Token::UnitVariant {

--- a/model/src/guild/audit_log/entry.rs
+++ b/model/src/guild/audit_log/entry.rs
@@ -67,7 +67,7 @@ mod tests {
 
     /// Test the deserialization and serialization of an audit log entry.
     #[test]
-    fn test_serde() {
+    fn serde() {
         let value = AuditLogEntry {
             action_type: AuditLogEventType::GuildUpdate,
             changes: Vec::from([AuditLogChange::IconHash {

--- a/model/src/guild/audit_log/mod.rs
+++ b/model/src/guild/audit_log/mod.rs
@@ -86,7 +86,7 @@ mod tests {
     /// we just need to test that fields are present in deserialization and
     /// serialization as expected.
     #[test]
-    fn test_serde() {
+    fn serde() {
         let value = AuditLog {
             entries: Vec::new(),
             guild_scheduled_events: Vec::new(),

--- a/model/src/guild/ban.rs
+++ b/model/src/guild/ban.rs
@@ -14,7 +14,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_ban() {
+    fn ban() {
         let ban = Ban {
             reason: Some("foo".to_owned()),
             user: User {

--- a/model/src/guild/default_message_notification_level.rs
+++ b/model/src/guild/default_message_notification_level.rs
@@ -15,7 +15,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&DefaultMessageNotificationLevel::All, &[Token::U8(0)]);
         serde_test::assert_tokens(&DefaultMessageNotificationLevel::Mentions, &[Token::U8(1)]);
     }

--- a/model/src/guild/emoji.rs
+++ b/model/src/guild/emoji.rs
@@ -36,7 +36,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_emoji() {
+    fn emoji() {
         let emoji = Emoji {
             animated: false,
             available: true,
@@ -112,7 +112,7 @@ mod tests {
     }
 
     #[test]
-    fn test_emoji_complete() {
+    fn emoji_complete() {
         let emoji = Emoji {
             animated: false,
             available: true,

--- a/model/src/guild/explicit_content_filter.rs
+++ b/model/src/guild/explicit_content_filter.rs
@@ -16,7 +16,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&ExplicitContentFilter::None, &[Token::U8(0)]);
         serde_test::assert_tokens(&ExplicitContentFilter::MembersWithoutRole, &[Token::U8(1)]);
         serde_test::assert_tokens(&ExplicitContentFilter::AllMembers, &[Token::U8(2)]);

--- a/model/src/guild/info.rs
+++ b/model/src/guild/info.rs
@@ -21,7 +21,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_guild_info() {
+    fn guild_info() {
         let value = GuildInfo {
             icon: Some(image_hash::ICON),
             id: Id::new(1),

--- a/model/src/guild/integration.rs
+++ b/model/src/guild/integration.rs
@@ -60,7 +60,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_guild_integration() -> Result<(), TimestampParseError> {
+    fn guild_integration() -> Result<(), TimestampParseError> {
         let synced_at = Timestamp::from_str("2021-01-01T01:01:01+00:00")?;
 
         let value = GuildIntegration {
@@ -185,7 +185,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_guild_integration_complete() -> Result<(), TimestampParseError> {
+    fn guild_integration_complete() -> Result<(), TimestampParseError> {
         let synced_at = Timestamp::from_str("2021-01-01T01:01:01+00:00")?;
 
         let value = GuildIntegration {

--- a/model/src/guild/integration_account.rs
+++ b/model/src/guild/integration_account.rs
@@ -12,7 +12,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_integration_account() {
+    fn integration_account() {
         let value = IntegrationAccount {
             id: "account-id".to_owned(),
             name: "account name".to_owned(),

--- a/model/src/guild/integration_application.rs
+++ b/model/src/guild/integration_application.rs
@@ -23,7 +23,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_integration_account() {
+    fn integration_account() {
         let value = IntegrationApplication {
             bot: None,
             description: "Friendship is Magic".to_string(),
@@ -54,7 +54,7 @@ mod tests {
     }
 
     #[test]
-    fn test_integration_account_complete() {
+    fn integration_account_complete() {
         let value = IntegrationApplication {
             bot: Some(User {
                 accent_color: None,

--- a/model/src/guild/integration_expire_behavior.rs
+++ b/model/src/guild/integration_expire_behavior.rs
@@ -18,7 +18,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_integration_expire_behavior() {
+    fn integration_expire_behavior() {
         serde_test::assert_tokens(&IntegrationExpireBehavior::RemoveRole, &[Token::U8(0)]);
         serde_test::assert_tokens(&IntegrationExpireBehavior::Kick, &[Token::U8(1)]);
     }

--- a/model/src/guild/member.rs
+++ b/model/src/guild/member.rs
@@ -222,7 +222,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_member_deserializer() -> Result<(), TimestampParseError> {
+    fn member_deserializer() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2015-04-26T06:26:56.936000+00:00")?;
         let premium_since = Timestamp::from_str("2021-03-16T14:29:19.046000+00:00")?;
 
@@ -317,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_member_communication_disabled_until() -> Result<(), TimestampParseError> {
+    fn guild_member_communication_disabled_until() -> Result<(), TimestampParseError> {
         let communication_disabled_until = Timestamp::from_str("2021-12-23T14:29:19.046000+00:00")?;
         let joined_at = Timestamp::from_str("2015-04-26T06:26:56.936000+00:00")?;
         let premium_since = Timestamp::from_str("2021-03-16T14:29:19.046000+00:00")?;

--- a/model/src/guild/mfa_level.rs
+++ b/model/src/guild/mfa_level.rs
@@ -15,7 +15,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&MfaLevel::None, &[Token::U8(0)]);
         serde_test::assert_tokens(&MfaLevel::Elevated, &[Token::U8(1)]);
     }

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -857,7 +857,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_guild() -> Result<(), TimestampParseError> {
+    fn guild() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2015-04-26T06:26:56.936000+00:00")?;
 
         let value = Guild {

--- a/model/src/guild/nsfw_level.rs
+++ b/model/src/guild/nsfw_level.rs
@@ -17,7 +17,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&NSFWLevel::Default, &[Token::U8(0)]);
         serde_test::assert_tokens(&NSFWLevel::Explicit, &[Token::U8(1)]);
         serde_test::assert_tokens(&NSFWLevel::Safe, &[Token::U8(2)]);

--- a/model/src/guild/partial_guild.rs
+++ b/model/src/guild/partial_guild.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_partial_guild() {
+    fn partial_guild() {
         let value = PartialGuild {
             id: Id::new(1),
             afk_channel_id: Some(Id::new(2)),

--- a/model/src/guild/partial_member.rs
+++ b/model/src/guild/partial_member.rs
@@ -39,7 +39,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_partial_member() -> Result<(), TimestampParseError> {
+    fn partial_member() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2015-04-26T06:26:56.936000+00:00")?;
 
         let value = PartialMember {

--- a/model/src/guild/premium_tier.rs
+++ b/model/src/guild/premium_tier.rs
@@ -23,7 +23,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&PremiumTier::None, &[Token::U8(0)]);
         serde_test::assert_tokens(&PremiumTier::Tier1, &[Token::U8(1)]);
         serde_test::assert_tokens(&PremiumTier::Tier2, &[Token::U8(2)]);

--- a/model/src/guild/preview.rs
+++ b/model/src/guild/preview.rs
@@ -29,7 +29,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_guild_preview() {
+    fn guild_preview() {
         let value = GuildPreview {
             approximate_member_count: 1_000,
             approximate_presence_count: 500,

--- a/model/src/guild/prune.rs
+++ b/model/src/guild/prune.rs
@@ -11,7 +11,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_guild_prune() {
+    fn guild_prune() {
         let prune = GuildPrune { pruned: 31 };
 
         serde_test::assert_tokens(

--- a/model/src/guild/role.rs
+++ b/model/src/guild/role.rs
@@ -174,7 +174,7 @@ mod tests {
     );
 
     #[test]
-    fn test_role() {
+    fn role() {
         let role = Role {
             color: 0,
             hoist: true,

--- a/model/src/guild/role_tags.rs
+++ b/model/src/guild/role_tags.rs
@@ -75,7 +75,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_role_tags_all() {
+    fn role_tags_all() {
         let tags = RoleTags {
             bot_id: Some(Id::new(1)),
             integration_id: Some(Id::new(2)),
@@ -108,7 +108,7 @@ mod tests {
     /// serialize back into the source payload (where all fields are not
     /// present).
     #[test]
-    fn test_role_tags_none() {
+    fn role_tags_none() {
         let tags = RoleTags {
             bot_id: None,
             integration_id: None,

--- a/model/src/guild/unavailable_guild.rs
+++ b/model/src/guild/unavailable_guild.rs
@@ -14,7 +14,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_unavailable_guild() {
+    fn unavailable_guild() {
         let value = UnavailableGuild {
             id: Id::new(1),
             unavailable: true,

--- a/model/src/guild/vanity_url.rs
+++ b/model/src/guild/vanity_url.rs
@@ -16,7 +16,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_vanity_url() {
+    fn vanity_url() {
         let url = VanityUrl {
             code: "a".to_owned(),
         };

--- a/model/src/guild/verification_level.rs
+++ b/model/src/guild/verification_level.rs
@@ -18,7 +18,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&VerificationLevel::None, &[Token::U8(0)]);
         serde_test::assert_tokens(&VerificationLevel::Low, &[Token::U8(1)]);
         serde_test::assert_tokens(&VerificationLevel::Medium, &[Token::U8(2)]);

--- a/model/src/guild/widget.rs
+++ b/model/src/guild/widget.rs
@@ -14,7 +14,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_guild_widget() {
+    fn guild_widget() {
         let value = GuildWidget {
             channel_id: Some(Id::new(111_111_111_111_111_111)),
             enabled: true,

--- a/model/src/http/interaction.rs
+++ b/model/src/http/interaction.rs
@@ -139,7 +139,7 @@ mod tests {
     );
 
     #[test]
-    fn test_interaction_response() {
+    fn interaction_response() {
         let value = InteractionResponse {
             kind: InteractionResponseType::ChannelMessageWithSource,
             data: Some(InteractionResponseData {
@@ -184,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    fn test_interaction_response_with_attachments() {
+    fn interaction_response_with_attachments() {
         let value = InteractionResponse {
             kind: InteractionResponseType::ChannelMessageWithSource,
             data: Some(InteractionResponseData {

--- a/model/src/http/permission_overwrite.rs
+++ b/model/src/http/permission_overwrite.rs
@@ -65,7 +65,7 @@ mod tests {
     const_assert_eq!(1, PermissionOverwriteType::Member as u8);
 
     #[test]
-    fn test_overwrite() {
+    fn overwrite() {
         let value = PermissionOverwrite {
             allow: Some(Permissions::CREATE_INVITE),
             deny: Some(Permissions::KICK_MEMBERS),
@@ -97,7 +97,7 @@ mod tests {
     }
 
     #[test]
-    fn test_blank_overwrite() {
+    fn blank_overwrite() {
         // Test integer deser used in guild templates.
         let raw = r#"{
   "allow": "1",
@@ -141,7 +141,7 @@ mod tests {
     }
 
     #[test]
-    fn test_overwrite_type_name() {
+    fn overwrite_type_name() {
         serde_test::assert_tokens(&PermissionOverwriteType::Member, &[Token::U8(1)]);
         serde_test::assert_tokens(&PermissionOverwriteType::Role, &[Token::U8(0)]);
     }

--- a/model/src/id/mod.rs
+++ b/model/src/id/mod.rs
@@ -447,7 +447,7 @@ mod tests {
     /// Test that various methods of initializing IDs are correct, such as via
     /// [`Id::new`] or [`Id`]'s [`TryFrom`] implementations.
     #[test]
-    fn test_initializers() -> Result<(), Box<dyn Error>> {
+    fn initializers() -> Result<(), Box<dyn Error>> {
         // `Id::new_checked`
         assert!(Id::<GenericMarker>::new_checked(0).is_none());
         assert_eq!(Some(1), Id::<GenericMarker>::new_checked(1).map(Id::get));
@@ -478,7 +478,7 @@ mod tests {
 
     /// Test that conversion methods are correct.
     #[test]
-    fn test_conversions() {
+    fn conversions() {
         // `Into`
         assert_eq!(1, u64::from(Id::<GenericMarker>::new(1)));
         assert_eq!(
@@ -496,14 +496,14 @@ mod tests {
 
     /// Test that casting IDs maintains the original value.
     #[test]
-    fn test_cast() {
+    fn cast() {
         let id = Id::<GenericMarker>::new(123);
         assert_eq!(123_u64, id.cast::<RoleMarker>());
     }
 
     /// Test that debugging IDs formats the generic and value as a newtype.
     #[test]
-    fn test_debug() {
+    fn debug() {
         let id = Id::<RoleMarker>::new(114_941_315_417_899_012);
 
         assert_eq!("Id<RoleMarker>(114941315417899012)", format!("{id:?}"));
@@ -511,7 +511,7 @@ mod tests {
 
     /// Test that display formatting an ID formats the value.
     #[test]
-    fn test_display() {
+    fn display() {
         let id = Id::<GenericMarker>::new(114_941_315_417_899_012);
 
         assert_eq!("114941315417899012", id.to_string());
@@ -519,7 +519,7 @@ mod tests {
 
     /// Test that hashing an ID is equivalent to hashing only its inner value.
     #[test]
-    fn test_hash() {
+    fn hash() {
         let id = Id::<GenericMarker>::new(123);
 
         let mut id_hasher = DefaultHasher::new();
@@ -533,7 +533,7 @@ mod tests {
 
     /// Test that IDs are ordered exactly like their inner values.
     #[test]
-    fn test_ordering() {
+    fn ordering() {
         let lesser = Id::<GenericMarker>::new(911_638_235_594_244_096);
         let center = Id::<GenericMarker>::new(911_638_263_322_800_208);
         let greater = Id::<GenericMarker>::new(911_638_287_939_166_208);
@@ -545,7 +545,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_serde() {
+    fn serde() {
         serde_test::assert_tokens(
             &Id::<ApplicationMarker>::new(114_941_315_417_899_012),
             &[

--- a/model/src/invite/channel.rs
+++ b/model/src/invite/channel.rs
@@ -23,7 +23,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_invite_channel() {
+    fn invite_channel() {
         let value = InviteChannel {
             id: Id::new(1),
             name: Some("channel name".to_owned()),

--- a/model/src/invite/mod.rs
+++ b/model/src/invite/mod.rs
@@ -91,7 +91,7 @@ mod tests {
     );
 
     #[test]
-    fn test_invite() {
+    fn invite() {
         let value = Invite {
             approximate_member_count: Some(31),
             approximate_presence_count: Some(7),
@@ -150,7 +150,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_invite_complete() -> Result<(), TimestampParseError> {
+    fn invite_complete() -> Result<(), TimestampParseError> {
         let created_at = Timestamp::from_str("2021-08-03T16:08:36.325000+00:00")?;
         let expires_at = Timestamp::from_str("2021-08-10T16:08:36.325000+00:00")?;
 

--- a/model/src/invite/target_type.rs
+++ b/model/src/invite/target_type.rs
@@ -13,7 +13,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&TargetType::Stream, &[Token::U8(1)]);
         serde_test::assert_tokens(&TargetType::EmbeddedApplication, &[Token::U8(2)]);
     }

--- a/model/src/invite/welcome_screen.rs
+++ b/model/src/invite/welcome_screen.rs
@@ -31,7 +31,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_welcome_screen() {
+    fn welcome_screen() {
         let value = WelcomeScreen {
             description: Some("welcome description".to_owned()),
             welcome_channels: vec![

--- a/model/src/oauth/application.rs
+++ b/model/src/oauth/application.rs
@@ -89,7 +89,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_current_application_info() {
+    fn current_application_info() {
         let value = Application {
             bot_public: true,
             bot_require_code_grant: false,

--- a/model/src/oauth/install_params.rs
+++ b/model/src/oauth/install_params.rs
@@ -35,7 +35,7 @@ mod tests {
     );
 
     #[test]
-    fn test_serde() {
+    fn serde() {
         let value = InstallParams {
             permissions: Permissions::empty(),
             scopes: Vec::from([

--- a/model/src/oauth/team/member.rs
+++ b/model/src/oauth/team/member.rs
@@ -20,7 +20,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_team_member() {
+    fn team_member() {
         let value = TeamMember {
             membership_state: TeamMembershipState::Accepted,
             permissions: vec!["*".to_owned()],

--- a/model/src/oauth/team/membership_state.rs
+++ b/model/src/oauth/team/membership_state.rs
@@ -15,7 +15,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&TeamMembershipState::Invited, &[Token::U8(1)]);
         serde_test::assert_tokens(&TeamMembershipState::Accepted, &[Token::U8(2)]);
     }

--- a/model/src/oauth/team/mod.rs
+++ b/model/src/oauth/team/mod.rs
@@ -43,7 +43,7 @@ mod tests {
     );
 
     #[test]
-    fn test_team() {
+    fn team() {
         let value = Team {
             icon: Some(image_hash::ICON),
             id: Id::new(1),

--- a/model/src/scheduled_event/mod.rs
+++ b/model/src/scheduled_event/mod.rs
@@ -135,7 +135,7 @@ mod tests {
     use std::error::Error;
 
     #[test]
-    fn test_scheduled_event() -> Result<(), Box<dyn Error>> {
+    fn scheduled_event() -> Result<(), Box<dyn Error>> {
         let scheduled_start_time = Timestamp::parse("2022-01-01T00:00:00.000000+00:00")?;
 
         let value = GuildScheduledEvent {

--- a/model/src/user/connection.rs
+++ b/model/src/user/connection.rs
@@ -24,7 +24,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_connection() {
+    fn connection() {
         let value = Connection {
             friend_sync: true,
             id: "connection id".to_owned(),

--- a/model/src/user/connection_visibility.rs
+++ b/model/src/user/connection_visibility.rs
@@ -15,7 +15,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&ConnectionVisibility::None, &[Token::U8(0)]);
         serde_test::assert_tokens(&ConnectionVisibility::Everyone, &[Token::U8(1)]);
     }

--- a/model/src/user/current_user.rs
+++ b/model/src/user/current_user.rs
@@ -170,7 +170,7 @@ mod tests {
     }
 
     #[test]
-    fn test_current_user() {
+    fn current_user() {
         let value = CurrentUser {
             accent_color: Some(16_711_680),
             avatar: Some(image_hash::AVATAR),
@@ -199,7 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn test_current_user_complete() {
+    fn current_user_complete() {
         let value = CurrentUser {
             accent_color: None,
             avatar: Some(image_hash::AVATAR),

--- a/model/src/user/current_user_guild.rs
+++ b/model/src/user/current_user_guild.rs
@@ -42,7 +42,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_current_user_guild() {
+    fn current_user_guild() {
         // The example partial guild from the Discord Docs
         let value = CurrentUserGuild {
             id: Id::new(80_351_110_224_678_912),

--- a/model/src/user/mod.rs
+++ b/model/src/user/mod.rs
@@ -287,7 +287,7 @@ mod tests {
     }
 
     #[test]
-    fn test_discriminator_display() {
+    fn discriminator_display() {
         assert_eq!(3030, DiscriminatorDisplay::new(3030).get());
         assert_eq!("0003", DiscriminatorDisplay::new(3).to_string());
         assert_eq!("0033", DiscriminatorDisplay::new(33).to_string());
@@ -296,7 +296,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user() {
+    fn user() {
         let value = User {
             accent_color: None,
             avatar: Some(image_hash::AVATAR),
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_complete() {
+    fn user_complete() {
         let value = User {
             accent_color: None,
             avatar: Some(image_hash::AVATAR),

--- a/model/src/user/premium_type.rs
+++ b/model/src/user/premium_type.rs
@@ -13,7 +13,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&PremiumType::None, &[Token::U8(0)]);
         serde_test::assert_tokens(&PremiumType::NitroClassic, &[Token::U8(1)]);
         serde_test::assert_tokens(&PremiumType::Nitro, &[Token::U8(2)]);

--- a/model/src/user/profile.rs
+++ b/model/src/user/profile.rs
@@ -103,7 +103,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_profile() {
+    fn user_profile() {
         let value = UserProfile {
             accent_color: Some(16_579_836),
             avatar: Some(image_hash::AVATAR),

--- a/model/src/util/datetime/display.rs
+++ b/model/src/util/datetime/display.rs
@@ -204,7 +204,7 @@ mod tests {
     assert_impl_all!(TimestampIso8601Display: Debug, Send, Serialize, Sync);
 
     #[test]
-    fn test_display() {
+    fn display() {
         const LONG: &str = "2020-02-02T02:02:02.020000+00:00";
         const SHORT: &str = "2020-02-02T02:02:02+00:00";
         const TIME: i64 = 1_580_608_922_020_000;

--- a/model/src/util/datetime/mod.rs
+++ b/model/src/util/datetime/mod.rs
@@ -334,7 +334,7 @@ mod tests {
 
     /// Test a variety of supported ISO 8601 datetime formats.
     #[test]
-    fn test_parse_iso8601() -> Result<(), TimestampParseError> {
+    fn parse_iso8601() -> Result<(), TimestampParseError> {
         // With milliseconds.
         let offset = OffsetDateTime::from_unix_timestamp_nanos(1_580_608_922_020_000_000).unwrap();
 
@@ -376,7 +376,7 @@ mod tests {
 
     /// Test the boundaries of valid ISO 8601 datetime boundaries.
     #[test]
-    fn test_parse_iso8601_boundaries() -> Result<(), TimestampParseError> {
+    fn parse_iso8601_boundaries() -> Result<(), TimestampParseError> {
         fn test(input: &str) -> Result<(), TimestampParseError> {
             assert_eq!(input, Timestamp::from_str(input)?.iso_8601().to_string());
 

--- a/model/src/util/image_hash.rs
+++ b/model/src/util/image_hash.rs
@@ -640,7 +640,7 @@ mod tests {
 
     /// Test that reconstruction of parted hashes is correct.
     #[test]
-    fn test_new() -> Result<(), ImageHashParseError> {
+    fn new() -> Result<(), ImageHashParseError> {
         let source = ImageHash::parse(b"85362c0262ef125a1182b1fad66b6a89")?;
         let (bytes, animated) = (source.bytes(), source.is_animated());
 
@@ -651,7 +651,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse() -> Result<(), ImageHashParseError> {
+    fn parse() -> Result<(), ImageHashParseError> {
         let actual = ImageHash::parse(b"77450a7713f093adaebab32b18dacc46")?;
         let expected = [
             70, 204, 218, 24, 43, 179, 186, 174, 173, 147, 240, 19, 119, 10, 69, 119,
@@ -662,7 +662,7 @@ mod tests {
     }
 
     #[test]
-    fn test_display() -> Result<(), ImageHashParseError> {
+    fn display() -> Result<(), ImageHashParseError> {
         assert_eq!(
             "58ec815c650e72f8eb31eec52e54b3b5",
             ImageHash::parse(b"58ec815c650e72f8eb31eec52e54b3b5")?.to_string()
@@ -677,7 +677,7 @@ mod tests {
 
     /// Test that various formats are indeed invalid.
     #[test]
-    fn test_parse_format() {
+    fn parse_format() {
         const INPUTS: &[&[u8]] = &[
             b"not correct length",
             b"",
@@ -697,7 +697,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_range() {
+    fn parse_range() {
         let mut input = [b'a'; 32];
         input[17] = b'-';
 
@@ -711,7 +711,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nibbles() -> Result<(), ImageHashParseError> {
+    fn nibbles() -> Result<(), ImageHashParseError> {
         const INPUT: &[u8] = b"39eb706d6fbaeb22837c350993b97b42";
 
         let hash = ImageHash::parse(INPUT)?;
@@ -729,7 +729,7 @@ mod tests {
     /// Test that the [`core::iter::DoubleEndedIterator`] implementation on
     /// [`Nibbles`] functions like a double ended iterator should.
     #[test]
-    fn test_nibbles_double_ended() -> Result<(), ImageHashParseError> {
+    fn nibbles_double_ended() -> Result<(), ImageHashParseError> {
         const INPUT: &[u8] = b"e72bbdec903c420b7aa9c45fc7994ac8";
 
         let hash = ImageHash::parse(INPUT)?;
@@ -767,7 +767,7 @@ mod tests {
     /// Test that image hash parsing correctly identifies animated hashes by its
     /// `a_` prefix.
     #[test]
-    fn test_is_animated() -> Result<(), ImageHashParseError> {
+    fn is_animated() -> Result<(), ImageHashParseError> {
         assert!(ImageHash::parse(b"a_06c16474723fe537c283b8efa61a30c8")?.is_animated());
         assert!(!ImageHash::parse(b"06c16474723fe537c283b8efa61a30c8")?.is_animated());
 

--- a/model/src/voice/close_code.rs
+++ b/model/src/voice/close_code.rs
@@ -92,7 +92,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&CloseCode::UnknownOpcode, &[Token::U16(4001)]);
         serde_test::assert_tokens(&CloseCode::DecodeError, &[Token::U16(4002)]);
         serde_test::assert_tokens(&CloseCode::NotAuthenticated, &[Token::U16(4003)]);
@@ -107,7 +107,7 @@ mod tests {
     }
 
     #[test]
-    fn test_conversion() {
+    fn conversion() {
         assert_eq!(CloseCode::try_from(4001).unwrap(), CloseCode::UnknownOpcode);
         assert_eq!(CloseCode::try_from(4002).unwrap(), CloseCode::DecodeError);
         assert_eq!(

--- a/model/src/voice/opcode.rs
+++ b/model/src/voice/opcode.rs
@@ -37,7 +37,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_variants() {
+    fn variants() {
         serde_test::assert_tokens(&OpCode::Identify, &[Token::U8(0)]);
         serde_test::assert_tokens(&OpCode::SelectProtocol, &[Token::U8(1)]);
         serde_test::assert_tokens(&OpCode::Ready, &[Token::U8(2)]);

--- a/model/src/voice/voice_region.rs
+++ b/model/src/voice/voice_region.rs
@@ -16,7 +16,7 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn test_voice_region() {
+    fn voice_region() {
         let value = VoiceRegion {
             custom: false,
             deprecated: false,

--- a/model/src/voice/voice_state.rs
+++ b/model/src/voice/voice_state.rs
@@ -298,7 +298,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_voice_state() {
+    fn voice_state() {
         let value = VoiceState {
             channel_id: Some(Id::new(1)),
             deaf: false,
@@ -359,7 +359,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     #[test]
-    fn test_voice_state_complete() -> Result<(), TimestampParseError> {
+    fn voice_state_complete() -> Result<(), TimestampParseError> {
         let joined_at = Timestamp::from_str("2015-04-26T06:26:56.936000+00:00")?;
         let premium_since = Timestamp::from_str("2021-03-16T14:29:19.046000+00:00")?;
         let request_to_speak_timestamp = Timestamp::from_str("2021-04-21T22:16:50.000000+00:00")?;

--- a/util/src/builder/command.rs
+++ b/util/src/builder/command.rs
@@ -1293,7 +1293,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate() {
+    fn validate() {
         let result = CommandBuilder::new("".into(), "".into(), CommandType::ChatInput).validate();
 
         assert!(result.is_err());

--- a/util/src/builder/embed/author.rs
+++ b/util/src/builder/embed/author.rs
@@ -77,7 +77,7 @@ mod tests {
     assert_impl_all!(EmbedAuthor: From<EmbedAuthorBuilder>);
 
     #[test]
-    fn test_builder() {
+    fn builder() {
         let expected = EmbedAuthor {
             icon_url: Some("https://example.com/1.png".to_owned()),
             name: "an author".to_owned(),

--- a/util/src/builder/embed/field.rs
+++ b/util/src/builder/embed/field.rs
@@ -80,7 +80,7 @@ mod tests {
     assert_impl_all!(EmbedField: From<EmbedFieldBuilder>);
 
     #[test]
-    fn test_builder_inline() {
+    fn builder_inline() {
         let expected = EmbedField {
             inline: true,
             name: "name".to_owned(),
@@ -92,7 +92,7 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_no_inline() {
+    fn builder_no_inline() {
         let expected = EmbedField {
             inline: false,
             name: "name".to_owned(),

--- a/util/src/builder/embed/footer.rs
+++ b/util/src/builder/embed/footer.rs
@@ -77,7 +77,7 @@ mod tests {
     assert_impl_all!(EmbedFooter: From<EmbedFooterBuilder>);
 
     #[test]
-    fn test_builder() {
+    fn builder() {
         let expected = EmbedFooter {
             icon_url: Some("https://example.com/1.png".to_owned()),
             proxy_icon_url: None,

--- a/util/src/builder/embed/image_source.rs
+++ b/util/src/builder/embed/image_source.rs
@@ -200,7 +200,7 @@ mod tests {
     assert_impl_all!(ImageSource: Clone, Debug, Eq, PartialEq, Send, Sync);
 
     #[test]
-    fn test_attachment() -> Result<(), Box<dyn Error>> {
+    fn attachment() -> Result<(), Box<dyn Error>> {
         assert!(matches!(
             ImageSource::attachment("abc").unwrap_err().kind(),
             ImageSourceAttachmentErrorType::ExtensionMissing
@@ -218,7 +218,7 @@ mod tests {
     }
 
     #[test]
-    fn test_url() -> Result<(), Box<dyn Error>> {
+    fn url() -> Result<(), Box<dyn Error>> {
         assert!(matches!(
             ImageSource::url("ftp://example.com/foo").unwrap_err().kind(),
             ImageSourceUrlErrorType::ProtocolUnsupported { url }

--- a/util/src/builder/embed/mod.rs
+++ b/util/src/builder/embed/mod.rs
@@ -379,7 +379,7 @@ mod tests {
     assert_impl_all!(Embed: TryFrom<EmbedBuilder>);
 
     #[test]
-    fn test_builder() {
+    fn builder() {
         let footer_image = ImageSource::url(
             "https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png",
         )

--- a/util/src/link/webhook.rs
+++ b/util/src/link/webhook.rs
@@ -169,7 +169,7 @@ mod tests {
     assert_impl_all!(WebhookParseError: Debug, Error, Send, Sync);
 
     #[test]
-    fn test_parse_no_token() {
+    fn parse_no_token() {
         assert_eq!(
             (Id::new(123), None),
             super::parse("https://discord.com/api/webhooks/123").unwrap(),
@@ -187,7 +187,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_with_token() {
+    fn parse_with_token() {
         assert_eq!(
             super::parse("https://discord.com/api/webhooks/456/token").unwrap(),
             (Id::new(456), Some("token")),
@@ -212,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_invalid() {
+    fn parse_invalid() {
         // Base URL is improper.
         assert!(matches!(
             super::parse("https://discord.com/foo/bar/456")

--- a/util/src/permission_calculator/bitops.rs
+++ b/util/src/permission_calculator/bitops.rs
@@ -19,7 +19,7 @@ mod tests {
     use twilight_model::guild::Permissions;
 
     #[test]
-    fn test_insert() {
+    fn insert() {
         let actual = super::insert(
             Permissions::KICK_MEMBERS,
             Permissions::BAN_MEMBERS | Permissions::CONNECT,
@@ -30,7 +30,7 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_duplicate() {
+    fn insert_duplicate() {
         let expected = Permissions::BAN_MEMBERS | Permissions::KICK_MEMBERS;
         let actual = super::insert(expected, Permissions::KICK_MEMBERS);
 
@@ -38,7 +38,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove() {
+    fn remove() {
         let actual = super::remove(
             Permissions::BAN_MEMBERS | Permissions::KICK_MEMBERS,
             Permissions::BAN_MEMBERS,
@@ -48,7 +48,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_nonexistent() {
+    fn remove_nonexistent() {
         let actual = super::remove(Permissions::KICK_MEMBERS, Permissions::BAN_MEMBERS);
 
         assert_eq!(actual, Permissions::KICK_MEMBERS);

--- a/util/src/permission_calculator/mod.rs
+++ b/util/src/permission_calculator/mod.rs
@@ -534,7 +534,7 @@ mod tests {
     assert_impl_all!(PermissionCalculator<'_>: Clone, Debug, Eq, PartialEq, Send, Sync);
 
     #[test]
-    fn test_owner_is_admin() {
+    fn owner_is_admin() {
         let guild_id = Id::new(1);
         let user_id = Id::new(2);
         let everyone_role = Permissions::SEND_MESSAGES;
@@ -549,7 +549,7 @@ mod tests {
     // Test that a permission overwrite denying the "View Channel" permission
     // implicitly denies all other permissions.
     #[test]
-    fn test_view_channel_deny_implicit() {
+    fn view_channel_deny_implicit() {
         let guild_id = Id::new(1);
         let user_id = Id::new(2);
         let everyone_role = Permissions::MENTION_EVERYONE | Permissions::SEND_MESSAGES;
@@ -588,7 +588,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_text_and_stage_perms_when_voice() {
+    fn remove_text_and_stage_perms_when_voice() {
         let guild_id = Id::new(1);
         let user_id = Id::new(2);
         let everyone_role = Permissions::CONNECT;
@@ -601,7 +601,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_audio_perms_when_text() {
+    fn remove_audio_perms_when_text() {
         let guild_id = Id::new(1);
         let user_id = Id::new(2);
         let everyone_role = Permissions::CONNECT;
@@ -618,7 +618,7 @@ mod tests {
     // Test that denying the "Send Messages" permission denies all message
     // send related permissions.
     #[test]
-    fn test_deny_send_messages_removes_related() {
+    fn deny_send_messages_removes_related() {
         let guild_id = Id::new(1);
         let user_id = Id::new(2);
         let everyone_role =
@@ -642,7 +642,7 @@ mod tests {
     /// Test that a member that has a role with the "administrator" permission
     /// has all denying overwrites ignored.
     #[test]
-    fn test_admin() {
+    fn admin() {
         let member_roles = &[(Id::new(3), Permissions::ADMINISTRATOR)];
         let calc =
             PermissionCalculator::new(Id::new(1), Id::new(2), Permissions::empty(), member_roles);
@@ -656,7 +656,7 @@ mod tests {
     /// Test that guild-level permissions are removed in the permissions for a
     /// channel of any type.
     #[test]
-    fn test_guild_level_removed_in_channel() {
+    fn guild_level_removed_in_channel() {
         const CHANNEL_TYPES: &[ChannelType] = &[
             ChannelType::GuildCategory,
             ChannelType::GuildNews,

--- a/util/src/permission_calculator/preset.rs
+++ b/util/src/permission_calculator/preset.rs
@@ -100,7 +100,7 @@ mod tests {
     use twilight_model::guild::Permissions;
 
     #[test]
-    fn test_permissions_stage_omitted() {
+    fn permissions_stage_omitted() {
         let expected = Permissions::ADD_REACTIONS
             | Permissions::PRIORITY_SPEAKER
             | Permissions::STREAM
@@ -122,7 +122,7 @@ mod tests {
     }
 
     #[test]
-    fn test_permissions_text_omitted() {
+    fn permissions_text_omitted() {
         let expected = Permissions::CONNECT
             | Permissions::DEAFEN_MEMBERS
             | Permissions::MOVE_MEMBERS
@@ -137,7 +137,7 @@ mod tests {
     }
 
     #[test]
-    fn test_permissions_voice_omitted() {
+    fn permissions_voice_omitted() {
         let expected = Permissions::ADD_REACTIONS
             | Permissions::ATTACH_FILES
             | Permissions::EMBED_LINKS

--- a/util/src/snowflake.rs
+++ b/util/src/snowflake.rs
@@ -260,7 +260,7 @@ mod tests {
     assert_obj_safe!(Snowflake);
 
     #[test]
-    fn test_timestamp() {
+    fn timestamp() {
         let expected: i64 = 1_445_219_918_546;
         let id = Id::<GenericMarker>::new(105_484_726_235_607_040);
 
@@ -268,7 +268,7 @@ mod tests {
     }
 
     #[test]
-    fn test_worker_id() {
+    fn worker_id() {
         let expected: u8 = 8;
         let id = Id::<GenericMarker>::new(762_022_344_856_174_632);
 
@@ -276,7 +276,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_id() {
+    fn process_id() {
         let expected: u8 = 1;
         let id = Id::<GenericMarker>::new(61_189_081_970_774_016);
 
@@ -284,7 +284,7 @@ mod tests {
     }
 
     #[test]
-    fn test_increment() {
+    fn increment() {
         let expected: u16 = 40;
         let id = Id::<GenericMarker>::new(762_022_344_856_174_632);
 

--- a/validate/src/channel.rs
+++ b/validate/src/channel.rs
@@ -187,7 +187,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn is_thread() {
+    fn thread_is_thread() {
         assert!(is_thread(ChannelType::GuildNewsThread).is_ok());
         assert!(is_thread(ChannelType::GuildPrivateThread).is_ok());
         assert!(is_thread(ChannelType::GuildPublicThread).is_ok());
@@ -205,7 +205,7 @@ mod tests {
     }
 
     #[test]
-    fn rate_limit_per_user() {
+    fn rate_limit_per_user_value() {
         assert!(rate_limit_per_user(0).is_ok());
         assert!(rate_limit_per_user(21_600).is_ok());
 
@@ -213,7 +213,7 @@ mod tests {
     }
 
     #[test]
-    fn topic() {
+    fn topic_length() {
         assert!(topic("").is_ok());
         assert!(topic("a").is_ok());
         assert!(topic("a".repeat(1_024)).is_ok());

--- a/validate/src/channel.rs
+++ b/validate/src/channel.rs
@@ -187,7 +187,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_is_thread() {
+    fn is_thread() {
         assert!(is_thread(ChannelType::GuildNewsThread).is_ok());
         assert!(is_thread(ChannelType::GuildPrivateThread).is_ok());
         assert!(is_thread(ChannelType::GuildPublicThread).is_ok());
@@ -196,7 +196,7 @@ mod tests {
     }
 
     #[test]
-    fn test_channel_name() {
+    fn channel_name() {
         assert!(name("a").is_ok());
         assert!(name("a".repeat(100)).is_ok());
 
@@ -205,7 +205,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rate_limit_per_user() {
+    fn rate_limit_per_user() {
         assert!(rate_limit_per_user(0).is_ok());
         assert!(rate_limit_per_user(21_600).is_ok());
 
@@ -213,7 +213,7 @@ mod tests {
     }
 
     #[test]
-    fn test_topic() {
+    fn topic() {
         assert!(topic("").is_ok());
         assert!(topic("a").is_ok());
         assert!(topic("a".repeat(1_024)).is_ok());

--- a/validate/src/command.rs
+++ b/validate/src/command.rs
@@ -512,7 +512,7 @@ mod tests {
 
     // This tests [`description`] and [`name`] by proxy.
     #[test]
-    fn command() {
+    fn command_length() {
         let valid_command = Command {
             application_id: Some(Id::new(1)),
             default_member_permissions: None,
@@ -543,7 +543,7 @@ mod tests {
     }
 
     #[test]
-    fn name_characters() {
+    fn name_allowed_characters() {
         assert!(name_characters("hello-command").is_ok()); // Latin language
         assert!(name_characters("Hello").is_err()); // Latin language with uppercase
         assert!(name_characters("hello!").is_err()); // Latin language with non-alphanumeric
@@ -557,7 +557,7 @@ mod tests {
     }
 
     #[test]
-    fn guild_permissions() {
+    fn guild_permissions_count() {
         assert!(guild_permissions(0).is_ok());
         assert!(guild_permissions(1).is_ok());
         assert!(guild_permissions(10).is_ok());

--- a/validate/src/command.rs
+++ b/validate/src/command.rs
@@ -512,7 +512,7 @@ mod tests {
 
     // This tests [`description`] and [`name`] by proxy.
     #[test]
-    fn test_command() {
+    fn command() {
         let valid_command = Command {
             application_id: Some(Id::new(1)),
             default_member_permissions: None,
@@ -543,7 +543,7 @@ mod tests {
     }
 
     #[test]
-    fn test_name_characters() {
+    fn name_characters() {
         assert!(name_characters("hello-command").is_ok()); // Latin language
         assert!(name_characters("Hello").is_err()); // Latin language with uppercase
         assert!(name_characters("hello!").is_err()); // Latin language with non-alphanumeric
@@ -557,7 +557,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_permissions() {
+    fn guild_permissions() {
         assert!(guild_permissions(0).is_ok());
         assert!(guild_permissions(1).is_ok());
         assert!(guild_permissions(10).is_ok());

--- a/validate/src/component.rs
+++ b/validate/src/component.rs
@@ -1124,7 +1124,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component() {
+    fn component() {
         let button = Button {
             custom_id: None,
             disabled: false,
@@ -1181,7 +1181,7 @@ mod tests {
     // Test that a button with both a custom ID and URL results in a
     // [`ComponentValidationErrorType::ButtonConflict`] error type.
     #[test]
-    fn test_button_conflict() {
+    fn button_conflict() {
         let button = Button {
             custom_id: Some("a".to_owned()),
             disabled: false,
@@ -1202,7 +1202,7 @@ mod tests {
     // Test that all button styles with no custom ID or URL results in a
     // [`ComponentValidationErrorType::ButtonStyle`] error type.
     #[test]
-    fn test_button_style() {
+    fn button_style() {
         for style in all_button_styles().iter() {
             let button = Button {
                 custom_id: None,
@@ -1226,7 +1226,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_label() {
+    fn component_label() {
         assert!(component_button_label("").is_ok());
         assert!(component_button_label("a").is_ok());
         assert!(component_button_label("a".repeat(80)).is_ok());
@@ -1235,7 +1235,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_custom_id() {
+    fn component_custom_id() {
         assert!(component_custom_id("").is_ok());
         assert!(component_custom_id("a").is_ok());
         assert!(component_custom_id("a".repeat(100)).is_ok());
@@ -1244,7 +1244,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_option_description() {
+    fn component_option_description() {
         assert!(component_option_description("").is_ok());
         assert!(component_option_description("a").is_ok());
         assert!(component_option_description("a".repeat(100)).is_ok());
@@ -1253,7 +1253,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_select_max_values() {
+    fn component_select_max_values() {
         assert!(component_select_max_values(1).is_ok());
         assert!(component_select_max_values(25).is_ok());
 
@@ -1262,7 +1262,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_select_min_values() {
+    fn component_select_min_values() {
         assert!(component_select_min_values(1).is_ok());
         assert!(component_select_min_values(25).is_ok());
 
@@ -1270,7 +1270,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_select_option_value() {
+    fn component_select_option_value() {
         assert!(component_select_option_value("a").is_ok());
         assert!(component_select_option_value("a".repeat(100)).is_ok());
 
@@ -1278,7 +1278,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_select_options() {
+    fn component_select_options() {
         let select_menu_options = Vec::from([SelectMenuOption {
             default: false,
             description: None,
@@ -1309,7 +1309,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_select_placeholder() {
+    fn component_select_placeholder() {
         assert!(component_select_placeholder("").is_ok());
         assert!(component_select_placeholder("a").is_ok());
         assert!(component_select_placeholder("a".repeat(150)).is_ok());
@@ -1318,7 +1318,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_text_input_label() {
+    fn component_text_input_label() {
         assert!(component_text_input_label("a").is_ok());
         assert!(component_text_input_label("a".repeat(45)).is_ok());
 
@@ -1327,7 +1327,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_text_input_max() {
+    fn component_text_input_max() {
         assert!(component_text_input_max(1).is_ok());
         assert!(component_text_input_max(4000).is_ok());
 
@@ -1336,7 +1336,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_text_input_min() {
+    fn component_text_input_min() {
         assert!(component_text_input_min(0).is_ok());
         assert!(component_text_input_min(1).is_ok());
         assert!(component_text_input_min(4000).is_ok());
@@ -1345,7 +1345,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_text_input_placeholder() {
+    fn component_text_input_placeholder() {
         assert!(component_text_input_placeholder("").is_ok());
         assert!(component_text_input_placeholder("a").is_ok());
         assert!(component_text_input_placeholder("a".repeat(100)).is_ok());
@@ -1354,7 +1354,7 @@ mod tests {
     }
 
     #[test]
-    fn test_component_text_input_value() {
+    fn component_text_input_value() {
         assert!(component_text_input_min(0).is_ok());
         assert!(component_text_input_min(1).is_ok());
         assert!(component_text_input_min(4000).is_ok());

--- a/validate/src/component.rs
+++ b/validate/src/component.rs
@@ -1124,7 +1124,7 @@ mod tests {
     }
 
     #[test]
-    fn component() {
+    fn component_action_row() {
         let button = Button {
             custom_id: None,
             disabled: false,
@@ -1235,7 +1235,7 @@ mod tests {
     }
 
     #[test]
-    fn component_custom_id() {
+    fn component_custom_id_length() {
         assert!(component_custom_id("").is_ok());
         assert!(component_custom_id("a").is_ok());
         assert!(component_custom_id("a".repeat(100)).is_ok());
@@ -1244,7 +1244,7 @@ mod tests {
     }
 
     #[test]
-    fn component_option_description() {
+    fn component_option_description_length() {
         assert!(component_option_description("").is_ok());
         assert!(component_option_description("a").is_ok());
         assert!(component_option_description("a".repeat(100)).is_ok());
@@ -1253,7 +1253,7 @@ mod tests {
     }
 
     #[test]
-    fn component_select_max_values() {
+    fn component_select_max_values_count() {
         assert!(component_select_max_values(1).is_ok());
         assert!(component_select_max_values(25).is_ok());
 
@@ -1262,7 +1262,7 @@ mod tests {
     }
 
     #[test]
-    fn component_select_min_values() {
+    fn component_select_min_values_count() {
         assert!(component_select_min_values(1).is_ok());
         assert!(component_select_min_values(25).is_ok());
 
@@ -1270,7 +1270,7 @@ mod tests {
     }
 
     #[test]
-    fn component_select_option_value() {
+    fn component_select_option_value_length() {
         assert!(component_select_option_value("a").is_ok());
         assert!(component_select_option_value("a".repeat(100)).is_ok());
 
@@ -1278,7 +1278,7 @@ mod tests {
     }
 
     #[test]
-    fn component_select_options() {
+    fn component_select_options_count() {
         let select_menu_options = Vec::from([SelectMenuOption {
             default: false,
             description: None,
@@ -1309,7 +1309,7 @@ mod tests {
     }
 
     #[test]
-    fn component_select_placeholder() {
+    fn component_select_placeholder_length() {
         assert!(component_select_placeholder("").is_ok());
         assert!(component_select_placeholder("a").is_ok());
         assert!(component_select_placeholder("a".repeat(150)).is_ok());
@@ -1318,7 +1318,7 @@ mod tests {
     }
 
     #[test]
-    fn component_text_input_label() {
+    fn component_text_input_label_length() {
         assert!(component_text_input_label("a").is_ok());
         assert!(component_text_input_label("a".repeat(45)).is_ok());
 
@@ -1327,7 +1327,7 @@ mod tests {
     }
 
     #[test]
-    fn component_text_input_max() {
+    fn component_text_input_max_count() {
         assert!(component_text_input_max(1).is_ok());
         assert!(component_text_input_max(4000).is_ok());
 
@@ -1336,7 +1336,7 @@ mod tests {
     }
 
     #[test]
-    fn component_text_input_min() {
+    fn component_text_input_min_count() {
         assert!(component_text_input_min(0).is_ok());
         assert!(component_text_input_min(1).is_ok());
         assert!(component_text_input_min(4000).is_ok());
@@ -1345,7 +1345,7 @@ mod tests {
     }
 
     #[test]
-    fn component_text_input_placeholder() {
+    fn component_text_input_placeholder_length() {
         assert!(component_text_input_placeholder("").is_ok());
         assert!(component_text_input_placeholder("a").is_ok());
         assert!(component_text_input_placeholder("a".repeat(100)).is_ok());

--- a/validate/src/embed.rs
+++ b/validate/src/embed.rs
@@ -381,14 +381,14 @@ mod tests {
     }
 
     #[test]
-    fn test_embed_base() {
+    fn embed_base() {
         let embed = base_embed();
 
         assert!(super::embed(&embed).is_ok());
     }
 
     #[test]
-    fn test_embed_normal() {
+    fn embed_normal() {
         let mut embed = base_embed();
         embed.author.replace(EmbedAuthor {
             icon_url: None,
@@ -409,7 +409,7 @@ mod tests {
     }
 
     #[test]
-    fn test_embed_author_name_limit() {
+    fn embed_author_name_limit() {
         let mut embed = base_embed();
         embed.author.replace(EmbedAuthor {
             icon_url: None,
@@ -432,7 +432,7 @@ mod tests {
     }
 
     #[test]
-    fn test_embed_description_limit() {
+    fn embed_description_limit() {
         let mut embed = base_embed();
         embed.description.replace(str::repeat("a", 2048));
         assert!(super::embed(&embed).is_ok());
@@ -448,7 +448,7 @@ mod tests {
     }
 
     #[test]
-    fn test_embed_field_count_limit() {
+    fn embed_field_count_limit() {
         let mut embed = base_embed();
 
         for _ in 0..26 {
@@ -466,7 +466,7 @@ mod tests {
     }
 
     #[test]
-    fn test_embed_field_name_limit() {
+    fn embed_field_name_limit() {
         let mut embed = base_embed();
         embed.fields.push(EmbedField {
             inline: true,
@@ -487,7 +487,7 @@ mod tests {
     }
 
     #[test]
-    fn test_embed_field_value_limit() {
+    fn embed_field_value_limit() {
         let mut embed = base_embed();
         embed.fields.push(EmbedField {
             inline: true,
@@ -508,7 +508,7 @@ mod tests {
     }
 
     #[test]
-    fn test_embed_footer_text_limit() {
+    fn embed_footer_text_limit() {
         let mut embed = base_embed();
         embed.footer.replace(EmbedFooter {
             icon_url: None,
@@ -529,7 +529,7 @@ mod tests {
     }
 
     #[test]
-    fn test_embed_title_limit() {
+    fn embed_title_limit() {
         let mut embed = base_embed();
         embed.title.replace(str::repeat("a", 256));
         assert!(super::embed(&embed).is_ok());
@@ -542,7 +542,7 @@ mod tests {
     }
 
     #[test]
-    fn test_embed_combined_limit() {
+    fn embed_combined_limit() {
         let mut embed = base_embed();
         embed.description.replace(str::repeat("a", 2048));
         embed.title.replace(str::repeat("a", 256));

--- a/validate/src/message.rs
+++ b/validate/src/message.rs
@@ -329,7 +329,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_attachment_filename() {
+    fn attachment_filename() {
         assert!(attachment_filename("one.jpg").is_ok());
         assert!(attachment_filename("two.png").is_ok());
         assert!(attachment_filename("three.gif").is_ok());
@@ -339,7 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn test_content() {
+    fn content() {
         assert!(content("").is_ok());
         assert!(content("a".repeat(2000)).is_ok());
 

--- a/validate/src/message.rs
+++ b/validate/src/message.rs
@@ -329,7 +329,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn attachment_filename() {
+    fn attachment_allowed_filename() {
         assert!(attachment_filename("one.jpg").is_ok());
         assert!(attachment_filename("two.png").is_ok());
         assert!(attachment_filename("three.gif").is_ok());
@@ -339,7 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn content() {
+    fn content_length() {
         assert!(content("").is_ok());
         assert!(content("a".repeat(2000)).is_ok());
 

--- a/validate/src/request.rs
+++ b/validate/src/request.rs
@@ -1082,7 +1082,7 @@ mod tests {
     }
 
     #[test]
-    fn audit_reason() {
+    fn audit_reason_length() {
         assert!(audit_reason("").is_ok());
         assert!(audit_reason("a").is_ok());
         assert!(audit_reason("a".repeat(500)).is_ok());
@@ -1092,7 +1092,7 @@ mod tests {
     }
 
     #[test]
-    fn create_guild_ban_delete_message_days() {
+    fn create_guild_ban_delete_message_days_length() {
         assert!(create_guild_ban_delete_message_days(0).is_ok());
         assert!(create_guild_ban_delete_message_days(1).is_ok());
         assert!(create_guild_ban_delete_message_days(7).is_ok());
@@ -1101,7 +1101,7 @@ mod tests {
     }
 
     #[test]
-    fn communication_disabled_until() {
+    fn communication_disabled_until_max() {
         #[allow(clippy::cast_possible_wrap)]
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -1118,7 +1118,7 @@ mod tests {
     }
 
     #[test]
-    fn get_channel_messages_limit() {
+    fn get_channel_messages_limit_count() {
         assert!(get_channel_messages_limit(1).is_ok());
         assert!(get_channel_messages_limit(100).is_ok());
 
@@ -1127,7 +1127,7 @@ mod tests {
     }
 
     #[test]
-    fn get_current_user_guilds_limit() {
+    fn get_current_user_guilds_limit_count() {
         assert!(get_current_user_guilds_limit(1).is_ok());
         assert!(get_current_user_guilds_limit(200).is_ok());
 
@@ -1136,7 +1136,7 @@ mod tests {
     }
 
     #[test]
-    fn get_audit_log_limit() {
+    fn get_auild_log_limit_count() {
         assert!(get_guild_audit_log_limit(1).is_ok());
         assert!(get_guild_audit_log_limit(100).is_ok());
 
@@ -1145,7 +1145,7 @@ mod tests {
     }
 
     #[test]
-    fn get_guild_bans_limit() {
+    fn get_guild_bans_limit_count() {
         assert!(get_guild_bans_limit(0).is_ok());
         assert!(get_guild_bans_limit(1000).is_ok());
 
@@ -1153,7 +1153,7 @@ mod tests {
     }
 
     #[test]
-    fn get_guild_members_limit() {
+    fn get_guild_members_limit_count() {
         assert!(get_guild_members_limit(1).is_ok());
         assert!(get_guild_members_limit(1000).is_ok());
 
@@ -1162,7 +1162,7 @@ mod tests {
     }
 
     #[test]
-    fn get_reactions_limit() {
+    fn get_reactions_limit_count() {
         assert!(get_reactions_limit(1).is_ok());
         assert!(get_reactions_limit(100).is_ok());
 
@@ -1171,7 +1171,7 @@ mod tests {
     }
 
     #[test]
-    fn guild_name() {
+    fn guild_name_length() {
         assert!(guild_name("aa").is_ok());
         assert!(guild_name("a".repeat(100)).is_ok());
 
@@ -1181,7 +1181,7 @@ mod tests {
     }
 
     #[test]
-    fn guild_prune_days() {
+    fn guild_prune_days_length() {
         assert!(guild_prune_days(1).is_ok());
         assert!(guild_prune_days(30).is_ok());
 
@@ -1191,7 +1191,7 @@ mod tests {
     }
 
     #[test]
-    fn invite_max_age() {
+    fn invite_max_age_length() {
         assert!(invite_max_age(0).is_ok());
         assert!(invite_max_age(86_400).is_ok());
         assert!(invite_max_age(604_800).is_ok());
@@ -1200,7 +1200,7 @@ mod tests {
     }
 
     #[test]
-    fn invite_max_uses() {
+    fn invite_max_uses_count() {
         assert!(invite_max_uses(0).is_ok());
         assert!(invite_max_uses(100).is_ok());
 
@@ -1208,7 +1208,7 @@ mod tests {
     }
 
     #[test]
-    fn nickname() {
+    fn nickname_length() {
         assert!(nickname("a").is_ok());
         assert!(nickname("a".repeat(32)).is_ok());
 
@@ -1217,7 +1217,7 @@ mod tests {
     }
 
     #[test]
-    fn scheduled_event_description() {
+    fn scheduled_event_description_length() {
         assert!(scheduled_event_description("a").is_ok());
         assert!(scheduled_event_description("a".repeat(1000)).is_ok());
 
@@ -1226,7 +1226,7 @@ mod tests {
     }
 
     #[test]
-    fn scheduled_event_name() {
+    fn scheduled_event_name_length() {
         assert!(scheduled_event_name("a").is_ok());
         assert!(scheduled_event_name("a".repeat(100)).is_ok());
 
@@ -1235,7 +1235,7 @@ mod tests {
     }
 
     #[test]
-    fn search_guild_members_limit() {
+    fn search_guild_members_limit_count() {
         assert!(search_guild_members_limit(1).is_ok());
         assert!(search_guild_members_limit(1000).is_ok());
 
@@ -1244,7 +1244,7 @@ mod tests {
     }
 
     #[test]
-    fn stage_topic() {
+    fn stage_topic_length() {
         assert!(stage_topic("a").is_ok());
         assert!(stage_topic("a".repeat(120)).is_ok());
 
@@ -1253,7 +1253,7 @@ mod tests {
     }
 
     #[test]
-    fn template_description() {
+    fn template_description_length() {
         assert!(template_description("").is_ok());
         assert!(template_description("a").is_ok());
         assert!(template_description("a".repeat(120)).is_ok());
@@ -1262,7 +1262,7 @@ mod tests {
     }
 
     #[test]
-    fn template_name() {
+    fn template_name_length() {
         assert!(template_name("a").is_ok());
         assert!(template_name("a".repeat(100)).is_ok());
 
@@ -1271,7 +1271,7 @@ mod tests {
     }
 
     #[test]
-    fn username() {
+    fn username_length() {
         assert!(username("aa").is_ok());
         assert!(username("a".repeat(32)).is_ok());
 
@@ -1288,7 +1288,7 @@ mod tests {
     }
 
     #[test]
-    fn webhook_username() {
+    fn webhook_username_length() {
         assert!(webhook_username("aa").is_ok());
         assert!(webhook_username("a".repeat(80)).is_ok());
 

--- a/validate/src/request.rs
+++ b/validate/src/request.rs
@@ -1046,7 +1046,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_username_variants() {
+    fn username_variants() {
         let expected = format!(
             "provided username length is 200, but it must be at least {USERNAME_LIMIT_MIN} and at \
             most {USERNAME_LIMIT_MAX}, and cannot contain :"
@@ -1082,7 +1082,7 @@ mod tests {
     }
 
     #[test]
-    fn test_audit_reason() {
+    fn audit_reason() {
         assert!(audit_reason("").is_ok());
         assert!(audit_reason("a").is_ok());
         assert!(audit_reason("a".repeat(500)).is_ok());
@@ -1092,7 +1092,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_guild_ban_delete_message_days() {
+    fn create_guild_ban_delete_message_days() {
         assert!(create_guild_ban_delete_message_days(0).is_ok());
         assert!(create_guild_ban_delete_message_days(1).is_ok());
         assert!(create_guild_ban_delete_message_days(7).is_ok());
@@ -1101,7 +1101,7 @@ mod tests {
     }
 
     #[test]
-    fn test_communication_disabled_until() {
+    fn communication_disabled_until() {
         #[allow(clippy::cast_possible_wrap)]
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -1118,7 +1118,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_channel_messages_limit() {
+    fn get_channel_messages_limit() {
         assert!(get_channel_messages_limit(1).is_ok());
         assert!(get_channel_messages_limit(100).is_ok());
 
@@ -1127,7 +1127,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_current_user_guilds_limit() {
+    fn get_current_user_guilds_limit() {
         assert!(get_current_user_guilds_limit(1).is_ok());
         assert!(get_current_user_guilds_limit(200).is_ok());
 
@@ -1136,7 +1136,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_audit_log_limit() {
+    fn get_audit_log_limit() {
         assert!(get_guild_audit_log_limit(1).is_ok());
         assert!(get_guild_audit_log_limit(100).is_ok());
 
@@ -1145,7 +1145,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_guild_bans_limit() {
+    fn get_guild_bans_limit() {
         assert!(get_guild_bans_limit(0).is_ok());
         assert!(get_guild_bans_limit(1000).is_ok());
 
@@ -1153,7 +1153,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_guild_members_limit() {
+    fn get_guild_members_limit() {
         assert!(get_guild_members_limit(1).is_ok());
         assert!(get_guild_members_limit(1000).is_ok());
 
@@ -1162,7 +1162,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_reactions_limit() {
+    fn get_reactions_limit() {
         assert!(get_reactions_limit(1).is_ok());
         assert!(get_reactions_limit(100).is_ok());
 
@@ -1171,7 +1171,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_name() {
+    fn guild_name() {
         assert!(guild_name("aa").is_ok());
         assert!(guild_name("a".repeat(100)).is_ok());
 
@@ -1181,7 +1181,7 @@ mod tests {
     }
 
     #[test]
-    fn test_guild_prune_days() {
+    fn guild_prune_days() {
         assert!(guild_prune_days(1).is_ok());
         assert!(guild_prune_days(30).is_ok());
 
@@ -1191,7 +1191,7 @@ mod tests {
     }
 
     #[test]
-    fn test_invite_max_age() {
+    fn invite_max_age() {
         assert!(invite_max_age(0).is_ok());
         assert!(invite_max_age(86_400).is_ok());
         assert!(invite_max_age(604_800).is_ok());
@@ -1200,7 +1200,7 @@ mod tests {
     }
 
     #[test]
-    fn test_invite_max_uses() {
+    fn invite_max_uses() {
         assert!(invite_max_uses(0).is_ok());
         assert!(invite_max_uses(100).is_ok());
 
@@ -1208,7 +1208,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nickname() {
+    fn nickname() {
         assert!(nickname("a").is_ok());
         assert!(nickname("a".repeat(32)).is_ok());
 
@@ -1217,7 +1217,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scheduled_event_description() {
+    fn scheduled_event_description() {
         assert!(scheduled_event_description("a").is_ok());
         assert!(scheduled_event_description("a".repeat(1000)).is_ok());
 
@@ -1226,7 +1226,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scheduled_event_name() {
+    fn scheduled_event_name() {
         assert!(scheduled_event_name("a").is_ok());
         assert!(scheduled_event_name("a".repeat(100)).is_ok());
 
@@ -1235,7 +1235,7 @@ mod tests {
     }
 
     #[test]
-    fn test_search_guild_members_limit() {
+    fn search_guild_members_limit() {
         assert!(search_guild_members_limit(1).is_ok());
         assert!(search_guild_members_limit(1000).is_ok());
 
@@ -1244,7 +1244,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stage_topic() {
+    fn stage_topic() {
         assert!(stage_topic("a").is_ok());
         assert!(stage_topic("a".repeat(120)).is_ok());
 
@@ -1253,7 +1253,7 @@ mod tests {
     }
 
     #[test]
-    fn test_template_description() {
+    fn template_description() {
         assert!(template_description("").is_ok());
         assert!(template_description("a").is_ok());
         assert!(template_description("a".repeat(120)).is_ok());
@@ -1262,7 +1262,7 @@ mod tests {
     }
 
     #[test]
-    fn test_template_name() {
+    fn template_name() {
         assert!(template_name("a").is_ok());
         assert!(template_name("a".repeat(100)).is_ok());
 
@@ -1271,7 +1271,7 @@ mod tests {
     }
 
     #[test]
-    fn test_username() {
+    fn username() {
         assert!(username("aa").is_ok());
         assert!(username("a".repeat(32)).is_ok());
 
@@ -1288,7 +1288,7 @@ mod tests {
     }
 
     #[test]
-    fn test_webhook_username() {
+    fn webhook_username() {
         assert!(webhook_username("aa").is_ok());
         assert!(webhook_username("a".repeat(80)).is_ok());
 

--- a/validate/src/sticker.rs
+++ b/validate/src/sticker.rs
@@ -158,7 +158,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn description() {
+    fn description_length() {
         assert!(description("aa").is_ok());
         assert!(description("a".repeat(200)).is_ok());
 
@@ -167,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn name() {
+    fn name_length() {
         assert!(name("aa").is_ok());
         assert!(name("a".repeat(30)).is_ok());
 
@@ -176,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn tags() {
+    fn tags_length() {
         assert!(tags("aa").is_ok());
         assert!(tags("a".repeat(200)).is_ok());
 

--- a/validate/src/sticker.rs
+++ b/validate/src/sticker.rs
@@ -158,7 +158,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_description() {
+    fn description() {
         assert!(description("aa").is_ok());
         assert!(description("a".repeat(200)).is_ok());
 
@@ -167,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn test_name() {
+    fn name() {
         assert!(name("aa").is_ok());
         assert!(name("a".repeat(30)).is_ok());
 
@@ -176,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tags() {
+    fn tags() {
         assert!(tags("aa").is_ok());
         assert!(tags("a".repeat(200)).is_ok());
 


### PR DESCRIPTION
Tests are already separated into their own module (`tests`) so prefixing them with `test_` is unnecessary.

Split into two parts to help review:

1. Global search and replace
2. Fixes from that
