### PR TITLE
Fix the large bot sharding hyperlink

### DIFF
--- a/gateway-queue/README.md
+++ b/gateway-queue/README.md
@@ -17,7 +17,7 @@ either mean using IPC to communicate ratelimiting or a broker.
 
 Most users only need the [`LocalQueue`]: it's a single-process queue for
 smaller bots. Larger bots need the [`LargeBotQueue`], which supports
-single-process [Sharding for Very Large Bots] through the use of bucket
+single-process [Sharding for Large Bots] through the use of bucket
 releasing.
 
 By default, the gateway's `Cluster` and `Shard`s use the [`LocalQueue`]. You
@@ -40,4 +40,4 @@ The `twilight-http` feature brings in support for [`LargeBotQueue`].
 
 This is enabled by default.
 
-[Sharding for Very Large Bots]: https://discord.com/developers/docs/topics/gateway#sharding-for-very-large-bots
+[Sharding for Large Bots]: https://discord.com/developers/docs/topics/gateway#sharding-for-large-bots


### PR DESCRIPTION
Update the documentation link for large bot sharding due to the link section being renamed.