### PR TITLE
feat: set `#[track_caller]` on public panicable functions

### DIFF
--- a/gateway/src/cluster/builder.rs
+++ b/gateway/src/cluster/builder.rs
@@ -220,6 +220,7 @@ impl ClusterBuilder {
     /// # Panics
     ///
     /// Panics if the provided value is below 50 or above 250.
+    #[track_caller]
     pub fn large_threshold(mut self, large_threshold: u64) -> Self {
         self.shard = self.shard.large_threshold(large_threshold);
 

--- a/gateway/src/shard/builder.rs
+++ b/gateway/src/shard/builder.rs
@@ -273,12 +273,12 @@ impl ShardBuilder {
     /// # Panics
     ///
     /// Panics if the provided value is below 50 or above 250.
-    #[allow(clippy::missing_const_for_fn)]
+    #[track_caller]
     pub fn large_threshold(mut self, large_threshold: u64) -> Self {
         match large_threshold {
-            0..=49 => panic!("provided large threshold value {large_threshold} is fewer than 50"),
+            0..=49 => panic!("threshold {large_threshold} is below 50"),
             50..=250 => (),
-            251.. => panic!("provided large threshold value {large_threshold} is more than 250"),
+            251.. => panic!("threshold {large_threshold} is above 250"),
         }
 
         self.large_threshold = large_threshold;

--- a/model/src/id/mod.rs
+++ b/model/src/id/mod.rs
@@ -107,6 +107,7 @@ impl<T> Id<T> {
     /// Panics if the value is 0.
     ///
     /// [`new_checked`]: Self::new_checked
+    #[track_caller]
     pub const fn new(n: u64) -> Self {
         if let Some(id) = Self::new_checked(n) {
             id


### PR DESCRIPTION
This attribute sets the panic info location to the caller's location, see https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#useful-line-numbers-in-option-and-result-panic-messages for more information.
