### PR TITLE
feat(http): impl `IntoFuture` for requests, deprecate `exec()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ async fn handle_event(
         Event::MessageCreate(msg) if msg.content == "!ping" => {
             http.create_message(msg.channel_id)
                 .content("Pong!")?
-                .exec()
                 .await?;
         }
         Event::ShardConnected(_) => {

--- a/book/src/chapter_1_crates/section_2_http.md
+++ b/book/src/chapter_1_crates/section_2_http.md
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let client = Client::new(env::var("DISCORD_TOKEN")?);
 
-    let me = client.current_user().exec().await?.model().await?;
+    let me = client.current_user().await?.model().await?;
     println!("Current user: {}#{}", me.name, me.discriminator);
 
     Ok(())

--- a/book/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
+++ b/book/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let shard_count = 1_u64;
 
     let http = HttpClient::new(token.clone());
-    let user_id = http.current_user().exec().await?.model().await?.id;
+    let user_id = http.current_user().await?.model().await?.id;
 
     let lavalink = Lavalink::new(user_id, shard_count);
     lavalink.add(lavalink_host, lavalink_auth).await?;

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -110,7 +110,7 @@ async fn handle_event(
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     match event {
         Event::MessageCreate(msg) if msg.content == "!ping" => {
-            http.create_message(msg.channel_id).content("Pong!")?.exec().await?;
+            http.create_message(msg.channel_id).content("Pong!")?.await?;
         }
         Event::ShardConnected(_) => {
             println!("Connected on shard {}", shard_id);

--- a/examples/http-allowed-mentions.rs
+++ b/examples/http-allowed-mentions.rs
@@ -32,7 +32,6 @@ async fn main() -> anyhow::Result<()> {
             "<@{user_id}> you are not allowed to ping @everyone!"
         ))?
         .allowed_mentions(Some(&allowed_mentions))
-        .exec()
         .await?;
 
     Ok(())

--- a/examples/http-get-message.rs
+++ b/examples/http-get-message.rs
@@ -1,5 +1,5 @@
 use futures_util::future;
-use std::env;
+use std::{env, future::IntoFuture};
 use twilight_http::Client;
 use twilight_model::id::Id;
 
@@ -16,11 +16,11 @@ async fn main() -> anyhow::Result<()> {
             .create_message(channel_id)
             .content(&format!("Ping #{x}"))
             .expect("content not a valid length")
-            .exec()
+            .into_future()
     }))
     .await;
 
-    let me = client.current_user().exec().await?.model().await?;
+    let me = client.current_user().await?.model().await?;
     println!("Current user: {}#{}", me.name, me.discriminator);
 
     Ok(())

--- a/examples/http-proxy.rs
+++ b/examples/http-proxy.rs
@@ -1,6 +1,5 @@
-use std::future::IntoFuture;
-
 use futures_util::future;
+use std::future::IntoFuture;
 use twilight_http::Client;
 use twilight_model::id::Id;
 

--- a/examples/http-proxy.rs
+++ b/examples/http-proxy.rs
@@ -1,3 +1,5 @@
+use std::future::IntoFuture;
+
 use futures_util::future;
 use twilight_http::Client;
 use twilight_model::id::Id;
@@ -18,11 +20,11 @@ async fn main() -> anyhow::Result<()> {
             .create_message(channel_id)
             .content(&format!("Ping #{x}"))
             .expect("content not a valid length")
-            .exec()
+            .into_future()
     }))
     .await;
 
-    let me = client.current_user().exec().await?.model().await?;
+    let me = client.current_user().await?.model().await?;
     println!("Current user: {}#{}", me.name, me.discriminator);
 
     Ok(())

--- a/examples/lavalink-basic-bot.rs
+++ b/examples/lavalink-basic-bot.rs
@@ -48,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
         let shard_count = 1u64;
 
         let http = HttpClient::new(token.clone());
-        let user_id = http.current_user().exec().await?.model().await?.id;
+        let user_id = http.current_user().await?.model().await?.id;
 
         let lavalink = Lavalink::new(user_id, shard_count);
         lavalink.add(lavalink_host, lavalink_auth).await?;
@@ -100,7 +100,6 @@ async fn join(msg: Message, state: State) -> anyhow::Result<()> {
         .http
         .create_message(msg.channel_id)
         .content("What's the channel ID you want me to join?")?
-        .exec()
         .await?;
 
     let author_id = msg.author.id;
@@ -127,7 +126,6 @@ async fn join(msg: Message, state: State) -> anyhow::Result<()> {
         .http
         .create_message(msg.channel_id)
         .content(&format!("Joined <#{channel_id}>!"))?
-        .exec()
         .await?;
 
     Ok(())
@@ -152,7 +150,6 @@ async fn leave(msg: Message, state: State) -> anyhow::Result<()> {
         .http
         .create_message(msg.channel_id)
         .content("Left the channel")?
-        .exec()
         .await?;
 
     Ok(())
@@ -168,7 +165,6 @@ async fn play(msg: Message, state: State) -> anyhow::Result<()> {
         .http
         .create_message(msg.channel_id)
         .content("What's the URL of the audio to play?")?
-        .exec()
         .await?;
 
     let author_id = msg.author.id;
@@ -204,14 +200,12 @@ async fn play(msg: Message, state: State) -> anyhow::Result<()> {
             .http
             .create_message(msg.channel_id)
             .content(&content)?
-            .exec()
             .await?;
     } else {
         state
             .http
             .create_message(msg.channel_id)
             .content("Didn't find any results")?
-            .exec()
             .await?;
     }
 
@@ -236,7 +230,6 @@ async fn pause(msg: Message, state: State) -> anyhow::Result<()> {
         .http
         .create_message(msg.channel_id)
         .content(&format!("{action} the track"))?
-        .exec()
         .await?;
 
     Ok(())
@@ -252,7 +245,6 @@ async fn seek(msg: Message, state: State) -> anyhow::Result<()> {
         .http
         .create_message(msg.channel_id)
         .content("Where in the track do you want to seek to (in seconds)?")?
-        .exec()
         .await?;
 
     let author_id = msg.author.id;
@@ -272,7 +264,6 @@ async fn seek(msg: Message, state: State) -> anyhow::Result<()> {
         .http
         .create_message(msg.channel_id)
         .content(&format!("Seeked to {position}s"))?
-        .exec()
         .await?;
 
     Ok(())
@@ -293,7 +284,6 @@ async fn stop(msg: Message, state: State) -> anyhow::Result<()> {
         .http
         .create_message(msg.channel_id)
         .content("Stopped the track")?
-        .exec()
         .await?;
 
     Ok(())
@@ -309,7 +299,6 @@ async fn volume(msg: Message, state: State) -> anyhow::Result<()> {
         .http
         .create_message(msg.channel_id)
         .content("What's the volume you want to set (0-1000, 100 being the default)?")?
-        .exec()
         .await?;
 
     let author_id = msg.author.id;
@@ -327,7 +316,6 @@ async fn volume(msg: Message, state: State) -> anyhow::Result<()> {
             .http
             .create_message(msg.channel_id)
             .content("That's more than 1000")?
-            .exec()
             .await?;
 
         return Ok(());
@@ -340,7 +328,6 @@ async fn volume(msg: Message, state: State) -> anyhow::Result<()> {
         .http
         .create_message(msg.channel_id)
         .content(&format!("Set the volume to {volume}"))?
-        .exec()
         .await?;
 
     Ok(())

--- a/twilight-gateway-queue/src/day_limiter.rs
+++ b/twilight-gateway-queue/src/day_limiter.rs
@@ -61,7 +61,6 @@ impl DayLimiter {
         let info = http
             .gateway()
             .authed()
-            .exec()
             .await
             .map_err(|source| DayLimiterError {
                 kind: DayLimiterErrorType::RetrievingSessionAvailability,
@@ -97,7 +96,7 @@ impl DayLimiter {
         } else {
             let wait = lock.last_check + lock.next_reset;
             time::sleep_until(wait).await;
-            if let Ok(res) = lock.http.gateway().authed().exec().await {
+            if let Ok(res) = lock.http.gateway().authed().await {
                 if let Ok(info) = res.model().await {
                     let last_check = Instant::now();
                     let next_reset = Duration::from_millis(info.session_start_limit.remaining);

--- a/twilight-gateway/src/cluster/builder.rs
+++ b/twilight-gateway/src/cluster/builder.rs
@@ -121,7 +121,6 @@ impl ClusterBuilder {
         let info = http
             .gateway()
             .authed()
-            .exec()
             .await
             .map_err(|source| ClusterStartError {
                 kind: ClusterStartErrorType::AutoSharding,

--- a/twilight-http/src/client/interaction.rs
+++ b/twilight-http/src/client/interaction.rs
@@ -41,12 +41,7 @@ use twilight_validate::command::CommandValidationError;
 ///
 /// let interaction_client = client.interaction(application_id);
 ///
-/// let commands = interaction_client
-///     .global_commands()
-///     .exec()
-///     .await?
-///     .models()
-///     .await?;
+/// let commands = interaction_client.global_commands().await?.models().await?;
 ///
 /// println!("there are {} global commands", commands.len());
 /// # Ok(()) }
@@ -137,7 +132,6 @@ impl<'a> InteractionClient<'a> {
     ///     .interaction(application_id)
     ///     .create_followup("webhook token")
     ///     .content("Pinkie...")?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -251,7 +251,7 @@ impl Client {
     ///
     /// // Cache the application ID for repeated use later in the process.
     /// let application_id = {
-    ///     let response = client.current_user_application().exec().await?;
+    ///     let response = client.current_user_application().await?;
     ///
     ///     response.model().await?.id
     /// };
@@ -260,7 +260,6 @@ impl Client {
     /// let commands = client
     ///     .interaction(application_id)
     ///     .global_commands()
-    ///     .exec()
     ///     .await?
     ///     .models()
     ///     .await?;
@@ -389,7 +388,7 @@ impl Client {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("token".to_owned());
     /// let guild_id = Id::new(101);
-    /// let audit_log = client.audit_log(guild_id).exec().await?;
+    /// let audit_log = client.audit_log(guild_id).await?;
     /// # Ok(()) }
     /// ```
     pub const fn audit_log(&self, guild_id: Id<GuildMarker>) -> GetAuditLog<'_> {
