### PR TITLE
docs(http): interaction endpoints not bound to global ratelimit

### DIFF
--- a/twilight-http/src/client/interaction.rs
+++ b/twilight-http/src/client/interaction.rs
@@ -72,6 +72,8 @@ impl<'a> InteractionClient<'a> {
     /// [`InteractionResponseData`], there is an [associated builder] in the
     /// [`twilight-util`] crate.
     ///
+    /// This endpoint is not bound to the application's global rate limit.
+    ///
     /// [`InteractionResponseData`]: twilight_model::http::interaction::InteractionResponseData
     /// [`twilight-util`]: https://docs.rs/twilight-util/latest/index.html
     /// [associated builder]: https://docs.rs/twilight-util/latest/twilight_util/builder/struct.InteractionResponseDataBuilder.html
@@ -85,16 +87,22 @@ impl<'a> InteractionClient<'a> {
     }
 
     /// Delete the original message, by its token.
+    ///
+    /// This endpoint is not bound to the application's global rate limit.
     pub const fn delete_response(&'a self, interaction_token: &'a str) -> DeleteResponse<'a> {
         DeleteResponse::new(self.client, self.application_id, interaction_token)
     }
 
     /// Get the original message, by its token.
+    ///
+    /// This endpoint is not bound to the application's global rate limit.
     pub const fn response(&'a self, interaction_token: &'a str) -> GetResponse<'a> {
         GetResponse::new(self.client, self.application_id, interaction_token)
     }
 
     /// Edit the original message, by its token.
+    ///
+    /// This endpoint is not bound to the application's global rate limit.
     pub const fn update_response(&'a self, interaction_token: &'a str) -> UpdateResponse<'a> {
         UpdateResponse::new(self.client, self.application_id, interaction_token)
     }
@@ -103,6 +111,8 @@ impl<'a> InteractionClient<'a> {
     ///
     /// The message must include at least one of [`attachments`], [`content`],
     /// or [`embeds`].
+    ///
+    /// This endpoint is not bound to the application's global rate limit.
     ///
     /// # Examples
     ///
@@ -133,6 +143,8 @@ impl<'a> InteractionClient<'a> {
 
     /// Delete a followup message to an interaction, by its token and message
     /// ID.
+    ///
+    /// This endpoint is not bound to the application's global rate limit.
     pub const fn delete_followup(
         &'a self,
         interaction_token: &'a str,
@@ -148,6 +160,8 @@ impl<'a> InteractionClient<'a> {
 
     /// Get a followup message of an interaction, by its token and the message
     /// ID.
+    ///
+    /// This endpoint is not bound to the application's global rate limit.
     pub const fn followup(
         &'a self,
         interaction_token: &'a str,
@@ -163,6 +177,8 @@ impl<'a> InteractionClient<'a> {
 
     /// Edit a followup message of an interaction, by its token and the message
     /// ID.
+    ///
+    /// This endpoint is not bound to the application's global rate limit.
     pub const fn update_followup(
         &'a self,
         interaction_token: &'a str,

--- a/twilight-http/src/request/application/interaction/create_followup.rs
+++ b/twilight-http/src/request/application/interaction/create_followup.rs
@@ -49,6 +49,8 @@ struct CreateFollowupFields<'a> {
 /// The message must include at least one of [`attachments`], [`content`], or
 /// [`embeds`].
 ///
+/// This endpoint is not bound to the application's global rate limit.
+///
 /// # Examples
 ///
 /// ```no_run

--- a/twilight-http/src/request/application/interaction/create_response.rs
+++ b/twilight-http/src/request/application/interaction/create_response.rs
@@ -11,6 +11,8 @@ use twilight_model::{
 };
 
 /// Respond to an interaction, by its ID and token.
+///
+/// This endpoint is not bound to the application's global rate limit.
 #[must_use = "requests must be configured and executed"]
 pub struct CreateResponse<'a> {
     interaction_id: Id<InteractionMarker>,

--- a/twilight-http/src/request/application/interaction/delete_followup.rs
+++ b/twilight-http/src/request/application/interaction/delete_followup.rs
@@ -12,6 +12,8 @@ use twilight_model::id::{
 
 /// Delete the original message, by its token.
 ///
+/// This endpoint is not bound to the application's global rate limit.
+///
 /// # Examples
 ///
 /// ```no_run

--- a/twilight-http/src/request/application/interaction/delete_response.rs
+++ b/twilight-http/src/request/application/interaction/delete_response.rs
@@ -9,6 +9,8 @@ use twilight_model::id::{marker::ApplicationMarker, Id};
 
 /// Delete a followup message to an interaction, by its token and message ID.
 ///
+/// This endpoint is not bound to the application's global rate limit.
+///
 /// # Examples
 ///
 /// ```no_run

--- a/twilight-http/src/request/application/interaction/get_followup.rs
+++ b/twilight-http/src/request/application/interaction/get_followup.rs
@@ -15,6 +15,8 @@ use twilight_model::{
 
 /// Get a followup message of an interaction, by its token and the message ID.
 ///
+/// This endpoint is not bound to the application's global rate limit.
+///
 /// # Examples
 ///
 /// ```no_run

--- a/twilight-http/src/request/application/interaction/get_response.rs
+++ b/twilight-http/src/request/application/interaction/get_response.rs
@@ -12,6 +12,8 @@ use twilight_model::{
 
 /// Get the original message, by its token.
 ///
+/// This endpoint is not bound to the application's global rate limit.
+///
 /// # Examples
 ///
 /// ```no_run

--- a/twilight-http/src/request/application/interaction/update_followup.rs
+++ b/twilight-http/src/request/application/interaction/update_followup.rs
@@ -49,6 +49,8 @@ struct UpdateFollowupFields<'a> {
 /// message still contains at least one of [`attachments`], [`content`], or
 /// [`embeds`].
 ///
+/// This endpoint is not bound to the application's global rate limit.
+///
 /// # Examples
 ///
 /// Update a followup message by setting the content to `test <@3>` -

--- a/twilight-http/src/request/application/interaction/update_response.rs
+++ b/twilight-http/src/request/application/interaction/update_response.rs
@@ -49,6 +49,8 @@ struct UpdateResponseFields<'a> {
 /// message still contains at least one of [`attachments`], [`content`], or
 /// [`embeds`].
 ///
+/// This endpoint is not bound to the application's global rate limit.
+///
 /// # Examples
 ///
 /// Update the original response by setting the content to `test <@3>` -


### PR DESCRIPTION
Closes #1717.
