### PR TITLE
refactor(mention): standardize clippy lints

### DIFF
--- a/mention/src/lib.rs
+++ b/mention/src/lib.rs
@@ -10,8 +10,13 @@
     unsafe_code,
     unused
 )]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::unnecessary_wraps,
+    clippy::used_underscore_binding
+)]
 #![doc = include_str!("../README.md")]
-#![allow(clippy::module_name_repetitions)]
 
 pub mod fmt;
 pub mod parse;


### PR DESCRIPTION
Based on #1644, standardize clippy lints and fix new ones that appear.
