### PR TITLE
fix(model): deserialize `Event::GuildStickersUpdate`

### DIFF
--- a/twilight-model/src/gateway/event/dispatch.rs
+++ b/twilight-model/src/gateway/event/dispatch.rs
@@ -35,6 +35,7 @@ pub enum DispatchEvent {
     GuildScheduledEventUpdate(Box<GuildScheduledEventUpdate>),
     GuildScheduledEventUserAdd(GuildScheduledEventUserAdd),
     GuildScheduledEventUserRemove(GuildScheduledEventUserRemove),
+    GuildStickersUpdate(GuildStickersUpdate),
     GuildUpdate(Box<GuildUpdate>),
     IntegrationCreate(Box<IntegrationCreate>),
     IntegrationDelete(IntegrationDelete),
@@ -103,6 +104,7 @@ impl DispatchEvent {
             Self::GuildScheduledEventUpdate(_) => EventType::GuildScheduledEventUpdate,
             Self::GuildScheduledEventUserAdd(_) => EventType::GuildScheduledEventUserAdd,
             Self::GuildScheduledEventUserRemove(_) => EventType::GuildScheduledEventUserRemove,
+            Self::GuildStickersUpdate(_) => EventType::GuildStickersUpdate,
             Self::GuildUpdate(_) => EventType::GuildUpdate,
             Self::IntegrationCreate(_) => EventType::IntegrationCreate,
             Self::IntegrationDelete(_) => EventType::IntegrationDelete,
@@ -319,6 +321,9 @@ impl<'de, 'a> DeserializeSeed<'de> for DispatchEventWithTypeDeserializer<'a> {
             }
             "GUILD_ROLE_UPDATE" => {
                 DispatchEvent::RoleUpdate(RoleUpdate::deserialize(deserializer)?)
+            }
+            "GUILD_STICKERS_UPDATE" => {
+                DispatchEvent::GuildStickersUpdate(GuildStickersUpdate::deserialize(deserializer)?)
             }
             "GUILD_UPDATE" => {
                 DispatchEvent::GuildUpdate(Box::new(GuildUpdate::deserialize(deserializer)?))

--- a/twilight-model/src/gateway/event/mod.rs
+++ b/twilight-model/src/gateway/event/mod.rs
@@ -294,6 +294,8 @@ impl From<DispatchEvent> for Event {
             DispatchEvent::GuildScheduledEventUserRemove(v) => {
                 Self::GuildScheduledEventUserRemove(v)
             }
+            DispatchEvent::GuildStickersUpdate(v) => Self::GuildStickersUpdate(v),
+            DispatchEvent::GuildUpdate(v) => Self::GuildUpdate(v),
             DispatchEvent::IntegrationCreate(v) => Self::IntegrationCreate(v),
             DispatchEvent::IntegrationDelete(v) => Self::IntegrationDelete(v),
             DispatchEvent::IntegrationUpdate(v) => Self::IntegrationUpdate(v),
@@ -307,7 +309,6 @@ impl From<DispatchEvent> for Event {
             DispatchEvent::RoleCreate(v) => Self::RoleCreate(v),
             DispatchEvent::RoleDelete(v) => Self::RoleDelete(v),
             DispatchEvent::RoleUpdate(v) => Self::RoleUpdate(v),
-            DispatchEvent::GuildUpdate(v) => Self::GuildUpdate(v),
             DispatchEvent::MessageCreate(v) => Self::MessageCreate(v),
             DispatchEvent::MessageDelete(v) => Self::MessageDelete(v),
             DispatchEvent::MessageDeleteBulk(v) => Self::MessageDeleteBulk(v),


### PR DESCRIPTION
Variant was added to `Event`, but not to `DispatchEvent`, which prevented it from being deserializable.
