### PR TITLE
fix(gateway): Add missing received events per intent

### DIFF
--- a/gateway/src/event.rs
+++ b/gateway/src/event.rs
@@ -199,7 +199,16 @@ impl EventTypeFlags {
             | EventTypeFlags::GUILD_UPDATE.bits()
             | EventTypeFlags::ROLE_CREATE.bits()
             | EventTypeFlags::ROLE_DELETE.bits()
-            | EventTypeFlags::ROLE_UPDATE.bits(),
+            | EventTypeFlags::ROLE_UPDATE.bits()
+            | EventTypeFlags::STAGE_INSTANCE_CREATE.bits()
+            | EventTypeFlags::STAGE_INSTANCE_UPDATE.bits()
+            | EventTypeFlags::STAGE_INSTANCE_DELETE.bits()
+            | EventTypeFlags::THREAD_CREATE.bits()
+            | EventTypeFlags::THREAD_UPDATE.bits()
+            | EventTypeFlags::THREAD_DELETE.bits()
+            | EventTypeFlags::THREAD_LIST_SYNC.bits()
+            | EventTypeFlags::THREAD_MEMBER_UPDATE.bits()
+            | EventTypeFlags::THREAD_MEMBERS_UPDATE.bits(),
     );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_BANS`].
@@ -219,8 +228,12 @@ impl EventTypeFlags {
     /// All [`EventTypeFlags`] in [`Intents::GUILD_INTEGRATIONS`].
     ///
     /// [`Intents::GUILD_INTEGRATIONS`]: crate::Intents::GUILD_INTEGRATIONS
-    pub const GUILD_INTEGRATIONS: EventTypeFlags =
-        EventTypeFlags::from_bits_truncate(EventTypeFlags::GUILD_INTEGRATIONS_UPDATE.bits());
+    pub const GUILD_INTEGRATIONS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
+        EventTypeFlags::GUILD_INTEGRATIONS_UPDATE.bits()
+            | EventTypeFlags::INTEGRATION_CREATE.bits()
+            | EventTypeFlags::INTEGRATION_UPDATE.bits()
+            | EventTypeFlags::INTEGRATION_DELETE.bits(),
+    );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_INVITES`].
     ///
