### PR TITLE
build: use version 2 of the feature resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ members = [
     "twilight-util",
     "twilight-validate",
 ]
+resolver = "2"


### PR DESCRIPTION
The default for normal crates as of the Rust 2021 edition, it's not enabled by default for workspaces. Version 2 of the feature resolver improves intercrate shared dependency feature resolution. See https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2 for more info.
