### PR TITLE
ci: use `dtolnay/rust-toolchain` over `actions-rs`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,11 +26,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install toolchain (${{ env.minrust }})
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.minrust }}
-          profile: minimal
-          override: true
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
@@ -54,11 +52,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-          profile: minimal
-          override: true
 
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"
@@ -122,10 +118,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-          profile: minimal
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
@@ -198,13 +193,6 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
-
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
 
       - name: Test
         working-directory: book

--- a/.github/workflows/deploy-lib.yml
+++ b/.github/workflows/deploy-lib.yml
@@ -19,11 +19,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-          profile: minimal
-          override: true
 
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"


### PR DESCRIPTION
`actions-rs` is now unmaintained.