### PR TITLE
refactor(gateway)!: don't store `client`

### DIFF
--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -313,6 +313,7 @@ impl Cluster {
                     fold
                 });
 
+        #[allow(clippy::from_iter_instead_of_collect)]
         let select_all = SelectAll::from_iter(streams);
 
         Ok((Self { config, shards }, Events::new(select_all)))

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -313,7 +313,6 @@ impl Cluster {
                     fold
                 });
 
-        #[allow(clippy::from_iter_instead_of_collect)]
         let select_all = SelectAll::from_iter(streams);
 
         Ok((Self { config, shards }, Events::new(select_all)))

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -146,8 +146,6 @@ impl ShardBuilder {
                 Some(s) => Cow::Owned(s),
                 None => Cow::Borrowed(crate::URL),
             },
-            #[cfg(feature = "twilight-http")]
-            http_client: self.http_client,
             identify_properties: self.identify_properties,
             intents: self.intents,
             large_threshold: self.large_threshold,

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -1,8 +1,6 @@
 use crate::EventTypeFlags;
 use std::{borrow::Cow, sync::Arc};
 use twilight_gateway_queue::Queue;
-#[cfg(feature = "twilight-http")]
-use twilight_http::Client;
 use twilight_model::gateway::{
     payload::outgoing::{identify::IdentifyProperties, update_presence::UpdatePresencePayload},
     Intents,
@@ -25,8 +23,6 @@ use super::tls::TlsContainer;
 pub struct Config {
     pub(super) event_types: EventTypeFlags,
     pub(super) gateway_url: Cow<'static, str>,
-    #[cfg(feature = "twilight-http")]
-    pub(super) http_client: Arc<Client>,
     pub(super) identify_properties: Option<IdentifyProperties>,
     pub(super) intents: Intents,
     pub(super) large_threshold: u64,
@@ -54,13 +50,6 @@ impl Config {
     /// Return an immutable reference to the url used to connect to the gateway.
     pub fn gateway_url(&self) -> &str {
         &self.gateway_url
-    }
-
-    /// Return an immutable reference to the `twilight_http` client to be used
-    /// by the shard.
-    #[cfg(feature = "twilight-http")]
-    pub fn http_client(&self) -> &Client {
-        &self.http_client
     }
 
     /// Return an immutable reference to the identification properties the shard


### PR DESCRIPTION
Only one HTTP request is ever done by the gateway. Users should user their own client for doing HTTP.

## Feedback requested
Should builders take an `Arc<Client>`? It allows clients to share ratelimit and keep-alive connection pooling, but it's only one request.
Should users even be able to overwrite it?
