### PR TITLE
refactor(util)!: remove `EmbedAuthorBuilder::name`

### DIFF
--- a/util/src/builder/embed/author.rs
+++ b/util/src/builder/embed/author.rs
@@ -37,18 +37,6 @@ impl EmbedAuthorBuilder {
         self
     }
 
-    /// The author's name.
-    ///
-    /// Refer to [`AUTHOR_NAME_LENGTH`] for the maximum number of UTF-16 code
-    /// points that can be in an author name.
-    ///
-    /// [`AUTHOR_NAME_LENGTH`]: twilight_validate::embed::AUTHOR_NAME_LENGTH
-    pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.0.name = name.into();
-
-        self
-    }
-
     /// The author's url.
     pub fn url(mut self, url: impl Into<String>) -> Self {
         self.0.url = Some(url.into());


### PR DESCRIPTION
Already set in `new`, aligns with other builders
