### PR TITLE
feat(cache)!: expose `VecDequeue` from `channel_messages`

### DIFF
--- a/cache/in-memory/src/event/message.rs
+++ b/cache/in-memory/src/event/message.rs
@@ -224,13 +224,14 @@ mod tests {
             assert_eq!(entry.value().len(), 2);
         }
 
-        let mut iter = cache
+        let messages = cache
             .channel_messages(Id::new(2))
             .expect("channel is in cache");
 
+        let mut iter = messages.iter();
         // messages are iterated over in descending order from insertion
-        assert_eq!(Some(5), iter.next().map(Id::get));
-        assert_eq!(Some(4), iter.next().map(Id::get));
+        assert_eq!(Some(&Id::new(5)), iter.next());
+        assert_eq!(Some(&Id::new(4)), iter.next());
         assert!(iter.next().is_none());
 
         Ok(())

--- a/cache/in-memory/src/iter.rs
+++ b/cache/in-memory/src/iter.rs
@@ -19,11 +19,8 @@ use crate::{
     },
     GuildResource, InMemoryCache,
 };
-use dashmap::{
-    iter::Iter,
-    mapref::{multiple::RefMulti, one::Ref},
-};
-use std::{collections::VecDeque, hash::Hash, ops::Deref};
+use dashmap::{iter::Iter, mapref::multiple::RefMulti};
+use std::{hash::Hash, ops::Deref};
 use twilight_model::{
     channel::{Channel, StageInstance},
     guild::{GuildIntegration, Role},
@@ -254,71 +251,9 @@ impl<'a, K: Eq + Hash, V> Iterator for ResourceIter<'a, K, V> {
     }
 }
 
-/// Iterator over a channel's list of recent message IDs.
-///
-/// The iterator is descending: the first is the most recent ID, the second is
-/// the second most recent ID, and so on.
-///
-/// # Examples
-///
-/// Iterate over the messages in a channel:
-///
-/// ```no_run
-/// # fn try_main() -> Option<()> {
-/// use twilight_cache_inmemory::InMemoryCache;
-/// use twilight_model::id::{ChannelId, MessageId};
-///
-/// let channel_id = ChannelId::new(1);
-///
-/// let cache = InMemoryCache::new();
-/// let message_ids = cache.channel_messages(channel_id)?;
-///
-/// for message_id in message_ids {
-///     if let Some(message) = cache.message(message_id) {
-///         println!("message {message_id} content: {}", message.content());
-///     }
-/// }
-/// # Some(()) }
-/// ```
-pub struct ChannelMessages<'a> {
-    index: usize,
-    message_ids: Ref<'a, Id<ChannelMarker>, VecDeque<Id<MessageMarker>>>,
-}
-
-impl<'a> ChannelMessages<'a> {
-    pub(super) const fn new(
-        message_ids: Ref<'a, Id<ChannelMarker>, VecDeque<Id<MessageMarker>>>,
-    ) -> Self {
-        Self {
-            index: 0,
-            message_ids,
-        }
-    }
-}
-
-impl<'a> Iterator for ChannelMessages<'a> {
-    type Item = Id<MessageMarker>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(message_id) = self.message_ids.get(self.index) {
-            self.index += 1;
-
-            return Some(*message_id);
-        }
-
-        None
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.index = self.index.saturating_add(n);
-
-        self.next()
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{ChannelMessages, InMemoryCacheIter, IterReference, ResourceIter};
+    use super::{InMemoryCacheIter, IterReference, ResourceIter};
     use crate::{test, InMemoryCache};
     use static_assertions::assert_impl_all;
     use std::{borrow::Cow, fmt::Debug};
@@ -327,7 +262,6 @@ mod tests {
         user::User,
     };
 
-    assert_impl_all!(ChannelMessages<'_>: Iterator, Send, Sync);
     assert_impl_all!(InMemoryCacheIter<'_>: Debug, Send, Sync);
     assert_impl_all!(IterReference<'_, Id<UserMarker>, User>: Send, Sync);
     assert_impl_all!(ResourceIter<'_, Id<UserMarker>, User>: Iterator, Send, Sync);

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -37,7 +37,6 @@ use dashmap::{
     mapref::{entry::Entry, one::Ref},
     DashMap, DashSet,
 };
-use iter::ChannelMessages;
 use std::{
     collections::{BTreeSet, HashSet, VecDeque},
     fmt::{Debug, Formatter, Result as FmtResult},
@@ -381,18 +380,13 @@ impl InMemoryCache {
     ///
     /// This requires the [`DIRECT_MESSAGES`] or [`GUILD_MESSAGES`] intents.
     ///
-    /// Returns `None` if the channel is not cached.
-    ///
-    /// # Examples
-    ///
-    /// Refer to [`ChannelMessages`].
-    ///
     /// [`DIRECT_MESSAGES`]: ::twilight_model::gateway::Intents::DIRECT_MESSAGES
     /// [`GUILD_MESSAGES`]: ::twilight_model::gateway::Intents::GUILD_MESSAGES
-    pub fn channel_messages(&self, channel_id: Id<ChannelMarker>) -> Option<ChannelMessages<'_>> {
-        let channel = self.channel_messages.get(&channel_id)?;
-
-        Some(ChannelMessages::new(channel))
+    pub fn channel_messages(
+        &self,
+        channel_id: Id<ChannelMarker>,
+    ) -> Option<Reference<'_, Id<ChannelMarker>, VecDeque<Id<MessageMarker>>>> {
+        self.channel_messages.get(&channel_id).map(Reference::new)
     }
 
     /// Gets an emoji by ID.


### PR DESCRIPTION
This type is stable, so exposing it is fine.
