### PR TITLE
feat(gateway,model): Add handling for gateway resume url

### DIFF
--- a/twilight-gateway/src/cluster/impl.rs
+++ b/twilight-gateway/src/cluster/impl.rs
@@ -298,6 +298,7 @@ impl Cluster {
                     if let Some(data) = config.resume_sessions.remove(&idx) {
                         shard_config.session_id = Some(data.session_id.into_boxed_str());
                         shard_config.sequence = Some(data.sequence);
+                        shard_config.resume_url = data.resume_url.map(String::into_boxed_str);
                     }
 
                     if let Some(shard_presence) = &config.shard_presence {

--- a/twilight-gateway/src/shard/builder.rs
+++ b/twilight-gateway/src/shard/builder.rs
@@ -145,6 +145,7 @@ impl ShardBuilder {
             large_threshold: self.large_threshold,
             presence: self.presence,
             queue: self.queue,
+            resume_url: None,
             ratelimit_payloads: self.ratelimit_payloads,
             session_id: None,
             sequence: None,

--- a/twilight-gateway/src/shard/config.rs
+++ b/twilight-gateway/src/shard/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub(crate) presence: Option<UpdatePresencePayload>,
     pub(super) queue: Arc<dyn Queue>,
     pub(crate) ratelimit_payloads: bool,
+    pub(crate) resume_url: Option<Box<str>>,
     pub(crate) session_id: Option<Box<str>>,
     pub(crate) sequence: Option<u64>,
     pub(crate) shard: [u64; 2],

--- a/twilight-gateway/src/shard/impl.rs
+++ b/twilight-gateway/src/shard/impl.rs
@@ -331,6 +331,9 @@ impl Information {
 /// Details to resume a gateway session.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ResumeSession {
+    /// URL used to resume
+    #[serde(default)]
+    pub resume_url: Option<String>,
     /// ID of the session being resumed.
     pub session_id: String,
     /// Last received event sequence number.
@@ -758,6 +761,7 @@ impl Shard {
         session.stop_heartbeater();
 
         let data = session_id.map(|id| ResumeSession {
+            resume_url: session.resume_url().map(String::from),
             session_id: id.into_string(),
             sequence,
         });

--- a/twilight-gateway/src/shard/processor/impl.rs
+++ b/twilight-gateway/src/shard/processor/impl.rs
@@ -325,7 +325,7 @@ impl ShardProcessor {
             config
                 .resume_url
                 .as_ref()
-                .map_or_else(|| config.gateway_url().to_string(), ToString::to_string)
+                .map_or_else(|| config.gateway_url().to_owned(), ToString::to_string)
         } else {
             tracing::debug!("shard {shard_id:?} is not resumable");
             tracing::debug!("shard {shard_id:?} queued");

--- a/twilight-gateway/src/shard/processor/impl.rs
+++ b/twilight-gateway/src/shard/processor/impl.rs
@@ -583,6 +583,8 @@ impl ShardProcessor {
         self.session.set_stage(Stage::Connected);
         self.session
             .set_id(ready.session_id.clone().into_boxed_str());
+        self.session
+            .set_resume_url(ready.resume_gateway_url.clone().into_boxed_str());
 
         self.emitter.event(Event::ShardConnected(Connected {
             heartbeat_interval: self.session.heartbeat_interval(),
@@ -1087,8 +1089,10 @@ impl ShardProcessor {
             shard_id: self.config.shard()[0],
         }));
 
+        let url = self.session.resume_url().unwrap_or_else(|| self.url.clone());
+
         let stream = Self::connect(
-            &self.url,
+            &url,
             #[cfg(any(
                 feature = "native",
                 feature = "rustls-native-roots",

--- a/twilight-gateway/src/shard/processor/session.rs
+++ b/twilight-gateway/src/shard/processor/session.rs
@@ -200,7 +200,10 @@ impl Session {
     }
 
     pub fn set_resume_url(&self, url: Box<str>) {
-        self.resume_url.lock().expect("resume_url poisoned").replace(url);
+        self.resume_url
+            .lock()
+            .expect("resume_url poisoned")
+            .replace(url);
     }
 
     pub fn stop_heartbeater(&self) {

--- a/twilight-gateway/src/shard/processor/session.rs
+++ b/twilight-gateway/src/shard/processor/session.rs
@@ -69,6 +69,7 @@ pub struct Session {
     pub heartbeats: Arc<Heartbeats>,
     pub heartbeat_interval: AtomicU64,
     pub id: MutexSync<Option<Box<str>>>,
+    pub resume_url: MutexSync<Option<Box<str>>>,
     pub seq: Arc<AtomicU64>,
     pub stage: AtomicU8,
     pub tx: UnboundedSender<TungsteniteMessage>,
@@ -82,6 +83,7 @@ impl Session {
             heartbeats: Arc::new(Heartbeats::default()),
             heartbeat_interval: AtomicU64::new(0),
             id: MutexSync::new(None),
+            resume_url: MutexSync::new(None),
             seq: Arc::new(AtomicU64::new(0)),
             stage: AtomicU8::new(Stage::default() as u8),
             tx,
@@ -191,6 +193,14 @@ impl Session {
 
     pub fn set_id(&self, new_id: Box<str>) {
         self.id.lock().expect("id poisoned").replace(new_id);
+    }
+
+    pub fn resume_url(&self) -> Option<Box<str>> {
+        self.resume_url.lock().expect("resume_url poisoned").clone()
+    }
+
+    pub fn set_resume_url(&self, url: Box<str>) {
+        self.resume_url.lock().expect("resume_url poisoned").replace(url);
     }
 
     pub fn stop_heartbeater(&self) {

--- a/twilight-model/src/gateway/payload/incoming/ready.rs
+++ b/twilight-model/src/gateway/payload/incoming/ready.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct Ready {
     pub application: PartialApplication,
     pub guilds: Vec<UnavailableGuild>,
+    pub resume_gateway_url: String,
     pub session_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard: Option<[u64; 2]>,
@@ -63,6 +64,7 @@ mod tests {
                 verified: None,
             },
             version: 8,
+            resume_gateway_url: "wss://gateway.discord.gg/".to_owned(),
         };
 
         serde_test::assert_tokens(
@@ -70,7 +72,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Ready",
-                    len: 6,
+                    len: 7,
                 },
                 Token::Str("application"),
                 Token::Struct {
@@ -106,6 +108,8 @@ mod tests {
                 Token::Bool(true),
                 Token::StructEnd,
                 Token::SeqEnd,
+                Token::Str("resume_gateway_url"),
+                Token::Str("wss://gateway.discord.gg/"),
                 Token::Str("session_id"),
                 Token::Str("foo"),
                 Token::Str("shard"),

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -1343,6 +1343,7 @@ mod tests {
                 locale: None,
             },
             version: 6,
+            resume_gateway_url: "wss://gateway.discord.gg/".to_owned(),
         };
         let event = Event::Ready(Box::new(ready));
 


### PR DESCRIPTION
This adds handling for the new `gateway_resume_url`, which is provided in the `READY` dispatch. Resuming should happen on that URL instead of the normal `wss://gateway.discord.gg`.

I tested this using `ClusterBuilder`:

```rs
let shards = ShardScheme::try_from((0..1, 1))?;
let (cluster, _) = ClusterBuilder::new(token.clone(), Intents::None)
    .shard_scheme(shards)
    .build()
    .await?;

cluster.up().await;

tokio::time::sleep(Duration::from_secs(1)).await;

let hashmap = cluster.down_resumable();

let (cluster, _) = ClusterBuilder::new(token, Intents::None)
    .shard_scheme(shards)
    .resume_sessions(hashmap)
    .build()
    .await?;

cluster.up().await;
```

Reference: https://github.com/discord/discord-api-docs/pull/5282