### PR TITLE
build: release automation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
     name: Minimum supported Rust version
     runs-on: ubuntu-latest
     env:
-      minrust: '1.60'
+      minrust: "1.60"
 
     steps:
       - name: Checkout sources
@@ -67,7 +67,7 @@ jobs:
         env:
           RUSTDOCFLAGS: --cfg docsrs
         run: |
-          cargo doc --no-deps --features=permission-calculator --workspace --exclude twilight-book
+          cargo doc --no-deps --features=permission-calculator --workspace --exclude book
           cargo doc -p twilight-util --no-deps --all-features
 
   # Lints
@@ -164,7 +164,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Run tests with nextest
-        run: cargo nextest --config-file ${{ github.workspace }}/nextest.toml run --profile ci --workspace --exclude twilight-book
+        run: cargo nextest --config-file ${{ github.workspace }}/nextest.toml run --profile ci --workspace --exclude book
 
       - name: Run doctests
         run: cargo test --doc

--- a/.github/workflows/deploy-lib.yml
+++ b/.github/workflows/deploy-lib.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           RUSTDOCFLAGS: --cfg docsrs
         run: |
-          cargo doc --no-deps --features=permission-calculator --workspace --exclude twilight-book
+          cargo doc --no-deps --features=permission-calculator --workspace --exclude book
           cargo doc -p twilight-util --no-deps --all-features
 
       - name: Prepare docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,19 @@ made targeting the `main` branch, while larger `refactor` pull requests target
 
 Pull requests require two approvals before merging.
 
+### Releases
+
+Twilight uses `git-cliff` and `cargo-release` for releases. These are both
+available as binaries from `crates.io`. They are executed via
+`gen-changelogs.sh` and `release.sh` respectively. Invoking `release.sh` with
+extra arguments passes them to the saved `cargo-release` command.
+
+Steps to create a minor release across the workspace:
+- generate the changelogs: `$ ./gen-changelogs.sh`
+- customize the changelogs as necessary, and commit them
+- preview the release process: `$ ./release.sh patch -vv`
+- execute the release: `$ ./release.sh patch --execute`
+
 ## Code Style
 
 Not all of our codebase follows this style. But, in an effort to reach

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,11 +90,11 @@ available as binaries from `crates.io`. They are executed via
 `gen-changelogs.sh` and `release.sh` respectively. Invoking `release.sh` with
 extra arguments passes them to the saved `cargo-release` command.
 
-Steps to create a patch release across the workspace:
+Steps to create a release across the workspace:
 - generate the changelogs: `$ ./gen-changelogs.sh`
 - customize the changelogs as necessary, and commit them
-- preview the release process: `$ ./release.sh patch -vv`
-- execute the release: `$ ./release.sh patch --execute`
+- preview the release process: `$ ./release.sh [level] -vv` (where level is `patch`, `minor` or `major`)
+- execute the release: `$ ./release.sh [level] --execute`
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ available as binaries from `crates.io`. They are executed via
 `gen-changelogs.sh` and `release.sh` respectively. Invoking `release.sh` with
 extra arguments passes them to the saved `cargo-release` command.
 
-Steps to create a minor release across the workspace:
+Steps to create a patch release across the workspace:
 - generate the changelogs: `$ ./gen-changelogs.sh`
 - customize the changelogs as necessary, and commit them
 - preview the release process: `$ ./release.sh patch -vv`

--- a/book/tests/Cargo.toml
+++ b/book/tests/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "twilight-book"
+name = "book"
 version = "0.1.0"
 authors = ["Twilight Contributors"]
 edition = "2018"

--- a/cache/in-memory/Cargo.toml
+++ b/cache/in-memory/Cargo.toml
@@ -19,10 +19,10 @@ version = "0.11.0"
 bitflags = { default-features = false, version = "1" }
 dashmap = { default-features = false, version = "5.3" }
 serde = { default-features = false, features = ["derive"], version = "1" }
-twilight-model = { default-features = false, path = "../../model" }
+twilight-model = { default-features = false, path = "../../model", version = "0.11.0" }
 
 # Optional dependencies.
