### PR TITLE
fix(gateway)!: within a stream, reinsert shard on error

### DIFF
--- a/twilight-gateway/README.md
+++ b/twilight-gateway/README.md
@@ -101,8 +101,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     loop {
         let (shard, event) = match stream.next().await {
-            Some(Ok((shard, event))) => (shard, event),
-            Some(Err(source)) => {
+            Some((shard, Ok(event))) => (shard, event),
+            Some((shard, Err(source))) => {
                 tracing::warn!(?source, "error receiving event");
     
                 if source.is_fatal() {

--- a/twilight-gateway/src/stream.rs
+++ b/twilight-gateway/src/stream.rs
@@ -108,8 +108,8 @@ pub enum StartRecommendedErrorType {
 ///
 /// loop {
 ///     let (shard, event) = match stream.next().await {
-///         Some(Ok((shard, event))) => (shard, event),
-///         Some(Err(source)) => {
+///         Some((shard, Ok(event))) => (shard, event),
+///         Some((shard, Err(source))) => {
 ///             tracing::warn!(?source, "error receiving event");
 ///
 ///             if source.is_fatal() {
@@ -155,22 +155,20 @@ impl<'a> ShardEventStream<'a> {
 }
 
 impl<'a> Stream for ShardEventStream<'a> {
-    type Item = Result<(ShardRef<'a>, Event), ReceiveMessageError>;
+    type Item = (ShardRef<'a>, Result<Event, ReceiveMessageError>);
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.as_mut();
         let poll = this.futures.borrow_mut().poll_next_unpin(cx);
 
         match poll {
-            Poll::Ready(Some(output)) => Poll::Ready(Some(output.result.map(|message| {
-                (
-                    ShardRef {
-                        list: ShardList::Events(Rc::clone(&this.futures)),
-                        shard: Some(output.shard),
-                    },
-                    message,
-                )
-            }))),
+            Poll::Ready(Some(output)) => Poll::Ready(Some((
+                ShardRef {
+                    list: ShardList::Events(Rc::clone(&this.futures)),
+                    shard: Some(output.shard),
+                },
+                output.result,
+            ))),
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
         }
@@ -211,8 +209,8 @@ impl<'a> Stream for ShardEventStream<'a> {
 ///
 /// loop {
 ///     let (shard, message) = match stream.next().await {
-///         Some(Ok((shard, message))) => (shard, message),
-///         Some(Err(source)) => {
+///         Some((shard, Ok(message))) => (shard, message),
+///         Some((shard, Err(source))) => {
 ///             tracing::warn!(?source, "error receiving message");
 ///
 ///             if source.is_fatal() {
@@ -258,22 +256,20 @@ impl<'a> ShardMessageStream<'a> {
 }
 
 impl<'a> Stream for ShardMessageStream<'a> {
-    type Item = Result<(ShardRef<'a>, Message), ReceiveMessageError>;
+    type Item = (ShardRef<'a>, Result<Message, ReceiveMessageError>);
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.as_mut();
         let poll = this.futures.borrow_mut().poll_next_unpin(cx);
 
         match poll {
-            Poll::Ready(Some(output)) => Poll::Ready(Some(output.result.map(|message| {
-                (
-                    ShardRef {
-                        list: ShardList::Messages(Rc::clone(&this.futures)),
-                        shard: Some(output.shard),
-                    },
-                    message,
-                )
-            }))),
+            Poll::Ready(Some(output)) => Poll::Ready(Some((
+                ShardRef {
+                    list: ShardList::Messages(Rc::clone(&this.futures)),
+                    shard: Some(output.shard),
+                },
+                output.result,
+            ))),
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
         }
@@ -408,6 +404,8 @@ pub fn start_range<F: Fn(ShardId) -> Config>(
     let range = calculate_range(range, total);
     let tls = TlsContainer::new().unwrap();
 
+    tracing::trace!(?range, "starting range of shards");
+
     range
         .map(|index| {
             let id = ShardId::new(index, total);
@@ -470,6 +468,8 @@ pub async fn start_recommended<F: Fn(ShardId) -> Config>(
     client: &Client,
     per_shard_config: F,
 ) -> Result<impl Stream<Item = Result<Shard, ShardInitializeError>> + Send, StartRecommendedError> {
+    tracing::trace!("starting recommended range of shards");
+
     let request = client.gateway().authed();
     let response = request
         .exec()

--- a/twilight-gateway/src/stream.rs
+++ b/twilight-gateway/src/stream.rs
@@ -404,8 +404,6 @@ pub fn start_range<F: Fn(ShardId) -> Config>(
     let range = calculate_range(range, total);
     let tls = TlsContainer::new().unwrap();
 
-    tracing::trace!(?range, "starting range of shards");
-
     range
         .map(|index| {
             let id = ShardId::new(index, total);
@@ -468,8 +466,6 @@ pub async fn start_recommended<F: Fn(ShardId) -> Config>(
     client: &Client,
     per_shard_config: F,
 ) -> Result<impl Stream<Item = Result<Shard, ShardInitializeError>> + Send, StartRecommendedError> {
-    tracing::trace!("starting recommended range of shards");
-
     let request = client.gateway().authed();
     let response = request
         .exec()


### PR DESCRIPTION
Previously, if a shard within a stream encountered any error, not just a failure, it would never re-insert back into the futures list because it never executed its drop implementation. This change always returns the shard when polling `ShardEventStream` or `ShardMessageStream`, regardless of if an error occurred, which ensures it is re-inserted.

Co-authored-by: Zeyla Hellyer <zeyla@hellyer.dev>
