### PR TITLE
refactor(gateway)!: Don't validate tokens in ShardBuilder

### DIFF
--- a/cache/in-memory/README.md
+++ b/cache/in-memory/README.md
@@ -41,7 +41,7 @@ use twilight_gateway::{Intents, Shard};
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let token = env::var("DISCORD_TOKEN")?;
-    let (shard, mut events) = Shard::new(token, Intents::GUILD_MESSAGES).await?;
+    let (shard, mut events) = Shard::new(token, Intents::GUILD_MESSAGES);
     shard.start().await?;
 
     // Create a cache, caching up to 10 messages per channel:

--- a/examples/gateway-intents.rs
+++ b/examples/gateway-intents.rs
@@ -8,7 +8,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let intents = Intents::GUILD_MESSAGES | Intents::DIRECT_MESSAGES;
-    let (shard, mut events) = Shard::new(env::var("DISCORD_TOKEN")?, intents).await?;
+    let (shard, mut events) = Shard::new(env::var("DISCORD_TOKEN")?, intents);
 
     shard.start().await?;
     println!("Created shard");

--- a/examples/gateway-request-members.rs
+++ b/examples/gateway-request-members.rs
@@ -12,8 +12,7 @@ async fn main() -> anyhow::Result<()> {
     let (shard, mut events) = Shard::new(
         env::var("DISCORD_TOKEN")?,
         Intents::GUILD_MEMBERS | Intents::GUILDS,
-    )
-    .await?;
+    );
     shard.start().await?;
     println!("Created shard");
 

--- a/examples/gateway-shard.rs
+++ b/examples/gateway-shard.rs
@@ -8,7 +8,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let intents = Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES;
-    let (shard, mut events) = Shard::new(env::var("DISCORD_TOKEN")?, intents).await?;
+    let (shard, mut events) = Shard::new(env::var("DISCORD_TOKEN")?, intents);
 
     shard.start().await?;
     println!("Created shard");

