### PR TITLE
ci(book): use camelCase for workingDirectory

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -16,14 +16,14 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: 'latest'
+          mdbook-version: "latest"
 
       - run: mdbook build book --dest-dir render
 
       - name: Publish book
         uses: cloudflare/wrangler-action@2.0.0
-        working-directory: book
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           command: pages publish render --project-name twilight-book --commit-dirty=true --branch docs
+          workingDirectory: "book"


### PR DESCRIPTION
According to the [action's docs], `workingDirectory` is camel cased and belongs in the `with` section.

[action's docs]: https://github.com/cloudflare/wrangler-action#configuration
