### PR TITLE
refactor(http-ratelimiting): standardize clippy lints

### DIFF
--- a/http-ratelimiting/src/lib.rs
+++ b/http-ratelimiting/src/lib.rs
@@ -1,21 +1,23 @@
 #![deny(
     clippy::all,
     clippy::missing_const_for_fn,
-    clippy::pedantic,
     clippy::missing_docs_in_private_items,
+    clippy::pedantic,
     future_incompatible,
+    missing_docs,
     nonstandard_style,
     rust_2018_idioms,
     rustdoc::broken_intra_doc_links,
     unsafe_code,
     unused
 )]
-#![doc = include_str!("../README.md")]
 #![allow(
     clippy::module_name_repetitions,
-    clippy::semicolon_if_nothing_returned,
-    clippy::unnecessary_wraps
+    clippy::must_use_candidate,
+    clippy::unnecessary_wraps,
+    clippy::used_underscore_binding
 )]
+#![doc = include_str!("../README.md")]
 
 pub mod headers;
 pub mod in_memory;


### PR DESCRIPTION
Based on #1644, standardize clippy lints and fix new ones that appear.
