### PR TITLE
docs(http): document component only messages

### DIFF
--- a/twilight-http/src/client/interaction.rs
+++ b/twilight-http/src/client/interaction.rs
@@ -102,15 +102,23 @@ impl<'a> InteractionClient<'a> {
 
     /// Edit the original message, by its token.
     ///
+    /// The update must include at least one of [`attachments`], [`components`],
+    /// [`content`] or [`embeds`].
+    ///
     /// This endpoint is not bound to the application's global rate limit.
+    ///
+    /// [`attachments`]: CreateFollowup::attachments
+    /// [`components`]: CreateFollowup::components
+    /// [`content`]: CreateFollowup::content
+    /// [`embeds`]: CreateFollowup::embeds
     pub const fn update_response(&'a self, interaction_token: &'a str) -> UpdateResponse<'a> {
         UpdateResponse::new(self.client, self.application_id, interaction_token)
     }
 
     /// Create a followup message to an interaction, by its token.
     ///
-    /// The message must include at least one of [`attachments`], [`content`],
-    /// [`components`], or [`embeds`].
+    /// The message must include at least one of [`attachments`], [`components`]
+    /// [`content`] or [`embeds`].
     ///
     /// This endpoint is not bound to the application's global rate limit.
     ///
@@ -135,8 +143,8 @@ impl<'a> InteractionClient<'a> {
     /// ```
     ///
     /// [`attachments`]: CreateFollowup::attachments
-    /// [`content`]: CreateFollowup::content
     /// [`components`]: CreateFollowup::components
+    /// [`content`]: CreateFollowup::content
     /// [`embeds`]: CreateFollowup::embeds
     pub const fn create_followup(&'a self, interaction_token: &'a str) -> CreateFollowup<'a> {
         CreateFollowup::new(self.client, self.application_id, interaction_token)

--- a/twilight-http/src/client/interaction.rs
+++ b/twilight-http/src/client/interaction.rs
@@ -110,7 +110,7 @@ impl<'a> InteractionClient<'a> {
     /// Create a followup message to an interaction, by its token.
     ///
     /// The message must include at least one of [`attachments`], [`content`],
-    /// or [`embeds`].
+    /// [`components`], or [`embeds`].
     ///
     /// This endpoint is not bound to the application's global rate limit.
     ///
@@ -136,6 +136,7 @@ impl<'a> InteractionClient<'a> {
     ///
     /// [`attachments`]: CreateFollowup::attachments
     /// [`content`]: CreateFollowup::content
+    /// [`components`]: CreateFollowup::components
     /// [`embeds`]: CreateFollowup::embeds
     pub const fn create_followup(&'a self, interaction_token: &'a str) -> CreateFollowup<'a> {
         CreateFollowup::new(self.client, self.application_id, interaction_token)

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -1229,8 +1229,8 @@ impl Client {
 
     /// Send a message to a channel.
     ///
-    /// The message must include at least one of [`attachments`], [`content`],
-    /// [`components`], [`embeds`], or [`sticker_ids`].
+    /// The message must include at least one of [`attachments`],
+    /// [`components`], [`content`] [`embeds`], or [`sticker_ids`].
     ///
     /// # Example
     ///
@@ -1252,8 +1252,8 @@ impl Client {
     /// ```
     ///
     /// [`attachments`]: CreateMessage::attachments
-    /// [`content`]: CreateMessage::content
     /// [`components`]: CreateMessage::components
+    /// [`content`]: CreateMessage::content
     /// [`embeds`]: CreateMessage::embeds
     /// [`sticker_ids`]: CreateMessage::sticker_ids
     pub const fn create_message(&self, channel_id: Id<ChannelMarker>) -> CreateMessage<'_> {
@@ -1290,7 +1290,7 @@ impl Client {
     /// You can pass [`None`] to any of the methods to remove the associated
     /// field. Pass [`None`] to [`content`] to remove the content. You must
     /// ensure that the message still contains at least one of [`attachments`],
-    /// [`content`], [`embeds`], or stickers.
+    /// [`components`], [`content`], [`embeds`], or stickers.
     ///
     /// # Examples
     ///
@@ -1328,6 +1328,7 @@ impl Client {
     /// ```
     ///
     /// [`attachments`]: UpdateMessage::attachments
+    /// [`components`]: UpdateMessage::components
     /// [`content`]: UpdateMessage::content
     /// [`embeds`]: UpdateMessage::embeds
     pub const fn update_message(
@@ -1937,8 +1938,8 @@ impl Client {
 
     /// Execute a webhook, sending a message to its channel.
     ///
-    /// The message must include at least one of [`attachments`], [`content`],
-    /// [`components`], or [`embeds`].
+    /// The message must include at least one of [`attachments`], [`components`]
+    /// [`content`], or [`embeds`].
     ///
     /// # Examples
     ///
@@ -1959,8 +1960,8 @@ impl Client {
     /// ```
     ///
     /// [`attachments`]: ExecuteWebhook::attachments
-    /// [`content`]: ExecuteWebhook::content
     /// [`components`]: ExecuteWebhook::components
+    /// [`content`]: ExecuteWebhook::content
     /// [`embeds`]: ExecuteWebhook::embeds
     pub const fn execute_webhook<'a>(
         &'a self,
@@ -1985,7 +1986,7 @@ impl Client {
     /// You can pass [`None`] to any of the methods to remove the associated
     /// field. Pass [`None`] to [`content`] to remove the content. You must
     /// ensure that the message still contains at least one of [`attachments`],
-    /// [`content`], or [`embeds`].
+    /// [`components`], [`content`], or [`embeds`].
     ///
     /// # Examples
     ///
@@ -2004,6 +2005,7 @@ impl Client {
     /// ```
     ///
     /// [`attachments`]: UpdateWebhookMessage::attachments
+    /// [`components`]: UpdateWebhookMessage::components
     /// [`content`]: UpdateWebhookMessage::content
     /// [`embeds`]: UpdateWebhookMessage::embeds
     pub const fn update_webhook_message<'a>(

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -1230,7 +1230,7 @@ impl Client {
     /// Send a message to a channel.
     ///
     /// The message must include at least one of [`attachments`], [`content`],
-    /// [`embeds`], or [`sticker_ids`].
+    /// [`components`], [`embeds`], or [`sticker_ids`].
     ///
     /// # Example
     ///
@@ -1253,6 +1253,7 @@ impl Client {
     ///
     /// [`attachments`]: CreateMessage::attachments
     /// [`content`]: CreateMessage::content
+    /// [`components`]: CreateMessage::components
     /// [`embeds`]: CreateMessage::embeds
     /// [`sticker_ids`]: CreateMessage::sticker_ids
     pub const fn create_message(&self, channel_id: Id<ChannelMarker>) -> CreateMessage<'_> {
@@ -1937,7 +1938,7 @@ impl Client {
     /// Execute a webhook, sending a message to its channel.
     ///
     /// The message must include at least one of [`attachments`], [`content`],
-    /// or [`embeds`].
+    /// [`components`], or [`embeds`].
     ///
     /// # Examples
     ///
@@ -1959,6 +1960,7 @@ impl Client {
     ///
     /// [`attachments`]: ExecuteWebhook::attachments
     /// [`content`]: ExecuteWebhook::content
+    /// [`components`]: ExecuteWebhook::components
     /// [`embeds`]: ExecuteWebhook::embeds
     pub const fn execute_webhook<'a>(
         &'a self,

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -1230,7 +1230,7 @@ impl Client {
     /// Send a message to a channel.
     ///
     /// The message must include at least one of [`attachments`],
-    /// [`components`], [`content`] [`embeds`], or [`sticker_ids`].
+    /// [`components`], [`content`], [`embeds`], or [`sticker_ids`].
     ///
     /// # Example
     ///

--- a/twilight-http/src/request/application/interaction/create_followup.rs
+++ b/twilight-http/src/request/application/interaction/create_followup.rs
@@ -46,8 +46,8 @@ struct CreateFollowupFields<'a> {
 
 /// Create a followup message to an interaction, by its token.
 ///
-/// The message must include at least one of [`attachments`], [`content`], or
-/// [`components`], [`embeds`].
+/// The message must include at least one of [`attachments`], [`content`],
+/// [`components`], or [`embeds`].
 ///
 /// This endpoint is not bound to the application's global rate limit.
 ///

--- a/twilight-http/src/request/application/interaction/create_followup.rs
+++ b/twilight-http/src/request/application/interaction/create_followup.rs
@@ -47,7 +47,7 @@ struct CreateFollowupFields<'a> {
 /// Create a followup message to an interaction, by its token.
 ///
 /// The message must include at least one of [`attachments`], [`content`], or
-/// [`embeds`].
+/// [`components`], [`embeds`].
 ///
 /// This endpoint is not bound to the application's global rate limit.
 ///
@@ -73,6 +73,7 @@ struct CreateFollowupFields<'a> {
 ///
 /// [`attachments`]: Self::attachments
 /// [`content`]: Self::content
+/// [`components`]: Self::components
 /// [`embeds`]: Self::embeds
 #[must_use = "requests must be configured and executed"]
 pub struct CreateFollowup<'a> {

--- a/twilight-http/src/request/application/interaction/create_followup.rs
+++ b/twilight-http/src/request/application/interaction/create_followup.rs
@@ -46,8 +46,8 @@ struct CreateFollowupFields<'a> {
 
 /// Create a followup message to an interaction, by its token.
 ///
-/// The message must include at least one of [`attachments`], [`content`],
-/// [`components`], or [`embeds`].
+/// The message must include at least one of [`attachments`], [`components`],
+/// [`content`], or [`embeds`].
 ///
 /// This endpoint is not bound to the application's global rate limit.
 ///
@@ -72,8 +72,8 @@ struct CreateFollowupFields<'a> {
 /// ```
 ///
 /// [`attachments`]: Self::attachments
-/// [`content`]: Self::content
 /// [`components`]: Self::components
+/// [`content`]: Self::content
 /// [`embeds`]: Self::embeds
 #[must_use = "requests must be configured and executed"]
 pub struct CreateFollowup<'a> {

--- a/twilight-http/src/request/application/interaction/update_followup.rs
+++ b/twilight-http/src/request/application/interaction/update_followup.rs
@@ -46,8 +46,8 @@ struct UpdateFollowupFields<'a> {
 ///
 /// You can pass [`None`] to any of the methods to remove the associated field.
 /// Pass [`None`] to [`content`] to remove the content. You must ensure that the
-/// message still contains at least one of [`attachments`], [`content`], or
-/// [`embeds`].
+/// message still contains at least one of [`attachments`], [`components`],
+/// [`content`], or [`embeds`].
 ///
 /// This endpoint is not bound to the application's global rate limit.
 ///
@@ -79,6 +79,7 @@ struct UpdateFollowupFields<'a> {
 /// ```
 ///
 /// [`attachments`]: Self::attachments
+/// [`components`]: Self::components
 /// [`content`]: Self::content
 /// [`embeds`]: Self::embeds
 #[must_use = "requests must be configured and executed"]

--- a/twilight-http/src/request/application/interaction/update_response.rs
+++ b/twilight-http/src/request/application/interaction/update_response.rs
@@ -46,8 +46,8 @@ struct UpdateResponseFields<'a> {
 ///
 /// You can pass [`None`] to any of the methods to remove the associated field.
 /// Pass [`None`] to [`content`] to remove the content. You must ensure that the
-/// message still contains at least one of [`attachments`], [`content`], or
-/// [`embeds`].
+/// message still contains at least one of [`attachments`], [`components`],
+/// [`content`] or [`embeds`].
 ///
 /// This endpoint is not bound to the application's global rate limit.
 ///
@@ -79,6 +79,7 @@ struct UpdateResponseFields<'a> {
 /// ```
 ///
 /// [`attachments`]: Self::attachments
+/// [`components`]: Self::components
 /// [`content`]: Self::content
 /// [`embeds`]: Self::embeds
 #[must_use = "requests must be configured and executed"]

--- a/twilight-http/src/request/channel/message/create_message.rs
+++ b/twilight-http/src/request/channel/message/create_message.rs
@@ -57,7 +57,7 @@ pub(crate) struct CreateMessageFields<'a> {
 /// Send a message to a channel.
 ///
 /// The message must include at least one of [`attachments`], [`content`],
-/// [`embeds`], or [`sticker_ids`].
+/// [`components`], [`embeds`], or [`sticker_ids`].
 ///
 /// # Example
 ///
@@ -80,6 +80,7 @@ pub(crate) struct CreateMessageFields<'a> {
 ///
 /// [`attachments`]: Self::attachments
 /// [`content`]: Self::content
+/// [`components`]: Self::components
 /// [`embeds`]: Self::embeds
 /// [`sticker_ids`]: Self::sticker_ids
 #[must_use = "requests must be configured and executed"]

--- a/twilight-http/src/request/channel/webhook/execute_webhook.rs
+++ b/twilight-http/src/request/channel/webhook/execute_webhook.rs
@@ -59,8 +59,8 @@ pub(crate) struct ExecuteWebhookFields<'a> {
 
 /// Execute a webhook, sending a message to its channel.
 ///
-/// The message must include at least one of [`attachments`], [`content`], or
-/// [`embeds`].
+/// The message must include at least one of [`attachments`], [`content`],
+/// [`components`], [`embeds`].
 ///
 /// # Examples
 ///
@@ -82,6 +82,7 @@ pub(crate) struct ExecuteWebhookFields<'a> {
 ///
 /// [`attachments`]: Self::attachments
 /// [`content`]: Self::content
+/// [`components`]: Self::components
 /// [`embeds`]: Self::embeds
 #[must_use = "requests must be configured and executed"]
 pub struct ExecuteWebhook<'a> {

--- a/twilight-http/src/request/channel/webhook/execute_webhook.rs
+++ b/twilight-http/src/request/channel/webhook/execute_webhook.rs
@@ -60,7 +60,7 @@ pub(crate) struct ExecuteWebhookFields<'a> {
 /// Execute a webhook, sending a message to its channel.
 ///
 /// The message must include at least one of [`attachments`], [`content`],
-/// [`components`], [`embeds`].
+/// [`components`], or [`embeds`].
 ///
 /// # Examples
 ///

--- a/twilight-http/src/request/channel/webhook/execute_webhook.rs
+++ b/twilight-http/src/request/channel/webhook/execute_webhook.rs
@@ -59,8 +59,8 @@ pub(crate) struct ExecuteWebhookFields<'a> {
 
 /// Execute a webhook, sending a message to its channel.
 ///
-/// The message must include at least one of [`attachments`], [`content`],
-/// [`components`], or [`embeds`].
+/// The message must include at least one of [`attachments`], [`components`],
+/// [`content`], or [`embeds`].
 ///
 /// # Examples
 ///
@@ -81,8 +81,8 @@ pub(crate) struct ExecuteWebhookFields<'a> {
 /// ```
 ///
 /// [`attachments`]: Self::attachments
-/// [`content`]: Self::content
 /// [`components`]: Self::components
+/// [`content`]: Self::content
 /// [`embeds`]: Self::embeds
 #[must_use = "requests must be configured and executed"]
 pub struct ExecuteWebhook<'a> {

--- a/twilight-http/src/request/channel/webhook/execute_webhook_and_wait.rs
+++ b/twilight-http/src/request/channel/webhook/execute_webhook_and_wait.rs
@@ -10,6 +10,9 @@ use twilight_model::channel::Message;
 /// Execute a webhook, sending a message to its channel, and then wait for the
 /// message to be created.
 ///
+/// The message must include at least one of [`attachments`], [`components`],
+/// [`content`], or [`embeds`].
+///
 /// # Examples
 ///
 /// ```no_run
@@ -34,9 +37,10 @@ use twilight_model::channel::Message;
 /// # Ok(()) }
 /// ```
 ///
+/// [`attachments`]: Self::attachments
+/// [`components`]: Self::components
 /// [`content`]: Self::content
 /// [`embeds`]: Self::embeds
-/// [`file`]: Self::file
 #[must_use = "requests must be configured and executed"]
 pub struct ExecuteWebhookAndWait<'a> {
     http: &'a Client,

--- a/twilight-http/src/request/channel/webhook/execute_webhook_and_wait.rs
+++ b/twilight-http/src/request/channel/webhook/execute_webhook_and_wait.rs
@@ -10,9 +10,6 @@ use twilight_model::channel::Message;
 /// Execute a webhook, sending a message to its channel, and then wait for the
 /// message to be created.
 ///
-/// The message must include at least one of [`attachments`], [`components`],
-/// [`content`], or [`embeds`].
-///
 /// # Examples
 ///
 /// ```no_run
@@ -36,11 +33,6 @@ use twilight_model::channel::Message;
 /// println!("message id: {}", message.id);
 /// # Ok(()) }
 /// ```
-///
-/// [`attachments`]: Self::attachments
-/// [`components`]: Self::components
-/// [`content`]: Self::content
-/// [`embeds`]: Self::embeds
 #[must_use = "requests must be configured and executed"]
 pub struct ExecuteWebhookAndWait<'a> {
     http: &'a Client,

--- a/twilight-http/src/request/channel/webhook/update_webhook_message.rs
+++ b/twilight-http/src/request/channel/webhook/update_webhook_message.rs
@@ -46,8 +46,8 @@ struct UpdateWebhookMessageFields<'a> {
 ///
 /// You can pass [`None`] to any of the methods to remove the associated field.
 /// Pass [`None`] to [`content`] to remove the content. You must ensure that the
-/// message still contains at least one of [`attachments`], [`content`], or
-/// [`embeds`].
+/// message still contains at least one of [`attachments`], [`components`],
+/// [`content`], or [`embeds`].
 ///
 /// # Examples
 ///
@@ -73,6 +73,7 @@ struct UpdateWebhookMessageFields<'a> {
 /// ```
 ///
 /// [`attachments`]: Self::attachments
+/// [`components`]: Self::components
 /// [`content`]: Self::content
 /// [`embeds`]: Self::embeds
 #[must_use = "requests must be configured and executed"]


### PR DESCRIPTION
Discord now allows users to send messages which only contain components.

Reference: https://github.com/discord/discord-api-docs/pull/5435

Closes: #1902