-twilight-util = { default-features = false, features = ["permission-calculator"], optional = true, path = "../../util" }
+twilight-util = { default-features = false, features = ["permission-calculator"], optional = true, path = "../../util", version = "0.11.0" }
 
 [dev-dependencies]
 futures = { default-features = false, version = "0.3" }

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,40 @@
+# configuration file for git-cliff (0.1.0)
+
+[changelog]
+header = "# Changelog\n\n"
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+# remove the leading and trailing whitespace from the template
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_preprocessors = [
+    # replace issues with issue links
+    { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/twilight-rs/twilight/issues/${2}))" },
+]
+commit_parsers = [
+    { message = "^build", group = "Build" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^test", group = "Testing" },
+    { message = "^ci", skip = true },
+]
+filter_commits = false
+date_order = true
+sort_commits = "oldest"

--- a/embed-builder/Cargo.toml
+++ b/embed-builder/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.60"
 version = "0.11.0"
 
 [dependencies]
-twilight-model = { default-features = false, path = "../model" }
+twilight-model = { default-features = false, path = "../model", version = "0.11.0" }
 
 [dev-dependencies]
 static_assertions = { default-features = false, version = "1" }

--- a/gateway-queue/Cargo.toml
+++ b/gateway-queue/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { default-features = false, features = ["rt", "sync", "time"], version =
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 
 # Optional dependencies.
-twilight-http = { default-features = false, optional = true, path = "../http" }
+twilight-http = { default-features = false, optional = true, path = "../http", version = "0.11.0" }
 
 [dev-dependencies]
 static_assertions = { default-features = false, version = "1" }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -23,9 +23,9 @@ serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.5" }
 tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.17" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
-twilight-gateway-queue = { default-features = false, path = "../gateway-queue" }
-twilight-http = { default-features = false, path = "../http" }
-twilight-model = { default-features = false, path = "../model" }
+twilight-gateway-queue = { default-features = false, path = "../gateway-queue", version = "0.11.0" }
+twilight-http = { default-features = false, path = "../http", version = "0.11.0" }
+twilight-model = { default-features = false, path = "../model", version = "0.11.0" }
 url = { default-features = false, version = "2" }
 leaky-bucket-lite = { default-features = false, features = ["tokio"], version = "0.5.1" }
 

--- a/gen-changelogs.sh
+++ b/gen-changelogs.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# collect crate names and paths
+list="$(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_members[]' | grep "^twilight")"
+
+echo "$list" | while read -r crate ; do
+    path="$(echo "$crate" | awk '{ print $3 }' | sed 's/^.*path\+file:\/\/\(.*\)).*$/\1/' | xargs realpath --relative-to `pwd`)"
+    tag="$(echo "$crate" | awk '{ print $1 "-" $2 }')"
+
+    git-cliff --include-path "$path/**/*.rs" --unreleased --prepend "$path/CHANGELOG.md" "$tag"..HEAD
+done

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -26,9 +26,9 @@ serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["sync", "time"], version = "1.0" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
-twilight-http-ratelimiting = { default-features = false, path = "../http-ratelimiting" }
-twilight-model = { default-features = false, path = "../model" }
-twilight-validate = { default-features = false, path = "../validate" }
+twilight-http-ratelimiting = { default-features = false, path = "../http-ratelimiting", version = "0.11.0" }
+twilight-model = { default-features = false, path = "../model", version = "0.11.0" }
+twilight-validate = { default-features = false, path = "../validate", version = "0.11.0" }
 
 # Optional dependencies.
 brotli = { default-features = false, features = ["std"], optional = true, version = "3.0.0" }
@@ -45,5 +45,5 @@ trust-dns = ["dep:hyper-trust-dns"]
 [dev-dependencies]
 serde_test = { default-features = false, version = "1" }
 static_assertions = { default-features = false, version = "1.1.0" }
-twilight-util = { default-features = false, features = ["builder"], path = "../util" }
+twilight-util = { default-features = false, features = ["builder"], path = "../util", version = "0.11.0" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }

--- a/lavalink/Cargo.toml
+++ b/lavalink/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["macros", "net", "rt", "sync", "time"], version = "1.0" }
 tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.17" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
-twilight-model = { default-features = false, path = "../model" }
+twilight-model = { default-features = false, path = "../model", version = "0.11.0" }
 
 # Optional dependencies.
 percent-encoding = { default-features = false, optional = true, version = "2" }
@@ -34,8 +34,8 @@ anyhow = { default-features = false, features = ["std"], version = "1" }
 serde_test = { default-features = false, version = "1" }
 static_assertions = { default-features = false, version = "1" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
-twilight-gateway = { default-features = false, features = ["rustls-native-roots"], path = "../gateway" }
-twilight-http = { default-features = false, features = ["rustls-native-roots"], path = "../http" }
+twilight-gateway = { default-features = false, features = ["rustls-native-roots"], path = "../gateway", version = "0.11.0" }
+twilight-http = { default-features = false, features = ["rustls-native-roots"], path = "../http", version = "0.11.0" }
 
 [features]
 default = ["http-support", "rustls-native-roots"]

--- a/mention/Cargo.toml
+++ b/mention/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.60"
 version = "0.11.0"
 
 [dependencies]
-twilight-model = { default-features = false, path = "../model" }
+twilight-model = { default-features = false, path = "../model", version = "0.11.0" }
 
 [dev-dependencies]
 criterion = { default-features = false, version = "0.3" }

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,3 @@
+#!/bin/sh 
+
+cargo release --workspace --exclude book --exclude examples $@

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,7 @@
+consolidate-pushes = true
+dependent-version = "upgrade"
+pre-release-commit-message = "release({{crate_name}}): bump to {{version}}"
+pre-release-replacements = [
+    { file = "CHANGELOG.md", search = "## \\[unreleased\\]", replace = "## [{{version}}] - {{date}}", min = 0 },
+]
+tag-name = "{{crate_name}}-{{version}}"

--- a/standby/Cargo.toml
+++ b/standby/Cargo.toml
@@ -20,7 +20,7 @@ dashmap = { default-features = false, version = "5.3" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 tokio = { default-features = false, features = ["sync"], version = "1.0" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
-twilight-model = { default-features = false, path = "../model" }
+twilight-model = { default-features = false, path = "../model", version = "0.11.0" }
 
 [dev-dependencies]
 anyhow = { default-features = false, features = ["std"], version = "1" }

--- a/twilight/Cargo.toml
+++ b/twilight/Cargo.toml
@@ -19,15 +19,15 @@ version = "0.11.0"
 anyhow = { default-features = false, features = ["std"], version = "1" }
 futures = { default-features = false, version = "0.3" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
-twilight-cache-inmemory = { default-features = false, path = "../cache/in-memory" }
-twilight-embed-builder = { default-features = false, path = "../embed-builder" }
-twilight-gateway = { default-features = false, features = ["rustls-native-roots"], path = "../gateway" }
-twilight-gateway-queue = { default-features = false, features = ["rustls-native-roots"], path = "../gateway-queue" }
-twilight-http = { default-features = false, features = ["rustls-native-roots"], path = "../http" }
-twilight-http-ratelimiting = { default-features = false, path = "../http-ratelimiting" }
-twilight-lavalink = { default-features = false, path = "../lavalink" }
-twilight-mention = { default-features = false, path = "../mention" }
-twilight-model = { default-features = false, path = "../model" }
-twilight-standby = { default-features = false, path = "../standby" }
-twilight-util = { default-features = false, path = "../util" }
-twilight-validate = { default-features = false, path = "../validate" }
+twilight-cache-inmemory = { default-features = false, path = "../cache/in-memory", version = "0.11.0" }
+twilight-embed-builder = { default-features = false, path = "../embed-builder", version = "0.11.0" }
+twilight-gateway = { default-features = false, features = ["rustls-native-roots"], path = "../gateway", version = "0.11.0" }
+twilight-gateway-queue = { default-features = false, features = ["rustls-native-roots"], path = "../gateway-queue", version = "0.11.0" }
+twilight-http = { default-features = false, features = ["rustls-native-roots"], path = "../http", version = "0.11.0" }
+twilight-http-ratelimiting = { default-features = false, path = "../http-ratelimiting", version = "0.11.0" }
+twilight-lavalink = { default-features = false, path = "../lavalink", version = "0.11.0" }
+twilight-mention = { default-features = false, path = "../mention", version = "0.11.0" }
+twilight-model = { default-features = false, path = "../model", version = "0.11.0" }
+twilight-standby = { default-features = false, path = "../standby", version = "0.11.0" }
+twilight-util = { default-features = false, path = "../util", version = "0.11.0" }
+twilight-validate = { default-features = false, path = "../validate", version = "0.11.0" }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -16,8 +16,8 @@ rust-version = "1.60"
 version = "0.11.0"
 
 [dependencies]
-twilight-model = { default-features = false, optional = true, path = "../model" }
-twilight-validate = { default-features = false, optional = true, path = "../validate" }
+twilight-model = { default-features = false, optional = true, path = "../model", version = "0.11.0" }
+twilight-validate = { default-features = false, optional = true, path = "../validate", version = "0.11.0" }
 
 [dev-dependencies]
 chrono = { default-features = false, features = ["std"], version = "0.4" }

--- a/validate/Cargo.toml
+++ b/validate/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.60"
 version = "0.11.0"
 
 [dependencies]
-twilight-model = { default-features = false, path = "../model" }
+twilight-model = { default-features = false, path = "../model", version = "0.11.0" }
 
 [dev-dependencies]
 static_assertions = { default-features = false, version = "1.1.0" }


### PR DESCRIPTION
This PR configures steps to automate patch releases using `git-cliff` (`cliff.toml`, `gen-changelogs.sh`) and `cargo-release` (`release.toml`, `release.sh`). In order to achieve this, it also does the following:

- rename `twilight-book` to `book`
- add crate's version to all `Cargo.toml` files alongside its path, so cargo-release can automatically increment it
- add instructions to `CONTRIBUTING.md`

This is currently untested, but I'm pretty sure it works. I would like more sets of eyes on it before I run it for real.
