### PR TITLE
fix: Properly initialize the tungstenite request via IntoClientRequest

### DIFF
--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -41,10 +41,7 @@ use tokio::{
     time as tokio_time,
 };
 use tokio_tungstenite::{
-    tungstenite::{
-        client::IntoClientRequest,
-        Error as TungsteniteError, Message,
-    },
+    tungstenite::{client::IntoClientRequest, Error as TungsteniteError, Message},
     MaybeTlsStream, WebSocketStream,
 };
 use twilight_model::id::{marker::UserMarker, Id};
@@ -603,7 +600,8 @@ impl Drop for Connection {
 }
 
 fn connect_request(state: &NodeConfig) -> Result<Request<()>, NodeError> {
-    let mut request = format!("ws://{}", state.address).into_client_request()
+    let mut request = format!("ws://{}", state.address)
+        .into_client_request()
         .map_err(|source| NodeError {
             kind: NodeErrorType::BuildingConnectionRequest,
             source: Some(Box::new(source)),

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -603,7 +603,7 @@ fn connect_request(state: &NodeConfig) -> Result<Request<()>, NodeError> {
     let host = format!("ws://{}", state.address);
     // All of these headers are required by either Lavalink or tungstenite
     let mut builder = Request::get(&host)
-        //.header("Host", host)
+        .header("Host", host)
         .header("Connection", "Upgrade")
         .header("Upgrade", "websocket")
         .header("Authorization", &state.authorization)

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -600,11 +600,17 @@ impl Drop for Connection {
 }
 
 fn connect_request(state: &NodeConfig) -> Result<Request<()>, NodeError> {
-    let mut builder = Request::get(format!("ws://{}", state.address));
-    builder = builder.header("Authorization", &state.authorization);
-    builder = builder.header("Num-Shards", state.shard_count);
-    builder = builder.header("Sec-WebSocket-Key", generate_key());
-    builder = builder.header("User-Id", state.user_id.get());
+    let host = format!("ws://{}", state.address);
+    // All of these headers are required by either Lavalink or tungstenite
+    let mut builder = Request::get(&host)
+        .header("Host", host)
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Authorization", &state.authorization)
+        .header("Num-Shards", state.shard_count)
+        .header("Sec-WebSocket-Key", "13")
+        .header("Sec-WebSocket-Key", generate_key())
+        .header("User-Id", state.user_id.get());
 
     if state.resume.is_some() {
         builder = builder.header("Resume-Key", state.address.to_string());

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -602,15 +602,17 @@ impl Drop for Connection {
 fn connect_request(state: &NodeConfig) -> Result<Request<()>, NodeError> {
     let host = format!("ws://{}", state.address);
     // All of these headers are required by either Lavalink or tungstenite
-    let mut builder = Request::get(&host)
-        .header("Host", host)
+    let mut builder = Request::builder()
+        .method("GET")
+        .header("Host", state.address.to_string())
         .header("Connection", "Upgrade")
         .header("Upgrade", "websocket")
-        .header("Authorization", &state.authorization)
-        .header("Num-Shards", state.shard_count)
         .header("Sec-WebSocket-Version", "13")
         .header("Sec-WebSocket-Key", generate_key())
-        .header("User-Id", state.user_id.get());
+        .header("User-Id", state.user_id.get())
+        .header("Authorization", &state.authorization)
+        .header("Num-Shards", state.shard_count)
+        .uri(host);
 
     if state.resume.is_some() {
         builder = builder.header("Resume-Key", state.address.to_string());

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -41,7 +41,10 @@ use tokio::{
     time as tokio_time,
 };
 use tokio_tungstenite::{
-    tungstenite::{handshake::client::generate_key, Error as TungsteniteError, Message},
+    tungstenite::{
+        client::IntoClientRequest,
+        Error as TungsteniteError, Message,
+    },
     MaybeTlsStream, WebSocketStream,
 };
 use twilight_model::id::{marker::UserMarker, Id};
@@ -600,28 +603,21 @@ impl Drop for Connection {
 }
 
 fn connect_request(state: &NodeConfig) -> Result<Request<()>, NodeError> {
-    let host = format!("ws://{}", state.address);
-    // All of these headers are required by either Lavalink or tungstenite
-    let mut builder = Request::builder()
-        .method("GET")
-        .header("Host", state.address.to_string())
-        .header("Connection", "Upgrade")
-        .header("Upgrade", "websocket")
-        .header("Sec-WebSocket-Version", "13")
-        .header("Sec-WebSocket-Key", generate_key())
-        .header("User-Id", state.user_id.get())
-        .header("Authorization", &state.authorization)
-        .header("Num-Shards", state.shard_count)
-        .uri(host);
+    let mut request = format!("ws://{}", state.address).into_client_request()
+        .map_err(|source| NodeError {
+            kind: NodeErrorType::BuildingConnectionRequest,
+            source: Some(Box::new(source)),
+        })?;
+    let headers = request.headers_mut();
+    headers.insert("User-Id", state.user_id.get().into());
+    headers.insert("Authorization", state.authorization.parse().unwrap());
+    headers.insert("Num-Shards", state.shard_count.into());
 
     if state.resume.is_some() {
-        builder = builder.header("Resume-Key", state.address.to_string());
+        headers.insert("Resume-Key", state.address.to_string().parse().unwrap());
     }
 
-    builder.body(()).map_err(|source| NodeError {
-        kind: NodeErrorType::BuildingConnectionRequest,
-        source: Some(Box::new(source)),
-    })
+    Ok(request)
 }
 
 async fn reconnect(

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -603,12 +603,12 @@ fn connect_request(state: &NodeConfig) -> Result<Request<()>, NodeError> {
     let host = format!("ws://{}", state.address);
     // All of these headers are required by either Lavalink or tungstenite
     let mut builder = Request::get(&host)
-        .header("Host", host)
+        //.header("Host", host)
         .header("Connection", "Upgrade")
         .header("Upgrade", "websocket")
         .header("Authorization", &state.authorization)
         .header("Num-Shards", state.shard_count)
-        .header("Sec-WebSocket-Key", "13")
+        .header("Sec-WebSocket-Version", "13")
         .header("Sec-WebSocket-Key", generate_key())
         .header("User-Id", state.user_id.get());
 


### PR DESCRIPTION
Actual fix to #1647. `tungstenite` seems to have a strict header requirement which is best created via their `IntoClientRequest` trait.

This does however require a slightly nastier APIs for adding the headers for lavalink. 