### PR TITLE
perf(gateway): remove one `Shard::next_message` allocation

### DIFF
--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -19,6 +19,7 @@ version = "0.13.3"
 bitflags = { default-features = false, version = "1" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 leaky-bucket-lite = { default-features = false, features = ["tokio"], version = "0.5.1" }
+pin-project-lite = { default-features = false, version = "0.2" }
 rand = {default-features = false, features = ["std", "std_rng"], version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }


### PR DESCRIPTION
Twilight uses `Box::pin` when pinning is required, but allocating a `Box` is in most cases not needed. `pin-project-lite` avoids this allocation and internally guarentees that the safety contract of `Pin::new_unchecked` is upheld.

Although the entire `NextMessageFuture` can be replaced with `tokio::select!` (with [biased](https://docs.rs/tokio/latest/tokio/macro.select.html#fairness)), this is not done due to its archaic syntax.

`pin-project-lite` is commonly used in the async ecosystem and Twilight already transiently depends upon it via, for example, `tokio` and `hyper`.

Doc comments cannot be put on struct items due to taiki-e/pin-project-lite#3, the recommended workaround is to use normal comments instead.