@@ -412,7 +411,7 @@ impl Client {
     /// #
     /// let guild_id = Id::new(1);
     ///
-    /// let bans = client.bans(guild_id).exec().await?;
+    /// let bans = client.bans(guild_id).await?;
     /// # Ok(()) }
     /// ```
     pub const fn bans(&self, guild_id: Id<GuildMarker>) -> GetBans<'_> {
@@ -448,7 +447,6 @@ impl Client {
     ///     .create_ban(guild_id, user_id)
     ///     .delete_message_seconds(86_400)?
     ///     .reason("memes")?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -477,7 +475,7 @@ impl Client {
     /// let guild_id = Id::new(100);
     /// let user_id = Id::new(200);
     ///
-    /// client.delete_ban(guild_id, user_id).exec().await?;
+    /// client.delete_ban(guild_id, user_id).await?;
     /// # Ok(()) }
     /// ```
     pub const fn delete_ban(
@@ -504,7 +502,7 @@ impl Client {
     /// #
     /// let channel_id = Id::new(100);
     /// #
-    /// let channel = client.channel(channel_id).exec().await?;
+    /// let channel = client.channel(channel_id).await?;
     /// # Ok(()) }
     /// ```
     pub const fn channel(&self, channel_id: Id<ChannelMarker>) -> GetChannel<'_> {
@@ -568,7 +566,6 @@ impl Client {
     ///     .channel_messages(channel_id)
     ///     .before(message_id)
     ///     .limit(limit)?
-    ///     .exec()
     ///     .await?;
     ///
     /// # Ok(()) }
@@ -625,7 +622,6 @@ impl Client {
     ///
     /// client
     ///     .update_channel_permission(channel_id, &permission_overwrite)
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -712,7 +708,6 @@ impl Client {
     ///     .after(after)
     ///     .before(before)
     ///     .limit(25)?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -736,7 +731,7 @@ impl Client {
     /// #
     /// let guild_id = Id::new(100);
     ///
-    /// client.emojis(guild_id).exec().await?;
+    /// client.emojis(guild_id).await?;
     /// # Ok(()) }
     /// ```
     pub const fn emojis(&self, guild_id: Id<GuildMarker>) -> GetEmojis<'_> {
@@ -760,7 +755,7 @@ impl Client {
     /// let guild_id = Id::new(50);
     /// let emoji_id = Id::new(100);
     ///
-    /// client.emoji(guild_id, emoji_id).exec().await?;
+    /// client.emoji(guild_id, emoji_id).await?;
     /// # Ok(()) }
     /// ```
     pub const fn emoji(
@@ -819,7 +814,7 @@ impl Client {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token".to_owned());
     /// #
-    /// let info = client.gateway().exec().await?;
+    /// let info = client.gateway().await?;
     /// # Ok(()) }
     /// ```
     ///
@@ -833,7 +828,7 @@ impl Client {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token".to_owned());
     /// #
-    /// let info = client.gateway().authed().exec().await?.model().await?;
+    /// let info = client.gateway().authed().await?.model().await?;
     ///
     /// println!("URL: {}", info.url);
     /// println!("Recommended shards to use: {}", info.shards);
@@ -993,7 +988,7 @@ impl Client {
     /// #
     /// let guild_id = Id::new(100);
     /// let user_id = Id::new(3000);
-    /// let members = client.guild_members(guild_id).after(user_id).exec().await?;
+    /// let members = client.guild_members(guild_id).after(user_id).await?;
     /// # Ok(()) }
     /// ```
     ///
@@ -1027,7 +1022,6 @@ impl Client {
     /// let members = client
     ///     .search_guild_members(guild_id, "Wumpus")
     ///     .limit(10)?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -1105,7 +1099,6 @@ impl Client {
     ///     .update_guild_member(Id::new(1), Id::new(2))
     ///     .mute(true)
     ///     .nick(Some("pinkie pie"))?
-    ///     .exec()
     ///     .await?
     ///     .model()
     ///     .await?;
@@ -1161,7 +1154,6 @@ impl Client {
     /// client
     ///     .add_guild_member_role(guild_id, user_id, role_id)
     ///     .reason("test")?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -1262,7 +1254,7 @@ impl Client {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("my token".to_owned());
     /// #
-    /// let invite = client.invite("code").with_counts().exec().await?;
+    /// let invite = client.invite("code").with_counts().await?;
     /// # Ok(()) }
     /// ```
     ///
@@ -1287,7 +1279,7 @@ impl Client {
     /// # let client = Client::new("my token".to_owned());
     /// #
     /// let channel_id = Id::new(123);
-    /// let invite = client.create_invite(channel_id).max_uses(3)?.exec().await?;
+    /// let invite = client.create_invite(channel_id).max_uses(3)?.await?;
     /// # Ok(()) }
     /// ```
     ///
@@ -1335,7 +1327,6 @@ impl Client {
     ///     .create_message(channel_id)
     ///     .content("Twilight is best pony")?
     ///     .tts(true)
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -1394,7 +1385,6 @@ impl Client {
     /// client
     ///     .update_message(Id::new(1), Id::new(2))
     ///     .content(Some("test update"))?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -1411,7 +1401,6 @@ impl Client {
     /// client
     ///     .update_message(Id::new(1), Id::new(2))
     ///     .content(None)?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -1492,7 +1481,6 @@ impl Client {
     ///
     /// let reaction = client
     ///     .create_reaction(channel_id, message_id, &emoji)
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -1583,7 +1571,6 @@ impl Client {
     ///     .create_role(guild_id)
     ///     .color(0xd90083)
     ///     .name("Bright Pink")
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -1752,12 +1739,7 @@ impl Client {
     /// let client = Client::new("my token".to_owned());
     /// let guild_id = Id::new(234);
     ///
-    /// let threads = client
-    ///     .active_threads(guild_id)
-    ///     .exec()
-    ///     .await?
-    ///     .model()
-    ///     .await?;
+    /// let threads = client.active_threads(guild_id).await?.model().await?;
     /// # Ok(()) }
     /// ```
     pub const fn active_threads(&self, guild_id: Id<GuildMarker>) -> GetActiveThreads<'_> {
@@ -1994,10 +1976,7 @@ impl Client {
     /// # let client = Client::new("my token".to_owned());
     /// let channel_id = Id::new(123);
     ///
-    /// let webhook = client
-    ///     .create_webhook(channel_id, "Twily Bot")?
-    ///     .exec()
-    ///     .await?;
+    /// let webhook = client.create_webhook(channel_id, "Twily Bot")?.await?;
     /// # Ok(()) }
     /// ```
     ///
@@ -2052,7 +2031,6 @@ impl Client {
     /// let webhook = client
     ///     .execute_webhook(id, "webhook token")
     ///     .content("Pinkie...")?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -2097,7 +2075,6 @@ impl Client {
     /// client
     ///     .update_webhook_message(Id::new(1), "token here", Id::new(2))
     ///     .content(Some("new message content"))?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -2128,7 +2105,6 @@ impl Client {
     /// # let client = Client::new("token".to_owned());
     /// client
     ///     .delete_webhook_message(Id::new(1), "token here", Id::new(2))
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -2156,7 +2132,6 @@ impl Client {
     ///
     /// client
     ///     .delete_guild_scheduled_event(guild_id, scheduled_event_id)
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -2199,7 +2174,6 @@ impl Client {
     ///         &garfield_start_time,
     ///     )?
     ///     .description("Discuss: How important is Garfield to You?")?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -2228,7 +2202,6 @@ impl Client {
     ///         "In a spiritual successor to BronyCon, Garfield fans from \
     /// around the globe celebrate all things related to the loveable cat.",
     ///     )?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -2315,7 +2288,7 @@ impl Client {
     /// let client = Client::new("my token".to_owned());
     ///
     /// let id = Id::new(123);
-    /// let sticker = client.sticker(id).exec().await?.model().await?;
+    /// let sticker = client.sticker(id).await?.model().await?;
     ///
     /// println!("{sticker:#?}");
     /// # Ok(()) }
@@ -2335,7 +2308,7 @@ impl Client {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new("my token".to_owned());
     ///
-    /// let packs = client.nitro_sticker_packs().exec().await?.model().await?;
+    /// let packs = client.nitro_sticker_packs().await?.model().await?;
     ///
     /// println!("{}", packs.sticker_packs.len());
     /// # Ok(()) }
@@ -2357,12 +2330,7 @@ impl Client {
     /// let client = Client::new("my token".to_owned());
     ///
     /// let guild_id = Id::new(1);
-    /// let stickers = client
-    ///     .guild_stickers(guild_id)
-    ///     .exec()
-    ///     .await?
-    ///     .models()
-    ///     .await?;
+    /// let stickers = client.guild_stickers(guild_id).await?.models().await?;
     ///
     /// println!("{}", stickers.len());
     /// # Ok(()) }
@@ -2387,7 +2355,6 @@ impl Client {
     /// let sticker_id = Id::new(2);
     /// let sticker = client
     ///     .guild_sticker(guild_id, sticker_id)
-    ///     .exec()
     ///     .await?
     ///     .model()
     ///     .await?;
@@ -2424,7 +2391,6 @@ impl Client {
     ///         &"sticker,tags",
     ///         &[23, 23, 23, 23],
     ///     )?
-    ///     .exec()
     ///     .await?
     ///     .model()
     ///     .await?;
@@ -2472,7 +2438,6 @@ impl Client {
     /// let sticker = client
     ///     .update_guild_sticker(guild_id, sticker_id)
     ///     .description("new description")?
-    ///     .exec()
     ///     .await?
     ///     .model()
     ///     .await?;
@@ -2503,10 +2468,7 @@ impl Client {
     /// let guild_id = Id::new(1);
     /// let sticker_id = Id::new(2);
     ///
-    /// client
-    ///     .delete_guild_sticker(guild_id, sticker_id)
-    ///     .exec()
-    ///     .await?;
+    /// client.delete_guild_sticker(guild_id, sticker_id).await?;
     /// # Ok(()) }
     /// ```
     pub const fn delete_guild_sticker(

--- a/twilight-http/src/request/application/command/create_global_command/chat_input.rs
+++ b/twilight-http/src/request/application/command/create_global_command/chat_input.rs
@@ -1,12 +1,12 @@
 use super::super::CommandBorrowed;
 use crate::{
     client::Client,
-    error::Error as HttpError,
+    error::Error,
     request::{Request, RequestBuilder, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, future::IntoFuture};
 use twilight_model::{
     application::command::{Command, CommandOption, CommandType},
     guild::Permissions,
@@ -153,9 +153,18 @@ impl<'a> CreateGlobalChatInputCommand<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateGlobalChatInputCommand<'_> {
+    type Output = Result<Response<Command>, Error>;
+
+    type IntoFuture = ResponseFuture<Command>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {
@@ -166,7 +175,7 @@ impl<'a> CreateGlobalChatInputCommand<'a> {
 }
 
 impl TryIntoRequest for CreateGlobalChatInputCommand<'_> {
-    fn try_into_request(self) -> Result<Request, HttpError> {
+    fn try_into_request(self) -> Result<Request, Error> {
         Request::builder(&Route::CreateGlobalCommand {
             application_id: self.application_id.get(),
         })

--- a/twilight-http/src/request/application/command/create_global_command/message.rs
+++ b/twilight-http/src/request/application/command/create_global_command/message.rs
@@ -3,10 +3,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, RequestBuilder, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, future::IntoFuture};
 use twilight_model::{
     application::command::{Command, CommandType},
     guild::Permissions,
@@ -90,9 +90,18 @@ impl<'a> CreateGlobalMessageCommand<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateGlobalMessageCommand<'_> {
+    type Output = Result<Response<Command>, Error>;
+
+    type IntoFuture = ResponseFuture<Command>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/create_global_command/user.rs
+++ b/twilight-http/src/request/application/command/create_global_command/user.rs
@@ -3,10 +3,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, RequestBuilder, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, future::IntoFuture};
 use twilight_model::{
     application::command::{Command, CommandType},
     guild::Permissions,
@@ -90,9 +90,18 @@ impl<'a> CreateGlobalUserCommand<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateGlobalUserCommand<'_> {
+    type Output = Result<Response<Command>, Error>;
+
+    type IntoFuture = ResponseFuture<Command>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/create_guild_command/message.rs
+++ b/twilight-http/src/request/application/command/create_guild_command/message.rs
@@ -3,10 +3,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, RequestBuilder, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, future::IntoFuture};
 use twilight_model::{
     application::command::{Command, CommandType},
     guild::Permissions,
@@ -85,9 +85,18 @@ impl<'a> CreateGuildMessageCommand<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateGuildMessageCommand<'_> {
+    type Output = Result<Response<Command>, Error>;
+
+    type IntoFuture = ResponseFuture<Command>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/create_guild_command/user.rs
+++ b/twilight-http/src/request/application/command/create_guild_command/user.rs
@@ -3,10 +3,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, RequestBuilder, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, future::IntoFuture};
 use twilight_model::{
     application::command::{Command, CommandType},
     guild::Permissions,
@@ -85,9 +85,18 @@ impl<'a> CreateGuildUserCommand<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateGuildUserCommand<'_> {
+    type Output = Result<Response<Command>, Error>;
+
+    type IntoFuture = ResponseFuture<Command>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/delete_global_command.rs
+++ b/twilight-http/src/request/application/command/delete_global_command.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ApplicationMarker, CommandMarker},
     Id,
@@ -32,9 +33,18 @@ impl<'a> DeleteGlobalCommand<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for DeleteGlobalCommand<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/delete_guild_command.rs
+++ b/twilight-http/src/request/application/command/delete_guild_command.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ApplicationMarker, CommandMarker, GuildMarker},
     Id,
@@ -34,7 +35,18 @@ impl<'a> DeleteGuildCommand<'a> {
         }
     }
 
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for DeleteGuildCommand<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/get_command_permissions.rs
+++ b/twilight-http/src/request/application/command/get_command_permissions.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     application::command::permissions::GuildCommandPermissions,
     id::{
@@ -38,9 +39,18 @@ impl<'a> GetCommandPermissions<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<GuildCommandPermissions> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetCommandPermissions<'_> {
+    type Output = Result<Response<GuildCommandPermissions>, Error>;
+
+    type IntoFuture = ResponseFuture<GuildCommandPermissions>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/get_global_command.rs
+++ b/twilight-http/src/request/application/command/get_global_command.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     application::command::Command,
     id::{
@@ -35,9 +36,18 @@ impl<'a> GetGlobalCommand<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGlobalCommand<'_> {
+    type Output = Result<Response<Command>, Error>;
+
+    type IntoFuture = ResponseFuture<Command>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/get_global_commands.rs
+++ b/twilight-http/src/request/application/command/get_global_commands.rs
@@ -38,6 +38,7 @@ impl<'a> GetGlobalCommands<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Command>> {
         self.into_future()
     }

--- a/twilight-http/src/request/application/command/get_global_commands.rs
+++ b/twilight-http/src/request/application/command/get_global_commands.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     application::command::Command,
     id::{marker::ApplicationMarker, Id},
@@ -37,9 +38,17 @@ impl<'a> GetGlobalCommands<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<ListBody<Command>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGlobalCommands<'_> {
+    type Output = Result<Response<ListBody<Command>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Command>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/get_guild_command.rs
+++ b/twilight-http/src/request/application/command/get_guild_command.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     application::command::Command,
     id::{
@@ -38,9 +39,18 @@ impl<'a> GetGuildCommand<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildCommand<'_> {
+    type Output = Result<Response<Command>, Error>;
+
+    type IntoFuture = ResponseFuture<Command>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/get_guild_command_permissions.rs
+++ b/twilight-http/src/request/application/command/get_guild_command_permissions.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     application::command::permissions::GuildCommandPermissions,
     id::{
@@ -35,9 +36,18 @@ impl<'a> GetGuildCommandPermissions<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<GuildCommandPermissions>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildCommandPermissions<'_> {
+    type Output = Result<Response<ListBody<GuildCommandPermissions>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<GuildCommandPermissions>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/get_guild_commands.rs
+++ b/twilight-http/src/request/application/command/get_guild_commands.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     application::command::Command,
     id::{
@@ -46,9 +47,18 @@ impl<'a> GetGuildCommands<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Command>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildCommands<'_> {
+    type Output = Result<Response<ListBody<Command>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Command>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/set_global_commands.rs
+++ b/twilight-http/src/request/application/command/set_global_commands.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, RequestBuilder, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     application::command::Command,
     id::{marker::ApplicationMarker, Id},
@@ -41,9 +42,18 @@ impl<'a> SetGlobalCommands<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Command>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for SetGlobalCommands<'_> {
+    type Output = Result<Response<ListBody<Command>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Command>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/set_guild_commands.rs
+++ b/twilight-http/src/request/application/command/set_guild_commands.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, RequestBuilder, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     application::command::Command,
     id::{
@@ -47,9 +48,18 @@ impl<'a> SetGuildCommands<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Command>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for SetGuildCommands<'_> {
+    type Output = Result<Response<ListBody<Command>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Command>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/update_command_permissions.rs
+++ b/twilight-http/src/request/application/command/update_command_permissions.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, RequestBuilder, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     application::command::permissions::CommandPermission,
     id::{
@@ -57,9 +58,18 @@ impl<'a> UpdateCommandPermissions<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<CommandPermission>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for UpdateCommandPermissions<'_> {
+    type Output = Result<Response<ListBody<CommandPermission>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<CommandPermission>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/update_global_command.rs
+++ b/twilight-http/src/request/application/command/update_global_command.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, RequestBuilder, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     application::command::{Command, CommandOption},
     id::{
@@ -78,9 +79,18 @@ impl<'a> UpdateGlobalCommand<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for UpdateGlobalCommand<'_> {
+    type Output = Result<Response<Command>, Error>;
+
+    type IntoFuture = ResponseFuture<Command>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/command/update_guild_command.rs
+++ b/twilight-http/src/request/application/command/update_guild_command.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, RequestBuilder, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     application::command::{Command, CommandOption},
     id::{
@@ -81,9 +82,18 @@ impl<'a> UpdateGuildCommand<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for UpdateGuildCommand<'_> {
+    type Output = Result<Response<Command>, Error>;
+
+    type IntoFuture = ResponseFuture<Command>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/interaction/create_followup.rs
+++ b/twilight-http/src/request/application/interaction/create_followup.rs
@@ -1,14 +1,15 @@
 use crate::{
     client::Client,
-    error::Error as HttpError,
+    error::Error,
     request::{
         attachment::{AttachmentManager, PartialAttachment},
         Nullable, Request, TryIntoRequest,
     },
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     channel::message::{AllowedMentions, Component, Embed, Message, MessageFlags},
     http::attachment::Attachment,
@@ -61,7 +62,6 @@ struct CreateFollowupFields<'a> {
 ///     .interaction(application_id)
 ///     .create_followup("webhook token")
 ///     .content("Pinkie...")?
-///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -244,9 +244,18 @@ impl<'a> CreateFollowup<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Message> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateFollowup<'_> {
+    type Output = Result<Response<Message>, Error>;
+
+    type IntoFuture = ResponseFuture<Message>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {
@@ -257,7 +266,7 @@ impl<'a> CreateFollowup<'a> {
 }
 
 impl TryIntoRequest for CreateFollowup<'_> {
-    fn try_into_request(mut self) -> Result<Request, HttpError> {
+    fn try_into_request(mut self) -> Result<Request, Error> {
         let mut request = Request::builder(&Route::ExecuteWebhook {
             thread_id: None,
             token: self.token,
@@ -284,7 +293,7 @@ impl TryIntoRequest for CreateFollowup<'_> {
             } else {
                 self.fields.attachments = Some(self.attachment_manager.get_partial_attachments());
 
-                let fields = crate::json::to_vec(&self.fields).map_err(HttpError::json)?;
+                let fields = crate::json::to_vec(&self.fields).map_err(Error::json)?;
 
                 self.attachment_manager.build_form(fields.as_ref())
             };

--- a/twilight-http/src/request/application/interaction/delete_followup.rs
+++ b/twilight-http/src/request/application/interaction/delete_followup.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ApplicationMarker, MessageMarker},
     Id,
@@ -28,7 +29,6 @@ use twilight_model::id::{
 /// client
 ///     .interaction(application_id)
 ///     .delete_followup("token here", Id::new(2))
-///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -56,9 +56,18 @@ impl<'a> DeleteFollowup<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for DeleteFollowup<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/interaction/delete_response.rs
+++ b/twilight-http/src/request/application/interaction/delete_response.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{marker::ApplicationMarker, Id};
 
 /// Delete a followup message to an interaction, by its token and message ID.
@@ -26,7 +27,6 @@ use twilight_model::id::{marker::ApplicationMarker, Id};
 /// client
 ///     .interaction(application_id)
 ///     .delete_response("token here")
-///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -51,9 +51,18 @@ impl<'a> DeleteResponse<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for DeleteResponse<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/interaction/get_followup.rs
+++ b/twilight-http/src/request/application/interaction/get_followup.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Message,
     id::{
@@ -32,7 +33,6 @@ use twilight_model::{
 /// let response = client
 ///     .interaction(application_id)
 ///     .followup("token here", Id::new(2))
-///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -60,9 +60,18 @@ impl<'a> GetFollowup<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Message> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetFollowup<'_> {
+    type Output = Result<Response<Message>, Error>;
+
+    type IntoFuture = ResponseFuture<Message>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/application/interaction/get_response.rs
+++ b/twilight-http/src/request/application/interaction/get_response.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Message,
     id::{marker::ApplicationMarker, Id},
@@ -29,7 +30,6 @@ use twilight_model::{
 /// client
 ///     .interaction(application_id)
 ///     .response("token here")
-///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -54,9 +54,18 @@ impl<'a> GetResponse<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Message> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetResponse<'_> {
+    type Output = Result<Response<Message>, Error>;
+
+    type IntoFuture = ResponseFuture<Message>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/create_pin.rs
+++ b/twilight-http/src/request/channel/create_pin.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker},
     Id,
@@ -35,15 +36,9 @@ impl<'a> CreatePin<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -54,6 +49,21 @@ impl<'a> AuditLogReason<'a> for CreatePin<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for CreatePin<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/channel/create_typing_trigger.rs
+++ b/twilight-http/src/request/channel/create_typing_trigger.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{marker::ChannelMarker, Id};
 
 /// Fire a Typing Start event in the channel.
@@ -20,9 +21,18 @@ impl<'a> CreateTypingTrigger<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateTypingTrigger<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/delete_channel.rs
+++ b/twilight-http/src/request/channel/delete_channel.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Channel,
     id::{marker::ChannelMarker, Id},
@@ -29,15 +30,9 @@ impl<'a> DeleteChannel<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Channel> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -48,6 +43,21 @@ impl<'a> AuditLogReason<'a> for DeleteChannel<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for DeleteChannel<'_> {
+    type Output = Result<Response<Channel>, Error>;
+
+    type IntoFuture = ResponseFuture<Channel>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/channel/delete_channel_permission_configured.rs
+++ b/twilight-http/src/request/channel/delete_channel_permission_configured.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{marker::ChannelMarker, Id};
 use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
@@ -34,15 +35,9 @@ impl<'a> DeleteChannelPermissionConfigured<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -53,6 +48,21 @@ impl<'a> AuditLogReason<'a> for DeleteChannelPermissionConfigured<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for DeleteChannelPermissionConfigured<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/channel/delete_pin.rs
+++ b/twilight-http/src/request/channel/delete_pin.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker},
     Id,
@@ -35,15 +36,9 @@ impl<'a> DeletePin<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -54,6 +49,21 @@ impl<'a> AuditLogReason<'a> for DeletePin<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for DeletePin<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/channel/follow_news_channel.rs
+++ b/twilight-http/src/request/channel/follow_news_channel.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     channel::FollowedChannel,
     id::{marker::ChannelMarker, Id},
@@ -38,9 +39,18 @@ impl<'a> FollowNewsChannel<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<FollowedChannel> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for FollowNewsChannel<'_> {
+    type Output = Result<Response<FollowedChannel>, Error>;
+
+    type IntoFuture = ResponseFuture<FollowedChannel>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/get_channel.rs
+++ b/twilight-http/src/request/channel/get_channel.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Channel,
     id::{marker::ChannelMarker, Id},
@@ -26,7 +27,7 @@ use twilight_model::{
 ///
 /// let channel_id = Id::new(100);
 ///
-/// let channel = client.channel(channel_id).exec().await?;
+/// let channel = client.channel(channel_id).await?;
 /// # Ok(()) }
 /// ```
 #[must_use = "requests must be configured and executed"]
@@ -41,9 +42,18 @@ impl<'a> GetChannel<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Channel> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetChannel<'_> {
+    type Output = Result<Response<Channel>, Error>;
+
+    type IntoFuture = ResponseFuture<Channel>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/get_pins.rs
+++ b/twilight-http/src/request/channel/get_pins.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Message,
     id::{marker::ChannelMarker, Id},
@@ -23,9 +24,18 @@ impl<'a> GetPins<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Message>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetPins<'_> {
+    type Output = Result<Response<ListBody<Message>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Message>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/invite/create_invite.rs
+++ b/twilight-http/src/request/channel/invite/create_invite.rs
@@ -1,11 +1,12 @@
 use crate::{
     client::Client,
-    error::Error as HttpError,
+    error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     guild::invite::{Invite, TargetType},
     id::{
@@ -51,7 +52,7 @@ struct CreateInviteFields {
 /// let client = Client::new("my token".to_owned());
 ///
 /// let channel_id = Id::new(123);
-/// let invite = client.create_invite(channel_id).max_uses(3)?.exec().await?;
+/// let invite = client.create_invite(channel_id).max_uses(3)?.await?;
 /// # Ok(()) }
 /// ```
 ///
@@ -103,7 +104,6 @@ impl<'a> CreateInvite<'a> {
     /// let invite = client
     ///     .create_invite(Id::new(1))
     ///     .max_age(60 * 60)?
-    ///     .exec()
     ///     .await?
     ///     .model()
     ///     .await?;
@@ -147,7 +147,6 @@ impl<'a> CreateInvite<'a> {
     /// let invite = client
     ///     .create_invite(Id::new(1))
     ///     .max_uses(5)?
-    ///     .exec()
     ///     .await?
     ///     .model()
     ///     .await?;
@@ -222,15 +221,9 @@ impl<'a> CreateInvite<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Invite> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -244,8 +237,23 @@ impl<'a> AuditLogReason<'a> for CreateInvite<'a> {
     }
 }
 
+impl IntoFuture for CreateInvite<'_> {
+    type Output = Result<Response<Invite>, Error>;
+
+    type IntoFuture = ResponseFuture<Invite>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
+    }
+}
+
 impl TryIntoRequest for CreateInvite<'_> {
-    fn try_into_request(self) -> Result<Request, HttpError> {
+    fn try_into_request(self) -> Result<Request, Error> {
         let mut request = Request::builder(&Route::CreateInvite {
             channel_id: self.channel_id.get(),
         });

--- a/twilight-http/src/request/channel/invite/delete_invite.rs
+++ b/twilight-http/src/request/channel/invite/delete_invite.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 /// Delete an invite by its code.
@@ -31,15 +32,9 @@ impl<'a> DeleteInvite<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -50,6 +45,21 @@ impl<'a> AuditLogReason<'a> for DeleteInvite<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for DeleteInvite<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/channel/invite/get_channel_invites.rs
+++ b/twilight-http/src/request/channel/invite/get_channel_invites.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::invite::Invite,
     id::{marker::ChannelMarker, Id},
@@ -28,9 +29,18 @@ impl<'a> GetChannelInvites<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Invite>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetChannelInvites<'_> {
+    type Output = Result<Response<ListBody<Invite>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Invite>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/invite/get_invite.rs
+++ b/twilight-http/src/request/channel/invite/get_invite.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::guild::invite::Invite;
 
 struct GetInviteFields {
@@ -27,7 +28,7 @@ struct GetInviteFields {
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token".to_owned());
 ///
-/// let invite = client.invite("code").with_counts().exec().await?;
+/// let invite = client.invite("code").with_counts().await?;
 /// # Ok(()) }
 /// ```
 ///
@@ -67,9 +68,18 @@ impl<'a> GetInvite<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Invite> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetInvite<'_> {
+    type Output = Result<Response<Invite>, Error>;
+
+    type IntoFuture = ResponseFuture<Invite>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/message/crosspost_message.rs
+++ b/twilight-http/src/request/channel/message/crosspost_message.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Message,
     id::{
@@ -35,9 +36,18 @@ impl<'a> CrosspostMessage<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Message> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CrosspostMessage<'_> {
+    type Output = Result<Response<Message>, Error>;
+
+    type IntoFuture = ResponseFuture<Message>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/message/delete_message.rs
+++ b/twilight-http/src/request/channel/message/delete_message.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker},
     Id,
@@ -35,15 +36,9 @@ impl<'a> DeleteMessage<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -54,6 +49,21 @@ impl<'a> AuditLogReason<'a> for DeleteMessage<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for DeleteMessage<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/channel/message/delete_messages.rs
+++ b/twilight-http/src/request/channel/message/delete_messages.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker},
     Id,
@@ -48,15 +49,9 @@ impl<'a> DeleteMessages<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -67,6 +62,21 @@ impl<'a> AuditLogReason<'a> for DeleteMessages<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for DeleteMessages<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/twilight-http/src/request/channel/message/get_channel_messages_configured.rs
@@ -1,10 +1,11 @@
 use crate::{
     client::Client,
-    error::Error as HttpError,
+    error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Message,
     id::{
@@ -78,9 +79,18 @@ impl<'a> GetChannelMessagesConfigured<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Message>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetChannelMessagesConfigured<'_> {
+    type Output = Result<Response<ListBody<Message>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Message>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {
@@ -91,7 +101,7 @@ impl<'a> GetChannelMessagesConfigured<'a> {
 }
 
 impl TryIntoRequest for GetChannelMessagesConfigured<'_> {
-    fn try_into_request(self) -> Result<Request, HttpError> {
+    fn try_into_request(self) -> Result<Request, Error> {
         Ok(Request::from_route(&Route::GetMessages {
             after: self.after.map(Id::get),
             around: self.around.map(Id::get),

--- a/twilight-http/src/request/channel/message/get_message.rs
+++ b/twilight-http/src/request/channel/message/get_message.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Message,
     id::{
@@ -35,9 +36,18 @@ impl<'a> GetMessage<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Message> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetMessage<'_> {
+    type Output = Result<Response<Message>, Error>;
+
+    type IntoFuture = ResponseFuture<Message>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/reaction/create_reaction.rs
+++ b/twilight-http/src/request/channel/reaction/create_reaction.rs
@@ -3,9 +3,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker},
     Id,
@@ -30,7 +31,6 @@ use twilight_model::id::{
 ///
 /// let reaction = client
 ///     .create_reaction(channel_id, message_id, &emoji)
-///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -58,9 +58,18 @@ impl<'a> CreateReaction<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateReaction<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/reaction/delete_all_reaction.rs
+++ b/twilight-http/src/request/channel/reaction/delete_all_reaction.rs
@@ -3,9 +3,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker},
     Id,
@@ -36,9 +37,18 @@ impl<'a> DeleteAllReaction<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for DeleteAllReaction<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/reaction/delete_all_reactions.rs
+++ b/twilight-http/src/request/channel/reaction/delete_all_reactions.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker},
     Id,
@@ -32,9 +33,18 @@ impl<'a> DeleteAllReactions<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for DeleteAllReactions<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/reaction/delete_reaction.rs
+++ b/twilight-http/src/request/channel/reaction/delete_reaction.rs
@@ -3,9 +3,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker, UserMarker},
     Id,
@@ -47,9 +48,18 @@ impl<'a> DeleteReaction<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for DeleteReaction<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/stage/delete_stage_instance.rs
+++ b/twilight-http/src/request/channel/stage/delete_stage_instance.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{marker::ChannelMarker, Id};
 
 /// Delete the stage instance of a stage channel.
@@ -22,9 +23,18 @@ impl<'a> DeleteStageInstance<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for DeleteStageInstance<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/stage/get_stage_instance.rs
+++ b/twilight-http/src/request/channel/stage/get_stage_instance.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::StageInstance,
     id::{marker::ChannelMarker, Id},
@@ -23,9 +24,18 @@ impl<'a> GetStageInstance<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<StageInstance> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetStageInstance<'_> {
+    type Output = Result<Response<StageInstance>, Error>;
+
+    type IntoFuture = ResponseFuture<StageInstance>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/thread/add_thread_member.rs
+++ b/twilight-http/src/request/channel/thread/add_thread_member.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, UserMarker},
     Id,
@@ -35,9 +36,18 @@ impl<'a> AddThreadMember<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for AddThreadMember<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/thread/create_forum_thread/message.rs
+++ b/twilight-http/src/request/channel/thread/create_forum_thread/message.rs
@@ -1,9 +1,11 @@
 use super::{CreateForumThread, ForumThread};
 use crate::{
-    request::{attachment::PartialAttachment, Nullable},
-    response::ResponseFuture,
+    request::{attachment::PartialAttachment, Nullable, TryIntoRequest},
+    response::{Response, ResponseFuture},
+    Error,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     channel::message::{AllowedMentions, Component, Embed, MessageFlags},
     http::attachment::Attachment,
@@ -196,9 +198,24 @@ impl<'a> CreateForumThreadMessage<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ForumThread> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateForumThreadMessage<'_> {
+    type Output = Result<Response<ForumThread>, Error>;
+
+    type IntoFuture = ResponseFuture<ForumThread>;
+
+    fn into_future(self) -> Self::IntoFuture {
         self.0.exec()
+    }
+}
+
+impl TryIntoRequest for CreateForumThreadMessage<'_> {
+    fn try_into_request(self) -> Result<crate::request::Request, Error> {
+        self.0.try_into_request()
     }
 }

--- a/twilight-http/src/request/channel/thread/create_forum_thread/mod.rs
+++ b/twilight-http/src/request/channel/thread/create_forum_thread/mod.rs
@@ -5,8 +5,8 @@ pub use self::message::CreateForumThreadMessage;
 use self::message::CreateForumThreadMessageFields;
 use crate::{
     client::Client,
-    error::Error as HttpError,
-    request::{attachment::AttachmentManager, Nullable, Request, TryIntoRequest},
+    error::Error,
+    request::{attachment::AttachmentManager, Nullable, Request},
     response::ResponseFuture,
     routing::Route,
 };
@@ -116,10 +116,8 @@ impl<'a> CreateForumThread<'a> {
             Err(source) => ResponseFuture::error(source),
         }
     }
-}
 
-impl TryIntoRequest for CreateForumThread<'_> {
-    fn try_into_request(mut self) -> Result<Request, HttpError> {
+    fn try_into_request(mut self) -> Result<Request, Error> {
         let mut request = Request::builder(&Route::CreateForumThread {
             channel_id: self.channel_id.get(),
         });
@@ -140,7 +138,7 @@ impl TryIntoRequest for CreateForumThread<'_> {
                 self.fields.message.attachments =
                     Some(self.attachment_manager.get_partial_attachments());
 
-                let fields = crate::json::to_vec(&self.fields).map_err(HttpError::json)?;
+                let fields = crate::json::to_vec(&self.fields).map_err(Error::json)?;
 
                 self.attachment_manager.build_form(fields.as_ref())
             };

--- a/twilight-http/src/request/channel/thread/create_thread.rs
+++ b/twilight-http/src/request/channel/thread/create_thread.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, RequestBuilder, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     channel::{thread::AutoArchiveDuration, Channel, ChannelType},
     id::{marker::ChannelMarker, Id},
@@ -82,9 +83,18 @@ impl<'a> CreateThread<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Channel> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateThread<'_> {
+    type Output = Result<Response<Channel>, Error>;
+
+    type IntoFuture = ResponseFuture<Channel>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/thread/create_thread_from_message.rs
+++ b/twilight-http/src/request/channel/thread/create_thread_from_message.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, RequestBuilder, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     channel::{thread::AutoArchiveDuration, Channel},
     id::{
@@ -84,9 +85,18 @@ impl<'a> CreateThreadFromMessage<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Channel> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateThreadFromMessage<'_> {
+    type Output = Result<Response<Channel>, Error>;
+
+    type IntoFuture = ResponseFuture<Channel>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/thread/get_joined_private_archived_threads.rs
+++ b/twilight-http/src/request/channel/thread/get_joined_private_archived_threads.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::thread::ThreadsListing,
     id::{marker::ChannelMarker, Id},
@@ -47,9 +48,18 @@ impl<'a> GetJoinedPrivateArchivedThreads<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ThreadsListing> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetJoinedPrivateArchivedThreads<'_> {
+    type Output = Result<Response<ThreadsListing>, Error>;
+
+    type IntoFuture = ResponseFuture<ThreadsListing>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/thread/get_private_archived_threads.rs
+++ b/twilight-http/src/request/channel/thread/get_private_archived_threads.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::thread::ThreadsListing,
     id::{marker::ChannelMarker, Id},
@@ -49,9 +50,18 @@ impl<'a> GetPrivateArchivedThreads<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ThreadsListing> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetPrivateArchivedThreads<'_> {
+    type Output = Result<Response<ThreadsListing>, Error>;
+
+    type IntoFuture = ResponseFuture<ThreadsListing>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/thread/get_public_archived_threads.rs
+++ b/twilight-http/src/request/channel/thread/get_public_archived_threads.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::thread::ThreadsListing,
     id::{marker::ChannelMarker, Id},
@@ -59,9 +60,18 @@ impl<'a> GetPublicArchivedThreads<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ThreadsListing> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetPublicArchivedThreads<'_> {
+    type Output = Result<Response<ThreadsListing>, Error>;
+
+    type IntoFuture = ResponseFuture<ThreadsListing>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/thread/get_thread_member.rs
+++ b/twilight-http/src/request/channel/thread/get_thread_member.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::thread::ThreadMember,
     id::{
@@ -37,9 +38,18 @@ impl<'a> GetThreadMember<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ThreadMember> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetThreadMember<'_> {
+    type Output = Result<Response<ThreadMember>, Error>;
+
+    type IntoFuture = ResponseFuture<ThreadMember>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/thread/get_thread_members.rs
+++ b/twilight-http/src/request/channel/thread/get_thread_members.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::thread::ThreadMember,
     id::{marker::ChannelMarker, Id},
@@ -25,9 +26,18 @@ impl<'a> GetThreadMembers<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<ThreadMember>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetThreadMembers<'_> {
+    type Output = Result<Response<ListBody<ThreadMember>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<ThreadMember>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/thread/join_thread.rs
+++ b/twilight-http/src/request/channel/thread/join_thread.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{marker::ChannelMarker, Id};
 
 /// Add the current user to a thread.
@@ -20,9 +21,18 @@ impl<'a> JoinThread<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for JoinThread<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/thread/leave_thread.rs
+++ b/twilight-http/src/request/channel/thread/leave_thread.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{marker::ChannelMarker, Id};
 
 /// Remove the current user from a thread.
@@ -22,9 +23,18 @@ impl<'a> LeaveThread<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for LeaveThread<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/thread/remove_thread_member.rs
+++ b/twilight-http/src/request/channel/thread/remove_thread_member.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, UserMarker},
     Id,
@@ -40,9 +41,18 @@ impl<'a> RemoveThreadMember<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for RemoveThreadMember<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/update_channel.rs
+++ b/twilight-http/src/request/channel/update_channel.rs
@@ -1,11 +1,12 @@
 use crate::{
     client::Client,
-    error::Error as HttpError,
+    error::Error,
     request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     channel::{
         forum::{DefaultReaction, ForumTag},
@@ -341,15 +342,9 @@ impl<'a> UpdateChannel<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Channel> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -363,8 +358,23 @@ impl<'a> AuditLogReason<'a> for UpdateChannel<'a> {
     }
 }
 
+impl IntoFuture for UpdateChannel<'_> {
+    type Output = Result<Response<Channel>, Error>;
+
+    type IntoFuture = ResponseFuture<Channel>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
+    }
+}
+
 impl TryIntoRequest for UpdateChannel<'_> {
-    fn try_into_request(self) -> Result<Request, HttpError> {
+    fn try_into_request(self) -> Result<Request, Error> {
         let mut request = Request::builder(&Route::UpdateChannel {
             channel_id: self.channel_id.get(),
         })

--- a/twilight-http/src/request/channel/webhook/delete_webhook.rs
+++ b/twilight-http/src/request/channel/webhook/delete_webhook.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{marker::WebhookMarker, Id};
 use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
@@ -39,15 +40,9 @@ impl<'a> DeleteWebhook<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -58,6 +53,21 @@ impl<'a> AuditLogReason<'a> for DeleteWebhook<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for DeleteWebhook<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/channel/webhook/delete_webhook_message.rs
+++ b/twilight-http/src/request/channel/webhook/delete_webhook_message.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, MessageMarker, WebhookMarker},
     Id,
@@ -26,7 +27,6 @@ use twilight_validate::request::{audit_reason as validate_audit_reason, Validati
 /// client
 ///     .delete_webhook_message(Id::new(1), "token here", Id::new(2))
 ///     .reason("reason here")?
-///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -66,15 +66,9 @@ impl<'a> DeleteWebhookMessage<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -85,6 +79,21 @@ impl<'a> AuditLogReason<'a> for DeleteWebhookMessage<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for DeleteWebhookMessage<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/channel/webhook/execute_webhook_and_wait.rs
+++ b/twilight-http/src/request/channel/webhook/execute_webhook_and_wait.rs
@@ -1,10 +1,11 @@
-use super::execute_webhook::ExecuteWebhook;
+use super::ExecuteWebhook;
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
 };
+use std::future::IntoFuture;
 use twilight_model::channel::Message;
 
 /// Execute a webhook, sending a message to its channel, and then wait for the
@@ -25,7 +26,6 @@ use twilight_model::channel::Message;
 ///     .execute_webhook(id, "webhook token")
 ///     .content("Pinkie...")?
 ///     .wait()
-///     .exec()
 ///     .await?
 ///     .model()
 ///     .await?;
@@ -45,9 +45,18 @@ impl<'a> ExecuteWebhookAndWait<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Message> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for ExecuteWebhookAndWait<'_> {
+    type Output = Result<Response<Message>, Error>;
+
+    type IntoFuture = ResponseFuture<Message>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/webhook/get_channel_webhooks.rs
+++ b/twilight-http/src/request/channel/webhook/get_channel_webhooks.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Webhook,
     id::{marker::ChannelMarker, Id},
@@ -23,9 +24,18 @@ impl<'a> GetChannelWebhooks<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Webhook>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetChannelWebhooks<'_> {
+    type Output = Result<Response<ListBody<Webhook>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Webhook>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/webhook/get_webhook.rs
+++ b/twilight-http/src/request/channel/webhook/get_webhook.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Webhook,
     id::{marker::WebhookMarker, Id},
@@ -40,9 +41,18 @@ impl<'a> GetWebhook<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Webhook> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetWebhook<'_> {
+    type Output = Result<Response<Webhook>, Error>;
+
+    type IntoFuture = ResponseFuture<Webhook>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/webhook/get_webhook_message.rs
+++ b/twilight-http/src/request/channel/webhook/get_webhook_message.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Message,
     id::{
@@ -48,9 +49,18 @@ impl<'a> GetWebhookMessage<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Message> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetWebhookMessage<'_> {
+    type Output = Result<Response<Message>, Error>;
+
+    type IntoFuture = ResponseFuture<Message>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/twilight-http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Nullable, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Webhook,
     id::{marker::WebhookMarker, Id},
@@ -76,9 +77,18 @@ impl<'a> UpdateWebhookWithToken<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Webhook> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for UpdateWebhookWithToken<'_> {
+    type Output = Result<Response<Webhook>, Error>;
+
+    type IntoFuture = ResponseFuture<Webhook>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/get_gateway.rs
+++ b/twilight-http/src/request/get_gateway.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{GetGatewayAuthed, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::gateway::connection_info::ConnectionInfo;
 
 /// Get information about the gateway, optionally with additional information detailing the
@@ -21,7 +22,7 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token".to_owned());
 ///
-/// let info = client.gateway().exec().await?.model().await?;
+/// let info = client.gateway().await?.model().await?;
 /// # Ok(()) }
 /// ```
 ///
@@ -35,7 +36,7 @@ use twilight_model::gateway::connection_info::ConnectionInfo;
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token".to_owned());
 ///
-/// let info = client.gateway().authed().exec().await?.model().await?;
+/// let info = client.gateway().authed().await?.model().await?;
 ///
 /// println!("URL: {}", info.url);
 /// println!("Recommended shards to use: {}", info.shards);
@@ -60,9 +61,18 @@ impl<'a> GetGateway<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ConnectionInfo> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGateway<'_> {
+    type Output = Result<Response<ConnectionInfo>, Error>;
+
+    type IntoFuture = ResponseFuture<ConnectionInfo>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/get_gateway_authed.rs
+++ b/twilight-http/src/request/get_gateway_authed.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::gateway::connection_info::BotConnectionInfo;
 
 /// Get information about the gateway, authenticated as a bot user.
@@ -22,9 +23,18 @@ impl<'a> GetGatewayAuthed<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<BotConnectionInfo> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGatewayAuthed<'_> {
+    type Output = Result<Response<BotConnectionInfo>, Error>;
+
+    type IntoFuture = ResponseFuture<BotConnectionInfo>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/get_user_application.rs
+++ b/twilight-http/src/request/get_user_application.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::oauth::Application;
 
 #[must_use = "requests must be configured and executed"]
@@ -18,9 +19,18 @@ impl<'a> GetUserApplicationInfo<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Application> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetUserApplicationInfo<'_> {
+    type Output = Result<Response<Application>, Error>;
+
+    type IntoFuture = ResponseFuture<Application>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/get_voice_regions.rs
+++ b/twilight-http/src/request/get_voice_regions.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::voice::VoiceRegion;
 
 /// Get a list of voice regions that can be used when creating a guild.
@@ -19,9 +20,18 @@ impl<'a> GetVoiceRegions<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<VoiceRegion>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetVoiceRegions<'_> {
+    type Output = Result<Response<ListBody<VoiceRegion>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<VoiceRegion>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/auto_moderation/delete_auto_moderation_rule.rs
+++ b/twilight-http/src/request/guild/auto_moderation/delete_auto_moderation_rule.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{AutoModerationRuleMarker, GuildMarker},
     Id,
@@ -39,15 +40,9 @@ impl<'a> DeleteAutoModerationRule<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -58,6 +53,21 @@ impl<'a> AuditLogReason<'a> for DeleteAutoModerationRule<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for DeleteAutoModerationRule<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/guild/auto_moderation/get_auto_moderation_rule.rs
+++ b/twilight-http/src/request/guild/auto_moderation/get_auto_moderation_rule.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::auto_moderation::AutoModerationRule,
     id::{
@@ -41,9 +42,18 @@ impl<'a> GetAutoModerationRule<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<AutoModerationRule> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetAutoModerationRule<'_> {
+    type Output = Result<Response<AutoModerationRule>, Error>;
+
+    type IntoFuture = ResponseFuture<AutoModerationRule>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/auto_moderation/get_guild_auto_moderation_rules.rs
+++ b/twilight-http/src/request/guild/auto_moderation/get_guild_auto_moderation_rules.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::auto_moderation::AutoModerationRule,
     id::{marker::GuildMarker, Id},
@@ -27,9 +28,18 @@ impl<'a> GetGuildAutoModerationRules<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<AutoModerationRule>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildAutoModerationRules<'_> {
+    type Output = Result<Response<ListBody<AutoModerationRule>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<AutoModerationRule>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/ban/get_ban.rs
+++ b/twilight-http/src/request/guild/ban/get_ban.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::Ban,
     id::{
@@ -37,9 +38,18 @@ impl<'a> GetBan<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Ban> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetBan<'_> {
+    type Output = Result<Response<Ban>, Error>;
+
+    type IntoFuture = ResponseFuture<Ban>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/ban/get_bans.rs
+++ b/twilight-http/src/request/guild/ban/get_bans.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::Ban,
     id::{
@@ -40,12 +41,7 @@ struct GetBansFields {
 /// let guild_id = Id::new(1);
 /// let user_id = Id::new(2);
 ///
-/// let response = client
-///     .bans(guild_id)
-///     .after(user_id)
-///     .limit(25)?
-///     .exec()
-///     .await?;
+/// let response = client.bans(guild_id).after(user_id).limit(25)?.await?;
 /// let bans = response.models().await?;
 ///
 /// for ban in bans {
@@ -121,9 +117,18 @@ impl<'a> GetBans<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Ban>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetBans<'_> {
+    type Output = Result<Response<ListBody<Ban>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Ban>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/create_guild/mod.rs
+++ b/twilight-http/src/request/guild/create_guild/mod.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error as HttpError,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -317,7 +318,6 @@ impl<'a> CreateGuild<'a> {
     /// let guild = client
     ///     .create_guild("guild name".to_owned())?
     ///     .channels(channels)?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -430,7 +430,6 @@ impl<'a> CreateGuild<'a> {
     /// client
     ///     .create_guild("guild name".to_owned())?
     ///     .roles(roles)?
-    ///     .exec()
     ///     .await?;
     /// # Ok(()) }
     /// ```
@@ -460,9 +459,18 @@ impl<'a> CreateGuild<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<PartialGuild> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateGuild<'_> {
+    type Output = Result<Response<PartialGuild>, HttpError>;
+
+    type IntoFuture = ResponseFuture<PartialGuild>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/create_guild_prune.rs
+++ b/twilight-http/src/request/guild/create_guild_prune.rs
@@ -1,10 +1,11 @@
 use crate::{
     client::Client,
-    error::Error as HttpError,
+    error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::GuildPrune,
     id::{
@@ -86,15 +87,9 @@ impl<'a> CreateGuildPrune<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<GuildPrune> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -108,8 +103,23 @@ impl<'a> AuditLogReason<'a> for CreateGuildPrune<'a> {
     }
 }
 
+impl IntoFuture for CreateGuildPrune<'_> {
+    type Output = Result<Response<GuildPrune>, Error>;
+
+    type IntoFuture = ResponseFuture<GuildPrune>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
+    }
+}
+
 impl TryIntoRequest for CreateGuildPrune<'_> {
-    fn try_into_request(self) -> Result<Request, HttpError> {
+    fn try_into_request(self) -> Result<Request, Error> {
         let mut request = Request::builder(&Route::CreateGuildPrune {
             compute_prune_count: self.fields.compute_prune_count,
             days: self.fields.days,

--- a/twilight-http/src/request/guild/delete_guild.rs
+++ b/twilight-http/src/request/guild/delete_guild.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{marker::GuildMarker, Id};
 
 /// Delete a guild permanently. The user must be the owner.
@@ -20,9 +21,18 @@ impl<'a> DeleteGuild<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for DeleteGuild<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/emoji/delete_emoji.rs
+++ b/twilight-http/src/request/guild/emoji/delete_emoji.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{EmojiMarker, GuildMarker},
     Id,
@@ -35,15 +36,9 @@ impl<'a> DeleteEmoji<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -54,6 +49,21 @@ impl<'a> AuditLogReason<'a> for DeleteEmoji<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for DeleteEmoji<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/guild/emoji/get_emoji.rs
+++ b/twilight-http/src/request/guild/emoji/get_emoji.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::Emoji,
     id::{
@@ -30,7 +31,7 @@ use twilight_model::{
 /// let guild_id = Id::new(50);
 /// let emoji_id = Id::new(100);
 ///
-/// client.emoji(guild_id, emoji_id).exec().await?;
+/// client.emoji(guild_id, emoji_id).await?;
 /// # Ok(()) }
 /// ```
 #[must_use = "requests must be configured and executed"]
@@ -54,9 +55,18 @@ impl<'a> GetEmoji<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Emoji> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetEmoji<'_> {
+    type Output = Result<Response<Emoji>, Error>;
+
+    type IntoFuture = ResponseFuture<Emoji>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/emoji/get_emojis.rs
+++ b/twilight-http/src/request/guild/emoji/get_emojis.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::Emoji,
     id::{marker::GuildMarker, Id},
@@ -26,7 +27,7 @@ use twilight_model::{
 ///
 /// let guild_id = Id::new(100);
 ///
-/// client.emojis(guild_id).exec().await?;
+/// client.emojis(guild_id).await?;
 /// # Ok(()) }
 /// ```
 #[must_use = "requests must be configured and executed"]
@@ -41,9 +42,18 @@ impl<'a> GetEmojis<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Emoji>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetEmojis<'_> {
+    type Output = Result<Response<ListBody<Emoji>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Emoji>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/get_active_threads.rs
+++ b/twilight-http/src/request/guild/get_active_threads.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::thread::ThreadsListing,
     id::{marker::GuildMarker, Id},
@@ -26,9 +27,18 @@ impl<'a> GetActiveThreads<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ThreadsListing> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetActiveThreads<'_> {
+    type Output = Result<Response<ThreadsListing>, Error>;
+
+    type IntoFuture = ResponseFuture<ThreadsListing>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/get_guild.rs
+++ b/twilight-http/src/request/guild/get_guild.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::Guild,
     id::{marker::GuildMarker, Id},
@@ -40,9 +41,18 @@ impl<'a> GetGuild<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Guild> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuild<'_> {
+    type Output = Result<Response<Guild>, Error>;
+
+    type IntoFuture = ResponseFuture<Guild>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/get_guild_channels.rs
+++ b/twilight-http/src/request/guild/get_guild_channels.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Channel,
     id::{marker::GuildMarker, Id},
@@ -23,9 +24,18 @@ impl<'a> GetGuildChannels<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Channel>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildChannels<'_> {
+    type Output = Result<Response<ListBody<Channel>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Channel>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/get_guild_invites.rs
+++ b/twilight-http/src/request/guild/get_guild_invites.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::invite::Invite,
     id::{marker::GuildMarker, Id},
@@ -27,9 +28,18 @@ impl<'a> GetGuildInvites<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Invite>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildInvites<'_> {
+    type Output = Result<Response<ListBody<Invite>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Invite>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/get_guild_preview.rs
+++ b/twilight-http/src/request/guild/get_guild_preview.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::GuildPreview,
     id::{marker::GuildMarker, Id},
@@ -25,9 +26,18 @@ impl<'a> GetGuildPreview<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<GuildPreview> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildPreview<'_> {
+    type Output = Result<Response<GuildPreview>, Error>;
+
+    type IntoFuture = ResponseFuture<GuildPreview>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/get_guild_prune_count.rs
+++ b/twilight-http/src/request/guild/get_guild_prune_count.rs
@@ -1,10 +1,11 @@
 use crate::{
     client::Client,
-    error::Error as HttpError,
+    error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::GuildPrune,
     id::{
@@ -69,9 +70,18 @@ impl<'a> GetGuildPruneCount<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<GuildPrune> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildPruneCount<'_> {
+    type Output = Result<Response<GuildPrune>, Error>;
+
+    type IntoFuture = ResponseFuture<GuildPrune>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {
@@ -82,7 +92,7 @@ impl<'a> GetGuildPruneCount<'a> {
 }
 
 impl TryIntoRequest for GetGuildPruneCount<'_> {
-    fn try_into_request(self) -> Result<Request, HttpError> {
+    fn try_into_request(self) -> Result<Request, Error> {
         Ok(Request::from_route(&Route::GetGuildPruneCount {
             days: self.fields.days,
             guild_id: self.guild_id.get(),

--- a/twilight-http/src/request/guild/get_guild_vanity_url.rs
+++ b/twilight-http/src/request/guild/get_guild_vanity_url.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::VanityUrl,
     id::{marker::GuildMarker, Id},
@@ -23,9 +24,18 @@ impl<'a> GetGuildVanityUrl<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<VanityUrl> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildVanityUrl<'_> {
+    type Output = Result<Response<VanityUrl>, Error>;
+
+    type IntoFuture = ResponseFuture<VanityUrl>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/get_guild_voice_regions.rs
+++ b/twilight-http/src/request/guild/get_guild_voice_regions.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     id::{marker::GuildMarker, Id},
     voice::VoiceRegion,
@@ -25,9 +26,18 @@ impl<'a> GetGuildVoiceRegions<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<VoiceRegion>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildVoiceRegions<'_> {
+    type Output = Result<Response<ListBody<VoiceRegion>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<VoiceRegion>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/get_guild_webhooks.rs
+++ b/twilight-http/src/request/guild/get_guild_webhooks.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Webhook,
     id::{marker::GuildMarker, Id},
@@ -23,9 +24,18 @@ impl<'a> GetGuildWebhooks<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Webhook>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildWebhooks<'_> {
+    type Output = Result<Response<ListBody<Webhook>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Webhook>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/get_guild_welcome_screen.rs
+++ b/twilight-http/src/request/guild/get_guild_welcome_screen.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::invite::WelcomeScreen,
     id::{marker::GuildMarker, Id},
@@ -28,9 +29,18 @@ impl<'a> GetGuildWelcomeScreen<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<WelcomeScreen> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildWelcomeScreen<'_> {
+    type Output = Result<Response<WelcomeScreen>, Error>;
+
+    type IntoFuture = ResponseFuture<WelcomeScreen>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/get_guild_widget.rs
+++ b/twilight-http/src/request/guild/get_guild_widget.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::GuildWidget,
     id::{marker::GuildMarker, Id},
@@ -27,9 +28,18 @@ impl<'a> GetGuildWidget<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<GuildWidget> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildWidget<'_> {
+    type Output = Result<Response<GuildWidget>, Error>;
+
+    type IntoFuture = ResponseFuture<GuildWidget>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/integration/delete_guild_integration.rs
+++ b/twilight-http/src/request/guild/integration/delete_guild_integration.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{GuildMarker, IntegrationMarker},
     Id,
@@ -35,15 +36,9 @@ impl<'a> DeleteGuildIntegration<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -54,6 +49,21 @@ impl<'a> AuditLogReason<'a> for DeleteGuildIntegration<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for DeleteGuildIntegration<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/guild/integration/get_guild_integrations.rs
+++ b/twilight-http/src/request/guild/integration/get_guild_integrations.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::GuildIntegration,
     id::{marker::GuildMarker, Id},
@@ -23,9 +24,18 @@ impl<'a> GetGuildIntegrations<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<GuildIntegration>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildIntegrations<'_> {
+    type Output = Result<Response<ListBody<GuildIntegration>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<GuildIntegration>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/member/add_role_to_member.rs
+++ b/twilight-http/src/request/guild/member/add_role_to_member.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{GuildMarker, RoleMarker, UserMarker},
     Id,
@@ -32,7 +33,6 @@ use twilight_validate::request::{audit_reason as validate_audit_reason, Validati
 /// client
 ///     .add_guild_member_role(guild_id, user_id, role_id)
 ///     .reason("test")?
-///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -62,15 +62,9 @@ impl<'a> AddRoleToMember<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -81,6 +75,21 @@ impl<'a> AuditLogReason<'a> for AddRoleToMember<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for AddRoleToMember<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/guild/member/get_member.rs
+++ b/twilight-http/src/request/guild/member/get_member.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::MemberBody, ResponseFuture},
+    response::{marker::MemberBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{GuildMarker, UserMarker},
     Id,
@@ -32,9 +33,17 @@ impl<'a> GetMember<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
     pub fn exec(self) -> ResponseFuture<MemberBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetMember<'_> {
+    type Output = Result<Response<MemberBody>, Error>;
+
+    type IntoFuture = ResponseFuture<MemberBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let guild_id = self.guild_id;
         let http = self.http;
 

--- a/twilight-http/src/request/guild/member/get_member.rs
+++ b/twilight-http/src/request/guild/member/get_member.rs
@@ -33,6 +33,7 @@ impl<'a> GetMember<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<MemberBody> {
         self.into_future()
     }

--- a/twilight-http/src/request/guild/member/remove_role_from_member.rs
+++ b/twilight-http/src/request/guild/member/remove_role_from_member.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{GuildMarker, RoleMarker, UserMarker},
     Id,
@@ -38,15 +39,9 @@ impl<'a> RemoveRoleFromMember<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -57,6 +52,21 @@ impl<'a> AuditLogReason<'a> for RemoveRoleFromMember<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for RemoveRoleFromMember<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/guild/member/search_guild_members.rs
+++ b/twilight-http/src/request/guild/member/search_guild_members.rs
@@ -1,10 +1,11 @@
 use crate::{
     client::Client,
-    error::Error as HttpError,
+    error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::MemberListBody, ResponseFuture},
+    response::{marker::MemberListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{marker::GuildMarker, Id};
 use twilight_validate::request::{
     search_guild_members_limit as validate_search_guild_members_limit, ValidationError,
@@ -35,7 +36,6 @@ struct SearchGuildMembersFields<'a> {
 /// let members = client
 ///     .search_guild_members(guild_id, "Wumpus")
 ///     .limit(10)?
-///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -84,9 +84,18 @@ impl<'a> SearchGuildMembers<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<MemberListBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for SearchGuildMembers<'_> {
+    type Output = Result<Response<MemberListBody>, Error>;
+
+    type IntoFuture = ResponseFuture<MemberListBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let guild_id = self.guild_id;
         let http = self.http;
 
@@ -103,7 +112,7 @@ impl<'a> SearchGuildMembers<'a> {
 }
 
 impl TryIntoRequest for SearchGuildMembers<'_> {
-    fn try_into_request(self) -> Result<Request, HttpError> {
+    fn try_into_request(self) -> Result<Request, Error> {
         Ok(Request::from_route(&Route::SearchGuildMembers {
             guild_id: self.guild_id.get(),
             limit: self.fields.limit,

--- a/twilight-http/src/request/guild/role/create_role.rs
+++ b/twilight-http/src/request/guild/role/create_role.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     guild::{Permissions, Role},
     id::{marker::GuildMarker, Id},
@@ -47,7 +48,6 @@ struct CreateRoleFields<'a> {
 ///     .create_role(guild_id)
 ///     .color(0xd90083)
 ///     .name("Bright Pink")
-///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -141,15 +141,9 @@ impl<'a> CreateRole<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Role> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -160,6 +154,21 @@ impl<'a> AuditLogReason<'a> for CreateRole<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for CreateRole<'_> {
+    type Output = Result<Response<Role>, Error>;
+
+    type IntoFuture = ResponseFuture<Role>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/guild/role/delete_role.rs
+++ b/twilight-http/src/request/guild/role/delete_role.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{GuildMarker, RoleMarker},
     Id,
@@ -35,15 +36,9 @@ impl<'a> DeleteRole<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -54,6 +49,21 @@ impl<'a> AuditLogReason<'a> for DeleteRole<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for DeleteRole<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/guild/role/get_guild_roles.rs
+++ b/twilight-http/src/request/guild/role/get_guild_roles.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::Role,
     id::{marker::GuildMarker, Id},
@@ -23,9 +24,18 @@ impl<'a> GetGuildRoles<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Role>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildRoles<'_> {
+    type Output = Result<Response<ListBody<Role>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Role>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/role/update_role_positions.rs
+++ b/twilight-http/src/request/guild/role/update_role_positions.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::Role,
     id::{
@@ -37,9 +38,18 @@ impl<'a> UpdateRolePositions<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Role>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for UpdateRolePositions<'_> {
+    type Output = Result<Response<ListBody<Role>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Role>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/sticker/delete_guild_sticker.rs
+++ b/twilight-http/src/request/guild/sticker/delete_guild_sticker.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{GuildMarker, StickerMarker},
     Id,
@@ -25,10 +26,7 @@ use twilight_model::id::{
 /// let guild_id = Id::new(1);
 /// let sticker_id = Id::new(2);
 ///
-/// client
-///     .delete_guild_sticker(guild_id, sticker_id)
-///     .exec()
-///     .await?;
+/// client.delete_guild_sticker(guild_id, sticker_id).await?;
 /// # Ok(()) }
 /// ```
 pub struct DeleteGuildSticker<'a> {
@@ -51,9 +49,18 @@ impl<'a> DeleteGuildSticker<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for DeleteGuildSticker<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/sticker/get_guild_sticker.rs
+++ b/twilight-http/src/request/guild/sticker/get_guild_sticker.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::message::sticker::Sticker,
     id::{
@@ -29,7 +30,6 @@ use twilight_model::{
 /// let sticker_id = Id::new(2);
 /// let sticker = client
 ///     .guild_sticker(guild_id, sticker_id)
-///     .exec()
 ///     .await?
 ///     .model()
 ///     .await?;
@@ -57,9 +57,18 @@ impl<'a> GetGuildSticker<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Sticker> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildSticker<'_> {
+    type Output = Result<Response<Sticker>, Error>;
+
+    type IntoFuture = ResponseFuture<Sticker>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/sticker/get_guild_stickers.rs
+++ b/twilight-http/src/request/guild/sticker/get_guild_stickers.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::message::sticker::Sticker,
     id::{marker::GuildMarker, Id},
@@ -23,12 +24,7 @@ use twilight_model::{
 /// let client = Client::new("my token".to_owned());
 ///
 /// let guild_id = Id::new(1);
-/// let stickers = client
-///     .guild_stickers(guild_id)
-///     .exec()
-///     .await?
-///     .models()
-///     .await?;
+/// let stickers = client.guild_stickers(guild_id).await?.models().await?;
 ///
 /// println!("{}", stickers.len());
 /// # Ok(()) }
@@ -44,9 +40,18 @@ impl<'a> GetGuildStickers<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Sticker>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildStickers<'_> {
+    type Output = Result<Response<ListBody<Sticker>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Sticker>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/update_guild.rs
+++ b/twilight-http/src/request/guild/update_guild.rs
@@ -1,11 +1,12 @@
 use crate::{
     client::Client,
-    error::Error as HttpError,
+    error::Error,
     request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     guild::{
         DefaultMessageNotificationLevel, ExplicitContentFilter, PartialGuild, SystemChannelFlags,
@@ -307,15 +308,9 @@ impl<'a> UpdateGuild<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<PartialGuild> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -329,8 +324,23 @@ impl<'a> AuditLogReason<'a> for UpdateGuild<'a> {
     }
 }
 
+impl IntoFuture for UpdateGuild<'_> {
+    type Output = Result<Response<PartialGuild>, Error>;
+
+    type IntoFuture = ResponseFuture<PartialGuild>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
+    }
+}
+
 impl TryIntoRequest for UpdateGuild<'_> {
-    fn try_into_request(self) -> Result<Request, HttpError> {
+    fn try_into_request(self) -> Result<Request, Error> {
         let mut request = Request::builder(&Route::UpdateGuild {
             guild_id: self.guild_id.get(),
         });

--- a/twilight-http/src/request/guild/update_guild_channel_positions.rs
+++ b/twilight-http/src/request/guild/update_guild_channel_positions.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, GuildMarker},
     Id,
@@ -60,9 +61,18 @@ impl<'a> UpdateGuildChannelPositions<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for UpdateGuildChannelPositions<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/update_guild_mfa.rs
+++ b/twilight-http/src/request/guild/update_guild_mfa.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     guild::MfaLevel,
     id::{marker::GuildMarker, Id},
@@ -39,9 +40,18 @@ impl<'a> UpdateGuildMfa<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<MfaLevel> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for UpdateGuildMfa<'_> {
+    type Output = Result<Response<MfaLevel>, Error>;
+
+    type IntoFuture = ResponseFuture<MfaLevel>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/update_guild_welcome_screen.rs
+++ b/twilight-http/src/request/guild/update_guild_welcome_screen.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     guild::invite::{WelcomeScreen, WelcomeScreenChannel},
     id::{marker::GuildMarker, Id},
@@ -68,9 +69,18 @@ impl<'a> UpdateGuildWelcomeScreen<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<WelcomeScreen> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for UpdateGuildWelcomeScreen<'_> {
+    type Output = Result<Response<WelcomeScreen>, Error>;
+
+    type IntoFuture = ResponseFuture<WelcomeScreen>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/update_guild_widget.rs
+++ b/twilight-http/src/request/guild/update_guild_widget.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Nullable, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     guild::GuildWidget,
     id::{
@@ -57,9 +58,18 @@ impl<'a> UpdateGuildWidget<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<GuildWidget> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for UpdateGuildWidget<'_> {
+    type Output = Result<Response<GuildWidget>, Error>;
+
+    type IntoFuture = ResponseFuture<GuildWidget>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/user/update_current_user_voice_state.rs
+++ b/twilight-http/src/request/guild/user/update_current_user_voice_state.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Nullable, Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, GuildMarker},
     Id,
@@ -86,9 +87,18 @@ impl<'a> UpdateCurrentUserVoiceState<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for UpdateCurrentUserVoiceState<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/guild/user/update_user_voice_state.rs
+++ b/twilight-http/src/request/guild/user/update_user_voice_state.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{ChannelMarker, GuildMarker, UserMarker},
     Id,
@@ -64,9 +65,18 @@ impl<'a> UpdateUserVoiceState<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for UpdateUserVoiceState<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/external.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/external.rs
@@ -4,8 +4,9 @@ use super::{
 use crate::{
     error::Error,
     request::{AuditLogReason, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::scheduled_event::{EntityType, GuildScheduledEvent},
     util::Timestamp,
@@ -75,10 +76,9 @@ impl<'a> CreateGuildExternalScheduledEvent<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<GuildScheduledEvent> {
-        self.0.exec()
+        self.into_future()
     }
 }
 
@@ -89,6 +89,16 @@ impl<'a> AuditLogReason<'a> for CreateGuildExternalScheduledEvent<'a> {
         self.0.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for CreateGuildExternalScheduledEvent<'_> {
+    type Output = Result<Response<GuildScheduledEvent>, Error>;
+
+    type IntoFuture = ResponseFuture<GuildScheduledEvent>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        self.0.into_future()
     }
 }
 

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/external.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/external.rs
@@ -98,7 +98,7 @@ impl IntoFuture for CreateGuildExternalScheduledEvent<'_> {
     type IntoFuture = ResponseFuture<GuildScheduledEvent>;
 
     fn into_future(self) -> Self::IntoFuture {
-        self.0.into_future()
+        self.0.exec()
     }
 }
 

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
@@ -11,7 +11,7 @@ use super::EntityMetadataFields;
 use crate::{
     client::Client,
     error::Error,
-    request::{AuditLogReason, Request, RequestBuilder, TryIntoRequest},
+    request::{AuditLogReason, Request, RequestBuilder},
     response::ResponseFuture,
     routing::Route,
 };
@@ -231,6 +231,14 @@ impl<'a> CreateGuildScheduledEvent<'a> {
             Err(source) => ResponseFuture::error(source),
         }
     }
+
+    fn try_into_request(self) -> Result<Request, Error> {
+        Request::builder(&Route::CreateGuildScheduledEvent {
+            guild_id: self.guild_id.get(),
+        })
+        .json(&self.fields)
+        .map(RequestBuilder::build)
+    }
 }
 
 impl<'a> AuditLogReason<'a> for CreateGuildScheduledEvent<'a> {
@@ -240,15 +248,5 @@ impl<'a> AuditLogReason<'a> for CreateGuildScheduledEvent<'a> {
         self.reason.replace(reason);
 
         Ok(self)
-    }
-}
-
-impl TryIntoRequest for CreateGuildScheduledEvent<'_> {
-    fn try_into_request(self) -> Result<Request, Error> {
-        Request::builder(&Route::CreateGuildScheduledEvent {
-            guild_id: self.guild_id.get(),
-        })
-        .json(&self.fields)
-        .map(RequestBuilder::build)
     }
 }

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
@@ -12,11 +12,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{AuditLogReason, Request, RequestBuilder, TryIntoRequest},
-    response::{Response, ResponseFuture},
+    response::ResponseFuture,
     routing::Route,
 };
 use serde::Serialize;
-use std::future::IntoFuture;
 use twilight_model::{
     guild::scheduled_event::{EntityType, GuildScheduledEvent, PrivacyLevel},
     id::{
@@ -223,6 +222,15 @@ impl<'a> CreateGuildScheduledEvent<'a> {
             scheduled_start_time,
         ))
     }
+
+    fn exec(self) -> ResponseFuture<GuildScheduledEvent> {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
+    }
 }
 
 impl<'a> AuditLogReason<'a> for CreateGuildScheduledEvent<'a> {
@@ -232,21 +240,6 @@ impl<'a> AuditLogReason<'a> for CreateGuildScheduledEvent<'a> {
         self.reason.replace(reason);
 
         Ok(self)
-    }
-}
-
-impl IntoFuture for CreateGuildScheduledEvent<'_> {
-    type Output = Result<Response<GuildScheduledEvent>, Error>;
-
-    type IntoFuture = ResponseFuture<GuildScheduledEvent>;
-
-    fn into_future(self) -> Self::IntoFuture {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
     }
 }
 

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/stage_instance.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/stage_instance.rs
@@ -101,7 +101,7 @@ impl IntoFuture for CreateGuildStageInstanceScheduledEvent<'_> {
     type IntoFuture = ResponseFuture<GuildScheduledEvent>;
 
     fn into_future(self) -> Self::IntoFuture {
-        self.0.into_future()
+        self.0.exec()
     }
 }
 

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/stage_instance.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/stage_instance.rs
@@ -2,8 +2,9 @@ use super::{CreateGuildScheduledEvent, CreateGuildScheduledEventFields};
 use crate::{
     error::Error,
     request::{AuditLogReason, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::scheduled_event::{EntityType, GuildScheduledEvent},
     id::{marker::ChannelMarker, Id},
@@ -78,10 +79,9 @@ impl<'a> CreateGuildStageInstanceScheduledEvent<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<GuildScheduledEvent> {
-        self.0.exec()
+        self.into_future()
     }
 }
 
@@ -92,6 +92,16 @@ impl<'a> AuditLogReason<'a> for CreateGuildStageInstanceScheduledEvent<'a> {
         self.0.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for CreateGuildStageInstanceScheduledEvent<'_> {
+    type Output = Result<Response<GuildScheduledEvent>, Error>;
+
+    type IntoFuture = ResponseFuture<GuildScheduledEvent>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        self.0.into_future()
     }
 }
 

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/voice.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/voice.rs
@@ -2,8 +2,9 @@ use super::{CreateGuildScheduledEvent, CreateGuildScheduledEventFields};
 use crate::{
     error::Error,
     request::{AuditLogReason, Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::scheduled_event::{EntityType, GuildScheduledEvent},
     id::{marker::ChannelMarker, Id},
@@ -78,10 +79,9 @@ impl<'a> CreateGuildVoiceScheduledEvent<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<GuildScheduledEvent> {
-        self.0.exec()
+        self.into_future()
     }
 }
 
@@ -92,6 +92,16 @@ impl<'a> AuditLogReason<'a> for CreateGuildVoiceScheduledEvent<'a> {
         self.0.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for CreateGuildVoiceScheduledEvent<'_> {
+    type Output = Result<Response<GuildScheduledEvent>, Error>;
+
+    type IntoFuture = ResponseFuture<GuildScheduledEvent>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        self.0.into_future()
     }
 }
 

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/voice.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/voice.rs
@@ -101,7 +101,7 @@ impl IntoFuture for CreateGuildVoiceScheduledEvent<'_> {
     type IntoFuture = ResponseFuture<GuildScheduledEvent>;
 
     fn into_future(self) -> Self::IntoFuture {
-        self.0.into_future()
+        self.0.exec()
     }
 }
 

--- a/twilight-http/src/request/scheduled_event/delete_guild_scheduled_event.rs
+++ b/twilight-http/src/request/scheduled_event/delete_guild_scheduled_event.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::scheduled_event::GuildScheduledEvent,
     id::{
@@ -28,7 +29,6 @@ use twilight_model::{
 ///
 /// client
 ///     .delete_guild_scheduled_event(guild_id, scheduled_event_id)
-///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -53,9 +53,18 @@ impl<'a> DeleteGuildScheduledEvent<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<GuildScheduledEvent> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for DeleteGuildScheduledEvent<'_> {
+    type Output = Result<Response<GuildScheduledEvent>, Error>;
+
+    type IntoFuture = ResponseFuture<GuildScheduledEvent>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/scheduled_event/get_guild_scheduled_event.rs
+++ b/twilight-http/src/request/scheduled_event/get_guild_scheduled_event.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::scheduled_event::GuildScheduledEvent,
     id::{
@@ -44,9 +45,18 @@ impl<'a> GetGuildScheduledEvent<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<GuildScheduledEvent> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildScheduledEvent<'_> {
+    type Output = Result<Response<GuildScheduledEvent>, Error>;
+
+    type IntoFuture = ResponseFuture<GuildScheduledEvent>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/scheduled_event/get_guild_scheduled_event_users.rs
+++ b/twilight-http/src/request/scheduled_event/get_guild_scheduled_event_users.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::scheduled_event::GuildScheduledEventUser,
     id::{
@@ -107,9 +108,18 @@ impl<'a> GetGuildScheduledEventUsers<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<GuildScheduledEventUser>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildScheduledEventUsers<'_> {
+    type Output = Result<Response<ListBody<GuildScheduledEventUser>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<GuildScheduledEventUser>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/scheduled_event/get_guild_scheduled_events.rs
+++ b/twilight-http/src/request/scheduled_event/get_guild_scheduled_events.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::scheduled_event::GuildScheduledEvent,
     id::{marker::GuildMarker, Id},
@@ -35,9 +36,18 @@ impl<'a> GetGuildScheduledEvents<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<GuildScheduledEvent>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetGuildScheduledEvents<'_> {
+    type Output = Result<Response<ListBody<GuildScheduledEvent>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<GuildScheduledEvent>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/scheduled_event/update_guild_scheduled_event.rs
+++ b/twilight-http/src/request/scheduled_event/update_guild_scheduled_event.rs
@@ -3,10 +3,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{AuditLogReason, Nullable, Request, RequestBuilder, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     guild::scheduled_event::{EntityType, GuildScheduledEvent, PrivacyLevel, Status},
     id::{
@@ -220,15 +221,9 @@ impl<'a> UpdateGuildScheduledEvent<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<GuildScheduledEvent> {
-        let http = self.http;
-
-        match self.try_into_request() {
-            Ok(request) => http.request(request),
-            Err(source) => ResponseFuture::error(source),
-        }
+        self.into_future()
     }
 }
 
@@ -239,6 +234,21 @@ impl<'a> AuditLogReason<'a> for UpdateGuildScheduledEvent<'a> {
         self.reason.replace(reason);
 
         Ok(self)
+    }
+}
+
+impl IntoFuture for UpdateGuildScheduledEvent<'_> {
+    type Output = Result<Response<GuildScheduledEvent>, Error>;
+
+    type IntoFuture = ResponseFuture<GuildScheduledEvent>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
     }
 }
 

--- a/twilight-http/src/request/sticker/get_nitro_sticker_packs.rs
+++ b/twilight-http/src/request/sticker/get_nitro_sticker_packs.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Deserialize;
+use std::future::IntoFuture;
 use twilight_model::channel::message::sticker::StickerPack;
 
 #[derive(Deserialize)]
@@ -24,7 +25,7 @@ pub struct StickerPackListing {
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = Client::new("my token".to_owned());
 ///
-/// let packs = client.nitro_sticker_packs().exec().await?.model().await?;
+/// let packs = client.nitro_sticker_packs().await?.model().await?;
 ///
 /// println!("{}", packs.sticker_packs.len());
 /// # Ok(()) }
@@ -40,9 +41,18 @@ impl<'a> GetNitroStickerPacks<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<StickerPackListing> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetNitroStickerPacks<'_> {
+    type Output = Result<Response<StickerPackListing>, Error>;
+
+    type IntoFuture = ResponseFuture<StickerPackListing>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/sticker/get_sticker.rs
+++ b/twilight-http/src/request/sticker/get_sticker.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     channel::message::sticker::Sticker,
     id::{marker::StickerMarker, Id},
@@ -23,7 +24,7 @@ use twilight_model::{
 /// let client = Client::new("my token".to_owned());
 ///
 /// let id = Id::new(123);
-/// let sticker = client.sticker(id).exec().await?.model().await?;
+/// let sticker = client.sticker(id).await?.model().await?;
 /// # Ok(()) }
 /// ```
 #[must_use = "requests must be configured and executed"]
@@ -38,9 +39,18 @@ impl<'a> GetSticker<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Sticker> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetSticker<'_> {
+    type Output = Result<Response<Sticker>, Error>;
+
+    type IntoFuture = ResponseFuture<Sticker>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/template/create_template.rs
+++ b/twilight-http/src/request/template/create_template.rs
@@ -1,11 +1,12 @@
 use crate::{
     client::Client,
-    error::Error as HttpError,
+    error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     guild::template::Template,
     id::{marker::GuildMarker, Id},
@@ -76,9 +77,18 @@ impl<'a> CreateTemplate<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Template> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreateTemplate<'_> {
+    type Output = Result<Response<Template>, Error>;
+
+    type IntoFuture = ResponseFuture<Template>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {
@@ -89,7 +99,7 @@ impl<'a> CreateTemplate<'a> {
 }
 
 impl TryIntoRequest for CreateTemplate<'_> {
-    fn try_into_request(self) -> Result<Request, HttpError> {
+    fn try_into_request(self) -> Result<Request, Error> {
         let mut request = Request::builder(&Route::CreateTemplate {
             guild_id: self.guild_id.get(),
         });

--- a/twilight-http/src/request/template/delete_template.rs
+++ b/twilight-http/src/request/template/delete_template.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{marker::GuildMarker, Id};
 
 /// Delete a template by ID and code.
@@ -29,9 +30,18 @@ impl<'a> DeleteTemplate<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for DeleteTemplate<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/template/get_template.rs
+++ b/twilight-http/src/request/template/get_template.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::guild::template::Template;
 
 /// Get a template by its code.
@@ -23,9 +24,18 @@ impl<'a> GetTemplate<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Template> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetTemplate<'_> {
+    type Output = Result<Response<Template>, Error>;
+
+    type IntoFuture = ResponseFuture<Template>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/template/get_templates.rs
+++ b/twilight-http/src/request/template/get_templates.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::template::Template,
     id::{marker::GuildMarker, Id},
@@ -23,9 +24,18 @@ impl<'a> GetTemplates<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Template>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetTemplates<'_> {
+    type Output = Result<Response<ListBody<Template>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Template>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/template/sync_template.rs
+++ b/twilight-http/src/request/template/sync_template.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     guild::template::Template,
     id::{marker::GuildMarker, Id},
@@ -32,9 +33,18 @@ impl<'a> SyncTemplate<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Template> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for SyncTemplate<'_> {
+    type Output = Result<Response<Template>, Error>;
+
+    type IntoFuture = ResponseFuture<Template>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/template/update_template.rs
+++ b/twilight-http/src/request/template/update_template.rs
@@ -1,11 +1,12 @@
 use crate::{
     client::Client,
-    error::Error as HttpError,
+    error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     guild::template::Template,
     id::{marker::GuildMarker, Id},
@@ -84,9 +85,18 @@ impl<'a> UpdateTemplate<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Template> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for UpdateTemplate<'_> {
+    type Output = Result<Response<Template>, Error>;
+
+    type IntoFuture = ResponseFuture<Template>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {
@@ -97,7 +107,7 @@ impl<'a> UpdateTemplate<'a> {
 }
 
 impl TryIntoRequest for UpdateTemplate<'_> {
-    fn try_into_request(self) -> Result<Request, HttpError> {
+    fn try_into_request(self) -> Result<Request, Error> {
         let mut request = Request::builder(&Route::UpdateTemplate {
             guild_id: self.guild_id.get(),
             template_code: self.template_code,

--- a/twilight-http/src/request/try_into_request.rs
+++ b/twilight-http/src/request/try_into_request.rs
@@ -72,10 +72,9 @@ mod private {
             UpdateGuildWidget,
         },
         scheduled_event::{
-            CreateGuildExternalScheduledEvent, CreateGuildScheduledEvent,
-            CreateGuildStageInstanceScheduledEvent, CreateGuildVoiceScheduledEvent,
-            DeleteGuildScheduledEvent, GetGuildScheduledEvent, GetGuildScheduledEventUsers,
-            GetGuildScheduledEvents, UpdateGuildScheduledEvent,
+            CreateGuildExternalScheduledEvent, CreateGuildStageInstanceScheduledEvent,
+            CreateGuildVoiceScheduledEvent, DeleteGuildScheduledEvent, GetGuildScheduledEvent,
+            GetGuildScheduledEventUsers, GetGuildScheduledEvents, UpdateGuildScheduledEvent,
         },
         sticker::{GetNitroStickerPacks, GetSticker},
         template::{
@@ -112,7 +111,6 @@ mod private {
     impl Sealed for CreateGuildFromTemplate<'_> {}
     impl Sealed for CreateGuildMessageCommand<'_> {}
     impl Sealed for CreateGuildPrune<'_> {}
-    impl Sealed for CreateGuildScheduledEvent<'_> {}
     impl Sealed for CreateGuildStageInstanceScheduledEvent<'_> {}
     impl Sealed for CreateGuildSticker<'_> {}
     impl Sealed for CreateGuildUserCommand<'_> {}

--- a/twilight-http/src/request/try_into_request.rs
+++ b/twilight-http/src/request/try_into_request.rs
@@ -32,10 +32,10 @@ mod private {
                 CreateStageInstance, DeleteStageInstance, GetStageInstance, UpdateStageInstance,
             },
             thread::{
-                AddThreadMember, CreateForumThread, CreateThread, CreateThreadFromMessage,
-                GetJoinedPrivateArchivedThreads, GetPrivateArchivedThreads,
-                GetPublicArchivedThreads, GetThreadMember, GetThreadMembers, JoinThread,
-                LeaveThread, RemoveThreadMember, UpdateThread,
+                create_forum_thread::CreateForumThreadMessage, AddThreadMember, CreateThread,
+                CreateThreadFromMessage, GetJoinedPrivateArchivedThreads,
+                GetPrivateArchivedThreads, GetPublicArchivedThreads, GetThreadMember,
+                GetThreadMembers, JoinThread, LeaveThread, RemoveThreadMember, UpdateThread,
             },
             webhook::{
                 CreateWebhook, DeleteWebhook, DeleteWebhookMessage, ExecuteWebhook,
@@ -99,7 +99,7 @@ mod private {
     impl Sealed for CreateBan<'_> {}
     impl Sealed for CreateEmoji<'_> {}
     impl Sealed for CreateFollowup<'_> {}
-    impl Sealed for CreateForumThread<'_> {}
+    impl Sealed for CreateForumThreadMessage<'_> {}
     impl Sealed for CreateGlobalChatInputCommand<'_> {}
     impl Sealed for CreateGlobalCommand<'_> {}
     impl Sealed for CreateGlobalMessageCommand<'_> {}

--- a/twilight-http/src/request/user/create_private_channel.rs
+++ b/twilight-http/src/request/user/create_private_channel.rs
@@ -2,10 +2,11 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
+use std::future::IntoFuture;
 use twilight_model::{
     channel::Channel,
     id::{marker::UserMarker, Id},
@@ -30,7 +31,19 @@ impl<'a> CreatePrivateChannel<'a> {
             http,
         }
     }
+
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Channel> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for CreatePrivateChannel<'_> {
+    type Output = Result<Response<Channel>, Error>;
+
+    type IntoFuture = ResponseFuture<Channel>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/user/get_current_user.rs
+++ b/twilight-http/src/request/user/get_current_user.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::user::CurrentUser;
 
 /// Get information about the current user.
@@ -19,9 +20,18 @@ impl<'a> GetCurrentUser<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<CurrentUser> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetCurrentUser<'_> {
+    type Output = Result<Response<CurrentUser>, Error>;
+
+    type IntoFuture = ResponseFuture<CurrentUser>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/user/get_current_user_connections.rs
+++ b/twilight-http/src/request/user/get_current_user_connections.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::user::Connection;
 
 /// Get the current user's connections.
@@ -21,9 +22,18 @@ impl<'a> GetCurrentUserConnections<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<Connection>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetCurrentUserConnections<'_> {
+    type Output = Result<Response<ListBody<Connection>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Connection>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/user/get_current_user_guild_member.rs
+++ b/twilight-http/src/request/user/get_current_user_guild_member.rs
@@ -1,10 +1,11 @@
 use crate::{
     client::Client,
     request::{Request, TryIntoRequest},
-    response::{marker::MemberBody, ResponseFuture},
+    response::{marker::MemberBody, Response, ResponseFuture},
     routing::Route,
     Error,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{marker::GuildMarker, Id};
 
 /// Get information about the current user in a guild.
@@ -19,7 +20,18 @@ impl<'a> GetCurrentUserGuildMember<'a> {
         Self { guild_id, http }
     }
 
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<MemberBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetCurrentUserGuildMember<'_> {
+    type Output = Result<Response<MemberBody>, Error>;
+
+    type IntoFuture = ResponseFuture<MemberBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let guild_id = self.guild_id;
         let http = self.http;
 

--- a/twilight-http/src/request/user/get_current_user_guilds.rs
+++ b/twilight-http/src/request/user/get_current_user_guilds.rs
@@ -1,10 +1,11 @@
 use crate::{
     client::Client,
-    error::Error as HttpError,
+    error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::{marker::ListBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     id::{marker::GuildMarker, Id},
     user::CurrentUserGuild,
@@ -41,7 +42,6 @@ struct GetCurrentUserGuildsFields {
 ///     .after(after)
 ///     .before(before)
 ///     .limit(25)?
-///     .exec()
 ///     .await?;
 /// # Ok(()) }
 /// ```
@@ -101,9 +101,18 @@ impl<'a> GetCurrentUserGuilds<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<CurrentUserGuild>> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetCurrentUserGuilds<'_> {
+    type Output = Result<Response<ListBody<CurrentUserGuild>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<CurrentUserGuild>>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {
@@ -114,7 +123,7 @@ impl<'a> GetCurrentUserGuilds<'a> {
 }
 
 impl TryIntoRequest for GetCurrentUserGuilds<'_> {
-    fn try_into_request(self) -> Result<Request, HttpError> {
+    fn try_into_request(self) -> Result<Request, Error> {
         Ok(Request::from_route(&Route::GetGuilds {
             after: self.fields.after.map(Id::get),
             before: self.fields.before.map(Id::get),

--- a/twilight-http/src/request/user/get_user.rs
+++ b/twilight-http/src/request/user/get_user.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::ResponseFuture,
+    response::{Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::{
     id::{marker::UserMarker, Id},
     user::User,
@@ -23,9 +24,18 @@ impl<'a> GetUser<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<User> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for GetUser<'_> {
+    type Output = Result<Response<User>, Error>;
+
+    type IntoFuture = ResponseFuture<User>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/request/user/leave_guild.rs
+++ b/twilight-http/src/request/user/leave_guild.rs
@@ -2,9 +2,10 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::EmptyBody, ResponseFuture},
+    response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use std::future::IntoFuture;
 use twilight_model::id::{marker::GuildMarker, Id};
 
 /// Leave a guild by id.
@@ -20,9 +21,18 @@ impl<'a> LeaveGuild<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
-    ///
-    /// [`Response`]: crate::response::Response
+    #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<EmptyBody> {
+        self.into_future()
+    }
+}
+
+impl IntoFuture for LeaveGuild<'_> {
+    type Output = Result<Response<EmptyBody>, Error>;
+
+    type IntoFuture = ResponseFuture<EmptyBody>;
+
+    fn into_future(self) -> Self::IntoFuture {
         let http = self.http;
 
         match self.try_into_request() {

--- a/twilight-http/src/response/future.rs
+++ b/twilight-http/src/response/future.rs
@@ -302,6 +302,7 @@ impl<T> ResponseFuture<T> {
     /// use std::{
     ///     collections::HashSet,
     ///     env,
+    ///     future::IntoFuture,
     ///     sync::{Arc, Mutex},
     /// };
     /// use twilight_http::{error::ErrorType, Client};
@@ -318,7 +319,7 @@ impl<T> ResponseFuture<T> {
     /// };
     ///
     /// let client = Client::new(env::var("DISCORD_TOKEN")?);
-    /// let mut req = client.delete_message(channel_id, message_id).exec();
+    /// let mut req = client.delete_message(channel_id, message_id).into_future();
     ///
     /// let channels_ignored_clone = channels_ignored.clone();
     /// req.set_pre_flight(Box::new(move || {

--- a/twilight-http/src/response/mod.rs
+++ b/twilight-http/src/response/mod.rs
@@ -23,7 +23,7 @@
 //! use twilight_http::Client;
 //!
 //! let client = Client::new(env::var("DISCORD_TOKEN")?);
-//! let response = client.user(user_id).exec().await?;
+//! let response = client.user(user_id).await?;
 //!
 //! if !response.status().is_success() {
 //!     println!("failed to get user");
@@ -170,7 +170,7 @@ pub enum DeserializeBodyErrorType {
 /// use twilight_http::Client;
 ///
 /// let client = Client::new(env::var("DISCORD_TOKEN")?);
-/// let response = client.user(user_id).exec().await?;
+/// let response = client.user(user_id).await?;
 /// println!("status code: {}", response.status());
 ///
 /// let user = response.model().await?;
@@ -226,7 +226,7 @@ impl<T> Response<T> {
     /// use twilight_http::Client;
     ///
     /// let client = Client::new(env::var("DISCORD_TOKEN")?);
-    /// let response = client.user(user_id).exec().await?;
+    /// let response = client.user(user_id).await?;
     /// let bytes = response.bytes().await?;
     ///
     /// println!("size of body: {}", bytes.len());
@@ -285,7 +285,7 @@ impl<T> Response<T> {
     /// use twilight_http::Client;
     ///
     /// let client = Client::new(env::var("DISCORD_TOKEN")?);
-    /// let response = client.current_user().exec().await?;
+    /// let response = client.current_user().await?;
     /// let text = response.text().await?;
     ///
     /// println!("body: {text}");
@@ -449,7 +449,6 @@ impl Response<MemberListBody> {
 /// let client = Client::new(env::var("DISCORD_TOKEN")?);
 /// let response = client.create_message(channel_id)
 //      .content("test")?
-///     .exec()
 ///     .await?;
 /// let mut headers = response.headers();
 ///
@@ -501,7 +500,7 @@ impl<'a> Iterator for HeaderIter<'a> {
 /// use twilight_http::Client;
 ///
 /// let client = Client::new(env::var("DISCORD_TOKEN")?);
-/// let response = client.message(channel_id, message_id).exec().await?;
+/// let response = client.message(channel_id, message_id).await?;
 /// let bytes = response.bytes().await?;
 ///
 /// println!("bytes of the body: {bytes:?}");
@@ -547,12 +546,7 @@ impl Future for BytesFuture {
 /// use twilight_http::Client;
 ///
 /// let client = Client::new(env::var("DISCORD_TOKEN")?);
-/// let emoji = client
-///     .emoji(guild_id, emoji_id)
-///     .exec()
-///     .await?
-///     .model()
-///     .await?;
+/// let emoji = client.emoji(guild_id, emoji_id).await?.model().await?;
 ///
 /// println!("emoji name: {}", emoji.name);
 /// # Ok(()) }
@@ -617,7 +611,6 @@ impl<T: DeserializeOwned + Unpin> Future for ModelFuture<T> {
 ///
 /// let member = client
 ///     .guild_member(guild_id, user_id)
-///     .exec()
 ///     .await?
 ///     .model()
 ///     .await?;
@@ -691,7 +684,6 @@ impl Future for MemberFuture {
 /// let members = client
 ///     .guild_members(guild_id)
 ///     .limit(100)?
-///     .exec()
 ///     .await?
 ///     .models()
 ///     .await?;
@@ -766,7 +758,7 @@ impl Future for MemberListFuture {
 /// use twilight_http::Client;
 ///
 /// let client = Client::new(env::var("DISCORD_TOKEN")?);
-/// let response = client.message(channel_id, message_id).exec().await?;
+/// let response = client.message(channel_id, message_id).await?;
 /// let text = response.text().await?;
 ///
 /// println!("body: {text}");

--- a/twilight-lavalink/README.md
+++ b/twilight-lavalink/README.md
@@ -76,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
     let shard_count = 1u64;
 
     let http = HttpClient::new(token.clone());
-    let user_id = http.current_user().exec().await?.model().await?.id;
+    let user_id = http.current_user().await?.model().await?.id;
 
     let lavalink = Lavalink::new(user_id, shard_count);
     lavalink.add(lavalink_host, lavalink_auth).await?;


### PR DESCRIPTION
Allows users who don't need `ResponseFuture` (for `set_pre_flight`) to just call `.await` on requests and create the `ResponseFuture` and await it in one go. The old behaviour of `exec()` is available by calling `into_future` as seen in the `set_pre_flight` doctest.