### PR TITLE
fix(model): bump user_limit from u8 to u32

### DIFF
--- a/twilight-model/src/channel/mod.rs
+++ b/twilight-model/src/channel/mod.rs
@@ -145,7 +145,7 @@ pub struct Channel {
     ///
     /// Zero refers to no limit.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_limit: Option<u8>,
+    pub user_limit: Option<u32>,
     /// Camera video quality mode of the channel.
     ///
     /// Defaults to [`VideoQualityMode::Auto`] for applicable channels.

--- a/twilight-model/src/template/mod.rs
+++ b/twilight-model/src/template/mod.rs
@@ -591,7 +591,7 @@ mod tests {
                 Token::I16(0),
                 Token::Str("user_limit"),
                 Token::Some,
-                Token::U8(0),
+                Token::U32(0),
                 Token::StructEnd,
                 Token::SeqEnd,
                 Token::Str("default_message_notifications"),


### PR DESCRIPTION
Today Discord has been sending `"user_limit": 10000`. Currently this is stored in a u8 which means deserialization breaks.