### PR TITLE
fix(model): fix thread max message count

### DIFF
--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -117,7 +117,7 @@ pub struct Channel {
     pub member_count: Option<u8>,
     /// Number of messages in the channel.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_count: Option<u64>,
+    pub message_count: Option<u32>,
     /// Name of the channel.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -367,7 +367,7 @@ mod tests {
                 user_id: Some(Id::new(5)),
             }),
             member_count: Some(50_u8),
-            message_count: Some(50_u64),
+            message_count: Some(50),
             name: Some("newsthread".into()),
             newly_created: Some(true),
             nsfw: None,
@@ -448,7 +448,7 @@ mod tests {
                 user_id: Some(Id::new(5)),
             }),
             member_count: Some(50_u8),
-            message_count: Some(50_u64),
+            message_count: Some(50),
             name: Some("publicthread".into()),
             newly_created: Some(true),
             nsfw: None,
@@ -530,7 +530,7 @@ mod tests {
                 user_id: Some(Id::new(5)),
             }),
             member_count: Some(50_u8),
-            message_count: Some(50_u64),
+            message_count: Some(50),
             name: Some("privatethread".into()),
             newly_created: Some(true),
             nsfw: None,

--- a/model/src/channel/mod.rs
+++ b/model/src/channel/mod.rs
@@ -116,11 +116,8 @@ pub struct Channel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub member_count: Option<u8>,
     /// Number of messages in the channel.
-    ///
-    /// At most a value of 50 is provided although the real number may be
-    /// higher.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_count: Option<u8>,
+    pub message_count: Option<u64>,
     /// Name of the channel.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -370,7 +367,7 @@ mod tests {
                 user_id: Some(Id::new(5)),
             }),
             member_count: Some(50_u8),
-            message_count: Some(50_u8),
+            message_count: Some(50_u64),
             name: Some("newsthread".into()),
             newly_created: Some(true),
             nsfw: None,
@@ -451,7 +448,7 @@ mod tests {
                 user_id: Some(Id::new(5)),
             }),
             member_count: Some(50_u8),
-            message_count: Some(50_u8),
+            message_count: Some(50_u64),
             name: Some("publicthread".into()),
             newly_created: Some(true),
             nsfw: None,
@@ -533,7 +530,7 @@ mod tests {
                 user_id: Some(Id::new(5)),
             }),
             member_count: Some(50_u8),
-            message_count: Some(50_u8),
+            message_count: Some(50_u64),
             name: Some("privatethread".into()),
             newly_created: Some(true),
             nsfw: None,


### PR DESCRIPTION
Change the type of channel's message_count to u64 to allow for larger integers, since Discord is starting to track more detailed counts. I've recently been receiving integers much larger than 50, such that a u8 would not suffice. This is currently not documented, however, I have clarified with a Discord staff and it is the intended behaviour.