### PR TITLE
Implement Clone, Eq & Partial Eq for ErrorKinds

### DIFF
--- a/twilight-cache-inmemory/src/permission.rs
+++ b/twilight-cache-inmemory/src/permission.rs
@@ -147,7 +147,7 @@ impl Display for ChannelError {
 impl Error for ChannelError {}
 
 /// Type of [`ChannelError`] that occurred.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ChannelErrorType {
     /// Channel is not in a guild.
@@ -254,7 +254,7 @@ impl Display for RootError {
 impl Error for RootError {}
 
 /// Type of [`RootError`] that occurred.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum RootErrorType {
     /// The user's member information is not available in the guild.
@@ -281,6 +281,7 @@ pub enum RootErrorType {
 
 /// Error type that occurred while getting a member's assigned roles'
 /// permissions as well as the `@everyone` role's permissions.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum MemberRolesErrorType {
     /// Role is missing from the cache.
     RoleMissing { role_id: Id<RoleMarker> },

--- a/twilight-http-ratelimiting/src/headers.rs
+++ b/twilight-http-ratelimiting/src/headers.rs
@@ -95,7 +95,7 @@ impl Error for HeaderParsingError {
 }
 
 /// Type of [`HeaderParsingError`] that occurred.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum HeaderParsingErrorType {
     /// Expected header is missing.

--- a/twilight-http/src/request/guild/create_guild/builder.rs
+++ b/twilight-http/src/request/guild/create_guild/builder.rs
@@ -59,7 +59,7 @@ impl Display for RoleFieldsError {
 impl Error for RoleFieldsError {}
 
 /// Type of [`RoleFieldsError`] that occurred.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum RoleFieldsErrorType {
     /// Color was larger than a valid RGB hexadecimal value.
@@ -230,7 +230,7 @@ impl Display for TextFieldsError {
 impl Error for TextFieldsError {}
 
 /// Type of [`TextFieldsError`] that occurred.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum TextFieldsErrorType {
     /// The name is too short.
@@ -427,7 +427,7 @@ impl Display for VoiceFieldsError {
 impl Error for VoiceFieldsError {}
 
 /// Type of [`VoiceFieldsError`] that occurred.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum VoiceFieldsErrorType {
     /// The name is too short.
@@ -575,7 +575,7 @@ impl Display for CategoryFieldsError {
 impl Error for CategoryFieldsError {}
 
 /// Type of [`CategoryFieldsError`] that occurred.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CategoryFieldsErrorType {
     /// The name is too short.

--- a/twilight-http/src/request/guild/create_guild/mod.rs
+++ b/twilight-http/src/request/guild/create_guild/mod.rs
@@ -72,7 +72,7 @@ impl Display for CreateGuildError {
 impl Error for CreateGuildError {}
 
 /// Type of [`CreateGuildError`] that occurred.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateGuildErrorType {
     /// The name of the guild is either fewer than 2 UTF-16 characters or more than 100 UTF-16

--- a/twilight-http/src/response/mod.rs
+++ b/twilight-http/src/response/mod.rs
@@ -135,7 +135,7 @@ impl Error for DeserializeBodyError {
 }
 
 /// Type of [`DeserializeBodyError`] that occurred.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum DeserializeBodyErrorType {
     /// Response body is not a UTF-8 valid string.


### PR DESCRIPTION
This PR adds utility derives to the error types enums used in the lib
Besides the HTTP Error type which contains an unclonable Response struct (there should be a solution to that however that would most likely lead to breaking changes, so I refrained from adding such), there should be all error types in this PR (if not please notify me and I can add them