### PR TITLE
docs(http,util): fix mention on how color works

### DIFF
--- a/twilight-http/src/request/guild/create_guild/builder.rs
+++ b/twilight-http/src/request/guild/create_guild/builder.rs
@@ -107,7 +107,10 @@ impl RoleFieldsBuilder {
 
     /// Set the role color.
     ///
-    /// This must be a valid hexadecimal RGB value.
+    /// This must be a valid hexadecimal RGB value. `0x000000` is ignored
+    /// and doesn't count towards the final computed color in the user list.
+    /// Refer to [`COLOR_MAXIMUM`] for the maximum
+    /// acceptable value.
     ///
     /// # Errors
     ///

--- a/twilight-http/src/request/guild/create_guild/builder.rs
+++ b/twilight-http/src/request/guild/create_guild/builder.rs
@@ -109,7 +109,7 @@ impl RoleFieldsBuilder {
     ///
     /// This must be a valid hexadecimal RGB value. `0x000000` is ignored
     /// and doesn't count towards the final computed color in the user list.
-    /// Refer to [`COLOR_MAXIMUM`] for the maximum
+    /// Refer to [`Self::COLOR_MAXIMUM`] for the maximum
     /// acceptable value.
     ///
     /// # Errors

--- a/twilight-http/src/request/guild/role/create_role.rs
+++ b/twilight-http/src/request/guild/role/create_role.rs
@@ -77,12 +77,13 @@ impl<'a> CreateRole<'a> {
         }
     }
 
-    /// Set the color of the role.
-    /// 
-    /// This must be a valid hexadecimal RGB value. `0x000000` is ignored
-    /// and doesn't count towards the final computed color in the user list.
-    /// Refer to [`RoleFieldsBuilder::COLOR_MAXIMUM`] for the maximum
-    /// acceptable value.
+    /// Set the role color.
+    ///
+    /// This must be a valid hexadecimal RGB value. `0x000000` is ignored and
+    /// doesn't count towards the final computed color in the user list. Refer
+    /// to [`COLOR_MAXIMUM`] for the maximum acceptable value.
+    ///
+    /// [`COLOR_MAXIMUM`]: twilight_validate::embed::COLOR_MAXIMUM
     pub const fn color(mut self, color: u32) -> Self {
         self.fields.color = Some(color);
 

--- a/twilight-http/src/request/guild/role/create_role.rs
+++ b/twilight-http/src/request/guild/role/create_role.rs
@@ -78,6 +78,11 @@ impl<'a> CreateRole<'a> {
     }
 
     /// Set the color of the role.
+    /// 
+    /// This must be a valid hexadecimal RGB value. `0x000000` is ignored
+    /// and doesn't count towards the final computed color in the user list.
+    /// Refer to [`RoleFieldsBuilder::COLOR_MAXIMUM`] for the maximum
+    /// acceptable value.
     pub const fn color(mut self, color: u32) -> Self {
         self.fields.color = Some(color);
 

--- a/twilight-http/src/request/guild/role/update_role.rs
+++ b/twilight-http/src/request/guild/role/update_role.rs
@@ -66,7 +66,13 @@ impl<'a> UpdateRole<'a> {
         }
     }
 
-    /// Set the color of the role.
+    /// Set the role color.
+    ///
+    /// This must be a valid hexadecimal RGB value. `0x000000` is ignored and
+    /// doesn't count towards the final computed color in the user list. Refer
+    /// to [`COLOR_MAXIMUM`] for the maximum acceptable value.
+    ///
+    /// [`COLOR_MAXIMUM`]: twilight_validate::embed::COLOR_MAXIMUM
     pub const fn color(mut self, color: Option<u32>) -> Self {
         self.fields.color = Some(Nullable(color));
 

--- a/twilight-util/src/builder/embed/mod.rs
+++ b/twilight-util/src/builder/embed/mod.rs
@@ -122,8 +122,7 @@ impl EmbedBuilder {
 
     /// Set the color.
     ///
-    /// This must be a valid hexadecimal RGB value. `0x000000` is not an
-    /// acceptable value as it would be thrown out by Discord. Refer to
+    /// This must be a valid hexadecimal RGB value. Refer to
     /// [`COLOR_MAXIMUM`] for the maximum acceptable value.
     ///
     /// # Examples


### PR DESCRIPTION
Embeds when you input color 0 it will actually give you a black embed
![as you can see](https://cdn.discordapp.com/attachments/745815089067851807/1016449684186857562/unknown.png)
Also role colors [specify in the documentation](https://discord.com/developers/docs/topics/permissions#role-object-role-structure
) that 0 will be ignored so i also updated that