### PR TITLE
ci(deploy): add missing workspace flag

### DIFF
--- a/.github/workflows/deploy-lib.yml
+++ b/.github/workflows/deploy-lib.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           RUSTDOCFLAGS: --cfg docsrs
         run: |
-          cargo doc --no-deps --features=permission-calculator --exclude twilight-book
+          cargo doc --no-deps --features=permission-calculator --workspace --exclude twilight-book
           cargo doc -p twilight-util --no-deps --all-features
 
       - name: Prepare docs


### PR DESCRIPTION
One of the steps for deploying API docs now excludes the book as a result of #1798, and while the `--exclude` flag was included for this the paired `--workspace` flag was missed.