### PR TITLE
refactor(cache/inmemory,http,model,util,validate)!: update `ChannelType` names

### DIFF
--- a/twilight-cache-inmemory/src/event/guild.rs
+++ b/twilight-cache-inmemory/src/event/guild.rs
@@ -340,7 +340,7 @@ mod tests {
             icon: None,
             id: Id::new(222),
             invitable: None,
-            kind: ChannelType::GuildPublicThread,
+            kind: ChannelType::PublicThread,
             last_message_id: None,
             last_pin_timestamp: None,
             member: Some(ThreadMember {

--- a/twilight-cache-inmemory/src/permission.rs
+++ b/twilight-cache-inmemory/src/permission.rs
@@ -420,7 +420,7 @@ impl<'a> InMemoryCachePermissions<'a> {
 
         let overwrites = match channel.kind {
             ChannelType::PrivateThread
-            | ChannelType::GuildAnnouncementThread
+            | ChannelType::AnnouncementThread
             | ChannelType::PublicThread => self.parent_overwrites(&channel)?,
             _ => channel.permission_overwrites.clone().unwrap_or_default(),
         };

--- a/twilight-cache-inmemory/src/permission.rs
+++ b/twilight-cache-inmemory/src/permission.rs
@@ -419,8 +419,8 @@ impl<'a> InMemoryCachePermissions<'a> {
             .map_err(ChannelError::from_member_roles)?;
 
         let overwrites = match channel.kind {
-            ChannelType::PrivateThread
-            | ChannelType::AnnouncementThread
+            ChannelType::AnnouncementThread
+            | ChannelType::PrivateThread
             | ChannelType::PublicThread => self.parent_overwrites(&channel)?,
             _ => channel.permission_overwrites.clone().unwrap_or_default(),
         };

--- a/twilight-cache-inmemory/src/permission.rs
+++ b/twilight-cache-inmemory/src/permission.rs
@@ -419,9 +419,9 @@ impl<'a> InMemoryCachePermissions<'a> {
             .map_err(ChannelError::from_member_roles)?;
 
         let overwrites = match channel.kind {
-            ChannelType::GuildPrivateThread
-            | ChannelType::GuildNewsThread
-            | ChannelType::GuildPublicThread => self.parent_overwrites(&channel)?,
+            ChannelType::PrivateThread
+            | ChannelType::GuildAnnouncementThread
+            | ChannelType::PublicThread => self.parent_overwrites(&channel)?,
             _ => channel.permission_overwrites.clone().unwrap_or_default(),
         };
 
@@ -817,7 +817,7 @@ mod tests {
             icon: None,
             id: THREAD_ID,
             invitable: None,
-            kind: ChannelType::GuildPublicThread,
+            kind: ChannelType::PublicThread,
             last_message_id: None,
             last_pin_timestamp: None,
             member: None,

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -1689,7 +1689,7 @@ impl Client {
     /// Automatic archive durations are not locked behind the guild's boost
     /// level.
     ///
-    /// To make a [`GuildPrivateThread`], the guild must also have the
+    /// To make a [`PrivateThread`], the guild must also have the
     /// `PRIVATE_THREADS` feature.
     ///
     /// # Errors
@@ -1699,7 +1699,7 @@ impl Client {
     ///
     /// Returns an error of type [`TypeInvalid`] if the channel is not a thread.
     ///
-    /// [`GuildPrivateThread`]: twilight_model::channel::ChannelType::GuildPrivateThread
+    /// [`PrivateThread`]: twilight_model::channel::ChannelType::PrivateThread
     /// [`NameInvalid`]: twilight_validate::channel::ChannelValidationErrorType::NameInvalid
     /// [`TypeInvalid`]: twilight_validate::channel::ChannelValidationErrorType::TypeInvalid
     pub fn create_thread<'a>(
@@ -1714,10 +1714,10 @@ impl Client {
     /// Create a new thread from an existing message.
     ///
     /// When called on a [`GuildText`] channel, this creates a
-    /// [`GuildPublicThread`].
+    /// [`PublicThread`].
     ///
-    /// When called on a [`GuildNews`] channel, this creates a
-    /// [`GuildNewsThread`].
+    /// When called on a [`GuildAnnouncement`] channel, this creates a
+    /// [`GuildAnnouncementThread`].
     ///
     /// Automatic archive durations are not locked behind the guild's boost
     /// level.
@@ -1732,9 +1732,9 @@ impl Client {
     ///
     /// Returns an error of type [`TypeInvalid`] if the channel is not a thread.
     ///
-    /// [`GuildNews`]: twilight_model::channel::ChannelType::GuildNews
-    /// [`GuildNewsThread`]: twilight_model::channel::ChannelType::GuildNewsThread
-    /// [`GuildPublicThread`]: twilight_model::channel::ChannelType::GuildPublicThread
+    /// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
+    /// [`GuildAnnouncementThread`]: twilight_model::channel::ChannelType::GuildAnnouncementThread
+    /// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
     /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
     /// [`NameInvalid`]: twilight_validate::channel::ChannelValidationErrorType::NameInvalid
     /// [`TypeInvalid`]: twilight_validate::channel::ChannelValidationErrorType::TypeInvalid
@@ -1789,14 +1789,14 @@ impl Client {
     ///
     /// Threads are ordered by [`archive_timestamp`] in descending order.
     ///
-    /// When called in a [`GuildText`] channel, returns [`GuildPublicThread`]s.
+    /// When called in a [`GuildText`] channel, returns [`PublicThread`]s.
     ///
-    /// When called in a [`GuildNews`] channel, returns [`GuildNewsThread`]s.
+    /// When called in a [`GuildAnnouncement`] channel, returns [`GuildAnnouncementThread`]s.
     ///
     /// [`archive_timestamp`]: twilight_model::channel::thread::ThreadMetadata::archive_timestamp
-    /// [`GuildNews`]: twilight_model::channel::ChannelType::GuildNews
-    /// [`GuildNewsThread`]: twilight_model::channel::ChannelType::GuildNewsThread
-    /// [`GuildPublicThread`]: twilight_model::channel::ChannelType::GuildPublicThread
+    /// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
+    /// [`GuildAnnouncementThread`]: twilight_model::channel::ChannelType::GuildAnnouncementThread
+    /// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
     /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
     /// [`READ_MESSAGE_HISTORY`]: twilight_model::guild::Permissions::READ_MESSAGE_HISTORY
     pub const fn public_archived_threads(
@@ -1811,10 +1811,10 @@ impl Client {
     /// Requires that the thread is not archived.
     ///
     /// Requires the [`MANAGE_THREADS`] permission, unless both the thread is a
-    /// [`GuildPrivateThread`], and the current user is the creator of the
+    /// [`PrivateThread`], and the current user is the creator of the
     /// thread.
     ///
-    /// [`GuildPrivateThread`]: twilight_model::channel::ChannelType::GuildPrivateThread
+    /// [`PrivateThread`]: twilight_model::channel::ChannelType::PrivateThread
     /// [`MANAGE_THREADS`]: twilight_model::guild::Permissions::MANAGE_THREADS
     pub const fn remove_thread_member(
         &self,

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -1814,8 +1814,8 @@ impl Client {
     /// [`PrivateThread`], and the current user is the creator of the
     /// thread.
     ///
-    /// [`PrivateThread`]: twilight_model::channel::ChannelType::PrivateThread
     /// [`MANAGE_THREADS`]: twilight_model::guild::Permissions::MANAGE_THREADS
+    /// [`PrivateThread`]: twilight_model::channel::ChannelType::PrivateThread
     pub const fn remove_thread_member(
         &self,
         channel_id: Id<ChannelMarker>,

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -1717,7 +1717,7 @@ impl Client {
     /// [`PublicThread`].
     ///
     /// When called on a [`GuildAnnouncement`] channel, this creates a
-    /// [`GuildAnnouncementThread`].
+    /// [`AnnouncementThread`].
     ///
     /// Automatic archive durations are not locked behind the guild's boost
     /// level.
@@ -1733,7 +1733,7 @@ impl Client {
     /// Returns an error of type [`TypeInvalid`] if the channel is not a thread.
     ///
     /// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
-    /// [`GuildAnnouncementThread`]: twilight_model::channel::ChannelType::GuildAnnouncementThread
+    /// [`AnnouncementThread`]: twilight_model::channel::ChannelType::AnnouncementThread
     /// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
     /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
     /// [`NameInvalid`]: twilight_validate::channel::ChannelValidationErrorType::NameInvalid
@@ -1791,11 +1791,11 @@ impl Client {
     ///
     /// When called in a [`GuildText`] channel, returns [`PublicThread`]s.
     ///
-    /// When called in a [`GuildAnnouncement`] channel, returns [`GuildAnnouncementThread`]s.
+    /// When called in a [`GuildAnnouncement`] channel, returns [`AnnouncementThread`]s.
     ///
     /// [`archive_timestamp`]: twilight_model::channel::thread::ThreadMetadata::archive_timestamp
     /// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
-    /// [`GuildAnnouncementThread`]: twilight_model::channel::ChannelType::GuildAnnouncementThread
+    /// [`AnnouncementThread`]: twilight_model::channel::ChannelType::AnnouncementThread
     /// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
     /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
     /// [`READ_MESSAGE_HISTORY`]: twilight_model::guild::Permissions::READ_MESSAGE_HISTORY

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -1699,8 +1699,8 @@ impl Client {
     ///
     /// Returns an error of type [`TypeInvalid`] if the channel is not a thread.
     ///
-    /// [`PrivateThread`]: twilight_model::channel::ChannelType::PrivateThread
     /// [`NameInvalid`]: twilight_validate::channel::ChannelValidationErrorType::NameInvalid
+    /// [`PrivateThread`]: twilight_model::channel::ChannelType::PrivateThread
     /// [`TypeInvalid`]: twilight_validate::channel::ChannelValidationErrorType::TypeInvalid
     pub fn create_thread<'a>(
         &'a self,
@@ -1732,11 +1732,11 @@ impl Client {
     ///
     /// Returns an error of type [`TypeInvalid`] if the channel is not a thread.
     ///
-    /// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
     /// [`AnnouncementThread`]: twilight_model::channel::ChannelType::AnnouncementThread
-    /// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
+    /// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
     /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
     /// [`NameInvalid`]: twilight_validate::channel::ChannelValidationErrorType::NameInvalid
+    /// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
     /// [`TypeInvalid`]: twilight_validate::channel::ChannelValidationErrorType::TypeInvalid
     pub fn create_thread_from_message<'a>(
         &'a self,
@@ -1793,11 +1793,11 @@ impl Client {
     ///
     /// When called in a [`GuildAnnouncement`] channel, returns [`AnnouncementThread`]s.
     ///
+    /// [`AnnouncementThread`]: twilight_model::channel::ChannelType::AnnouncementThread
     /// [`archive_timestamp`]: twilight_model::channel::thread::ThreadMetadata::archive_timestamp
     /// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
-    /// [`AnnouncementThread`]: twilight_model::channel::ChannelType::AnnouncementThread
-    /// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
     /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
+    /// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
     /// [`READ_MESSAGE_HISTORY`]: twilight_model::guild::Permissions::READ_MESSAGE_HISTORY
     pub const fn public_archived_threads(
         &self,

--- a/twilight-http/src/request/channel/thread/create_thread.rs
+++ b/twilight-http/src/request/channel/thread/create_thread.rs
@@ -27,10 +27,10 @@ struct CreateThreadFields<'a> {
 
 /// Start a thread that is not connected to a message.
 ///
-/// To make a [`GuildPrivateThread`], the guild must also have the
+/// To make a [`PrivateThread`], the guild must also have the
 /// `PRIVATE_THREADS` feature.
 ///
-/// [`GuildPrivateThread`]: twilight_model::channel::ChannelType::GuildPrivateThread
+/// [`PrivateThread`]: twilight_model::channel::ChannelType::PrivateThread
 #[must_use = "requests must be configured and executed"]
 pub struct CreateThread<'a> {
     channel_id: Id<ChannelMarker>,

--- a/twilight-http/src/request/channel/thread/create_thread_from_message.rs
+++ b/twilight-http/src/request/channel/thread/create_thread_from_message.rs
@@ -36,8 +36,8 @@ struct CreateThreadFromMessageFields<'a> {
 ///
 /// [`AnnouncementThread`]: twilight_model::channel::ChannelType::AnnouncementThread
 /// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
-/// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
 /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
+/// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
 #[must_use = "requests must be configured and executed"]
 pub struct CreateThreadFromMessage<'a> {
     channel_id: Id<ChannelMarker>,

--- a/twilight-http/src/request/channel/thread/create_thread_from_message.rs
+++ b/twilight-http/src/request/channel/thread/create_thread_from_message.rs
@@ -25,18 +25,18 @@ struct CreateThreadFromMessageFields<'a> {
 /// Create a new thread from an existing message.
 ///
 /// When called on a [`GuildText`] channel, this creates a
-/// [`GuildPublicThread`].
+/// [`PublicThread`].
 ///
-/// When called on a [`GuildNews`] channel, this creates a [`GuildNewsThread`].
+/// When called on a [`GuildAnnouncement`] channel, this creates a [`GuildAnnouncementThread`].
 ///
 /// Automatic archive durations are not locked behind the guild's boost level.
 ///
 /// The thread's ID will be the same as its parent message. This ensures only
 /// one thread can be created per message.
 ///
-/// [`GuildNewsThread`]: twilight_model::channel::ChannelType::GuildNewsThread
-/// [`GuildNews`]: twilight_model::channel::ChannelType::GuildNews
-/// [`GuildPublicThread`]: twilight_model::channel::ChannelType::GuildPublicThread
+/// [`GuildAnnouncementThread`]: twilight_model::channel::ChannelType::GuildAnnouncementThread
+/// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
+/// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
 /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
 #[must_use = "requests must be configured and executed"]
 pub struct CreateThreadFromMessage<'a> {

--- a/twilight-http/src/request/channel/thread/create_thread_from_message.rs
+++ b/twilight-http/src/request/channel/thread/create_thread_from_message.rs
@@ -27,14 +27,14 @@ struct CreateThreadFromMessageFields<'a> {
 /// When called on a [`GuildText`] channel, this creates a
 /// [`PublicThread`].
 ///
-/// When called on a [`GuildAnnouncement`] channel, this creates a [`GuildAnnouncementThread`].
+/// When called on a [`GuildAnnouncement`] channel, this creates a [`AnnouncementThread`].
 ///
 /// Automatic archive durations are not locked behind the guild's boost level.
 ///
 /// The thread's ID will be the same as its parent message. This ensures only
 /// one thread can be created per message.
 ///
-/// [`GuildAnnouncementThread`]: twilight_model::channel::ChannelType::GuildAnnouncementThread
+/// [`AnnouncementThread`]: twilight_model::channel::ChannelType::AnnouncementThread
 /// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
 /// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
 /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText

--- a/twilight-http/src/request/channel/thread/get_public_archived_threads.rs
+++ b/twilight-http/src/request/channel/thread/get_public_archived_threads.rs
@@ -20,11 +20,11 @@ use twilight_model::{
 ///
 /// When called in a [`GuildAnnouncement`] channel, returns [`AnnouncementThread`]s.
 ///
+/// [`AnnouncementThread`]: twilight_model::channel::ChannelType::AnnouncementThread
 /// [`archive_timestamp`]: twilight_model::channel::thread::ThreadMetadata::archive_timestamp
 /// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
-/// [`AnnouncementThread`]: twilight_model::channel::ChannelType::AnnouncementThread
-/// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
 /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
+/// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
 /// [`READ_MESSAGE_HISTORY`]: twilight_model::guild::Permissions::READ_MESSAGE_HISTORY
 #[must_use = "requests must be configured and executed"]
 pub struct GetPublicArchivedThreads<'a> {

--- a/twilight-http/src/request/channel/thread/get_public_archived_threads.rs
+++ b/twilight-http/src/request/channel/thread/get_public_archived_threads.rs
@@ -16,14 +16,14 @@ use twilight_model::{
 ///
 /// Threads are ordered by [`archive_timestamp`] in descending order.
 ///
-/// When called in a [`GuildText`] channel, returns [`GuildPublicThread`]s.
+/// When called in a [`GuildText`] channel, returns [`PublicThread`]s.
 ///
-/// When called in a [`GuildNews`] channel, returns [`GuildNewsThread`]s.
+/// When called in a [`GuildAnnouncement`] channel, returns [`GuildAnnouncementThread`]s.
 ///
 /// [`archive_timestamp`]: twilight_model::channel::thread::ThreadMetadata::archive_timestamp
-/// [`GuildNews`]: twilight_model::channel::ChannelType::GuildNews
-/// [`GuildNewsThread`]: twilight_model::channel::ChannelType::GuildNewsThread
-/// [`GuildPublicThread`]: twilight_model::channel::ChannelType::GuildPublicThread
+/// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
+/// [`GuildAnnouncementThread`]: twilight_model::channel::ChannelType::GuildAnnouncementThread
+/// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
 /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
 /// [`READ_MESSAGE_HISTORY`]: twilight_model::guild::Permissions::READ_MESSAGE_HISTORY
 #[must_use = "requests must be configured and executed"]

--- a/twilight-http/src/request/channel/thread/get_public_archived_threads.rs
+++ b/twilight-http/src/request/channel/thread/get_public_archived_threads.rs
@@ -18,11 +18,11 @@ use twilight_model::{
 ///
 /// When called in a [`GuildText`] channel, returns [`PublicThread`]s.
 ///
-/// When called in a [`GuildAnnouncement`] channel, returns [`GuildAnnouncementThread`]s.
+/// When called in a [`GuildAnnouncement`] channel, returns [`AnnouncementThread`]s.
 ///
 /// [`archive_timestamp`]: twilight_model::channel::thread::ThreadMetadata::archive_timestamp
 /// [`GuildAnnouncement`]: twilight_model::channel::ChannelType::GuildAnnouncement
-/// [`GuildAnnouncementThread`]: twilight_model::channel::ChannelType::GuildAnnouncementThread
+/// [`AnnouncementThread`]: twilight_model::channel::ChannelType::AnnouncementThread
 /// [`PublicThread`]: twilight_model::channel::ChannelType::PublicThread
 /// [`GuildText`]: twilight_model::channel::ChannelType::GuildText
 /// [`READ_MESSAGE_HISTORY`]: twilight_model::guild::Permissions::READ_MESSAGE_HISTORY

--- a/twilight-http/src/request/channel/thread/remove_thread_member.rs
+++ b/twilight-http/src/request/channel/thread/remove_thread_member.rs
@@ -15,9 +15,9 @@ use twilight_model::id::{
 /// Requires that the thread is not archived.
 ///
 /// Requires the [`MANAGE_THREADS`] permission, unless both the thread is a
-/// [`GuildPrivateThread`], and the current user is the creator of the thread.
+/// [`PrivateThread`], and the current user is the creator of the thread.
 ///
-/// [`GuildPrivateThread`]: twilight_model::channel::ChannelType::GuildPrivateThread
+/// [`PrivateThread`]: twilight_model::channel::ChannelType::PrivateThread
 /// [`MANAGE_THREADS`]: twilight_model::guild::Permissions::MANAGE_THREADS
 #[must_use = "requests must be configured and executed"]
 pub struct RemoveThreadMember<'a> {

--- a/twilight-http/src/request/channel/update_channel.rs
+++ b/twilight-http/src/request/channel/update_channel.rs
@@ -234,7 +234,7 @@ impl<'a> UpdateChannel<'a> {
     /// Set the kind of channel.
     ///
     /// Only conversion between `ChannelType::GuildText` and
-    /// `ChannelType::GuildNews` is possible, and only if the guild has the
+    /// `ChannelType::GuildAnnouncement` is possible, and only if the guild has the
     /// `NEWS` feature enabled. See [Discord Docs/Modify Channel].
     ///
     /// [Discord Docs/Modify Channel]: https://discord.com/developers/docs/resources/channel#modify-channel-json-params-guild-channel

--- a/twilight-model/src/channel/channel_type.rs
+++ b/twilight-model/src/channel/channel_type.rs
@@ -68,15 +68,15 @@ impl ChannelType {
     ///
     /// The following channel types are considered guild channel types:
     ///
+    /// - [`AnnouncementThread`][`Self::AnnouncementThread`]
+    /// - [`GuildAnnouncement`][`Self::GuildAnnouncement`]
     /// - [`GuildCategory`][`Self::GuildCategory`]
     /// - [`GuildDirectory`][`Self::GuildDirectory`]
-    /// - [`GuildAnnouncement`][`Self::GuildAnnouncement`]
-    /// - [`AnnouncementThread`][`Self::AnnouncementThread`]
-    /// - [`PublicThread`][`Self::PublicThread`]
-    /// - [`PrivateThread`][`Self::PrivateThread`]
     /// - [`GuildStageVoice`][`Self::GuildStageVoice`]
     /// - [`GuildText`][`Self::GuildText`]
     /// - [`GuildVoice`][`Self::GuildVoice`]
+    /// - [`PublicThread`][`Self::PublicThread`]
+    /// - [`PrivateThread`][`Self::PrivateThread`]
     pub const fn is_guild(self) -> bool {
         matches!(
             self,
@@ -97,8 +97,8 @@ impl ChannelType {
     /// The following channel types are considered guild channel types:
     ///
     /// - [`AnnouncementThread`][`Self::AnnouncementThread`]
-    /// - [`PublicThread`][`Self::PublicThread`]
     /// - [`PrivateThread`][`Self::PrivateThread`]
+    /// - [`PublicThread`][`Self::PublicThread`]
     pub const fn is_thread(self) -> bool {
         matches!(
             self,
@@ -109,18 +109,18 @@ impl ChannelType {
     /// Name of the variant as a string slice.
     pub const fn name(self) -> &'static str {
         match self {
+            Self::AnnouncementThread => "AnnouncementThread",
             Self::Group => "Group",
             Self::GuildCategory => "GuildCategory",
             Self::GuildDirectory => "GuildDirectory",
             Self::GuildForum => "GuildForum",
             Self::GuildAnnouncement => "GuildAnnouncement",
-            Self::AnnouncementThread => "AnnouncementThread",
-            Self::PrivateThread => "PrivateThread",
-            Self::PublicThread => "PublicThread",
             Self::GuildStageVoice => "GuildStageVoice",
             Self::GuildText => "GuildText",
             Self::GuildVoice => "GuildVoice",
             Self::Private => "Private",
+            Self::PrivateThread => "PrivateThread",
+            Self::PublicThread => "PublicThread",
             Self::Unknown(_) => "Unknown",
         }
     }
@@ -164,17 +164,17 @@ mod tests {
 
     #[test]
     fn names() {
+        assert_eq!("AnnouncementThread", ChannelType::AnnouncementThread.name());
         assert_eq!("Group", ChannelType::Group.name());
         assert_eq!("GuildCategory", ChannelType::GuildCategory.name());
         assert_eq!("GuildDirectory", ChannelType::GuildDirectory.name());
         assert_eq!("GuildAnnouncement", ChannelType::GuildAnnouncement.name());
-        assert_eq!("AnnouncementThread", ChannelType::AnnouncementThread.name());
-        assert_eq!("PrivateThread", ChannelType::PrivateThread.name());
-        assert_eq!("PublicThread", ChannelType::PublicThread.name());
         assert_eq!("GuildStageVoice", ChannelType::GuildStageVoice.name());
         assert_eq!("GuildText", ChannelType::GuildText.name());
         assert_eq!("GuildVoice", ChannelType::GuildVoice.name());
         assert_eq!("Private", ChannelType::Private.name());
+        assert_eq!("PrivateThread", ChannelType::PrivateThread.name());
+        assert_eq!("PublicThread", ChannelType::PublicThread.name());
         assert_eq!("Unknown", ChannelType::Unknown(99).name());
     }
 }

--- a/twilight-model/src/channel/channel_type.rs
+++ b/twilight-model/src/channel/channel_type.rs
@@ -168,7 +168,10 @@ mod tests {
         assert_eq!("GuildCategory", ChannelType::GuildCategory.name());
         assert_eq!("GuildDirectory", ChannelType::GuildDirectory.name());
         assert_eq!("GuildAnnouncement", ChannelType::GuildAnnouncement.name());
-        assert_eq!("GuildAnnouncementThread", ChannelType::GuildAnnouncementThread.name());
+        assert_eq!(
+            "GuildAnnouncementThread",
+            ChannelType::GuildAnnouncementThread.name()
+        );
         assert_eq!("PrivateThread", ChannelType::PrivateThread.name());
         assert_eq!("PublicThread", ChannelType::PublicThread.name());
         assert_eq!("GuildStageVoice", ChannelType::GuildStageVoice.name());

--- a/twilight-model/src/channel/channel_type.rs
+++ b/twilight-model/src/channel/channel_type.rs
@@ -9,10 +9,10 @@ pub enum ChannelType {
     GuildVoice,
     Group,
     GuildCategory,
-    GuildNews,
-    GuildNewsThread,
-    GuildPublicThread,
-    GuildPrivateThread,
+    GuildAnnouncement,
+    GuildAnnouncementThread,
+    PublicThread,
+    PrivateThread,
     GuildStageVoice,
     /// Channel in a [hub] containing the listed servers.
     ///
@@ -31,10 +31,10 @@ impl From<u8> for ChannelType {
             2 => ChannelType::GuildVoice,
             3 => ChannelType::Group,
             4 => ChannelType::GuildCategory,
-            5 => ChannelType::GuildNews,
-            10 => ChannelType::GuildNewsThread,
-            11 => ChannelType::GuildPublicThread,
-            12 => ChannelType::GuildPrivateThread,
+            5 => ChannelType::GuildAnnouncement,
+            10 => ChannelType::GuildAnnouncementThread,
+            11 => ChannelType::PublicThread,
+            12 => ChannelType::PrivateThread,
             13 => ChannelType::GuildStageVoice,
             14 => ChannelType::GuildDirectory,
             15 => ChannelType::GuildForum,
@@ -51,10 +51,10 @@ impl From<ChannelType> for u8 {
             ChannelType::GuildVoice => 2,
             ChannelType::Group => 3,
             ChannelType::GuildCategory => 4,
-            ChannelType::GuildNews => 5,
-            ChannelType::GuildNewsThread => 10,
-            ChannelType::GuildPublicThread => 11,
-            ChannelType::GuildPrivateThread => 12,
+            ChannelType::GuildAnnouncement => 5,
+            ChannelType::GuildAnnouncementThread => 10,
+            ChannelType::PublicThread => 11,
+            ChannelType::PrivateThread => 12,
             ChannelType::GuildStageVoice => 13,
             ChannelType::GuildDirectory => 14,
             ChannelType::GuildForum => 15,
@@ -70,10 +70,10 @@ impl ChannelType {
     ///
     /// - [`GuildCategory`][`Self::GuildCategory`]
     /// - [`GuildDirectory`][`Self::GuildDirectory`]
-    /// - [`GuildNews`][`Self::GuildNews`]
-    /// - [`GuildNewsThread`][`Self::GuildNewsThread`]
-    /// - [`GuildPublicThread`][`Self::GuildPublicThread`]
-    /// - [`GuildPrivateThread`][`Self::GuildPrivateThread`]
+    /// - [`GuildAnnouncement`][`Self::GuildAnnouncement`]
+    /// - [`GuildAnnouncementThread`][`Self::GuildAnnouncementThread`]
+    /// - [`PublicThread`][`Self::PublicThread`]
+    /// - [`PrivateThread`][`Self::PrivateThread`]
     /// - [`GuildStageVoice`][`Self::GuildStageVoice`]
     /// - [`GuildText`][`Self::GuildText`]
     /// - [`GuildVoice`][`Self::GuildVoice`]
@@ -82,10 +82,10 @@ impl ChannelType {
             self,
             Self::GuildCategory
                 | Self::GuildDirectory
-                | Self::GuildNews
-                | Self::GuildNewsThread
-                | Self::GuildPublicThread
-                | Self::GuildPrivateThread
+                | Self::GuildAnnouncement
+                | Self::GuildAnnouncementThread
+                | Self::PublicThread
+                | Self::PrivateThread
                 | Self::GuildStageVoice
                 | Self::GuildText
                 | Self::GuildVoice
@@ -96,13 +96,13 @@ impl ChannelType {
     ///
     /// The following channel types are considered guild channel types:
     ///
-    /// - [`GuildNewsThread`][`Self::GuildNewsThread`]
-    /// - [`GuildPublicThread`][`Self::GuildPublicThread`]
-    /// - [`GuildPrivateThread`][`Self::GuildPrivateThread`]
+    /// - [`GuildAnnouncementThread`][`Self::GuildAnnouncementThread`]
+    /// - [`PublicThread`][`Self::PublicThread`]
+    /// - [`PrivateThread`][`Self::PrivateThread`]
     pub const fn is_thread(self) -> bool {
         matches!(
             self,
-            Self::GuildNewsThread | Self::GuildPublicThread | Self::GuildPrivateThread
+            Self::GuildAnnouncementThread | Self::PublicThread | Self::PrivateThread
         )
     }
 
@@ -113,10 +113,10 @@ impl ChannelType {
             Self::GuildCategory => "GuildCategory",
             Self::GuildDirectory => "GuildDirectory",
             Self::GuildForum => "GuildForum",
-            Self::GuildNews => "GuildNews",
-            Self::GuildNewsThread => "GuildNewsThread",
-            Self::GuildPrivateThread => "GuildPrivateThread",
-            Self::GuildPublicThread => "GuildPublicThread",
+            Self::GuildAnnouncement => "GuildAnnouncement",
+            Self::GuildAnnouncementThread => "GuildAnnouncementThread",
+            Self::PrivateThread => "PrivateThread",
+            Self::PublicThread => "PublicThread",
             Self::GuildStageVoice => "GuildStageVoice",
             Self::GuildText => "GuildText",
             Self::GuildVoice => "GuildVoice",
@@ -134,17 +134,17 @@ mod tests {
 
     const_assert!(ChannelType::GuildCategory.is_guild());
     const_assert!(ChannelType::GuildDirectory.is_guild());
-    const_assert!(ChannelType::GuildNews.is_guild());
-    const_assert!(ChannelType::GuildNewsThread.is_guild());
-    const_assert!(ChannelType::GuildPublicThread.is_guild());
-    const_assert!(ChannelType::GuildPrivateThread.is_guild());
+    const_assert!(ChannelType::GuildAnnouncement.is_guild());
+    const_assert!(ChannelType::GuildAnnouncementThread.is_guild());
+    const_assert!(ChannelType::PublicThread.is_guild());
+    const_assert!(ChannelType::PrivateThread.is_guild());
     const_assert!(ChannelType::GuildStageVoice.is_guild());
     const_assert!(ChannelType::GuildText.is_guild());
     const_assert!(ChannelType::GuildVoice.is_guild());
 
-    const_assert!(ChannelType::GuildNewsThread.is_thread());
-    const_assert!(ChannelType::GuildPublicThread.is_thread());
-    const_assert!(ChannelType::GuildPrivateThread.is_thread());
+    const_assert!(ChannelType::GuildAnnouncementThread.is_thread());
+    const_assert!(ChannelType::PublicThread.is_thread());
+    const_assert!(ChannelType::PrivateThread.is_thread());
 
     #[test]
     fn variants() {
@@ -153,10 +153,10 @@ mod tests {
         serde_test::assert_tokens(&ChannelType::GuildVoice, &[Token::U8(2)]);
         serde_test::assert_tokens(&ChannelType::Group, &[Token::U8(3)]);
         serde_test::assert_tokens(&ChannelType::GuildCategory, &[Token::U8(4)]);
-        serde_test::assert_tokens(&ChannelType::GuildNews, &[Token::U8(5)]);
-        serde_test::assert_tokens(&ChannelType::GuildNewsThread, &[Token::U8(10)]);
-        serde_test::assert_tokens(&ChannelType::GuildPublicThread, &[Token::U8(11)]);
-        serde_test::assert_tokens(&ChannelType::GuildPrivateThread, &[Token::U8(12)]);
+        serde_test::assert_tokens(&ChannelType::GuildAnnouncement, &[Token::U8(5)]);
+        serde_test::assert_tokens(&ChannelType::GuildAnnouncementThread, &[Token::U8(10)]);
+        serde_test::assert_tokens(&ChannelType::PublicThread, &[Token::U8(11)]);
+        serde_test::assert_tokens(&ChannelType::PrivateThread, &[Token::U8(12)]);
         serde_test::assert_tokens(&ChannelType::GuildStageVoice, &[Token::U8(13)]);
         serde_test::assert_tokens(&ChannelType::GuildDirectory, &[Token::U8(14)]);
         serde_test::assert_tokens(&ChannelType::Unknown(99), &[Token::U8(99)]);
@@ -167,10 +167,10 @@ mod tests {
         assert_eq!("Group", ChannelType::Group.name());
         assert_eq!("GuildCategory", ChannelType::GuildCategory.name());
         assert_eq!("GuildDirectory", ChannelType::GuildDirectory.name());
-        assert_eq!("GuildNews", ChannelType::GuildNews.name());
-        assert_eq!("GuildNewsThread", ChannelType::GuildNewsThread.name());
-        assert_eq!("GuildPrivateThread", ChannelType::GuildPrivateThread.name());
-        assert_eq!("GuildPublicThread", ChannelType::GuildPublicThread.name());
+        assert_eq!("GuildAnnouncement", ChannelType::GuildAnnouncement.name());
+        assert_eq!("GuildAnnouncementThread", ChannelType::GuildAnnouncementThread.name());
+        assert_eq!("PrivateThread", ChannelType::PrivateThread.name());
+        assert_eq!("PublicThread", ChannelType::PublicThread.name());
         assert_eq!("GuildStageVoice", ChannelType::GuildStageVoice.name());
         assert_eq!("GuildText", ChannelType::GuildText.name());
         assert_eq!("GuildVoice", ChannelType::GuildVoice.name());

--- a/twilight-model/src/channel/channel_type.rs
+++ b/twilight-model/src/channel/channel_type.rs
@@ -10,7 +10,7 @@ pub enum ChannelType {
     Group,
     GuildCategory,
     GuildAnnouncement,
-    GuildAnnouncementThread,
+    AnnouncementThread,
     PublicThread,
     PrivateThread,
     GuildStageVoice,
@@ -32,7 +32,7 @@ impl From<u8> for ChannelType {
             3 => ChannelType::Group,
             4 => ChannelType::GuildCategory,
             5 => ChannelType::GuildAnnouncement,
-            10 => ChannelType::GuildAnnouncementThread,
+            10 => ChannelType::AnnouncementThread,
             11 => ChannelType::PublicThread,
             12 => ChannelType::PrivateThread,
             13 => ChannelType::GuildStageVoice,
@@ -52,7 +52,7 @@ impl From<ChannelType> for u8 {
             ChannelType::Group => 3,
             ChannelType::GuildCategory => 4,
             ChannelType::GuildAnnouncement => 5,
-            ChannelType::GuildAnnouncementThread => 10,
+            ChannelType::AnnouncementThread => 10,
             ChannelType::PublicThread => 11,
             ChannelType::PrivateThread => 12,
             ChannelType::GuildStageVoice => 13,
@@ -71,7 +71,7 @@ impl ChannelType {
     /// - [`GuildCategory`][`Self::GuildCategory`]
     /// - [`GuildDirectory`][`Self::GuildDirectory`]
     /// - [`GuildAnnouncement`][`Self::GuildAnnouncement`]
-    /// - [`GuildAnnouncementThread`][`Self::GuildAnnouncementThread`]
+    /// - [`AnnouncementThread`][`Self::AnnouncementThread`]
     /// - [`PublicThread`][`Self::PublicThread`]
     /// - [`PrivateThread`][`Self::PrivateThread`]
     /// - [`GuildStageVoice`][`Self::GuildStageVoice`]
@@ -83,7 +83,7 @@ impl ChannelType {
             Self::GuildCategory
                 | Self::GuildDirectory
                 | Self::GuildAnnouncement
-                | Self::GuildAnnouncementThread
+                | Self::AnnouncementThread
                 | Self::PublicThread
                 | Self::PrivateThread
                 | Self::GuildStageVoice
@@ -96,13 +96,13 @@ impl ChannelType {
     ///
     /// The following channel types are considered guild channel types:
     ///
-    /// - [`GuildAnnouncementThread`][`Self::GuildAnnouncementThread`]
+    /// - [`AnnouncementThread`][`Self::AnnouncementThread`]
     /// - [`PublicThread`][`Self::PublicThread`]
     /// - [`PrivateThread`][`Self::PrivateThread`]
     pub const fn is_thread(self) -> bool {
         matches!(
             self,
-            Self::GuildAnnouncementThread | Self::PublicThread | Self::PrivateThread
+            Self::AnnouncementThread | Self::PublicThread | Self::PrivateThread
         )
     }
 
@@ -114,7 +114,7 @@ impl ChannelType {
             Self::GuildDirectory => "GuildDirectory",
             Self::GuildForum => "GuildForum",
             Self::GuildAnnouncement => "GuildAnnouncement",
-            Self::GuildAnnouncementThread => "GuildAnnouncementThread",
+            Self::AnnouncementThread => "AnnouncementThread",
             Self::PrivateThread => "PrivateThread",
             Self::PublicThread => "PublicThread",
             Self::GuildStageVoice => "GuildStageVoice",
@@ -135,14 +135,14 @@ mod tests {
     const_assert!(ChannelType::GuildCategory.is_guild());
     const_assert!(ChannelType::GuildDirectory.is_guild());
     const_assert!(ChannelType::GuildAnnouncement.is_guild());
-    const_assert!(ChannelType::GuildAnnouncementThread.is_guild());
+    const_assert!(ChannelType::AnnouncementThread.is_guild());
     const_assert!(ChannelType::PublicThread.is_guild());
     const_assert!(ChannelType::PrivateThread.is_guild());
     const_assert!(ChannelType::GuildStageVoice.is_guild());
     const_assert!(ChannelType::GuildText.is_guild());
     const_assert!(ChannelType::GuildVoice.is_guild());
 
-    const_assert!(ChannelType::GuildAnnouncementThread.is_thread());
+    const_assert!(ChannelType::AnnouncementThread.is_thread());
     const_assert!(ChannelType::PublicThread.is_thread());
     const_assert!(ChannelType::PrivateThread.is_thread());
 
@@ -154,7 +154,7 @@ mod tests {
         serde_test::assert_tokens(&ChannelType::Group, &[Token::U8(3)]);
         serde_test::assert_tokens(&ChannelType::GuildCategory, &[Token::U8(4)]);
         serde_test::assert_tokens(&ChannelType::GuildAnnouncement, &[Token::U8(5)]);
-        serde_test::assert_tokens(&ChannelType::GuildAnnouncementThread, &[Token::U8(10)]);
+        serde_test::assert_tokens(&ChannelType::AnnouncementThread, &[Token::U8(10)]);
         serde_test::assert_tokens(&ChannelType::PublicThread, &[Token::U8(11)]);
         serde_test::assert_tokens(&ChannelType::PrivateThread, &[Token::U8(12)]);
         serde_test::assert_tokens(&ChannelType::GuildStageVoice, &[Token::U8(13)]);
@@ -168,10 +168,7 @@ mod tests {
         assert_eq!("GuildCategory", ChannelType::GuildCategory.name());
         assert_eq!("GuildDirectory", ChannelType::GuildDirectory.name());
         assert_eq!("GuildAnnouncement", ChannelType::GuildAnnouncement.name());
-        assert_eq!(
-            "GuildAnnouncementThread",
-            ChannelType::GuildAnnouncementThread.name()
-        );
+        assert_eq!("AnnouncementThread", ChannelType::AnnouncementThread.name());
         assert_eq!("PrivateThread", ChannelType::PrivateThread.name());
         assert_eq!("PublicThread", ChannelType::PublicThread.name());
         assert_eq!("GuildStageVoice", ChannelType::GuildStageVoice.name());

--- a/twilight-model/src/channel/mod.rs
+++ b/twilight-model/src/channel/mod.rs
@@ -338,7 +338,7 @@ mod tests {
             icon: None,
             id: Id::new(6),
             invitable: None,
-            kind: ChannelType::GuildAnnouncementThread,
+            kind: ChannelType::AnnouncementThread,
             last_message_id: Some(Id::new(3)),
             last_pin_timestamp: None,
             member: Some(ThreadMember {
@@ -379,7 +379,7 @@ mod tests {
             serde_json::from_value(serde_json::json!({
                 "id": "6",
                 "guild_id": "1",
-                "type": ChannelType::GuildAnnouncementThread,
+                "type": ChannelType::AnnouncementThread,
                 "last_message_id": "3",
                 "member": {
                     "flags": 0,

--- a/twilight-model/src/channel/mod.rs
+++ b/twilight-model/src/channel/mod.rs
@@ -275,7 +275,7 @@ mod tests {
     }
 
     #[test]
-    fn guild_news_channel_deserialization() {
+    fn guild_announcement_channel_deserialization() {
         let value = Channel {
             application_id: None,
             bitrate: None,
@@ -284,7 +284,7 @@ mod tests {
             icon: None,
             id: Id::new(1),
             invitable: None,
-            kind: ChannelType::GuildNews,
+            kind: ChannelType::GuildAnnouncement,
             last_message_id: Some(Id::new(4)),
             last_pin_timestamp: None,
             member: None,
@@ -319,14 +319,14 @@ mod tests {
                 "permission_overwrites": permission_overwrites,
                 "position": 3,
                 "topic": "a news channel",
-                "type": ChannelType::GuildNews,
+                "type": ChannelType::GuildAnnouncement,
             }))
             .unwrap()
         );
     }
 
     #[test]
-    fn guild_news_thread_deserialization() {
+    fn guild_announcement_thread_deserialization() {
         let timestamp = Timestamp::from_secs(1_632_074_792).expect("non zero");
         let formatted = timestamp.iso_8601().to_string();
 
@@ -338,7 +338,7 @@ mod tests {
             icon: None,
             id: Id::new(6),
             invitable: None,
-            kind: ChannelType::GuildNewsThread,
+            kind: ChannelType::GuildAnnouncementThread,
             last_message_id: Some(Id::new(3)),
             last_pin_timestamp: None,
             member: Some(ThreadMember {
@@ -379,7 +379,7 @@ mod tests {
             serde_json::from_value(serde_json::json!({
                 "id": "6",
                 "guild_id": "1",
-                "type": ChannelType::GuildNewsThread,
+                "type": ChannelType::GuildAnnouncementThread,
                 "last_message_id": "3",
                 "member": {
                     "flags": 0,
@@ -408,7 +408,7 @@ mod tests {
     }
 
     #[test]
-    fn guild_public_thread_deserialization() {
+    fn public_thread_deserialization() {
         let timestamp = Timestamp::from_secs(1_632_074_792).expect("non zero");
 
         let value = Channel {
@@ -419,7 +419,7 @@ mod tests {
             icon: None,
             id: Id::new(6),
             invitable: None,
-            kind: ChannelType::GuildPublicThread,
+            kind: ChannelType::PublicThread,
             last_message_id: Some(Id::new(3)),
             last_pin_timestamp: None,
             member: Some(ThreadMember {
@@ -460,7 +460,7 @@ mod tests {
             serde_json::from_value(serde_json::json!({
                 "id": "6",
                 "guild_id": "1",
-                "type": ChannelType::GuildPublicThread,
+                "type": ChannelType::PublicThread,
                 "last_message_id": "3",
                 "member": {
                     "flags": 0,
@@ -489,7 +489,7 @@ mod tests {
     }
 
     #[test]
-    fn guild_private_thread_deserialization() {
+    fn private_thread_deserialization() {
         let timestamp = Timestamp::from_secs(1_632_074_792).expect("non zero");
         let formatted = timestamp.iso_8601().to_string();
 
@@ -501,7 +501,7 @@ mod tests {
             icon: None,
             id: Id::new(6),
             invitable: Some(true),
-            kind: ChannelType::GuildPrivateThread,
+            kind: ChannelType::PrivateThread,
             last_message_id: Some(Id::new(3)),
             last_pin_timestamp: None,
             member: Some(ThreadMember {
@@ -547,7 +547,7 @@ mod tests {
             serde_json::from_value(serde_json::json!({
                 "id": "6",
                 "guild_id": "1",
-                "type": ChannelType::GuildPrivateThread,
+                "type": ChannelType::PrivateThread,
                 "last_message_id": "3",
                 "member": {
                     "flags": 0,

--- a/twilight-util/src/permission_calculator/mod.rs
+++ b/twilight-util/src/permission_calculator/mod.rs
@@ -683,7 +683,7 @@ mod tests {
     fn guild_level_removed_in_channel() {
         const CHANNEL_TYPES: &[ChannelType] = &[
             ChannelType::GuildCategory,
-            ChannelType::GuildNews,
+            ChannelType::GuildAnnouncement,
             ChannelType::GuildStageVoice,
             ChannelType::GuildText,
             ChannelType::GuildVoice,

--- a/twilight-validate/src/channel.rs
+++ b/twilight-validate/src/channel.rs
@@ -130,9 +130,9 @@ pub const fn bitrate(value: u32) -> Result<(), ChannelValidationError> {
 pub const fn is_thread(kind: ChannelType) -> Result<(), ChannelValidationError> {
     if matches!(
         kind,
-        ChannelType::GuildNewsThread
-            | ChannelType::GuildPublicThread
-            | ChannelType::GuildPrivateThread
+        ChannelType::GuildAnnouncementThread
+            | ChannelType::PublicThread
+            | ChannelType::PrivateThread
     ) {
         Ok(())
     } else {
@@ -223,9 +223,9 @@ mod tests {
 
     #[test]
     fn thread_is_thread() {
-        assert!(is_thread(ChannelType::GuildNewsThread).is_ok());
-        assert!(is_thread(ChannelType::GuildPrivateThread).is_ok());
-        assert!(is_thread(ChannelType::GuildPublicThread).is_ok());
+        assert!(is_thread(ChannelType::GuildAnnouncementThread).is_ok());
+        assert!(is_thread(ChannelType::PrivateThread).is_ok());
+        assert!(is_thread(ChannelType::PublicThread).is_ok());
 
         assert!(is_thread(ChannelType::Group).is_err());
     }

--- a/twilight-validate/src/channel.rs
+++ b/twilight-validate/src/channel.rs
@@ -130,9 +130,7 @@ pub const fn bitrate(value: u32) -> Result<(), ChannelValidationError> {
 pub const fn is_thread(kind: ChannelType) -> Result<(), ChannelValidationError> {
     if matches!(
         kind,
-        ChannelType::GuildAnnouncementThread
-            | ChannelType::PublicThread
-            | ChannelType::PrivateThread
+        ChannelType::AnnouncementThread | ChannelType::PublicThread | ChannelType::PrivateThread
     ) {
         Ok(())
     } else {
@@ -223,7 +221,7 @@ mod tests {
 
     #[test]
     fn thread_is_thread() {
-        assert!(is_thread(ChannelType::GuildAnnouncementThread).is_ok());
+        assert!(is_thread(ChannelType::AnnouncementThread).is_ok());
         assert!(is_thread(ChannelType::PrivateThread).is_ok());
         assert!(is_thread(ChannelType::PublicThread).is_ok());
 


### PR DESCRIPTION
Discord has renamed a few channel types:
 - `GuildNews` => `GuildAnnouncement`
 - `GuildNewsThread` => `GuildAnnouncementThread`
 - `GuildPublicThread` => `PublicThread`
 - `GuildPrivateThread` => `PrivateThread`

Reference: https://github.com/discord/discord-api-docs/pull/5322

Closes: #1908