### PR TITLE
feat!(http,validate): validate attachment descriptions

### DIFF
--- a/twilight-http/src/request/application/interaction/create_followup.rs
+++ b/twilight-http/src/request/application/interaction/create_followup.rs
@@ -20,7 +20,7 @@ use twilight_model::{
     id::{marker::ApplicationMarker, Id},
 };
 use twilight_validate::message::{
-    attachment_filename as validate_attachment_filename, components as validate_components,
+    attachment as validate_attachment, components as validate_components,
     content as validate_content, embeds as validate_embeds, MessageValidationError,
 };
 
@@ -123,17 +123,19 @@ impl<'a> CreateFollowup<'a> {
     ///
     /// # Errors
     ///
+    /// Returns an error of type [`AttachmentDescriptionTooLarge`] if
+    /// the attachments's description is too large.
+    ///
     /// Returns an error of type [`AttachmentFilename`] if any filename is
     /// invalid.
     ///
+    /// [`AttachmentDescriptionTooLarge`]: twilight_validate::message::MessageValidationErrorType::AttachmentDescriptionTooLarge
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
         attachments: &'a [Attachment],
     ) -> Result<Self, MessageValidationError> {
-        attachments
-            .iter()
-            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+        attachments.iter().try_for_each(validate_attachment)?;
 
         self.attachment_manager = self
             .attachment_manager

--- a/twilight-http/src/request/application/interaction/update_followup.rs
+++ b/twilight-http/src/request/application/interaction/update_followup.rs
@@ -21,7 +21,7 @@ use twilight_model::{
     },
 };
 use twilight_validate::message::{
-    attachment_filename as validate_attachment_filename, components as validate_components,
+    attachment as validate_attachment, components as validate_components,
     content as validate_content, embeds as validate_embeds, MessageValidationError,
 };
 
@@ -131,17 +131,19 @@ impl<'a> UpdateFollowup<'a> {
     ///
     /// # Errors
     ///
+    /// Returns an error of type [`AttachmentDescriptionTooLarge`] if
+    /// the attachments's description is too large.
+    ///
     /// Returns an error of type [`AttachmentFilename`] if any filename is
     /// invalid.
     ///
+    /// [`AttachmentDescriptionTooLarge`]: twilight_validate::message::MessageValidationErrorType::AttachmentDescriptionTooLarge
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
         attachments: &'a [Attachment],
     ) -> Result<Self, MessageValidationError> {
-        attachments
-            .iter()
-            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+        attachments.iter().try_for_each(validate_attachment)?;
 
         self.attachment_manager = self
             .attachment_manager

--- a/twilight-http/src/request/application/interaction/update_response.rs
+++ b/twilight-http/src/request/application/interaction/update_response.rs
@@ -21,7 +21,7 @@ use twilight_model::{
     },
 };
 use twilight_validate::message::{
-    attachment_filename as validate_attachment_filename, components as validate_components,
+    attachment as validate_attachment, components as validate_components,
     content as validate_content, embeds as validate_embeds, MessageValidationError,
 };
 
@@ -128,17 +128,19 @@ impl<'a> UpdateResponse<'a> {
     ///
     /// # Errors
     ///
+    /// Returns an error of type [`AttachmentDescriptionTooLarge`] if
+    /// the attachments's description is too large.
+    ///
     /// Returns an error of type [`AttachmentFilename`] if any filename is
     /// invalid.
     ///
+    /// [`AttachmentDescriptionTooLarge`]: twilight_validate::message::MessageValidationErrorType::AttachmentDescriptionTooLarge
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
         attachments: &'a [Attachment],
     ) -> Result<Self, MessageValidationError> {
-        attachments
-            .iter()
-            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+        attachments.iter().try_for_each(validate_attachment)?;
 
         self.attachment_manager = self
             .attachment_manager

--- a/twilight-http/src/request/channel/message/create_message.rs
+++ b/twilight-http/src/request/channel/message/create_message.rs
@@ -23,7 +23,7 @@ use twilight_model::{
     },
 };
 use twilight_validate::message::{
-    attachment_filename as validate_attachment_filename, components as validate_components,
+    attachment as validate_attachment, components as validate_components,
     content as validate_content, embeds as validate_embeds, sticker_ids as validate_sticker_ids,
     MessageValidationError,
 };
