### PR TITLE
refactor(standby): standardize clippy lints

### DIFF
--- a/standby/src/event.rs
+++ b/standby/src/event.rs
@@ -71,8 +71,8 @@ pub const fn guild_id(event: &Event) -> Option<Id<GuildMarker>> {
         Event::VoiceStateUpdate(e) => e.0.guild_id,
         Event::WebhooksUpdate(e) => Some(e.guild_id),
         Event::ChannelPinsUpdate(_)
-        | Event::GatewayHeartbeatAck
         | Event::GatewayHeartbeat(_)
+        | Event::GatewayHeartbeatAck
         | Event::GatewayHello(_)
         | Event::GatewayInvalidateSession(_)
         | Event::GatewayReconnect
@@ -90,7 +90,7 @@ pub const fn guild_id(event: &Event) -> Option<Id<GuildMarker>> {
         | Event::ShardPayload(_)
         | Event::ShardReconnecting(_)
         | Event::ShardResuming(_)
-        | Event::ThreadMemberUpdate(_) => None,
-        Event::UserUpdate(_) => None,
+        | Event::ThreadMemberUpdate(_)
+        | Event::UserUpdate(_) => None,
     }
 }

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(
     clippy::all,
     clippy::missing_const_for_fn,
-    clippy::missing_docs_in_private_items,
+    clippy::pedantic,
     future_incompatible,
     missing_docs,
     nonstandard_style,
@@ -9,6 +9,12 @@
     rustdoc::broken_intra_doc_links,
     unsafe_code,
     unused
+)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::unnecessary_wraps,
+    clippy::used_underscore_binding
 )]
 #![doc = include_str!("../README.md")]
 
@@ -663,7 +669,8 @@ impl Standby {
     ///
     /// # Examples
     ///
-    /// Wait for multiple button components on message 123 with a custom_id of "Click":
+    /// Wait for multiple button components on message 123 with a `custom_id` of
+    /// "Click":
     ///
     /// ```no_run
     /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -1343,7 +1350,7 @@ mod tests {
 
         let standby = Standby::new();
         let wait = standby.wait_for_event(|event: &Event| match event {
-            Event::Ready(ready) => ready.shard.map(|[id, _]| id == 5).unwrap_or(false),
+            Event::Ready(ready) => ready.shard.map_or(false, |[id, _]| id == 5),
             _ => false,
         });
         assert!(!standby.events.is_empty());

--- a/standby/src/lib.rs
+++ b/standby/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(
     clippy::all,
     clippy::missing_const_for_fn,
+    clippy::missing_docs_in_private_items,
     clippy::pedantic,
     future_incompatible,
     missing_docs,


### PR DESCRIPTION
Based on #1644, standardize clippy lints and fix new ones that appear.
