### PR TITLE
refactor(gateway-queue)!: drop TLS features

### DIFF
--- a/gateway-queue/Cargo.toml
+++ b/gateway-queue/Cargo.toml
@@ -26,10 +26,7 @@ twilight-http = { default-features = false, optional = true, path = "../http" }
 static_assertions = { default-features = false, version = "1" }
 
 [features]
-default = ["rustls-native-roots"]
-native = ["dep:twilight-http", "twilight-http?/native"]
-rustls-native-roots = ["dep:twilight-http", "twilight-http?/rustls-native-roots"]
-rustls-webpki-roots = ["dep:twilight-http", "twilight-http?/rustls-webpki-roots"]
+default = ["twilight-http"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gateway-queue/src/lib.rs
+++ b/gateway-queue/src/lib.rs
@@ -2,24 +2,12 @@
 #![deny(unsafe_code)]
 #![doc = include_str!("../README.md")]
 
-#[cfg(any(
-    feature = "native",
-    feature = "rustls-native-roots",
-    feature = "rustls-webpki-roots"
-))]
+#[cfg(feature = "twilight-http")]
 mod day_limiter;
-#[cfg(any(
-    feature = "native",
-    feature = "rustls-native-roots",
-    feature = "rustls-webpki-roots"
-))]
+#[cfg(feature = "twilight-http")]
 mod large_bot_queue;
 
-#[cfg(any(
-    feature = "native",
-    feature = "rustls-native-roots",
-    feature = "rustls-webpki-roots"
-))]
+#[cfg(feature = "twilight-http")]
 pub use large_bot_queue::LargeBotQueue;
 
 use std::{

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -53,9 +53,9 @@ tokio = { default-features = false, features = ["macros", "rt-multi-thread"], ve
 
 [features]
 default = ["rustls-native-roots", "twilight-http", "zlib-stock"]
-native = ["dep:native-tls", "twilight-http?/native", "twilight-gateway-queue/native", "tokio-tungstenite/native-tls"]
-rustls-native-roots = ["dep:rustls-tls", "dep:rustls-native-certs", "twilight-http?/rustls-native-roots", "twilight-gateway-queue/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]
-rustls-webpki-roots = ["dep:rustls-tls", "dep:webpki-roots", "twilight-http?/rustls-webpki-roots", "twilight-gateway-queue/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
+native = ["dep:native-tls", "twilight-http?/native", "tokio-tungstenite/native-tls"]
+rustls-native-roots = ["dep:rustls-tls", "dep:rustls-native-certs", "twilight-http?/rustls-native-roots", "tokio-tungstenite/rustls-tls-native-roots"]
+rustls-webpki-roots = ["dep:rustls-tls", "dep:webpki-roots", "twilight-http?/rustls-webpki-roots", "tokio-tungstenite/rustls-tls-webpki-roots"]
 zlib-simd = ["dep:flate2", "flate2?/zlib-ng"]
 zlib-stock = ["dep:flate2", "flate2?/zlib"]
 

--- a/twilight/Cargo.toml
+++ b/twilight/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { default-features = false, features = ["macros", "rt-multi-thread"], ve
 twilight-cache-inmemory = { default-features = false, path = "../cache/in-memory" }
 twilight-embed-builder = { default-features = false, path = "../embed-builder" }
 twilight-gateway = { default-features = false, features = ["rustls-native-roots"], path = "../gateway" }
-twilight-gateway-queue = { default-features = false, features = ["rustls-native-roots"], path = "../gateway-queue" }
+twilight-gateway-queue = { default-features = false, path = "../gateway-queue" }
 twilight-http = { default-features = false, features = ["rustls-native-roots"], path = "../http" }
 twilight-http-ratelimiting = { default-features = false, path = "../http-ratelimiting" }
 twilight-lavalink = { default-features = false, path = "../lavalink" }


### PR DESCRIPTION
`LargeBotQueue` requires a `Client` from `twilight-http`, meaning that users have to also depend on `twilight-http`. It makes more sense for them to specify their TLS requirements there, instead of also in `gateway-queue`.

Also fixes the README, which errorously mentions the non existant `twilight-http` feature.

This PR finally fixes all errors to `gateway-queue` introduced in #1690

Closes #1514 as gateway TLS support no longer pulls in `twilight-http`
