### PR TITLE
fix(cache): compare reaction emojis by resource instead of object

### DIFF
--- a/cache/in-memory/src/event/reaction.rs
+++ b/cache/in-memory/src/event/reaction.rs
@@ -1,7 +1,6 @@
 use crate::{config::ResourceType, InMemoryCache, UpdateCache};
-use twilight_model::channel::ReactionType;
 use twilight_model::{
-    channel::message::MessageReaction,
+    channel::{message::MessageReaction, ReactionType},
     gateway::payload::incoming::{
         ReactionAdd, ReactionRemove, ReactionRemoveAll, ReactionRemoveEmoji,
     },

--- a/cache/in-memory/src/test.rs
+++ b/cache/in-memory/src/test.rs
@@ -177,6 +177,14 @@ pub fn cache_with_message_and_reactions() -> InMemoryCache {
 
     cache.update(&reaction);
 
+    reaction.emoji = ReactionType::Custom {
+        animated: true,
+        id: Id::new(6),
+        name: Some("custom".to_owned()),
+    };
+
+    cache.update(&reaction);
+
     cache
 }
 


### PR DESCRIPTION
Compares emoji IDs if the emojis are custom or emoji names if they're unicode instead of comparing every field of the emoji