### PR TITLE
refactor(util): standardize clippy lints

### DIFF
--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(
     clippy::all,
     clippy::missing_const_for_fn,
@@ -7,11 +6,19 @@
     missing_docs,
     nonstandard_style,
     rust_2018_idioms,
+    rustdoc::broken_intra_doc_links,
     unsafe_code,
     unused
 )]
-#![doc = include_str!("../README.md")]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::unnecessary_wraps,
+    clippy::used_underscore_binding
+)]
 #![allow(clippy::semicolon_if_nothing_returned)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc = include_str!("../README.md")]
 
 #[cfg(feature = "builder")]
 pub mod builder;

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -16,7 +16,6 @@
     clippy::unnecessary_wraps,
     clippy::used_underscore_binding
 )]
-#![allow(clippy::semicolon_if_nothing_returned)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 

--- a/util/src/snowflake.rs
+++ b/util/src/snowflake.rs
@@ -264,7 +264,7 @@ mod tests {
         let expected: i64 = 1_445_219_918_546;
         let id = Id::<GenericMarker>::new(105_484_726_235_607_040);
 
-        assert_eq!(expected, id.timestamp())
+        assert_eq!(expected, id.timestamp());
     }
 
     #[test]
@@ -272,7 +272,7 @@ mod tests {
         let expected: u8 = 8;
         let id = Id::<GenericMarker>::new(762_022_344_856_174_632);
 
-        assert_eq!(expected, id.worker_id())
+        assert_eq!(expected, id.worker_id());
     }
 
     #[test]
@@ -280,7 +280,7 @@ mod tests {
         let expected: u8 = 1;
         let id = Id::<GenericMarker>::new(61_189_081_970_774_016);
 
-        assert_eq!(expected, id.process_id())
+        assert_eq!(expected, id.process_id());
     }
 
     #[test]
@@ -288,6 +288,6 @@ mod tests {
         let expected: u16 = 40;
         let id = Id::<GenericMarker>::new(762_022_344_856_174_632);
 
-        assert_eq!(expected, id.increment())
+        assert_eq!(expected, id.increment());
     }
 }


### PR DESCRIPTION
Based on #1644, standardize clippy lints nd fix new ones that appear.
