### PR TITLE
refactor(model): add `#[non_exhaustive]` to c-style enums

### DIFF
--- a/http/src/response/status_code.rs
+++ b/http/src/response/status_code.rs
@@ -7,7 +7,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 /// Status codes can easily be compared with status code integers due to
 /// implementing `PartialEq<u16>`. This is equivalent to checking against the
 /// value returned by [`StatusCode::raw`].
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct StatusCode(u16);
 
 impl StatusCode {

--- a/model/src/application/command/command_type.rs
+++ b/model/src/application/command/command_type.rs
@@ -1,5 +1,6 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
+// Keep this is sync with `twilight-validate`!
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]

--- a/model/src/application/command/command_type.rs
+++ b/model/src/application/command/command_type.rs
@@ -1,6 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum CommandType {
     /// Slash command.

--- a/model/src/application/command/command_type.rs
+++ b/model/src/application/command/command_type.rs
@@ -1,6 +1,6 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-// Keep this is sync with `twilight-validate`!
+// Keep in sync with `twilight-validate`!
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]

--- a/model/src/application/command/command_type.rs
+++ b/model/src/application/command/command_type.rs
@@ -1,6 +1,6 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-// Keep in sync with `twilight-validate`!
+// Keep in sync with `twilight-validate::command`!
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]

