### PR TITLE
ci(book): fix build

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -3,6 +3,7 @@ name: Twilight Book
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/book/book.toml
+++ b/book/book.toml
@@ -10,5 +10,4 @@ title = "Twilight"
 edition = "2021"
 
 [output.html]
-theme = "rust"
 default-theme = "rust"


### PR DESCRIPTION
Setting the `theme` option searches for a directory. Only the `default-theme` option is needed.
