### PR TITLE
feat(model): add `two_way_link` to `Connection`

### DIFF
--- a/twilight-model/src/user/connection.rs
+++ b/twilight-model/src/user/connection.rs
@@ -14,6 +14,8 @@ pub struct Connection {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub revoked: Option<bool>,
     pub show_activity: bool,
+    /// Whether this connection has a corresponding third party OAuth2 token.
+    pub two_way_link: bool,
     pub verified: bool,
     pub visibility: ConnectionVisibility,
 }
@@ -34,6 +36,7 @@ mod tests {
             revoked: Some(false),
             show_activity: true,
             verified: true,
+            two_way_link: false,
             visibility: ConnectionVisibility::Everyone,
         };
 
@@ -60,6 +63,8 @@ mod tests {
                 Token::Bool(false),
                 Token::Str("show_activity"),
                 Token::Bool(true),
+                Token::Str("two_way_link"),
+                Token::Bool(false),
                 Token::Str("verified"),
                 Token::Bool(true),
                 Token::Str("visibility"),

--- a/twilight-model/src/user/connection.rs
+++ b/twilight-model/src/user/connection.rs
@@ -45,7 +45,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Connection",
-                    len: 9,
+                    len: 10,
                 },
                 Token::Str("friend_sync"),
                 Token::Bool(true),


### PR DESCRIPTION
When the connection has a corresponding thrid party OAuth2 token `two_way_link` will be set to `true`.

Reference: https://github.com/discord/discord-api-docs/pull/5259

Closes: #1917