### PR TITLE
docs(http): fix create_private_channel description

### DIFF
--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -1454,9 +1454,7 @@ impl Client {
         CreateTypingTrigger::new(self, channel_id)
     }
 
-    /// Create a group DM.
-    ///
-    /// This endpoint is limited to 10 active group DMs.
+    /// Create a DM channel with a user.
     pub const fn create_private_channel(
         &self,
         recipient_id: Id<UserMarker>,

--- a/twilight-http/src/request/user/create_private_channel.rs
+++ b/twilight-http/src/request/user/create_private_channel.rs
@@ -16,9 +16,7 @@ struct CreatePrivateChannelFields {
     recipient_id: Id<UserMarker>,
 }
 
-/// Create a group DM.
-///
-/// This endpoint is limited to 10 active group DMs.
+/// Create a DM channel with a user.
 #[must_use = "requests must be configured and executed"]
 pub struct CreatePrivateChannel<'a> {
     fields: CreatePrivateChannelFields,


### PR DESCRIPTION
This method is incorrectly documented, threw me off for a moment.