### PR TITLE
Use bytes for file field on attachment

### DIFF
--- a/twilight-model/Cargo.toml
+++ b/twilight-model/Cargo.toml
@@ -22,6 +22,7 @@ serde-value = { default-features = false, version = "0.7" }
 serde_repr = { default-features = false, version = "0.1.5" }
 time = { default-features = false, features = ["parsing", "std"], version = "0.3" }
 tracing = { default-features = false, version = "0.1.16" }
+bytes = { default-features = false, version = "1" }
 
 [dev-dependencies]
 criterion = { default-features = false, version = "0.3" }

--- a/twilight-model/src/http/attachment.rs
+++ b/twilight-model/src/http/attachment.rs
@@ -1,5 +1,6 @@
 //! Models used when sending attachments to Discord.
 
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 /// Attachments used in messages.
@@ -32,7 +33,7 @@ pub struct Attachment {
     pub description: Option<String>,
     /// Content of the file.
     #[serde(skip)]
-    pub file: Vec<u8>,
+    pub file: Bytes,
     /// Name of the file.
     ///
     /// Examples may be "twilight_sparkle.png", "cat.jpg", or "logs.txt".
@@ -62,7 +63,7 @@ impl Attachment {
     ///
     /// let attachment = Attachment::from_bytes(filename, file_content, id);
     /// ```
-    pub const fn from_bytes(filename: String, file: Vec<u8>, id: u64) -> Self {
+    pub const fn from_bytes(filename: String, file: Bytes, id: u64) -> Self {
         Self {
             description: None,
             file,


### PR DESCRIPTION
The idea of using the Bytes struct comes from being able to have more flexibility when adding attachments.
Quoting the [docs](https://docs.rs/bytes/latest/bytes/) it mentions that
> ``Bytes`` values facilitate zero-copy network programming by allowing multiple ``Bytes`` objects to point to the same underlying memory. This is managed by using a reference count to track when the memory is no longer needed and can be freed.

I would honestly just add an ``impl Into<Bytes>`` for the ``from_bytes`` function but it would stop being ``const`` so it would also require a breaking change.