### PR TITLE
refactor(gateway-queue): standardize clippy lints

### DIFF
--- a/gateway-queue/src/large_bot_queue.rs
+++ b/gateway-queue/src/large_bot_queue.rs
@@ -36,7 +36,7 @@ impl LargeBotQueue {
 
             tokio::spawn(waiter(rx));
 
-            queues.push(tx)
+            queues.push(tx);
         }
 
         let limiter = DayLimiter::new(http).await.expect(

--- a/gateway-queue/src/lib.rs
+++ b/gateway-queue/src/lib.rs
@@ -1,5 +1,22 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![deny(unsafe_code)]
+#![deny(
+    clippy::all,
+    clippy::missing_const_for_fn,
+    clippy::pedantic,
+    future_incompatible,
+    missing_docs,
+    nonstandard_style,
+    rust_2018_idioms,
+    rustdoc::broken_intra_doc_links,
+    unsafe_code,
+    unused
+)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::unnecessary_wraps,
+    clippy::used_underscore_binding
+)]
 #![doc = include_str!("../README.md")]
 
 #[cfg(any(


### PR DESCRIPTION
Based on #1644, standardize clippy lints and fix new ones that appear.
