### PR TITLE
refactor(validate): standardize clippy lints

### DIFF
--- a/validate/src/lib.rs
+++ b/validate/src/lib.rs
@@ -1,17 +1,22 @@
 #![deny(
     clippy::all,
     clippy::missing_const_for_fn,
-    clippy::missing_docs_in_private_items,
     clippy::pedantic,
     future_incompatible,
     missing_docs,
     nonstandard_style,
     rust_2018_idioms,
+    rustdoc::broken_intra_doc_links,
     unsafe_code,
     unused
 )]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::unnecessary_wraps,
+    clippy::used_underscore_binding
+)]
 #![doc = include_str!("../README.md")]
-#![allow(clippy::module_name_repetitions)]
 
 pub mod channel;
 pub mod command;

--- a/validate/src/lib.rs
+++ b/validate/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(
     clippy::all,
     clippy::missing_const_for_fn,
+    clippy::missing_docs_in_private_items,
     clippy::pedantic,
     future_incompatible,
     missing_docs,


### PR DESCRIPTION
Based on #1644, standardize clippy lints nd fix new ones that appear.
