### PR TITLE
feat(http): implement `AuditLogReason` for `UpdateGuildMfa`

### DIFF
--- a/twilight-http/src/request/audit_reason.rs
+++ b/twilight-http/src/request/audit_reason.rs
@@ -30,7 +30,7 @@ mod private {
             member::{AddRoleToMember, RemoveMember, RemoveRoleFromMember, UpdateGuildMember},
             role::{CreateRole, DeleteRole, UpdateRole},
             sticker::{CreateGuildSticker, UpdateGuildSticker},
-            CreateGuildChannel, CreateGuildPrune, UpdateCurrentMember, UpdateGuild,
+            CreateGuildChannel, CreateGuildPrune, UpdateCurrentMember, UpdateGuild, UpdateGuildMfa,
         },
         scheduled_event::{
             CreateGuildExternalScheduledEvent, CreateGuildScheduledEvent,
@@ -78,6 +78,7 @@ mod private {
     impl Sealed for UpdateEmoji<'_> {}
     impl Sealed for UpdateGuild<'_> {}
     impl Sealed for UpdateGuildMember<'_> {}
+    impl Sealed for UpdateGuildMfa<'_> {}
     impl Sealed for UpdateGuildScheduledEvent<'_> {}
     impl Sealed for UpdateGuildSticker<'_> {}
     impl Sealed for UpdateRole<'_> {}

--- a/twilight-http/src/request/guild/update_guild_mfa.rs
+++ b/twilight-http/src/request/guild/update_guild_mfa.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{Request, TryIntoRequest, AuditLogReason, self},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::ResponseFuture,
     routing::Route,
 };
@@ -10,7 +10,7 @@ use twilight_model::{
     guild::MfaLevel,
     id::{marker::GuildMarker, Id},
 };
-use twilight_validate::request::{ValidationError,audit_reason as validate_audit_reason};
+use twilight_validate::request::{audit_reason as validate_audit_reason, ValidationError};
 
 #[derive(Serialize)]
 struct UpdateGuildMfaFields<'a> {
@@ -29,7 +29,10 @@ pub struct UpdateGuildMfa<'a> {
 impl<'a> UpdateGuildMfa<'a> {
     pub(crate) const fn new(http: &'a Client, guild_id: Id<GuildMarker>, level: MfaLevel) -> Self {
         Self {
-            fields: UpdateGuildMfaFields { level, reason: None },
+            fields: UpdateGuildMfaFields {
+                level,
+                reason: None,
+            },
             guild_id,
             http,
         }
@@ -57,7 +60,6 @@ impl<'a> AuditLogReason<'a> for UpdateGuildMfa<'a> {
         Ok(self)
     }
 }
-
 
 impl TryIntoRequest for UpdateGuildMfa<'_> {
     fn try_into_request(self) -> Result<Request, Error> {

--- a/twilight-http/src/request/guild/update_guild_mfa.rs
+++ b/twilight-http/src/request/guild/update_guild_mfa.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{Request, TryIntoRequest},
+    request::{Request, TryIntoRequest, AuditLogReason, self},
     response::ResponseFuture,
     routing::Route,
 };
@@ -10,16 +10,18 @@ use twilight_model::{
     guild::MfaLevel,
     id::{marker::GuildMarker, Id},
 };
+use twilight_validate::request::{ValidationError,audit_reason as validate_audit_reason};
 
 #[derive(Serialize)]
-struct UpdateGuildMfaFields {
+struct UpdateGuildMfaFields<'a> {
     level: MfaLevel,
+    reason: Option<&'a str>,
 }
 
 /// Update a guild's MFA level.
 #[must_use = "requests must be configured and executed"]
 pub struct UpdateGuildMfa<'a> {
-    fields: UpdateGuildMfaFields,
+    fields: UpdateGuildMfaFields<'a>,
     guild_id: Id<GuildMarker>,
     http: &'a Client,
 }
@@ -27,7 +29,7 @@ pub struct UpdateGuildMfa<'a> {
 impl<'a> UpdateGuildMfa<'a> {
     pub(crate) const fn new(http: &'a Client, guild_id: Id<GuildMarker>, level: MfaLevel) -> Self {
         Self {
-            fields: UpdateGuildMfaFields { level },
+            fields: UpdateGuildMfaFields { level, reason: None },
             guild_id,
             http,
         }
@@ -46,11 +48,28 @@ impl<'a> UpdateGuildMfa<'a> {
     }
 }
 
+impl<'a> AuditLogReason<'a> for UpdateGuildMfa<'a> {
+    fn reason(mut self, reason: &'a str) -> Result<Self, ValidationError> {
+        validate_audit_reason(reason)?;
+
+        self.fields.reason.replace(reason);
+
+        Ok(self)
+    }
+}
+
+
 impl TryIntoRequest for UpdateGuildMfa<'_> {
     fn try_into_request(self) -> Result<Request, Error> {
         let mut request = Request::builder(&Route::UpdateGuildMfa {
             guild_id: self.guild_id.get(),
         });
+
+        if let Some(reason) = self.fields.reason.as_ref() {
+            let header = request::audit_header(reason)?;
+
+            request = request.headers(header);
+        }
 
         request = request.json(&self.fields)?;
 


### PR DESCRIPTION
Discord supports the `x-audit-log-reason` header for the update guild mfa endpoint.

Reference: https://github.com/discord/discord-api-docs/pull/5072

Closes: #1866