--- a/model/src/application/command/option.rs
+++ b/model/src/application/command/option.rs
@@ -690,6 +690,7 @@ pub enum CommandOptionValue {
 
 /// Type of a [`CommandOption`].
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum CommandOptionType {
     SubCommand = 1,

--- a/model/src/application/command/permissions.rs
+++ b/model/src/application/command/permissions.rs
@@ -38,6 +38,7 @@ struct CommandPermissionsData {
 }
 
 #[derive(Clone, Debug, Deserialize_repr, Eq, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 enum CommandPermissionsDataType {
     Role = 1,

--- a/model/src/application/component/button.rs
+++ b/model/src/application/component/button.rs
@@ -36,7 +36,7 @@ pub struct Button {
 /// Refer to [the Discord Docs/Button Object] for additional information.
 ///
 /// [the Discord Docs/Button Object]: https://discord.com/developers/docs/interactions/message-components#button-object-button-styles
-// Keep this is sync with `twilight-validate`!
+// Keep in sync with `twilight-validate`!
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]

--- a/model/src/application/component/button.rs
+++ b/model/src/application/component/button.rs
@@ -36,6 +36,7 @@ pub struct Button {
 /// Refer to [the Discord Docs/Button Object] for additional information.
 ///
 /// [the Discord Docs/Button Object]: https://discord.com/developers/docs/interactions/message-components#button-object-button-styles
+// Keep this is sync with `twilight-validate`!
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]

--- a/model/src/application/component/button.rs
+++ b/model/src/application/component/button.rs
@@ -36,7 +36,7 @@ pub struct Button {
 /// Refer to [the Discord Docs/Button Object] for additional information.
 ///
 /// [the Discord Docs/Button Object]: https://discord.com/developers/docs/interactions/message-components#button-object-button-styles
-// Keep in sync with `twilight-validate`!
+// Keep in sync with `twilight-validate::component`!
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]

--- a/model/src/application/component/button.rs
+++ b/model/src/application/component/button.rs
@@ -36,7 +36,8 @@ pub struct Button {
 /// Refer to [the Discord Docs/Button Object] for additional information.
 ///
 /// [the Discord Docs/Button Object]: https://discord.com/developers/docs/interactions/message-components#button-object-button-styles
-#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Serialize_repr)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ButtonStyle {
     /// Button indicates a primary action.
@@ -86,7 +87,6 @@ mod tests {
         Eq,
         Hash,
         PartialEq,
-        PartialOrd,
         Send,
         Serialize,
         Sync

--- a/model/src/application/component/kind.rs
+++ b/model/src/application/component/kind.rs
@@ -7,6 +7,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 ///
 /// [Discord Docs/Message Components]: https://discord.com/developers/docs/interactions/message-components#component-types
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ComponentType {
     /// Component is an [`ActionRow`].

--- a/model/src/application/component/text_input.rs
+++ b/model/src/application/component/text_input.rs
@@ -30,7 +30,8 @@ pub struct TextInput {
 /// Style of an [`TextInput`].
 ///
 /// Refer to [the discord docs] for additional information.
-#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Serialize_repr)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum TextInputStyle {
     /// Intended for short single-line text.
@@ -66,7 +67,6 @@ mod tests {
         Eq,
         Hash,
         PartialEq,
-        PartialOrd,
         Send,
         Serialize,
         Sync

--- a/model/src/application/interaction/application_command_autocomplete/option.rs
+++ b/model/src/application/interaction/application_command_autocomplete/option.rs
@@ -18,6 +18,7 @@ pub struct ApplicationCommandAutocompleteDataOption {
 
 /// Type of option data received.
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ApplicationCommandAutocompleteDataOptionType {
     SubCommand = 1,

--- a/model/src/application/interaction/interaction_type.rs
+++ b/model/src/application/interaction/interaction_type.rs
@@ -7,6 +7,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 ///
 /// [Discord Docs/Interaction Object]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum InteractionType {
     Ping = 1,

--- a/model/src/channel/channel_type.rs
+++ b/model/src/channel/channel_type.rs
@@ -1,6 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ChannelType {
     GuildText = 0,

--- a/model/src/channel/message/activity_type.rs
+++ b/model/src/channel/message/activity_type.rs
@@ -1,6 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum MessageActivityType {
     Join = 1,

--- a/model/src/channel/message/kind.rs
+++ b/model/src/channel/message/kind.rs
@@ -2,6 +2,7 @@ use crate::channel::ConversionError;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum MessageType {
     Regular = 0,

--- a/model/src/channel/message/sticker/format_type.rs
+++ b/model/src/channel/message/sticker/format_type.rs
@@ -8,6 +8,7 @@ use std::{
 ///
 /// [`Sticker`]: super::Sticker
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum StickerFormatType {
     /// Sticker format is a PNG.

--- a/model/src/channel/message/sticker/kind.rs
+++ b/model/src/channel/message/sticker/kind.rs
@@ -8,6 +8,7 @@ use std::{
 ///
 /// [`Sticker`]: super::Sticker
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum StickerType {
     /// Official sticker in a pack.

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -17,6 +17,7 @@ pub struct PermissionOverwrite {
 
 /// Type of a permission overwrite target.
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionOverwriteType {

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -16,6 +16,7 @@ pub struct PermissionOverwrite {
 }
 
 /// Type of a permission overwrite target.
+// Keep in sync with `PermissionCalculator`!
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]

--- a/model/src/channel/permission_overwrite.rs
+++ b/model/src/channel/permission_overwrite.rs
@@ -16,7 +16,7 @@ pub struct PermissionOverwrite {
 }
 
 /// Type of a permission overwrite target.
-// Keep in sync with `PermissionCalculator`!
+// Keep in sync with `twilight_util::permission_calculator::PermissionCalculator`!
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]

--- a/model/src/channel/stage_instance/privacy_level.rs
+++ b/model/src/channel/stage_instance/privacy_level.rs
@@ -1,8 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum PrivacyLevel {
     GuildOnly = 2,

--- a/model/src/channel/video_quality_mode.rs
+++ b/model/src/channel/video_quality_mode.rs
@@ -1,8 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum VideoQualityMode {
     /// Discord chooses the quality for optimal performance.

--- a/model/src/channel/webhook/kind.rs
+++ b/model/src/channel/webhook/kind.rs
@@ -1,6 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum WebhookType {
     Incoming = 1,

--- a/model/src/gateway/close_code.rs
+++ b/model/src/gateway/close_code.rs
@@ -5,9 +5,7 @@ use std::{
 };
 
 /// Gateway close event codes.
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum CloseCode {

--- a/model/src/gateway/opcode.rs
+++ b/model/src/gateway/opcode.rs
@@ -1,9 +1,8 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Gateway opcodes.
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum OpCode {
     /// An event was received.

--- a/model/src/gateway/presence/activity_type.rs
+++ b/model/src/gateway/presence/activity_type.rs
@@ -1,6 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ActivityType {
     Playing = 0,

--- a/model/src/guild/default_message_notification_level.rs
+++ b/model/src/guild/default_message_notification_level.rs
@@ -1,8 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum DefaultMessageNotificationLevel {
     All = 0,

--- a/model/src/guild/explicit_content_filter.rs
+++ b/model/src/guild/explicit_content_filter.rs
@@ -1,8 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ExplicitContentFilter {
     None = 0,

--- a/model/src/guild/integration_expire_behavior.rs
+++ b/model/src/guild/integration_expire_behavior.rs
@@ -1,9 +1,8 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// Behavior to perform when the user's integration expires.
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum IntegrationExpireBehavior {
     /// Remove the role when the integration expires.

--- a/model/src/guild/mfa_level.rs
+++ b/model/src/guild/mfa_level.rs
@@ -1,8 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum MfaLevel {
     None = 0,

--- a/model/src/guild/nsfw_level.rs
+++ b/model/src/guild/nsfw_level.rs
@@ -1,8 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum NSFWLevel {
     Default = 0,

--- a/model/src/guild/premium_tier.rs
+++ b/model/src/guild/premium_tier.rs
@@ -1,8 +1,9 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
+    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
 )]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum PremiumTier {
     None = 0,

--- a/model/src/guild/verification_level.rs
+++ b/model/src/guild/verification_level.rs
@@ -1,8 +1,9 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
+    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
 )]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum VerificationLevel {
     None = 0,

--- a/model/src/http/interaction.rs
+++ b/model/src/http/interaction.rs
@@ -80,6 +80,7 @@ pub struct InteractionResponseData {
 
 /// Type of interaction response.
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum InteractionResponseType {
     /// Used when responding to a Ping from Discord.

--- a/model/src/http/permission_overwrite.rs
+++ b/model/src/http/permission_overwrite.rs
@@ -21,6 +21,7 @@ pub struct PermissionOverwrite {
 
 /// Type of a permission overwrite target.
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionOverwriteType {

--- a/model/src/invite/target_type.rs
+++ b/model/src/invite/target_type.rs
@@ -1,6 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum TargetType {
     Stream = 1,

--- a/model/src/oauth/team/membership_state.rs
+++ b/model/src/oauth/team/membership_state.rs
@@ -1,8 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum TeamMembershipState {
     Invited = 1,

--- a/model/src/scheduled_event/mod.rs
+++ b/model/src/scheduled_event/mod.rs
@@ -91,6 +91,7 @@ pub struct EntityMetadata {
 
 /// Type of event.
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum EntityType {
     /// Event takes place in a stage instance.
@@ -103,6 +104,7 @@ pub enum EntityType {
 
 /// Privacy level of an event.
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum PrivacyLevel {
     /// Event is only accessible to guild members.
@@ -111,6 +113,7 @@ pub enum PrivacyLevel {
 
 /// Status of an event.
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum Status {
     /// Event is scheduled.

--- a/model/src/user/connection_visibility.rs
+++ b/model/src/user/connection_visibility.rs
@@ -1,8 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum ConnectionVisibility {
     None = 0,

--- a/model/src/user/premium_type.rs
+++ b/model/src/user/premium_type.rs
@@ -1,5 +1,6 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[non_exhaustive]
 #[repr(u8)]
 pub enum PremiumType {
     None = 0,

--- a/model/src/voice/close_code.rs
+++ b/model/src/voice/close_code.rs
@@ -5,9 +5,7 @@ use std::{
 };
 
 /// Voice gateway close event codes.
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum CloseCode {

--- a/model/src/voice/opcode.rs
+++ b/model/src/voice/opcode.rs
@@ -1,9 +1,7 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 // Voice gateway opcodes.
-#[derive(
-    Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize_repr,
-)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum OpCode {

--- a/util/src/permission_calculator/mod.rs
+++ b/util/src/permission_calculator/mod.rs
@@ -477,6 +477,7 @@ const fn process_permission_overwrites(
                     member_deny = bitops::insert(member_deny, overwrite.deny);
                 }
             }
+            _ => return Permissions::empty(),
         }
 
         idx += 1;

--- a/validate/src/command.rs
+++ b/validate/src/command.rs
@@ -243,6 +243,7 @@ pub fn command(value: &Command) -> Result<(), CommandValidationError> {
             match kind {
                 CommandType::ChatInput => self::chat_input_name(name)?,
                 CommandType::User | CommandType::Message => self::name(name)?,
+                _ => unreachable!(),
             }
         }
     }
@@ -250,6 +251,7 @@ pub fn command(value: &Command) -> Result<(), CommandValidationError> {
     match kind {
         CommandType::ChatInput => self::chat_input_name(name),
         CommandType::User | CommandType::Message => self::name(name),
+        _ => unreachable!(),
     }
 }
 

--- a/validate/src/component.rs
+++ b/validate/src/component.rs
@@ -1100,7 +1100,7 @@ mod tests {
     assert_impl_all!(ComponentValidationError: Debug, Send, Sync);
 
     // All styles of buttons.
-    const ALL_BUTTON_STYLES: &'static [ButtonStyle] = &[
+    const ALL_BUTTON_STYLES: &[ButtonStyle] = &[
         ButtonStyle::Primary,
         ButtonStyle::Secondary,
         ButtonStyle::Success,

--- a/validate/src/component.rs
+++ b/validate/src/component.rs
@@ -1100,28 +1100,13 @@ mod tests {
     assert_impl_all!(ComponentValidationError: Debug, Send, Sync);
 
     // All styles of buttons.
-    const fn all_button_styles() -> &'static [ButtonStyle] {
-        const BUTTON_STYLES: &[ButtonStyle] = &[
-            ButtonStyle::Primary,
-            ButtonStyle::Secondary,
-            ButtonStyle::Success,
-            ButtonStyle::Danger,
-            ButtonStyle::Link,
-        ];
-
-        // No-op match to ensure we've registered all styles.
-        //
-        // If a new variant has been added please add it to the above constant.
-        match ButtonStyle::Primary {
-            ButtonStyle::Primary
-            | ButtonStyle::Secondary
-            | ButtonStyle::Success
-            | ButtonStyle::Danger
-            | ButtonStyle::Link => {}
-        }
-
-        BUTTON_STYLES
-    }
+    const ALL_BUTTON_STYLES: &'static [ButtonStyle] = &[
+        ButtonStyle::Primary,
+        ButtonStyle::Secondary,
+        ButtonStyle::Success,
+        ButtonStyle::Danger,
+        ButtonStyle::Link,
+    ];
 
     #[test]
     fn component_action_row() {
@@ -1203,7 +1188,7 @@ mod tests {
     // [`ComponentValidationErrorType::ButtonStyle`] error type.
     #[test]
     fn button_style() {
-        for style in all_button_styles().iter() {
+        for style in ALL_BUTTON_STYLES.iter() {
             let button = Button {
                 custom_id: None,
                 disabled: false,


### PR DESCRIPTION
Although soft breaking `twilight-model` is okay, it's better not to.
This has little cost for us and users, as `#[non_exhaustive]` doesn't apply inside the current crate and users generally don't match on it (it's an implementation detail).

The PR also removes some out of place `Ord` and `PartialOrd` implementations and alphabetizes the order.
