### PR TITLE
refactor(cache): standardize clippy lints

### DIFF
--- a/cache/in-memory/src/builder.rs
+++ b/cache/in-memory/src/builder.rs
@@ -5,6 +5,7 @@ use super::{
 
 /// Builder to configure and construct an [`InMemoryCache`].
 #[derive(Debug, Default)]
+#[must_use = "has no effect if not built"]
 pub struct InMemoryCacheBuilder(Config);
 
 impl InMemoryCacheBuilder {

--- a/cache/in-memory/src/event/emoji.rs
+++ b/cache/in-memory/src/event/emoji.rs
@@ -81,8 +81,6 @@ mod tests {
 
     #[test]
     fn cache_emoji() {
-        let cache = InMemoryCache::new();
-
         // The user to do some of the inserts
         fn user_mod(id: Id<EmojiMarker>) -> Option<User> {
             if id.get() % 2 == 0 {
@@ -92,6 +90,8 @@ mod tests {
                 None
             }
         }
+
+        let cache = InMemoryCache::new();
 
         // Single inserts
         {
@@ -106,7 +106,7 @@ mod tests {
                 cache.cache_emoji(Id::new(1), emoji);
             }
 
-            for id in guild_1_emoji_ids.iter().cloned() {
+            for id in guild_1_emoji_ids.iter().copied() {
                 let global_emoji = cache.emoji(id);
                 assert!(global_emoji.is_some());
             }
@@ -131,7 +131,7 @@ mod tests {
                 .collect::<Vec<_>>();
             cache.cache_emojis(Id::new(2), guild_2_emojis);
 
-            for id in guild_2_emoji_ids.iter().cloned() {
+            for id in guild_2_emoji_ids.iter().copied() {
                 let global_emoji = cache.emoji(id);
                 assert!(global_emoji.is_some());
             }

--- a/cache/in-memory/src/event/guild.rs
+++ b/cache/in-memory/src/event/guild.rs
@@ -12,6 +12,7 @@ use twilight_model::{
 };
 
 impl InMemoryCache {
+    #[allow(clippy::too_many_lines)]
     fn cache_guild(&self, guild: Guild) {
         let Guild {
             afk_channel_id,
@@ -119,7 +120,6 @@ impl InMemoryCache {
         }
 
         let guild = CachedGuild {
-            id,
             afk_channel_id,
             afk_timeout,
             application_id,
@@ -130,6 +130,7 @@ impl InMemoryCache {
             explicit_content_filter,
             features,
             icon,
+            id,
             joined_at,
             large,
             max_members,
@@ -139,8 +140,8 @@ impl InMemoryCache {
             mfa_level,
             name,
             nsfw_level,
-            owner,
             owner_id,
+            owner,
             permissions,
             preferred_locale,
             premium_progress_bar_enabled,
@@ -151,8 +152,8 @@ impl InMemoryCache {
             system_channel_id,
             system_channel_flags,
             unavailable,
-            verification_level,
             vanity_url_code,
+            verification_level,
             widget_channel_id,
             widget_enabled,
         };
@@ -298,6 +299,7 @@ mod tests {
         util::datetime::{Timestamp, TimestampParseError},
     };
 
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn guild_create_channels_have_guild_ids() -> Result<(), TimestampParseError> {
         const DATETIME: &str = "2021-09-19T14:17:32.000000+00:00";

--- a/cache/in-memory/src/event/interaction.rs
+++ b/cache/in-memory/src/event/interaction.rs
@@ -88,6 +88,7 @@ mod tests {
         util::{image_hash::ImageHashParseError, ImageHash, Timestamp},
     };
 
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn interaction_create() -> Result<(), ImageHashParseError> {
         let timestamp = Timestamp::from_secs(1_632_072_645).expect("non zero");

--- a/cache/in-memory/src/event/message.rs
+++ b/cache/in-memory/src/event/message.rs
@@ -15,7 +15,7 @@ impl UpdateCache for MessageCreate {
             self.guild_id,
             cache.wants(ResourceType::MEMBER),
         ) {
-            cache.cache_borrowed_partial_member(guild_id, member, self.author.id)
+            cache.cache_borrowed_partial_member(guild_id, member, self.author.id);
         }
 
         if !cache.wants(ResourceType::MESSAGE) {

--- a/cache/in-memory/src/event/role.rs
+++ b/cache/in-memory/src/event/role.rs
@@ -120,7 +120,7 @@ mod tests {
                 .role(role.id)
                 .expect("Role missing from cache")
                 .resource()
-                == &role))
+                == &role));
         }
 
         // Bulk inserts
@@ -146,7 +146,7 @@ mod tests {
                 .role(role.id)
                 .expect("Role missing from cache")
                 .resource()
-                == &role))
+                == &role));
         }
     }
 }

--- a/cache/in-memory/src/event/voice_state.rs
+++ b/cache/in-memory/src/event/voice_state.rs
@@ -90,15 +90,16 @@ impl UpdateCache for VoiceStateUpdate {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use super::*;
     use crate::test;
+    use std::str::FromStr;
     use twilight_model::{
+        guild::Member,
         id::{
             marker::{ChannelMarker, GuildMarker, UserMarker},
             Id,
         },
+        user::User,
         util::{image_hash::ImageHashParseError, ImageHash, Timestamp},
     };
 
@@ -281,7 +282,6 @@ mod tests {
     #[test]
     fn voice_states_members() -> Result<(), ImageHashParseError> {
         let joined_at = Timestamp::from_secs(1_632_072_645).expect("non zero");
-        use twilight_model::{guild::member::Member, user::User};
 
         let cache = InMemoryCache::new();
 

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -1,11 +1,21 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(
+    clippy::all,
     clippy::missing_const_for_fn,
+    clippy::pedantic,
+    future_incompatible,
     missing_docs,
+    nonstandard_style,
     rust_2018_idioms,
     rustdoc::broken_intra_doc_links,
     unsafe_code,
     unused
+)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::unnecessary_wraps,
+    clippy::used_underscore_binding
 )]
 #![doc = include_str!("../README.md")]
 
@@ -32,7 +42,13 @@ pub use self::{
 #[cfg(feature = "permission-calculator")]
 pub use self::permission::InMemoryCachePermissions;
 
-use self::{iter::InMemoryCacheIter, model::*};
+use self::{
+    iter::InMemoryCacheIter,
+    model::{
+        CachedEmoji, CachedGuild, CachedMember, CachedMessage, CachedPresence, CachedSticker,
+        CachedVoiceState,
+    },
+};
 use dashmap::{
     mapref::{entry::Entry, one::Ref},
     DashMap, DashSet,
@@ -97,7 +113,7 @@ pub struct Reference<'a, K, V> {
 }
 
 impl<'a, K: Eq + Hash, V> Reference<'a, K, V> {
-    /// Create a new reference from a DashMap reference.
+    /// Create a new reference from a `DashMap` reference.
     #[allow(clippy::missing_const_for_fn)]
     fn new(inner: Ref<'a, K, V>) -> Self {
         Self { inner }
@@ -297,6 +313,7 @@ impl InMemoryCache {
     ///     println!("{}: {}", guild.id(), guild.name());
     /// }
     /// ```
+    #[allow(clippy::iter_not_returning_iterator)]
     pub const fn iter(&self) -> InMemoryCacheIter<'_> {
         InMemoryCacheIter::new(self)
     }
@@ -719,7 +736,7 @@ impl InMemoryCache {
     fn new_with_config(config: Config) -> Self {
         Self {
             config,
-            ..Default::default()
+            ..InMemoryCache::default()
         }
     }
 
@@ -825,82 +842,82 @@ impl<'a> Iterator for VoiceChannelStates<'a> {
 }
 
 impl UpdateCache for Event {
-    #[allow(clippy::cognitive_complexity)]
+    // clippy: using `.deref()` is cleaner
+    #[allow(clippy::cognitive_complexity, clippy::explicit_deref_methods)]
     fn update(&self, c: &InMemoryCache) {
-        use Event::*;
-
         match self {
-            BanAdd(_) => {}
-            BanRemove(_) => {}
-            ChannelCreate(v) => c.update(v.deref()),
-            ChannelDelete(v) => c.update(v.deref()),
-            ChannelPinsUpdate(v) => c.update(v),
-            ChannelUpdate(v) => c.update(v.deref()),
-            CommandPermissionsUpdate(_) => {}
-            GatewayHeartbeat(_) => {}
-            GatewayHeartbeatAck => {}
-            GatewayHello(_) => {}
-            GatewayInvalidateSession(_v) => {}
-            GatewayReconnect => {}
-            GiftCodeUpdate => {}
-            GuildCreate(v) => c.update(v.deref()),
-            GuildDelete(v) => c.update(v),
-            GuildEmojisUpdate(v) => c.update(v),
-            GuildStickersUpdate(v) => c.update(v),
-            GuildIntegrationsUpdate(_) => {}
-            GuildScheduledEventCreate(_) => {}
-            GuildScheduledEventDelete(_) => {}
-            GuildScheduledEventUpdate(_) => {}
-            GuildScheduledEventUserAdd(_) => {}
-            GuildScheduledEventUserRemove(_) => {}
-            GuildUpdate(v) => c.update(v.deref()),
-            IntegrationCreate(v) => c.update(v.deref()),
-            IntegrationDelete(v) => c.update(v.deref()),
-            IntegrationUpdate(v) => c.update(v.deref()),
-            InteractionCreate(v) => c.update(v),
-            InviteCreate(_) => {}
-            InviteDelete(_) => {}
-            MemberAdd(v) => c.update(v.deref()),
-            MemberRemove(v) => c.update(v),
-            MemberUpdate(v) => c.update(v.deref()),
-            MemberChunk(v) => c.update(v),
-            MessageCreate(v) => c.update(v.deref()),
-            MessageDelete(v) => c.update(v),
-            MessageDeleteBulk(v) => c.update(v),
-            MessageUpdate(v) => c.update(v.deref()),
-            PresenceUpdate(v) => c.update(v.deref()),
-            PresencesReplace => {}
-            ReactionAdd(v) => c.update(v.deref()),
-            ReactionRemove(v) => c.update(v.deref()),
-            ReactionRemoveAll(v) => c.update(v),
-            ReactionRemoveEmoji(v) => c.update(v),
-            Ready(v) => c.update(v.deref()),
-            Resumed => {}
-            RoleCreate(v) => c.update(v),
-            RoleDelete(v) => c.update(v),
-            RoleUpdate(v) => c.update(v),
-            ShardConnected(_) => {}
-            ShardConnecting(_) => {}
-            ShardDisconnected(_) => {}
-            ShardIdentifying(_) => {}
-            ShardReconnecting(_) => {}
-            ShardPayload(_) => {}
-            ShardResuming(_) => {}
-            StageInstanceCreate(v) => c.update(v),
-            StageInstanceDelete(v) => c.update(v),
-            StageInstanceUpdate(v) => c.update(v),
-            ThreadCreate(v) => c.update(v.deref()),
-            ThreadUpdate(v) => c.update(v.deref()),
-            ThreadDelete(v) => c.update(v),
-            ThreadListSync(v) => c.update(v),
-            ThreadMemberUpdate(_) => {}
-            ThreadMembersUpdate(_) => {}
-            TypingStart(_) => {}
-            UnavailableGuild(v) => c.update(v),
-            UserUpdate(v) => c.update(v),
-            VoiceServerUpdate(_) => {}
-            VoiceStateUpdate(v) => c.update(v.deref()),
-            WebhooksUpdate(_) => {}
+            Event::ChannelCreate(v) => c.update(v.deref()),
+            Event::ChannelDelete(v) => c.update(v.deref()),
+            Event::ChannelPinsUpdate(v) => c.update(v),
+            Event::ChannelUpdate(v) => c.update(v.deref()),
+            Event::GuildCreate(v) => c.update(v.deref()),
+            Event::GuildDelete(v) => c.update(v),
+            Event::GuildEmojisUpdate(v) => c.update(v),
+            Event::GuildStickersUpdate(v) => c.update(v),
+            Event::GuildUpdate(v) => c.update(v.deref()),
+            Event::IntegrationCreate(v) => c.update(v.deref()),
+            Event::IntegrationDelete(v) => c.update(v.deref()),
+            Event::IntegrationUpdate(v) => c.update(v.deref()),
+            Event::InteractionCreate(v) => c.update(v),
+            Event::MemberAdd(v) => c.update(v.deref()),
+            Event::MemberRemove(v) => c.update(v),
+            Event::MemberUpdate(v) => c.update(v.deref()),
+            Event::MemberChunk(v) => c.update(v),
+            Event::MessageCreate(v) => c.update(v.deref()),
+            Event::MessageDelete(v) => c.update(v),
+            Event::MessageDeleteBulk(v) => c.update(v),
+            Event::MessageUpdate(v) => c.update(v.deref()),
+            Event::PresenceUpdate(v) => c.update(v.deref()),
+            Event::ReactionAdd(v) => c.update(v.deref()),
+            Event::ReactionRemove(v) => c.update(v.deref()),
+            Event::ReactionRemoveAll(v) => c.update(v),
+            Event::ReactionRemoveEmoji(v) => c.update(v),
+            Event::Ready(v) => c.update(v.deref()),
+            Event::RoleCreate(v) => c.update(v),
+            Event::RoleDelete(v) => c.update(v),
+            Event::RoleUpdate(v) => c.update(v),
+            Event::StageInstanceCreate(v) => c.update(v),
+            Event::StageInstanceDelete(v) => c.update(v),
+            Event::StageInstanceUpdate(v) => c.update(v),
+            Event::ThreadCreate(v) => c.update(v.deref()),
+            Event::ThreadUpdate(v) => c.update(v.deref()),
+            Event::ThreadDelete(v) => c.update(v),
+            Event::ThreadListSync(v) => c.update(v),
+            Event::UnavailableGuild(v) => c.update(v),
+            Event::UserUpdate(v) => c.update(v),
+            Event::VoiceStateUpdate(v) => c.update(v.deref()),
+            // Ignored events.
+            Event::BanAdd(_)
+            | Event::BanRemove(_)
+            | Event::CommandPermissionsUpdate(_)
+            | Event::GatewayHeartbeat(_)
+            | Event::GatewayHeartbeatAck
+            | Event::GatewayHello(_)
+            | Event::GatewayInvalidateSession(_)
+            | Event::GatewayReconnect
+            | Event::GiftCodeUpdate
+            | Event::GuildIntegrationsUpdate(_)
+            | Event::GuildScheduledEventCreate(_)
+            | Event::GuildScheduledEventDelete(_)
+            | Event::GuildScheduledEventUpdate(_)
+            | Event::GuildScheduledEventUserAdd(_)
+            | Event::GuildScheduledEventUserRemove(_)
+            | Event::InviteCreate(_)
+            | Event::InviteDelete(_)
+            | Event::PresencesReplace
+            | Event::Resumed
+            | Event::ShardConnected(_)
+            | Event::ShardConnecting(_)
+            | Event::ShardDisconnected(_)
+            | Event::ShardIdentifying(_)
+            | Event::ShardPayload(_)
+            | Event::ShardReconnecting(_)
+            | Event::ShardResuming(_)
+            | Event::ThreadMembersUpdate(_)
+            | Event::ThreadMemberUpdate(_)
+            | Event::TypingStart(_)
+            | Event::VoiceServerUpdate(_)
+            | Event::WebhooksUpdate(_) => {}
         }
     }
 }

--- a/cache/in-memory/src/lib.rs
+++ b/cache/in-memory/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(
     clippy::all,
     clippy::missing_const_for_fn,
@@ -17,6 +16,7 @@
     clippy::unnecessary_wraps,
     clippy::used_underscore_binding
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 
 pub mod iter;

--- a/cache/in-memory/src/model/emoji.rs
+++ b/cache/in-memory/src/model/emoji.rs
@@ -10,6 +10,7 @@ use twilight_model::{
 /// Represents a cached [`Emoji`].
 ///
 /// [`Emoji`]: twilight_model::guild::Emoji
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedEmoji {
     pub(crate) animated: bool,

--- a/cache/in-memory/src/model/member.rs
+++ b/cache/in-memory/src/model/member.rs
@@ -132,7 +132,8 @@ impl CachedMember {
     }
 
     // clippy: the member field's destructor needs to drop
-    #[allow(clippy::missing_const_for_fn)]
+    // clippy: the contents of `fields` is consumed
+    #[allow(clippy::missing_const_for_fn, clippy::needless_pass_by_value)]
     pub(crate) fn from_interaction_member(
         guild_id: Id<GuildMarker>,
         user_id: Id<UserMarker>,
@@ -195,7 +196,7 @@ impl CachedMember {
             pending: false,
             premium_since,
             roles,
-            user_id: user.map(|user| user.id).unwrap_or(user_id),
+            user_id: user.map_or(user_id, |user| user.id),
         }
     }
 }

--- a/cache/in-memory/src/model/voice_state.rs
+++ b/cache/in-memory/src/model/voice_state.rs
@@ -11,6 +11,7 @@ use twilight_model::{
 /// Represents a cached [`VoiceState`].
 ///
 /// [`VoiceState`]: twilight_model::voice::VoiceState
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CachedVoiceState {
     channel_id: Id<ChannelMarker>,

--- a/cache/in-memory/src/permission.rs
+++ b/cache/in-memory/src/permission.rs
@@ -92,6 +92,8 @@ impl ChannelError {
     }
 
     /// Create a root error from an error while retrieving a member's roles.
+    // clippy: the contents of `member_roles_error` is consumed
+    #[allow(clippy::needless_pass_by_value)]
     fn from_member_roles(member_roles_error: MemberRolesErrorType) -> Self {
         Self {
             kind: match member_roles_error {
@@ -215,6 +217,8 @@ impl RootError {
     }
 
     /// Create a root error from an error while retrieving a member's roles.
+    // clippy: the contents of `member_roles_error` is consumed
+    #[allow(clippy::needless_pass_by_value)]
     fn from_member_roles(member_roles_error: MemberRolesErrorType) -> Self {
         Self {
             kind: match member_roles_error {
@@ -293,6 +297,7 @@ struct MemberRoles {
 
 /// Calculate the permissions of a member with information from the cache.
 #[derive(Clone, Debug)]
+#[must_use = "has no effect if unused"]
 pub struct InMemoryCachePermissions<'a> {
     cache: &'a InMemoryCache,
     check_member_communication_disabled: bool,

--- a/cache/in-memory/src/test.rs
+++ b/cache/in-memory/src/test.rs
@@ -27,6 +27,7 @@ pub fn cache() -> InMemoryCache {
     InMemoryCache::new()
 }
 
+#[allow(clippy::too_many_lines)]
 pub fn cache_with_message_and_reactions() -> InMemoryCache {
     let joined_at = Timestamp::from_secs(1_632_072_645).expect("non zero");
     let cache = InMemoryCache::new();
@@ -181,7 +182,7 @@ pub fn cache_with_message_and_reactions() -> InMemoryCache {
 
 pub fn current_user(id: u64) -> CurrentUser {
     CurrentUser {
-        accent_color: Some(16711680),
+        accent_color: Some(16_711_680),
         avatar: None,
         banner: None,
         bot: true,

--- a/cache/in-memory/src/test.rs
+++ b/cache/in-memory/src/test.rs
@@ -182,7 +182,7 @@ pub fn cache_with_message_and_reactions() -> InMemoryCache {
 
 pub fn current_user(id: u64) -> CurrentUser {
     CurrentUser {
-        accent_color: Some(16_711_680),
+        accent_color: Some(0xFF_00_00),
         avatar: None,
         banner: None,
         bot: true,


### PR DESCRIPTION
Based on #1644, standardize clippy lints and fix new ones that appear.  Some exceptions have been made.
