### PR TITLE
docs(gateway-queue): clarify `buckets` for large bot queue

### DIFF
--- a/twilight-gateway-queue/src/large_bot_queue.rs
+++ b/twilight-gateway-queue/src/large_bot_queue.rs
@@ -29,6 +29,9 @@ impl LargeBotQueue {
     ///
     /// You must provide the number of buckets Discord requires your bot to
     /// connect with.
+    ///
+    /// The number of buckets is provided via Discord as `max_concurrency`
+    /// which can be fetched with [`Client::gateway`].
     pub async fn new(buckets: usize, http: Arc<Client>) -> Self {
         let mut queues = Vec::with_capacity(buckets);
         for _ in 0..buckets {


### PR DESCRIPTION
The term "buckets" here was not immediately obvious to me; I had to ask for clarification, so let's spell it out.