--- a/examples/lavalink-basic-bot.rs
+++ b/examples/lavalink-basic-bot.rs
@@ -54,7 +54,7 @@ async fn main() -> anyhow::Result<()> {
         lavalink.add(lavalink_host, lavalink_auth).await?;
 
         let intents = Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES;
-        let (shard, events) = Shard::new(token, intents).await?;
+        let (shard, events) = Shard::new(token, intents);
 
         shard.start().await?;
 

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -47,7 +47,7 @@ use crate::shard::tls::TlsContainer;
 // Remember to sync this with the custom Debug implementation.
 #[must_use = "has no effect if not built"]
 pub struct ClusterBuilder {
-    cluster_http_client: Arc<Client>,
+    http: Arc<Client>,
     queue: Arc<dyn Queue>,
     resume_sessions: HashMap<u64, ResumeSession>,
     shard: ShardBuilder,
@@ -60,7 +60,7 @@ impl ClusterBuilder {
     /// Create a new builder to construct and configure a cluster.
     pub fn new(token: String, intents: Intents) -> Self {
         Self {
-            cluster_http_client: Arc::new(Client::new(token.clone())),
+            http: Arc::new(Client::new(token.clone())),
             queue: Arc::new(LocalQueue::new()),
             resume_sessions: HashMap::new(),
             shard: ShardBuilder::new(token, intents),
@@ -79,7 +79,7 @@ impl ClusterBuilder {
     /// [`ClusterStartErrorType::AutoSharding`]: super::ClusterStartErrorType::AutoSharding
     pub async fn build(mut self) -> Result<(Cluster, Events), ClusterStartError> {
         if self.shard_scheme.is_none() {
-            self.shard_scheme = Some(Self::recommended_shards(&self.cluster_http_client).await?);
+            self.shard_scheme = Some(Self::recommended_shards(&self.http).await?);
         }
 
         #[cfg(not(any(
@@ -172,7 +172,7 @@ impl ClusterBuilder {
     ///
     /// Defaults to a new, default HTTP client is used.
     pub fn http_client(mut self, http_client: Arc<Client>) -> Self {
-        self.cluster_http_client = http_client;
+        self.http = http_client;
 
         self
     }

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -113,7 +113,7 @@ impl ClusterBuilder {
             shard_scheme: self.shard_scheme.expect("always set"),
         };
 
-        Cluster::new_with_config(config, shard_config)
+        Ok(Cluster::new_with_config(config, &shard_config))
     }
 
     /// Retrieves the recommended shard count as a [`ShardScheme::Range`].

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -325,6 +325,7 @@ impl ClusterBuilder {
 impl Debug for ClusterBuilder {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.debug_struct("ClusterBuilder")
+            .field("http", &self.http)
             .field("queue", &self.queue)
             .field("resume_sessions", &self.resume_sessions)
             .field("shard", &self.shard)

--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -47,6 +47,7 @@ use crate::shard::tls::TlsContainer;
 // Remember to sync this with the custom Debug implementation.
 #[must_use = "has no effect if not built"]
 pub struct ClusterBuilder {
+    cluster_http_client: Arc<Client>,
     queue: Arc<dyn Queue>,
     resume_sessions: HashMap<u64, ResumeSession>,
     shard: ShardBuilder,
@@ -59,6 +60,7 @@ impl ClusterBuilder {
     /// Create a new builder to construct and configure a cluster.
     pub fn new(token: String, intents: Intents) -> Self {
         Self {
+            cluster_http_client: Arc::new(Client::new(token.clone())),
             queue: Arc::new(LocalQueue::new()),
             resume_sessions: HashMap::new(),
             shard: ShardBuilder::new(token, intents),
@@ -77,7 +79,7 @@ impl ClusterBuilder {
     /// [`ClusterStartErrorType::AutoSharding`]: super::ClusterStartErrorType::AutoSharding
     pub async fn build(mut self) -> Result<(Cluster, Events), ClusterStartError> {
         if self.shard_scheme.is_none() {
-            self.shard_scheme = Some(Self::recommended_shards(&self.shard.http_client).await?);
+            self.shard_scheme = Some(Self::recommended_shards(&self.cluster_http_client).await?);
         }
 
         #[cfg(not(any(
@@ -111,7 +113,7 @@ impl ClusterBuilder {
             shard_scheme: self.shard_scheme.expect("always set"),
         };
 
-        Cluster::new_with_config(config, shard_config).await
+        Cluster::new_with_config(config, shard_config)
     }
 
     /// Retrieves the recommended shard count as a [`ShardScheme::Range`].
@@ -163,15 +165,14 @@ impl ClusterBuilder {
         self
     }
 
-    /// Set the `twilight_http` Client used by the cluster and the shards it
-    /// manages.
+    /// Set the `twilight_http` Client used by the cluster.
     ///
-    /// This is needed so that the cluster and shards can retrieve gateway
+    /// This is needed so that the cluster can retrieve gateway
     /// information.
     ///
     /// Defaults to a new, default HTTP client is used.
     pub fn http_client(mut self, http_client: Arc<Client>) -> Self {
-        self.shard = self.shard.http_client(http_client);
+        self.cluster_http_client = http_client;
 
         self
     }

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -269,7 +269,7 @@ impl Cluster {
         Self::builder(token, intents).build().await
     }
 
-    pub(super) async fn new_with_config(
+    pub(super) fn new_with_config(
         mut config: Config,
         shard_config: ShardConfig,
     ) -> Result<(Self, Events), ClusterStartError> {

--- a/gateway/src/cluster/impl.rs
+++ b/gateway/src/cluster/impl.rs
@@ -271,8 +271,8 @@ impl Cluster {
 
     pub(super) fn new_with_config(
         mut config: Config,
-        shard_config: ShardConfig,
-    ) -> Result<(Self, Events), ClusterStartError> {
+        shard_config: &ShardConfig,
+    ) -> (Self, Events) {
         #[derive(Default)]
         struct ShardFold {
             shards: HashMap<u64, Shard>,
@@ -315,7 +315,7 @@ impl Cluster {
         #[allow(clippy::from_iter_instead_of_collect)]
         let select_all = SelectAll::from_iter(streams);
 
-        Ok((Self { config, shards }, Events::new(select_all)))
+        (Self { config, shards }, Events::new(select_all))
     }
 
     /// Create a builder to configure and construct a cluster.

--- a/gateway/src/shard/config.rs
+++ b/gateway/src/shard/config.rs
@@ -1,7 +1,6 @@
 use crate::EventTypeFlags;
 use std::{borrow::Cow, sync::Arc};
 use twilight_gateway_queue::Queue;
-use twilight_http::Client;
 use twilight_model::gateway::{
     payload::outgoing::{identify::IdentifyProperties, update_presence::UpdatePresencePayload},
     Intents,
@@ -24,7 +23,6 @@ use super::tls::TlsContainer;
 pub struct Config {
     pub(super) event_types: EventTypeFlags,
     pub(super) gateway_url: Cow<'static, str>,
-    pub(super) http_client: Arc<Client>,
     pub(super) identify_properties: Option<IdentifyProperties>,
     pub(super) intents: Intents,
     pub(super) large_threshold: u64,
@@ -52,12 +50,6 @@ impl Config {
     /// Return an immutable reference to the url used to connect to the gateway.
     pub fn gateway_url(&self) -> &str {
         &self.gateway_url
-    }
-
-    /// Return an immutable reference to the `twilight_http` client to be used
-    /// by the shard.
-    pub fn http_client(&self) -> &Client {
-        &self.http_client
     }
 
     /// Return an immutable reference to the identification properties the shard

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -425,7 +425,7 @@ impl Shard {
     /// let token = env::var("DISCORD_TOKEN")?;
     ///
     /// let intents = Intents::GUILD_MESSAGES | Intents::GUILD_MESSAGE_TYPING;
-    /// let (shard, _) = Shard::new(token, intents).await?;
+    /// let (shard, _) = Shard::new(token, intents);
     /// shard.start().await?;
     ///
     /// tokio_time::sleep(Duration::from_secs(1)).await;
@@ -435,14 +435,9 @@ impl Shard {
     /// # Ok(()) }
     /// ```
     ///
-    /// # Errors
-    ///
-    /// Returns a [`ShardStartErrorType::InvalidToken`] error type if
-    /// the token failed validation.
-    ///
     /// [`start`]: Self::start
-    pub async fn new(token: String, intents: Intents) -> Result<(Self, Events), ShardStartError> {
-        Self::builder(token, intents).build().await
+    pub fn new(token: String, intents: Intents) -> (Self, Events) {
+        Self::builder(token, intents).build()
     }
 
     pub(crate) fn new_with_config(config: Config) -> (Self, Events) {

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -226,7 +226,6 @@ impl Display for ShardStartError {
 
                 f.write_str("` is invalid")
             }
-            ShardStartErrorType::InvalidToken => f.write_str("token is invid"),
         }
     }
 }
@@ -250,8 +249,6 @@ pub enum ShardStartErrorType {
     AlreadyStarted,
     /// Establishing a connection to the gateway failed.
     Establishing,
-    /// Token is invalid.
-    InvalidToken,
     /// Parsing the gateway URL provided by Discord to connect to the gateway
     /// failed due to an invalid URL.
     ParsingGatewayUrl {

--- a/gateway/src/shard/impl.rs
+++ b/gateway/src/shard/impl.rs
@@ -373,8 +373,7 @@ pub struct ResumeSession {
 ///
 /// let (shard, mut events) = Shard::builder(token, Intents::GUILD_MESSAGES)
 ///     .event_types(event_types)
-///     .build()
-///     .await?;
+///     .build();
 ///
 /// // Start the shard.
 /// shard.start().await?;
@@ -582,7 +581,7 @@ impl Shard {
     /// let intents = Intents::GUILDS;
     /// let token = env::var("DISCORD_TOKEN")?;
     ///
-    /// let (shard, _events) = Shard::new(token, intents).await?;
+    /// let (shard, _events) = Shard::new(token, intents);
     /// shard.start().await?;
     ///
     /// let minimal_activity = MinimalActivity {
@@ -636,7 +635,7 @@ impl Shard {
     /// use twilight_gateway::{shard::{raw_message::Message, Shard}, Intents};
     ///
     /// let token = env::var("DISCORD_TOKEN")?;
-    /// let (shard, _) = Shard::new(token, Intents::GUILDS).await?;
+    /// let (shard, _) = Shard::new(token, Intents::GUILDS);
     /// shard.start().await?;
     ///
     /// shard.send(Message::Ping(Vec::new())).await?;
@@ -657,7 +656,7 @@ impl Shard {
     /// };
     ///
     /// let token = env::var("DISCORD_TOKEN")?;
-    /// let (shard, _) = Shard::new(token, Intents::GUILDS).await?;
+    /// let (shard, _) = Shard::new(token, Intents::GUILDS);
     /// shard.start().await?;
     ///
     /// let close = CloseFrame::from((1000, ""));

--- a/gateway/src/shard/mod.rs
+++ b/gateway/src/shard/mod.rs
@@ -30,7 +30,7 @@
 //! let intents = Intents::GUILD_MEMBERS;
 //! let token = env::var("DISCORD_TOKEN")?;
 //!
-//! let (shard, _events) = Shard::new(token, intents).await?;
+//! let (shard, _events) = Shard::new(token, intents);
 //! shard.start().await?;
 //!
 //! // Query members whose names start with "tw" and limit the results to

--- a/gateway/tests/test_shard_command_ratelimit.rs
+++ b/gateway/tests/test_shard_command_ratelimit.rs
@@ -15,7 +15,7 @@ use twilight_model::gateway::{
 async fn shard() -> (Shard, Events) {
     let token = env::var("DISCORD_TOKEN").unwrap();
 
-    Shard::new(token, Intents::empty()).await.unwrap()
+    Shard::new(token, Intents::empty())
 }
 
 #[ignore]

--- a/gateway/tests/test_shard_state_events.rs
+++ b/gateway/tests/test_shard_state_events.rs
@@ -8,7 +8,7 @@ use twilight_gateway::{
 async fn shard() -> Result<(Shard, Events), Box<dyn Error>> {
     let token = env::var("DISCORD_TOKEN")?;
 
-    Ok(Shard::new(token, Intents::empty()).await?)
+    Ok(Shard::new(token, Intents::empty()))
 }
 
 #[ignore]

--- a/lavalink/README.md
+++ b/lavalink/README.md
@@ -82,7 +82,7 @@ async fn main() -> anyhow::Result<()> {
     lavalink.add(lavalink_host, lavalink_auth).await?;
 
     let intents = Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES;
-    let (shard, mut events) = Shard::new(token, intents).await?;
+    let (shard, mut events) = Shard::new(token, intents);
     shard.start().await?;
 
     while let Some(event) = events.next().await {

--- a/standby/README.md
+++ b/standby/README.md
@@ -82,7 +82,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Start a shard connected to the gateway to receive events.
     let intents = Intents::GUILD_MESSAGES | Intents::GUILD_MESSAGE_REACTIONS;
-    let (shard, mut events) = Shard::new(token, intents).await?;
+    let (shard, mut events) = Shard::new(token, intents);
     shard.start().await?;
 
     let standby = Arc::new(Standby::new());


### PR DESCRIPTION
This makes little sense and allows for removing `http_client` on ShardBuilder and making some methods infallible + no longer async. Instead, Cluster has to store a HTTP client for now.