### PR TITLE
refactor(model)!: remove `Number`

### DIFF
--- a/twilight-model/src/application/command/mod.rs
+++ b/twilight-model/src/application/command/mod.rs
@@ -9,8 +9,8 @@ pub use self::{
     command_type::CommandType,
     option::{
         BaseCommandOptionData, ChannelCommandOptionData, ChoiceCommandOptionData, CommandOption,
-        CommandOptionChoice, CommandOptionType, CommandOptionValue, Number,
-        NumberCommandOptionData, OptionsCommandOptionData,
+        CommandOptionChoice, CommandOptionType, CommandOptionValue, NumberCommandOptionData,
+        OptionsCommandOptionData,
     },
 };
 
@@ -35,7 +35,7 @@ use std::collections::HashMap;
 /// [`twilight-util`]: https://docs.rs/twilight-util/latest/index.html
 /// [associated builder]: https://docs.rs/twilight-util/latest/twilight_util/builder/command/struct.CommandBuilder.html
 /// [Discord Docs/Application Command Object]: https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Command {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub application_id: Option<Id<ApplicationMarker>>,

--- a/twilight-model/src/application/interaction/application_command/mod.rs
+++ b/twilight-model/src/application/interaction/application_command/mod.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 /// [`ApplicationCommand`]: crate::application::interaction::InteractionType::ApplicationCommand
 /// [`ApplicationCommandAutocomplete`]: crate::application::interaction::InteractionType::ApplicationCommandAutocomplete
 /// [Discord Docs/Application Command Data Structure]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-application-command-data-structure
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct CommandData {
     /// ID of the guild the command is registered to.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -1,5 +1,5 @@
 use crate::{
-    application::command::{CommandOptionType, Number},
+    application::command::CommandOptionType,
     id::{
         marker::{AttachmentMarker, ChannelMarker, GenericMarker, RoleMarker, UserMarker},
         Id,
@@ -17,7 +17,7 @@ use std::fmt::{Debug, Formatter, Result as FmtResult};
 /// See [Discord Docs/Application Command Object].
 ///
 /// [Discord Docs/Application Command Object]: https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CommandDataOption {
     /// Name of the option.
     pub name: String,
@@ -261,9 +261,9 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                                     // but it is safe to cast as there can
                                     // not occur any loss.
                                     #[allow(clippy::cast_precision_loss)]
-                                    CommandOptionValue::Number(Number(i as f64))
+                                    CommandOptionValue::Number(i as f64)
                                 }
-                                ValueEnvelope::Number(f) => CommandOptionValue::Number(Number(f)),
+                                ValueEnvelope::Number(f) => CommandOptionValue::Number(f),
                                 other => {
                                     return Err(DeError::invalid_type(
                                         other.as_unexpected(),
@@ -322,7 +322,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
 }
 
 /// Combined value and value type for a [`CommandDataOption`].
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum CommandOptionValue {
     /// Attachment option.
     Attachment(Id<AttachmentMarker>),
@@ -347,7 +347,7 @@ pub enum CommandOptionValue {
     /// Mentionable option.
     Mentionable(Id<GenericMarker>),
     /// Number option.
-    Number(Number),
+    Number(f64),
     /// Role option.
     Role(Id<RoleMarker>),
     /// String option.
@@ -383,7 +383,7 @@ impl CommandOptionValue {
 mod tests {
     use crate::{
         application::{
-            command::{CommandOptionType, CommandType, Number},
+            command::{CommandOptionType, CommandType},
             interaction::application_command::{
                 CommandData, CommandDataOption, CommandOptionValue,
             },
@@ -603,7 +603,7 @@ mod tests {
     fn numbers() {
         let value = CommandDataOption {
             name: "opt".to_string(),
-            value: CommandOptionValue::Number(Number(5.0)),
+            value: CommandOptionValue::Number(5.0),
         };
 
         serde_test::assert_de_tokens(

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -37,7 +37,7 @@ use std::fmt::{Formatter, Result as FmtResult};
 /// See [Discord Docs/Interaction Object].
 ///
 /// [Discord Docs/Interaction Object]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Interaction {
     /// App's permissions in the channel the interaction was sent from.
     ///
@@ -382,7 +382,7 @@ impl<'de> Visitor<'de> for InteractionVisitor {
 }
 
 /// Additional [`Interaction`] data, such as the invoking user.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum InteractionData {
     /// Data received for the [`ApplicationCommand`] and [`ApplicationCommandAutocomplete`]

--- a/twilight-model/src/gateway/event/dispatch.rs
+++ b/twilight-model/src/gateway/event/dispatch.rs
@@ -11,7 +11,7 @@ use serde::{
 /// [`DispatchEventWithTypeDeserializer`].
 // **NOTE**: When adding a variant, be sure to add it to the DeserializeSeed
 // implementation.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum DispatchEvent {
     AutoModerationActionExecution(AutoModerationActionExecution),

--- a/twilight-model/src/gateway/event/mod.rs
+++ b/twilight-model/src/gateway/event/mod.rs
@@ -21,7 +21,7 @@ use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 ///
 /// This brings together all of the types of [`DispatchEvent`]s,
 /// [`GatewayEvent`]s, and [`ShardEvent`]s.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Event {
     /// Message was blocked by AutoMod according to a rule.
     AutoModerationActionExecution(AutoModerationActionExecution),

--- a/twilight-model/src/gateway/payload/incoming/interaction_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/interaction_create.rs
@@ -2,7 +2,7 @@ use crate::application::interaction::Interaction;
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InteractionCreate(pub Interaction);
 
 impl Deref for InteractionCreate {

--- a/twilight-model/src/http/interaction.rs
+++ b/twilight-model/src/http/interaction.rs
@@ -16,7 +16,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 /// See [Discord Docs/Interaction Object].
 ///
 /// [Discord Docs/Interaction Object]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct InteractionResponse {
     /// Type of the response.
     #[serde(rename = "type")]
@@ -38,7 +38,7 @@ pub struct InteractionResponse {
 }
 
 /// Data included in an interaction response.
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct InteractionResponseData {
     /// Allowed mentions of the response.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -132,7 +132,6 @@ mod tests {
         InteractionResponseData: Clone,
         Debug,
         Deserialize<'static>,
-        Eq,
         PartialEq,
         Send,
         Serialize,

--- a/twilight-util/src/builder/command.rs
+++ b/twilight-util/src/builder/command.rs
@@ -48,7 +48,7 @@
 use twilight_model::{
     application::command::{
         BaseCommandOptionData, ChannelCommandOptionData, ChoiceCommandOptionData, Command,
-        CommandOption, CommandOptionChoice, CommandOptionValue, CommandType, Number,
+        CommandOption, CommandOptionChoice, CommandOptionValue, CommandType,
         NumberCommandOptionData, OptionsCommandOptionData,
     },
     channel::ChannelType,
@@ -638,7 +638,7 @@ impl From<MentionableBuilder> for CommandOption {
     }
 }
 
-/// Create a [`Number`] option with a builder.
+/// Create a number option with a builder.
 #[derive(Clone, Debug)]
 #[must_use = "should be used in a command builder"]
 pub struct NumberBuilder(NumberCommandOptionData);
@@ -700,7 +700,7 @@ impl NumberBuilder {
 
     /// Set the list of choices for an option.
     ///
-    /// Accepts tuples of `(String, Number)` corresponding to the name and
+    /// Accepts tuples of `(String, f64)` corresponding to the name and
     /// value. Localization may be added with [`choice_localizations`].
     ///
     /// Defaults to no choices.
@@ -712,7 +712,7 @@ impl NumberBuilder {
             .map(|(name, value, ..)| CommandOptionChoice::Number {
                 name: name.into(),
                 name_localizations: None,
-                value: Number(value),
+                value,
             })
             .collect();
 
@@ -740,7 +740,7 @@ impl NumberBuilder {
     ///
     /// Defaults to no limit.
     pub const fn max_value(mut self, value: f64) -> Self {
-        self.0.max_value = Some(CommandOptionValue::Number(Number(value)));
+        self.0.max_value = Some(CommandOptionValue::Number(value));
 
         self
     }
@@ -749,7 +749,7 @@ impl NumberBuilder {
     ///
     /// Defaults to no limit.
     pub const fn min_value(mut self, value: f64) -> Self {
-        self.0.min_value = Some(CommandOptionValue::Number(Number(value)));
+        self.0.min_value = Some(CommandOptionValue::Number(value));
 
         self
     }


### PR DESCRIPTION
Deriving `Eq` for `Number` in it's current implementation is just plain wrong. As `Eq` is not necessary for these types this is fine. `Eq` is mostly for `HashMap` keys, which is not a usecase for any of these types.

Why not fix `Number` so that it's `Eq` and `Hash` implementation is correct?
Because floating point numbers are notoriously hard to deal with.