@@ -235,7 +248,8 @@ impl EventTypeFlags {
     pub const GUILD_MEMBERS: EventTypeFlags = EventTypeFlags::from_bits_truncate(
         EventTypeFlags::MEMBER_ADD.bits()
             | EventTypeFlags::MEMBER_REMOVE.bits()
-            | EventTypeFlags::MEMBER_UPDATE.bits(),
+            | EventTypeFlags::MEMBER_UPDATE.bits()
+            | EventTypeFlags::THREAD_MEMBERS_UPDATE.bits(),
     );
 
     /// All [`EventTypeFlags`] in [`Intents::GUILD_MESSAGES`].

--- a/model/src/gateway/intents.rs
+++ b/model/src/gateway/intents.rs
@@ -27,6 +27,15 @@ bitflags! {
         ///  - [`CHANNEL_UPDATE`]
         ///  - [`CHANNEL_DELETE`]
         ///  - [`CHANNEL_PINS_UPDATE`]
+        ///  - [`THREAD_CREATE`]
+        ///  - [`THREAD_UPDATE`]
+        ///  - [`THREAD_DELETE`]
+        ///  - [`THREAD_LIST_SYNC`]
+        ///  - [`THREAD_MEMBER_UPDATE`]
+        ///  - [`THREAD_MEMBERS_UPDATE`]
+        ///  - [`STAGE_INSTANCE_CREATE`]
+        ///  - [`STAGE_INSTANCE_UPDATE`]
+        ///  - [`STAGE_INSTANCE_DELETE`]
         ///
         /// [`GUILD_CREATE`]: super::event::Event::GuildCreate
         /// [`GUILD_UPDATE`]: super::event::Event::GuildUpdate
@@ -38,6 +47,15 @@ bitflags! {
         /// [`CHANNEL_UPDATE`]: super::event::Event::ChannelUpdate
         /// [`CHANNEL_DELETE`]: super::event::Event::ChannelDelete
         /// [`CHANNEL_PINS_UPDATE`]: super::event::Event::ChannelPinsUpdate
+        /// [`THREAD_CREATE`]: super::event::Event::ThreadCreate
+        /// [`THREAD_UPDATE`]: super::event::Event::ThreadUpdate
+        /// [`THREAD_DELETE`]: super::event::Event::ThreadDelete
+        /// [`THREAD_LIST_SYNC`]: super::event::Event::ThreadListSync
+        /// [`THREAD_MEMBER_UPDATE`]: super::event::Event::ThreadMemberUpdate
+        /// [`THREAD_MEMBERS_UPDATE`]: super::event::Event::ThreadMembersUpdate
+        /// [`STAGE_INSTANCE_CREATE`]: super::event::Event::StageInstanceCreate
+        /// [`STAGE_INSTANCE_UPDATE`]: super::event::Event::StageInstanceUpdate
+        /// [`STAGE_INSTANCE_DELETE`]: super::event::Event::StageInstanceDelete
         const GUILDS = 1;
         /// Guild members intent.
         ///
@@ -47,11 +65,13 @@ bitflags! {
         ///  - [`GUILD_MEMBER_ADD`]
         ///  - [`GUILD_MEMBER_UPDATE`]
         ///  - [`GUILD_MEMBER_REMOVE`]
+        ///  - [`THREAD_MEMBERS_UPDATE`]
         ///
         /// [Discord Docs/Privileged Intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents
         /// [`GUILD_MEMBER_ADD`]: super::event::Event::MemberAdd
         /// [`GUILD_MEMBER_UPDATE`]: super::event::Event::MemberUpdate
         /// [`GUILD_MEMBER_REMOVE`]: super::event::Event::MemberRemove
+        /// [`THREAD_MEMBERS_UPDATE`]: super::event::Event::ThreadMembersUpdate
         const GUILD_MEMBERS = 1 << 1;
         /// Guild bans intent.
         ///
@@ -75,8 +95,14 @@ bitflags! {
         ///
         /// Event(s) received:
         ///  - [`GUILD_INTEGRATIONS_UPDATE`]
+        ///  - [`INTEGRATION_CREATE`]
+        ///  - [`INTEGRATION_UPDATE`]
+        ///  - [`INTEGRATION_DELETE`]
         ///
         /// [`GUILD_INTEGRATIONS_UPDATE`]: super::event::Event::GuildIntegrationsUpdate
+        /// [`INTEGRATION_CREATE`]: super::event::Event::IntegrationCreate
+        /// [`INTEGRATION_UPDATE`]: super::event::Event::IntegrationUpdate
+        /// [`INTEGRATION_DELETE`]: super::event::Event::IntegrationDelete
         const GUILD_INTEGRATIONS = 1 << 4;
         /// Guild webhooks intent.
         ///

--- a/model/src/gateway/intents.rs
+++ b/model/src/gateway/intents.rs
@@ -120,22 +120,6 @@ bitflags! {
         /// [`INVITE_CREATE`]: super::event::Event::InviteCreate
         /// [`INVITE_DELETE`]: super::event::Event::InviteDelete
         const GUILD_INVITES = 1 << 6;
-        /// Guild scheduled events intent.
-        ///
-        /// Event(s) received:
-        ///
-        /// - [`GUILD_SCHEDULED_EVENT_CREATE`]
-        /// - [`GUILD_SCHEDULED_EVENT_UPDATE`]
-        /// - [`GUILD_SCHEDULED_EVENT_DELETE`]
-        /// - [`GUILD_SCHEDULED_EVENT_USER_ADD`]
-        /// - [`GUILD_SCHEDULED_EVENT_USER_REMOVE`]
-        ///
-        /// [`GUILD_SCHEDULED_EVENT_CREATE`]: super::event::Event::GuildScheduledEventCreate
-        /// [`GUILD_SCHEDULED_EVENT_UPDATE`]: super::event::Event::GuildScheduledEventDelete
-        /// [`GUILD_SCHEDULED_EVENT_DELETE`]: super::event::Event::GuildScheduledEventUpdate
-        /// [`GUILD_SCHEDULED_EVENT_USER_ADD`]: super::event::Event::GuildScheduledEventUserAdd
-        /// [`GUILD_SCHEDULED_EVENT_USER_REMOVE`]: super::event::Event::GuildScheduledEventUserRemove
-        const GUILD_SCHEDULED_EVENTS = 1 << 16;
         /// Guild voice states intent.
         ///
         /// Event(s) received:
@@ -241,6 +225,22 @@ bitflags! {
         ///
         /// [Discord Docs/Privileged Intents]: https://discord.com/developers/docs/topics/gateway#privileged-intents
         const MESSAGE_CONTENT = 1 << 15;
+                /// Guild scheduled events intent.
+                ///
+                /// Event(s) received:
+                ///
+                /// - [`GUILD_SCHEDULED_EVENT_CREATE`]
+                /// - [`GUILD_SCHEDULED_EVENT_UPDATE`]
+                /// - [`GUILD_SCHEDULED_EVENT_DELETE`]
+                /// - [`GUILD_SCHEDULED_EVENT_USER_ADD`]
+                /// - [`GUILD_SCHEDULED_EVENT_USER_REMOVE`]
+                ///
+                /// [`GUILD_SCHEDULED_EVENT_CREATE`]: super::event::Event::GuildScheduledEventCreate
+                /// [`GUILD_SCHEDULED_EVENT_UPDATE`]: super::event::Event::GuildScheduledEventDelete
+                /// [`GUILD_SCHEDULED_EVENT_DELETE`]: super::event::Event::GuildScheduledEventUpdate
+                /// [`GUILD_SCHEDULED_EVENT_USER_ADD`]: super::event::Event::GuildScheduledEventUserAdd
+                /// [`GUILD_SCHEDULED_EVENT_USER_REMOVE`]: super::event::Event::GuildScheduledEventUserRemove
+        const GUILD_SCHEDULED_EVENTS = 1 << 16;
     }
 }
 


### PR DESCRIPTION
Syncs [Discord's docs on intents](https://discord.com/developers/docs/topics/gateway#gateway-intents) with Twilight's and adds the documented events to `EventTypeFlags` constants for intents