@@ -128,17 +128,19 @@ impl<'a> CreateMessage<'a> {
     ///
     /// # Errors
     ///
+    /// Returns an error of type [`AttachmentDescriptionTooLarge`] if
+    /// the attachments's description is too large.
+    ///
     /// Returns an error of type [`AttachmentFilename`] if any filename is
     /// invalid.
     ///
+    /// [`AttachmentDescriptionTooLarge`]: twilight_validate::message::MessageValidationErrorType::AttachmentDescriptionTooLarge
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
         attachments: &'a [Attachment],
     ) -> Result<Self, MessageValidationError> {
-        attachments
-            .iter()
-            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+        attachments.iter().try_for_each(validate_attachment)?;
 
         self.attachment_manager = self
             .attachment_manager

--- a/twilight-http/src/request/channel/message/update_message.rs
+++ b/twilight-http/src/request/channel/message/update_message.rs
@@ -23,7 +23,7 @@ use twilight_model::{
     },
 };
 use twilight_validate::message::{
-    attachment_filename as validate_attachment_filename, components as validate_components,
+    attachment as validate_attachment, components as validate_components,
     content as validate_content, embeds as validate_embeds, MessageValidationError,
 };
 
@@ -139,17 +139,19 @@ impl<'a> UpdateMessage<'a> {
     ///
     /// # Errors
     ///
+    /// Returns an error of type [`AttachmentDescriptionTooLarge`] if
+    /// the attachments's description is too large.
+    ///
     /// Returns an error of type [`AttachmentFilename`] if any filename is
     /// invalid.
     ///
+    /// [`AttachmentDescriptionTooLarge`]: twilight_validate::message::MessageValidationErrorType::AttachmentDescriptionTooLarge
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
         attachments: &'a [Attachment],
     ) -> Result<Self, MessageValidationError> {
-        attachments
-            .iter()
-            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+        attachments.iter().try_for_each(validate_attachment)?;
 
         self.attachment_manager = self
             .attachment_manager

--- a/twilight-http/src/request/channel/webhook/execute_webhook.rs
+++ b/twilight-http/src/request/channel/webhook/execute_webhook.rs
@@ -24,7 +24,7 @@ use twilight_model::{
 };
 use twilight_validate::{
     message::{
-        attachment_filename as validate_attachment_filename, components as validate_components,
+        attachment as validate_attachment, components as validate_components,
         content as validate_content, embeds as validate_embeds, MessageValidationError,
         MessageValidationErrorType,
     },
@@ -139,17 +139,19 @@ impl<'a> ExecuteWebhook<'a> {
     ///
     /// # Errors
     ///
+    /// Returns an error of type [`AttachmentDescriptionTooLarge`] if
+    /// the attachments's description is too large.
+    ///
     /// Returns an error of type [`AttachmentFilename`] if any filename is
     /// invalid.
     ///
+    /// [`AttachmentDescriptionTooLarge`]: twilight_validate::message::MessageValidationErrorType::AttachmentDescriptionTooLarge
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
         attachments: &'a [Attachment],
     ) -> Result<Self, MessageValidationError> {
-        attachments
-            .iter()
-            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+        attachments.iter().try_for_each(validate_attachment)?;
 
         self.attachment_manager = self
             .attachment_manager

--- a/twilight-http/src/request/channel/webhook/update_webhook_message.rs
+++ b/twilight-http/src/request/channel/webhook/update_webhook_message.rs
@@ -21,7 +21,7 @@ use twilight_model::{
     },
 };
 use twilight_validate::message::{
-    attachment_filename as validate_attachment_filename, components as validate_components,
+    attachment as validate_attachment, components as validate_components,
     content as validate_content, embeds as validate_embeds, MessageValidationError,
 };
 
@@ -127,17 +127,19 @@ impl<'a> UpdateWebhookMessage<'a> {
     ///
     /// # Errors
     ///
+    /// Returns an error of type [`AttachmentDescriptionTooLarge`] if
+    /// the attachments's description is too large.
+    ///
     /// Returns an error of type [`AttachmentFilename`] if any filename is
     /// invalid.
     ///
+    /// [`AttachmentDescriptionTooLarge`]: twilight_validate::message::MessageValidationErrorType::AttachmentDescriptionTooLarge
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
         attachments: &'a [Attachment],
     ) -> Result<Self, MessageValidationError> {
-        attachments
-            .iter()
-            .try_for_each(|attachment| validate_attachment_filename(&attachment.filename))?;
+        attachments.iter().try_for_each(validate_attachment)?;
 
         self.attachment_manager = self
             .attachment_manager

--- a/twilight-validate/src/message.rs
+++ b/twilight-validate/src/message.rs
@@ -14,8 +14,12 @@ use std::{
 use twilight_model::{
     application::component::Component,
     channel::embed::Embed,
+    http::attachment::Attachment,
     id::{marker::StickerMarker, Id},
 };
+
+/// Maximum length of an attachment's description.
+pub const ATTACHMENT_DESCIPTION_LENGTH_MAX: usize = 1024;
 
 /// Maximum number of embeds that a message may have.
 pub const EMBED_COUNT_LIMIT: usize = 10;
@@ -84,6 +88,13 @@ impl MessageValidationError {
 impl Display for MessageValidationError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
+            MessageValidationErrorType::AttachmentDescriptionTooLarge { chars } => {
+                f.write_str("the attachment description is ")?;
+                Display::fmt(chars, f)?;
+                f.write_str(" characters long, but the max is ")?;
+
+                Display::fmt(&ATTACHMENT_DESCIPTION_LENGTH_MAX, f)
+            }
             MessageValidationErrorType::AttachmentFilename { filename } => {
                 f.write_str("attachment filename `")?;
                 Display::fmt(filename, f)?;
@@ -138,6 +149,11 @@ pub enum MessageValidationErrorType {
         /// Invalid filename.
         filename: String,
     },
+    /// Attachment description is too large.
+    AttachmentDescriptionTooLarge {
+        /// Provided number of codepoints.
+        chars: usize,
+    },
     /// Too many message components were provided.
     ComponentCount {
         /// Number of components that were provided.
@@ -172,7 +188,49 @@ pub enum MessageValidationErrorType {
     WebhookUsername,
 }
 
-/// Ensure an attachment's filename is correct.
+/// Ensure an attachment is correct.
+///
+/// # Errors
+///
+/// Returns an error of type [`AttachmentDescriptionTooLarge`] if
+/// the attachments's description is too large.
+///
+/// Returns an error of type [`AttachmentFilename`] if the
+/// filename is invalid.
+///
+/// [`AttachmentDescriptionTooLarge`]: MessageValidationErrorType::AttachmentDescriptionTooLarge
+/// [`AttachmentFilename`]: MessageValidationErrorType::AttachmentFilename
+pub fn attachment(attachment: &Attachment) -> Result<(), MessageValidationError> {
+    attachment_filename(&attachment.filename)?;
+
+    if let Some(description) = &attachment.description {
+        attachment_description(description)?;
+    }
+
+    Ok(())
+}
+
+/// Ensure an attachment's description is correct.
+///
+/// # Errors
+///
+/// Returns an error of type [`AttachmentDescriptionTooLarge`] if
+/// the attachment's description is too large.
+///
+/// [`AttachmentDescriptionTooLarge`]: MessageValidationErrorType::AttachmentDescriptionTooLarge
+pub fn attachment_description(description: impl AsRef<str>) -> Result<(), MessageValidationError> {
+    let chars = description.as_ref().chars().count();
+    if chars <= ATTACHMENT_DESCIPTION_LENGTH_MAX {
+        Ok(())
+    } else {
+        Err(MessageValidationError {
+            kind: MessageValidationErrorType::AttachmentDescriptionTooLarge { chars },
+            source: None,
+        })
+    }
+}
+
+/// Ensure an attachment's description is correct.
 ///
 /// The filename can contain ASCII alphanumeric characters, dots, dashes, and
 /// underscores.
@@ -327,6 +385,19 @@ pub fn sticker_ids(sticker_ids: &[Id<StickerMarker>]) -> Result<(), MessageValid
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn attachment_description_limit() {
+        assert!(attachment_description("").is_ok());
+        assert!(attachment_description(str::repeat("a", 1024)).is_ok());
+
+        assert!(matches!(
+            attachment_description(str::repeat("a", 1025))
+                .unwrap_err()
+                .kind(),
+            MessageValidationErrorType::AttachmentDescriptionTooLarge { chars: 1025 }
+        ));
+    }
 
     #[test]
     fn attachment_allowed_filename() {


### PR DESCRIPTION
Also adds a function to validate attachments.

Reference: https://github.com/discord/discord-api-docs/pull/5233

Closes: #1889