### PR TITLE
refactor(lavalink): standardize clippy lints

### DIFF
--- a/lavalink/src/client.rs
+++ b/lavalink/src/client.rs
@@ -270,6 +270,10 @@ impl Lavalink {
     ///
     /// If a node already exists with the provided address, then it will be
     /// replaced.
+    ///
+    /// # Errors
+    ///
+    /// See the errors section of [`Node::connect`].
     pub async fn add(
         &self,
         address: SocketAddr,

--- a/lavalink/src/http.rs
+++ b/lavalink/src/http.rs
@@ -247,6 +247,10 @@ pub struct RotatingNanoIpDetails {
 ///
 /// The response will include a body which can be deserialized into a
 /// [`LoadedTracks`].
+///
+/// # Errors
+///
+/// See the documentation for [`http::Error`].
 pub fn load_track(
     address: SocketAddr,
     identifier: impl AsRef<str>,
@@ -268,6 +272,10 @@ pub fn load_track(
 ///
 /// The response will include a body which can be deserialized into a
 /// [`RoutePlanner`].
+///
+/// # Errors
+///
+/// See the documentation for [`http::Error`].
 pub fn get_route_planner(
     address: SocketAddr,
     authorization: impl AsRef<str>,
@@ -283,6 +291,14 @@ pub fn get_route_planner(
 /// Unmark an IP address as being failed, meaning that it can be used again.
 ///
 /// The response will not include a body on success.
+///
+/// # Errors
+///
+/// See the documentation for [`http::Error`].
+///
+/// # Panics
+///
+/// Panics if serde serialization fails.
 pub fn unmark_failed_address(
     node_address: impl Into<SocketAddr>,
     authorization: impl AsRef<str>,

--- a/lavalink/src/lib.rs
+++ b/lavalink/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(
     clippy::all,
     clippy::missing_const_for_fn,
+    clippy::pedantic,
     future_incompatible,
     missing_docs,
     nonstandard_style,
@@ -8,6 +9,12 @@
     rustdoc::broken_intra_doc_links,
     unsafe_code,
     unused
+)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::unnecessary_wraps,
+    clippy::used_underscore_binding
 )]
 #![doc = include_str!("../README.md")]
 

--- a/lavalink/src/model.rs
+++ b/lavalink/src/model.rs
@@ -958,18 +958,25 @@ mod tests {
 
     #[test]
     fn stats_frames_not_provided() {
+        const LAVALINK_LOAD: f64 = 0.276_119_402_985_074_65;
+        const MEM_ALLOCATED: u64 = 62_914_560;
+        const MEM_FREE: u64 = 27_664_576;
+        const MEM_RESERVABLE: u64 = 4_294_967_296;
+        const MEM_USED: u64 = 35_249_984;
+        const SYSTEM_LOAD: f64 = 0.195_380_536_378_835_9;
+
         let expected = Stats {
             cpu: StatsCpu {
                 cores: 4,
-                lavalink_load: 0.27611940298507465,
-                system_load: 0.1953805363788359,
+                lavalink_load: LAVALINK_LOAD,
+                system_load: SYSTEM_LOAD,
             },
             frames: None,
             memory: StatsMemory {
-                allocated: 62914560,
-                free: 27664576,
-                reservable: 4294967296,
-                used: 35249984,
+                allocated: MEM_ALLOCATED,
+                free: MEM_FREE,
+                reservable: MEM_RESERVABLE,
+                used: MEM_USED,
             },
             players: 0,
             playing_players: 0,
@@ -992,9 +999,9 @@ mod tests {
                 Token::Str("cores"),
                 Token::U64(4),
                 Token::Str("lavalinkLoad"),
-                Token::F64(0.27611940298507465),
+                Token::F64(LAVALINK_LOAD),
                 Token::Str("systemLoad"),
-                Token::F64(0.1953805363788359),
+                Token::F64(SYSTEM_LOAD),
                 Token::StructEnd,
                 Token::Str("memory"),
                 Token::Struct {
@@ -1002,13 +1009,13 @@ mod tests {
                     len: 4,
                 },
                 Token::Str("allocated"),
-                Token::U64(62914560),
+                Token::U64(MEM_ALLOCATED),
                 Token::Str("free"),
-                Token::U64(27664576),
+                Token::U64(MEM_FREE),
                 Token::Str("reservable"),
-                Token::U64(4294967296),
+                Token::U64(MEM_RESERVABLE),
                 Token::Str("used"),
-                Token::U64(35249984),
+                Token::U64(MEM_USED),
                 Token::StructEnd,
                 Token::Str("op"),
                 Token::UnitVariant {

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -339,8 +339,8 @@ impl Node {
     /// Returns an error of type [`BuildingConnectionRequest`] if the request
     /// failed to build.
     ///
-    /// Returns an error of type [`Unauthorized`] if the given authorization for
-    /// the node is incorrect.
+    /// Returns an error of type [`Unauthorized`] if the supplied authorization
+    /// is rejected by the node.
     ///
     /// [`Connecting`]: crate::node::NodeErrorType::Connecting
     /// [`BuildingConnectionRequest`]: crate::node::NodeErrorType::BuildingConnectionRequest

--- a/lavalink/src/node.rs
+++ b/lavalink/src/node.rs
@@ -330,6 +330,21 @@ impl Node {
     ///
     /// [`Lavalink`]: crate::client::Lavalink
     /// [module]: crate
+    ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`Connecting`] if the connection fails after
+    /// several backoff attempts.
+    ///
+    /// Returns an error of type [`BuildingConnectionRequest`] if the request
+    /// failed to build.
+    ///
+    /// Returns an error of type [`Unauthorized`] if the given authorization for
+    /// the node is incorrect.
+    ///
+    /// [`Connecting`]: crate::node::NodeErrorType::Connecting
+    /// [`BuildingConnectionRequest`]: crate::node::NodeErrorType::BuildingConnectionRequest
+    /// [`Unauthorized`]: crate::node::NodeErrorType::Unauthorized
     pub async fn connect(
         config: NodeConfig,
         players: PlayerManager,
@@ -415,6 +430,7 @@ impl Node {
     ///
     /// This score can be used to calculate how loaded the server is. A higher
     /// number means it is more heavily loaded.
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
     pub async fn penalty(&self) -> i32 {
         let stats = self.stats.lock().await;
         let cpu = 1.05f64.powf(100f64 * stats.cpu.system_load) * 10f64 - 10f64;
@@ -521,7 +537,7 @@ impl Connection {
         let text = match incoming {
             Message::Close(_) => {
                 tracing::debug!("got close, closing connection");
-                let _ = self.connection.send(Message::Close(None)).await;
+                let _result = self.connection.send(Message::Close(None)).await;
 
                 return Ok(false);
             }
@@ -530,7 +546,7 @@ impl Connection {
                 let msg = Message::Pong(data);
 
                 // We don't need to immediately care if a pong fails.
-                let _ = self.connection.send(msg).await;
+                let _result = self.connection.send(msg).await;
 
                 return Ok(true);
             }
@@ -559,7 +575,7 @@ impl Connection {
         // It's fine if the rx end dropped, often users don't need to care about
         // these events.
         if !self.node_to.is_closed() {
-            let _ = self.node_to.send(event);
+            let _result = self.node_to.send(event);
         }
 
         Ok(true)
@@ -653,10 +669,10 @@ async fn backoff(
     let mut seconds = 1;
 
     loop {
-        let req = connect_request(config)?;
+        let request = connect_request(config)?;
 
-        match tokio_tungstenite::connect_async(req).await {
-            Ok((stream, res)) => return Ok((stream, res)),
+        match tokio_tungstenite::connect_async(request).await {
+            Ok((stream, response)) => return Ok((stream, response)),
             Err(source) => {
                 tracing::warn!("failed to connect to node {source}: {:?}", config.address);
 
@@ -665,7 +681,7 @@ async fn backoff(
                     return Err(NodeError {
                         kind: NodeErrorType::Unauthorized {
                             address: config.address,
-                            authorization: config.authorization.to_owned(),
+                            authorization: config.authorization.clone(),
                         },
                         source: None,
                     });

--- a/lavalink/src/player.rs
+++ b/lavalink/src/player.rs
@@ -10,7 +10,7 @@
 //! [read the position]: Player::position
 
 use crate::{
-    model::*,
+    model::{Destroy, OutgoingEvent},
     node::{Node, NodeSenderError},
 };
 use dashmap::DashMap;
@@ -148,7 +148,8 @@ impl Player {
         match &event {
             OutgoingEvent::Pause(event) => self.paused.store(event.pause, Ordering::Release),
             OutgoingEvent::Volume(event) => {
-                self.volume.store(event.volume as u16, Ordering::Release)
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                self.volume.store(event.volume as u16, Ordering::Release);
             }
             _ => {}
         }
@@ -174,10 +175,8 @@ impl Player {
 
     /// Sets the channel ID the player is currently connected to.
     pub(crate) fn set_channel_id(&self, channel_id: Option<Id<ChannelMarker>>) {
-        self.channel_id.store(
-            channel_id.map(|id| id.get()).unwrap_or(0_u64),
-            Ordering::Release,
-        );
+        self.channel_id
+            .store(channel_id.map_or(0_u64, Id::get), Ordering::Release);
     }
 
     /// Return the player's guild ID.
@@ -197,7 +196,7 @@ impl Player {
 
     /// Set the player's position.
     pub(crate) fn set_position(&self, position: i64) {
-        self.position.store(position, Ordering::Release)
+        self.position.store(position, Ordering::Release);
     }
 
     /// Return the player's time.
@@ -207,7 +206,7 @@ impl Player {
 
     /// Set the player's time.
     pub(crate) fn set_time(&self, time: i64) {
-        self.time.store(time, Ordering::Release)
+        self.time.store(time, Ordering::Release);
     }
 
     /// Return the player's volume.


### PR DESCRIPTION
Based on #1644, standardize clippy lints and fix new ones that appear.
