### PR TITLE
docs(http): document mutable guild features

### DIFF
--- a/twilight-http/src/request/guild/update_guild.rs
+++ b/twilight-http/src/request/guild/update_guild.rs
@@ -164,8 +164,16 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// Attempting to add or remove the `COMMUNITY` feature requires the
     /// [`Permissions::ADMINISTRATOR`] permission.
+    /// 
+    /// Attempting to add or remove the `INVITES_DISABLED` feature requires
+    /// the [`Permissions::MANAGE_GUILD`] permission.
+    /// 
+    /// Attempting to add or remove the `DISCOVERABLE` feature requires
+    /// the [`Permissions::ADMINISTRATOR`] permission. Additionally the guild
+    /// must pass all the discovery requirements.
     ///
     /// [`Permissions::ADMINISTRATOR`]: twilight_model::guild::Permissions::ADMINISTRATOR
+    /// [`Permissions::MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
     pub const fn features(mut self, features: &'a [&'a str]) -> Self {
         self.fields.features = Some(features);
 

--- a/twilight-http/src/request/guild/update_guild.rs
+++ b/twilight-http/src/request/guild/update_guild.rs
@@ -172,9 +172,9 @@ impl<'a> UpdateGuild<'a> {
     /// Attempting to add or remove the [`GuildFeature::InvitesDisabled`] feature requires
     /// the [`Permissions::MANAGE_GUILD`] permission.
     ///
-    /// [`GuildFeature::Community`]: twilight_model::guild::GuildFeature
-    /// [`GuildFeature::Discoverable`]: twilight_model::guild::Discoverable
-    /// [`GuildFeature::InvitesDisabled`]: twilight_model::guild::InvitesDisabled
+    /// [`GuildFeature::Community`]: twilight_model::guild::GuildFeature::Community
+    /// [`GuildFeature::Discoverable`]: twilight_model::guild::GuildFeature::Discoverable
+    /// [`GuildFeature::InvitesDisabled`]: twilight_model::guild::GuildFeature::InvitesDisabled
     /// [`Permissions::ADMINISTRATOR`]: twilight_model::guild::Permissions::ADMINISTRATOR
     /// [`Permissions::MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
     pub const fn features(mut self, features: &'a [&'a str]) -> Self {

--- a/twilight-http/src/request/guild/update_guild.rs
+++ b/twilight-http/src/request/guild/update_guild.rs
@@ -162,16 +162,19 @@ impl<'a> UpdateGuild<'a> {
 
     /// Set the enabled features of the guild.
     ///
-    /// Attempting to add or remove the `COMMUNITY` feature requires the
+    /// Attempting to add or remove the [`GuildFeature::Community`] feature requires the
     /// [`Permissions::ADMINISTRATOR`] permission.
     ///
-    /// Attempting to add or remove the `DISCOVERABLE` feature requires
+    /// Attempting to add or remove the [`GuildFeature::Discoverable`] feature requires
     /// the [`Permissions::ADMINISTRATOR`] permission. Additionally the guild
     /// must pass all the discovery requirements.
     ///
-    /// Attempting to add or remove the `INVITES_DISABLED` feature requires
+    /// Attempting to add or remove the [`GuildFeature::InvitesDisabled`] feature requires
     /// the [`Permissions::MANAGE_GUILD`] permission.
     ///
+    /// [`GuildFeature::Community`]: twilight_model::guild::GuildFeature
+    /// [`GuildFeature::Discoverable`]: twilight_model::guild::Discoverable
+    /// [`GuildFeature::InvitesDisabled`]: twilight_model::guild::InvitesDisabled
     /// [`Permissions::ADMINISTRATOR`]: twilight_model::guild::Permissions::ADMINISTRATOR
     /// [`Permissions::MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
     pub const fn features(mut self, features: &'a [&'a str]) -> Self {

--- a/twilight-http/src/request/guild/update_guild.rs
+++ b/twilight-http/src/request/guild/update_guild.rs
@@ -164,11 +164,11 @@ impl<'a> UpdateGuild<'a> {
     ///
     /// Attempting to add or remove the `COMMUNITY` feature requires the
     /// [`Permissions::ADMINISTRATOR`] permission.
-    /// 
+    ///
     /// Attempting to add or remove the `DISCOVERABLE` feature requires
     /// the [`Permissions::ADMINISTRATOR`] permission. Additionally the guild
     /// must pass all the discovery requirements.
-    /// 
+    ///
     /// Attempting to add or remove the `INVITES_DISABLED` feature requires
     /// the [`Permissions::MANAGE_GUILD`] permission.
     ///

--- a/twilight-http/src/request/guild/update_guild.rs
+++ b/twilight-http/src/request/guild/update_guild.rs
@@ -165,12 +165,12 @@ impl<'a> UpdateGuild<'a> {
     /// Attempting to add or remove the `COMMUNITY` feature requires the
     /// [`Permissions::ADMINISTRATOR`] permission.
     /// 
-    /// Attempting to add or remove the `INVITES_DISABLED` feature requires
-    /// the [`Permissions::MANAGE_GUILD`] permission.
-    /// 
     /// Attempting to add or remove the `DISCOVERABLE` feature requires
     /// the [`Permissions::ADMINISTRATOR`] permission. Additionally the guild
     /// must pass all the discovery requirements.
+    /// 
+    /// Attempting to add or remove the `INVITES_DISABLED` feature requires
+    /// the [`Permissions::MANAGE_GUILD`] permission.
     ///
     /// [`Permissions::ADMINISTRATOR`]: twilight_model::guild::Permissions::ADMINISTRATOR
     /// [`Permissions::MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD


### PR DESCRIPTION
Discord only allows the `COMMUNITY`, `DISCOVERABLE` and `INVITES_DISABLED` features to be edited manually.

Reference: https://github.com/discord/discord-api-docs/pull/5270

Closes: #1906