### PR TITLE
deps(http): upgrade `hyper-trust-dns`

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.11.0"
 hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
 hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.23" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
-hyper-trust-dns = { default-features = false, optional = true, version = "0.3.1" }
+hyper-trust-dns = { default-features = false, optional = true, version = "0.4" }
 percent-encoding = { default-features = false, version = "2" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1" }

--- a/http/src/client/connector.rs
+++ b/http/src/client/connector.rs
@@ -37,7 +37,7 @@ pub fn create() -> Connector {
     #[cfg(not(feature = "trust-dns"))]
     let mut connector = hyper::client::HttpConnector::new();
     #[cfg(feature = "trust-dns")]
-    let mut connector = hyper_trust_dns::new_trust_dns_http_connector();
+    let mut connector = hyper_trust_dns::TrustDnsResolver::default().into_http_connector();
 
     connector.enforce_http(false);
 


### PR DESCRIPTION
This PR updates the `hyper-trust-dns` dependency to `0.4`. Upstream breaking changes have been addressed. However, there should be no breaking changes for the consumers of `twilight-http`. Thanks! 🎉