### PR TITLE
feat(model)!: add `GuildFeature`

### DIFF
--- a/cache/in-memory/src/model/guild.rs
+++ b/cache/in-memory/src/model/guild.rs
@@ -1,3 +1,5 @@
+use std::slice::Iter;
+
 use serde::Serialize;
 use twilight_model::{
     guild::{
@@ -106,8 +108,10 @@ impl CachedGuild {
     /// Enabled [guild features].
     ///
     /// [guild features]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
-    pub fn features(&self) -> &[GuildFeature] {
-        &self.features
+    pub fn features(&self) -> Features<'_> {
+        Features {
+            inner: self.features.iter(),
+        }
     }
 
     /// Icon hash.
@@ -255,6 +259,18 @@ impl CachedGuild {
     /// Whether the widget is enabled.
     pub const fn widget_enabled(&self) -> Option<bool> {
         self.widget_enabled
+    }
+}
+
+pub struct Features<'a> {
+    inner: Iter<'a, GuildFeature>,
+}
+
+impl<'a> Iterator for Features<'a> {
+    type Item = &'a GuildFeature;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
     }
 }
 

--- a/cache/in-memory/src/model/guild.rs
+++ b/cache/in-memory/src/model/guild.rs
@@ -276,7 +276,7 @@ impl<'a> Iterator for Features<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::CachedGuild;
+    use super::{CachedGuild, Features};
     use serde::Serialize;
     use static_assertions::{assert_fields, assert_impl_all};
     use std::fmt::Debug;
@@ -328,4 +328,5 @@ mod tests {
         Serialize,
         Sync,
     );
+    assert_impl_all!(Features<'_>: Iterator, Send, Sync);
 }

--- a/cache/in-memory/src/model/guild.rs
+++ b/cache/in-memory/src/model/guild.rs
@@ -1,10 +1,8 @@
-use std::slice::Iter;
-
 use serde::Serialize;
 use twilight_model::{
     guild::{
-        DefaultMessageNotificationLevel, ExplicitContentFilter, MfaLevel, NSFWLevel, Permissions,
-        PremiumTier, SystemChannelFlags, VerificationLevel,
+        DefaultMessageNotificationLevel, ExplicitContentFilter, GuildFeature, MfaLevel, NSFWLevel,
+        Permissions, PremiumTier, SystemChannelFlags, VerificationLevel,
     },
     id::{
         marker::{ApplicationMarker, ChannelMarker, GuildMarker, UserMarker},
@@ -26,7 +24,7 @@ pub struct CachedGuild {
     pub(crate) description: Option<String>,
     pub(crate) discovery_splash: Option<ImageHash>,
     pub(crate) explicit_content_filter: ExplicitContentFilter,
-    pub(crate) features: Vec<String>,
+    pub(crate) features: Vec<GuildFeature>,
     pub(crate) icon: Option<ImageHash>,
     pub(crate) id: Id<GuildMarker>,
     pub(crate) joined_at: Option<Timestamp>,
@@ -108,10 +106,8 @@ impl CachedGuild {
     /// Enabled [guild features].
     ///
     /// [guild features]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
-    pub fn features(&self) -> Features<'_> {
-        Features {
-            inner: self.features.iter(),
-        }
+    pub fn features(&self) -> &[GuildFeature] {
+        &self.features
     }
 
     /// Icon hash.
@@ -262,21 +258,9 @@ impl CachedGuild {
     }
 }
 
-pub struct Features<'a> {
-    inner: Iter<'a, String>,
-}
-
-impl<'a> Iterator for Features<'a> {
-    type Item = &'a str;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(AsRef::as_ref)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{CachedGuild, Features};
+    use super::CachedGuild;
     use serde::Serialize;
     use static_assertions::{assert_fields, assert_impl_all};
     use std::fmt::Debug;
@@ -328,5 +312,4 @@ mod tests {
         Serialize,
         Sync,
     );
-    assert_impl_all!(Features<'_>: Iterator, Send, Sync);
 }

--- a/model/src/guild/feature.rs
+++ b/model/src/guild/feature.rs
@@ -4,6 +4,10 @@ use std::borrow::Cow;
 use serde::{Deserialize, Serialize};
 
 /// Special and optional guild features.
+///
+/// See [Discord Docs/Guild Features]
+///
+/// [Discord Docs/Guild Features]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "String", into = "Cow<'static, str>")]

--- a/model/src/guild/feature.rs
+++ b/model/src/guild/feature.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// Special and optional guild features.
 ///
-/// See [Discord Docs/Guild Features]
+/// See [Discord Docs/Guild Features].
 ///
 /// [Discord Docs/Guild Features]: https://discord.com/developers/docs/resources/guild#guild-object-guild-features
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]

--- a/model/src/guild/feature.rs
+++ b/model/src/guild/feature.rs
@@ -1,0 +1,181 @@
+#![allow(deprecated)]
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+
+/// Special and optional guild features.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(from = "String", into = "Cow<'static, str>")]
+pub enum GuildFeature {
+    /// Has access to set an animated guild banner image.
+    AnimatedBanner,
+    /// Has access to set an animated guild icon.
+    AnimatedIcon,
+    /// Has set up auto moderation rules.
+    AutoModeration,
+    /// Has access to set a guild banner image.
+    Banner,
+    /// Has access to use commerce features (create store channels).
+    #[deprecated]
+    Commerce,
+    /// Can enable welcome screen, membership screening, stage channels,
+    /// discovery, and receives community updates.
+    Community,
+    /// Is able to be discovered in the directory.
+    Discoverable,
+    /// Is able to be featured in the directory.
+    Featurable,
+    /// Has access to set an invite splash background.
+    InviteSplash,
+    /// Has enabled membership screening.
+    MemberVerificationGateEnabled,
+    /// Has enabled monetization.
+    MonetizationEnabled,
+    /// Has increased custom sticker slots.
+    MoreStickers,
+    /// Has access to create news channels.
+    News,
+    /// Is partnered.
+    Partnered,
+    /// Can be previewed before joining via membership screening or the directory.
+    PreviewEnabled,
+    /// Has access to create private threads.
+    PrivateThreads,
+    /// Is able to set role icons.
+    RoleIcons,
+    /// Has enabled ticketed events.
+    TicketedEventsEnabled,
+    /// Has access to set a vanity URL.
+    VanityUrl,
+    /// Is verified.
+    Verified,
+    /// Has access to set 384kps bitrate in voice (previously VIP voice servers).
+    VipRegions,
+    /// Has enabled the welcome screen.
+    WelcomeScreenEnabled,
+    /// Variant value is unknown to the library.
+    Unknown(String),
+}
+
+impl From<GuildFeature> for Cow<'static, str> {
+    fn from(value: GuildFeature) -> Self {
+        match value {
+            GuildFeature::AnimatedBanner => "ANIMATED_BANNER".into(),
+            GuildFeature::AnimatedIcon => "ANIMATED_ICON".into(),
+            GuildFeature::AutoModeration => "AUTO_MODERATION".into(),
+            GuildFeature::Banner => "BANNER".into(),
+            GuildFeature::Commerce => "COMMERCE".into(),
+            GuildFeature::Community => "COMMUNITY".into(),
+            GuildFeature::Discoverable => "DISCOVERABLE".into(),
+            GuildFeature::Featurable => "FEATURABLE".into(),
+            GuildFeature::InviteSplash => "INVITE_SPLASH".into(),
+            GuildFeature::MemberVerificationGateEnabled => {
+                "MEMBER_VERIFICATION_GATE_ENABLED".into()
+            }
+            GuildFeature::MonetizationEnabled => "MONETIZATION_ENABLED".into(),
+            GuildFeature::MoreStickers => "MORE_STICKERS".into(),
+            GuildFeature::News => "NEWS".into(),
+            GuildFeature::Partnered => "PARTNERED".into(),
+            GuildFeature::PreviewEnabled => "PREVIEW_ENABLED".into(),
+            GuildFeature::PrivateThreads => "PRIVATE_THREADS".into(),
+            GuildFeature::RoleIcons => "ROLE_ICONS".into(),
+            GuildFeature::TicketedEventsEnabled => "TICKETED_EVENTS_ENABLED".into(),
+            GuildFeature::VanityUrl => "VANITY_URL".into(),
+            GuildFeature::Verified => "VERIFIED".into(),
+            GuildFeature::VipRegions => "VIP_REGIONS".into(),
+            GuildFeature::WelcomeScreenEnabled => "WELCOME_SCREEN_ENABLED".into(),
+            GuildFeature::Unknown(unknown) => unknown.into(),
+        }
+    }
+}
+
+impl From<String> for GuildFeature {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "ANIMATED_BANNER" => Self::AnimatedBanner,
+            "ANIMATED_ICON" => Self::AnimatedIcon,
+            "AUTO_MODERATION" => Self::AutoModeration,
+            "BANNER" => Self::Banner,
+            "COMMERCE" => Self::Commerce,
+            "COMMUNITY" => Self::Community,
+            "DISCOVERABLE" => Self::Discoverable,
+            "FEATURABLE" => Self::Featurable,
+            "INVITE_SPLASH" => Self::InviteSplash,
+            "MEMBER_VERIFICATION_GATE_ENABLED" => Self::MemberVerificationGateEnabled,
+            "MONETIZATION_ENABLED" => Self::MonetizationEnabled,
+            "MORE_STICKERS" => Self::MoreStickers,
+            "NEWS" => Self::News,
+            "PARTNERED" => Self::Partnered,
+            "PREVIEW_ENABLED" => Self::PreviewEnabled,
+            "PRIVATE_THREADS" => Self::PrivateThreads,
+            "ROLE_ICONS" => Self::RoleIcons,
+            "TICKETED_EVENTS_ENABLED" => Self::TicketedEventsEnabled,
+            "VANITY_URL" => Self::VanityUrl,
+            "VERIFIED" => Self::Verified,
+            "VIP_REGIONS" => Self::VipRegions,
+            "WELCOME_SCREEN_ENABLED" => Self::WelcomeScreenEnabled,
+            _ => Self::Unknown(value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GuildFeature;
+    use serde_test::Token;
+
+    #[test]
+    fn variants() {
+        serde_test::assert_tokens(
+            &GuildFeature::AnimatedBanner,
+            &[Token::Str("ANIMATED_BANNER")],
+        );
+        serde_test::assert_tokens(&GuildFeature::AnimatedIcon, &[Token::Str("ANIMATED_ICON")]);
+        serde_test::assert_tokens(
+            &GuildFeature::AutoModeration,
+            &[Token::Str("AUTO_MODERATION")],
+        );
+        serde_test::assert_tokens(&GuildFeature::Banner, &[Token::Str("BANNER")]);
+        serde_test::assert_tokens(&GuildFeature::Commerce, &[Token::Str("COMMERCE")]);
+        serde_test::assert_tokens(&GuildFeature::Community, &[Token::Str("COMMUNITY")]);
+        serde_test::assert_tokens(&GuildFeature::Discoverable, &[Token::Str("DISCOVERABLE")]);
+        serde_test::assert_tokens(&GuildFeature::Featurable, &[Token::Str("FEATURABLE")]);
+        serde_test::assert_tokens(&GuildFeature::InviteSplash, &[Token::Str("INVITE_SPLASH")]);
+        serde_test::assert_tokens(
+            &GuildFeature::MemberVerificationGateEnabled,
+            &[Token::Str("MEMBER_VERIFICATION_GATE_ENABLED")],
+        );
+        serde_test::assert_tokens(
+            &GuildFeature::MonetizationEnabled,
+            &[Token::Str("MONETIZATION_ENABLED")],
+        );
+        serde_test::assert_tokens(&GuildFeature::MoreStickers, &[Token::Str("MORE_STICKERS")]);
+        serde_test::assert_tokens(&GuildFeature::News, &[Token::Str("NEWS")]);
+        serde_test::assert_tokens(&GuildFeature::Partnered, &[Token::Str("PARTNERED")]);
+        serde_test::assert_tokens(
+            &GuildFeature::PreviewEnabled,
+            &[Token::Str("PREVIEW_ENABLED")],
+        );
+        serde_test::assert_tokens(
+            &GuildFeature::PrivateThreads,
+            &[Token::Str("PRIVATE_THREADS")],
+        );
+        serde_test::assert_tokens(&GuildFeature::RoleIcons, &[Token::Str("ROLE_ICONS")]);
+        serde_test::assert_tokens(
+            &GuildFeature::TicketedEventsEnabled,
+            &[Token::Str("TICKETED_EVENTS_ENABLED")],
+        );
+        serde_test::assert_tokens(&GuildFeature::VanityUrl, &[Token::Str("VANITY_URL")]);
+        serde_test::assert_tokens(&GuildFeature::Verified, &[Token::Str("VERIFIED")]);
+        serde_test::assert_tokens(&GuildFeature::VipRegions, &[Token::Str("VIP_REGIONS")]);
+        serde_test::assert_tokens(
+            &GuildFeature::WelcomeScreenEnabled,
+            &[Token::Str("WELCOME_SCREEN_ENABLED")],
+        );
+        serde_test::assert_tokens(
+            &GuildFeature::Unknown("UNKNOWN".to_owned()),
+            &[Token::Str("UNKNOWN")],
+        );
+    }
+}

--- a/model/src/guild/mod.rs
+++ b/model/src/guild/mod.rs
@@ -5,6 +5,7 @@ mod ban;
 mod default_message_notification_level;
 mod emoji;
 mod explicit_content_filter;
+mod feature;
 mod info;
 mod integration;
 mod integration_account;
@@ -28,8 +29,9 @@ mod widget;
 
 pub use self::{
     ban::Ban, default_message_notification_level::DefaultMessageNotificationLevel, emoji::Emoji,
-    explicit_content_filter::ExplicitContentFilter, info::GuildInfo, integration::GuildIntegration,
-    integration_account::IntegrationAccount, integration_application::IntegrationApplication,
+    explicit_content_filter::ExplicitContentFilter, feature::GuildFeature, info::GuildInfo,
+    integration::GuildIntegration, integration_account::IntegrationAccount,
+    integration_application::IntegrationApplication,
     integration_expire_behavior::IntegrationExpireBehavior, member::Member, mfa_level::MfaLevel,
     nsfw_level::NSFWLevel, partial_guild::PartialGuild, partial_member::PartialMember,
     permissions::Permissions, premium_tier::PremiumTier, preview::GuildPreview, prune::GuildPrune,
@@ -73,7 +75,8 @@ pub struct Guild {
     pub discovery_splash: Option<ImageHash>,
     pub emojis: Vec<Emoji>,
     pub explicit_content_filter: ExplicitContentFilter,
-    pub features: Vec<String>,
+    /// Enabled guild features
+    pub features: Vec<GuildFeature>,
     pub icon: Option<ImageHash>,
     pub id: Id<GuildMarker>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -844,8 +847,8 @@ impl<'de> Deserialize<'de> for Guild {
 #[cfg(test)]
 mod tests {
     use super::{
-        DefaultMessageNotificationLevel, ExplicitContentFilter, Guild, MfaLevel, NSFWLevel,
-        Permissions, PremiumTier, SystemChannelFlags, VerificationLevel,
+        DefaultMessageNotificationLevel, ExplicitContentFilter, Guild, GuildFeature, MfaLevel,
+        NSFWLevel, Permissions, PremiumTier, SystemChannelFlags, VerificationLevel,
     };
     use crate::{
         id::Id,
@@ -873,7 +876,7 @@ mod tests {
             discovery_splash: Some(image_hash::SPLASH),
             emojis: Vec::new(),
             explicit_content_filter: ExplicitContentFilter::MembersWithoutRole,
-            features: vec!["a feature".to_owned()],
+            features: Vec::from([GuildFeature::Banner]),
             icon: Some(image_hash::ICON),
             id: Id::new(1),
             joined_at: Some(joined_at),
@@ -954,7 +957,7 @@ mod tests {
                 Token::U8(1),
                 Token::Str("features"),
                 Token::Seq { len: Some(1) },
-                Token::Str("a feature"),
+                Token::Str("BANNER"),
                 Token::SeqEnd,
                 Token::Str("icon"),
                 Token::Some,

--- a/model/src/guild/partial_guild.rs
+++ b/model/src/guild/partial_guild.rs
@@ -1,8 +1,8 @@
+use super::{
+    DefaultMessageNotificationLevel, Emoji, ExplicitContentFilter, GuildFeature, MfaLevel,
+    NSFWLevel, Permissions, PremiumTier, Role, SystemChannelFlags, VerificationLevel,
+};
 use crate::{
-    guild::{
-        DefaultMessageNotificationLevel, Emoji, ExplicitContentFilter, MfaLevel, NSFWLevel,
-        Permissions, PremiumTier, Role, SystemChannelFlags, VerificationLevel,
-    },
     id::{
         marker::{ApplicationMarker, ChannelMarker, GuildMarker, UserMarker},
         Id,
@@ -23,7 +23,7 @@ pub struct PartialGuild {
     pub discovery_splash: Option<ImageHash>,
     pub emojis: Vec<Emoji>,
     pub explicit_content_filter: ExplicitContentFilter,
-    pub features: Vec<String>,
+    pub features: Vec<GuildFeature>,
     pub icon: Option<ImageHash>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_members: Option<u64>,
@@ -60,7 +60,7 @@ pub struct PartialGuild {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::image_hash;
+    use crate::{guild::GuildFeature, test::image_hash};
 
     use super::{
         DefaultMessageNotificationLevel, ExplicitContentFilter, MfaLevel, NSFWLevel, PartialGuild,
@@ -83,7 +83,7 @@ mod tests {
             discovery_splash: Some(image_hash::SPLASH),
             emojis: Vec::new(),
             explicit_content_filter: ExplicitContentFilter::MembersWithoutRole,
-            features: vec!["a feature".to_owned()],
+            features: Vec::from([GuildFeature::AnimatedBanner]),
             icon: Some(image_hash::ICON),
             max_members: Some(25_000),
             max_presences: Some(10_000),
@@ -147,7 +147,7 @@ mod tests {
                 Token::U8(1),
                 Token::Str("features"),
                 Token::Seq { len: Some(1) },
-                Token::Str("a feature"),
+                Token::Str("ANIMATED_BANNER"),
                 Token::SeqEnd,
                 Token::Str("icon"),
                 Token::Some,


### PR DESCRIPTION
Eases matching on guilds' features and removes some heap allocations at cost of `GuildFeature` being 32 bytes vs `String`'s 24.
