### PR TITLE
feat(model): derive `Default` for `ActionRow`

### DIFF
--- a/model/src/application/component/action_row.rs
+++ b/model/src/application/component/action_row.rs
@@ -18,5 +18,5 @@ mod tests {
     use std::{fmt::Debug, hash::Hash};
 
     assert_fields!(ActionRow: components);
-    assert_impl_all!(ActionRow: Clone, Debug, Debug, Eq, Hash, PartialEq, Send, Sync);
+    assert_impl_all!(ActionRow: Clone, Debug, Default, Eq, Hash, PartialEq, Send, Sync);
 }

--- a/model/src/application/component/action_row.rs
+++ b/model/src/application/component/action_row.rs
@@ -18,5 +18,14 @@ mod tests {
     use std::{fmt::Debug, hash::Hash};
 
     assert_fields!(ActionRow: components);
-    assert_impl_all!(ActionRow: Clone, Debug, Default, Eq, Hash, PartialEq, Send, Sync);
+    assert_impl_all!(
+        ActionRow: Clone,
+        Debug,
+        Default,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Sync
+    );
 }

--- a/model/src/application/component/action_row.rs
+++ b/model/src/application/component/action_row.rs
@@ -5,7 +5,7 @@ use crate::application::component::Component;
 /// Refer to [Discord Docs/Message Components] for additional information.
 ///
 /// [Discord Docs/Message Components]: https://discord.com/developers/docs/interactions/message-components#action-rows
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct ActionRow {
     /// List of components in the action row.
     pub components: Vec<Component>,

--- a/model/src/application/component/action_row.rs
+++ b/model/src/application/component/action_row.rs
@@ -18,5 +18,5 @@ mod tests {
     use std::{fmt::Debug, hash::Hash};
 
     assert_fields!(ActionRow: components);
-    assert_impl_all!(ActionRow: Clone, Debug, Eq, Hash, PartialEq, Send, Sync);
+    assert_impl_all!(ActionRow: Clone, Debug, Debug, Eq, Hash, PartialEq, Send, Sync);
 }


### PR DESCRIPTION
Since action rows only contain a components vector deriving default should be no problem.