### PR TITLE
feat(model)!: bring audit log up to date

### DIFF
--- a/twilight-model/src/guild/audit_log/event_type.rs
+++ b/twilight-model/src/guild/audit_log/event_type.rs
@@ -220,8 +220,12 @@ pub enum AuditLogEventType {
     ///
     /// [`AutoModerationRule`]: crate::guild::auto_moderation::AutoModerationRule
     AutoModerationRuleDelete,
-    /// Message has been blocked by AutoMod according to a rule.
+    /// Message has been blocked by AutoMod.
     AutoModerationBlockMessage,
+    /// Message has been flagged by AutoMod.
+    AutoModerationFlagToChannel,
+    /// A member has been timed out by AutoMod.
+    AutoModerationUserCommunicationDisabled,
     /// Variant value is unknown to the library.
     Unknown(u16),
 }
@@ -281,6 +285,8 @@ impl From<u16> for AuditLogEventType {
             141 => AuditLogEventType::AutoModerationRuleUpdate,
             142 => AuditLogEventType::AutoModerationRuleDelete,
             143 => AuditLogEventType::AutoModerationBlockMessage,
+            144 => AuditLogEventType::AutoModerationFlagToChannel,
+            145 => AuditLogEventType::AutoModerationUserCommunicationDisabled,
             unknown => AuditLogEventType::Unknown(unknown),
         }
     }
@@ -341,6 +347,8 @@ impl From<AuditLogEventType> for u16 {
             AuditLogEventType::AutoModerationRuleUpdate => 141,
             AuditLogEventType::AutoModerationRuleDelete => 142,
             AuditLogEventType::AutoModerationBlockMessage => 143,
+            AuditLogEventType::AutoModerationFlagToChannel => 144,
+            AuditLogEventType::AutoModerationUserCommunicationDisabled => 145,
             AuditLogEventType::Unknown(unknown) => unknown,
         }
     }
@@ -424,6 +432,14 @@ mod tests {
         assert_eq!(
             143,
             u16::from(AuditLogEventType::AutoModerationBlockMessage)
+        );
+        assert_eq!(
+            144,
+            u16::from(AuditLogEventType::AutoModerationFlagToChannel)
+        );
+        assert_eq!(
+            145,
+            u16::from(AuditLogEventType::AutoModerationUserCommunicationDisabled)
         );
         assert_eq!(250, u16::from(AuditLogEventType::Unknown(250)));
     }

--- a/twilight-model/src/guild/audit_log/mod.rs
+++ b/twilight-model/src/guild/audit_log/mod.rs
@@ -37,6 +37,7 @@ use serde::{Deserialize, Serialize};
 /// [1]: https://discord.com/developers/docs/resources/audit-log#audit-log-object
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct AuditLog {
+    /// List of referenced application commands.
     pub application_commands: Vec<Command>,
     /// List of referenced auto moderation rules.
     pub auto_moderation_rules: Vec<AutoModerationRule>,

--- a/twilight-model/src/guild/audit_log/mod.rs
+++ b/twilight-model/src/guild/audit_log/mod.rs
@@ -23,6 +23,7 @@ pub use self::{
 
 use super::auto_moderation::AutoModerationRule;
 use crate::{
+    application::command::Command,
     channel::{Channel, Webhook},
     scheduled_event::GuildScheduledEvent,
     user::User,
@@ -34,8 +35,9 @@ use serde::{Deserialize, Serialize};
 /// For additional information refer to [Discord Docs/Audit Logs][1].
 ///
 /// [1]: https://discord.com/developers/docs/resources/audit-log#audit-log-object
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct AuditLog {
+    pub application_commands: Vec<Command>,
     /// List of referenced auto moderation rules.
     pub auto_moderation_rules: Vec<AutoModerationRule>,
     /// Paginated entries in a guild's audit log.
@@ -62,7 +64,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serde_test::Token;
     use static_assertions::{assert_fields, assert_impl_all};
-    use std::{fmt::Debug, hash::Hash};
+    use std::fmt::Debug;
 
     assert_fields!(
         AuditLog: entries,
@@ -75,8 +77,6 @@ mod tests {
         AuditLog: Clone,
         Debug,
         Deserialize<'static>,
-        Eq,
-        Hash,
         PartialEq,
         Send,
         Serialize,
@@ -91,6 +91,7 @@ mod tests {
     #[test]
     fn serde() {
         let value = AuditLog {
+            application_commands: Vec::new(),
             auto_moderation_rules: Vec::new(),
             entries: Vec::new(),
             guild_scheduled_events: Vec::new(),
@@ -105,8 +106,11 @@ mod tests {
             &[
                 Token::Struct {
                     name: "AuditLog",
-                    len: 7,
+                    len: 8,
                 },
+                Token::Str("application_commands"),
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
                 Token::Str("auto_moderation_rules"),
                 Token::Seq { len: Some(0) },
                 Token::SeqEnd,

--- a/twilight-model/src/guild/audit_log/optional_entry_info.rs
+++ b/twilight-model/src/guild/audit_log/optional_entry_info.rs
@@ -9,10 +9,39 @@ use serde::{Deserialize, Serialize};
 /// [`AuditLogEventType`]: super::AuditLogEventType
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct AuditLogOptionalEntryInfo {
+    /// Name of the Auto Moderation rule that was triggered.
+    ///
+    /// The following events have this option:
+    ///
+    /// - [`AuditLogEventType::AutoModerationBlockMessage`]
+    /// - [`AuditLogEventType::AutoModerationFlagToChannel`]
+    /// - [`AuditLogEventType::AutoModerationUserCommunicationDisabled`]
+    ///
+    /// [`AuditLogEventType::AutoModerationBlockMessage`]: super::AuditLogEventType::AutoModerationBlockMessage
+    /// [`AuditLogEventType::AutoModerationFlagToChannel`]: super::AuditLogEventType::AutoModerationFlagToChannel
+    /// [`AuditLogEventType::AutoModerationUserCommunicationDisabled`]: super::AuditLogEventType::AutoModerationUserCommunicationDisabled
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_moderation_rule_name: Option<String>,
+    /// Trigger type of the Auto Moderation rule that was triggered.
+    ///
+    /// The following events have this option:
+    ///
+    /// - [`AuditLogEventType::AutoModerationBlockMessage`]
+    /// - [`AuditLogEventType::AutoModerationFlagToChannel`]
+    /// - [`AuditLogEventType::AutoModerationUserCommunicationDisabled`]
+    ///
+    /// [`AuditLogEventType::AutoModerationBlockMessage`]: super::AuditLogEventType::AutoModerationBlockMessage
+    /// [`AuditLogEventType::AutoModerationFlagToChannel`]: super::AuditLogEventType::AutoModerationFlagToChannel
+    /// [`AuditLogEventType::AutoModerationUserCommunicationDisabled`]: super::AuditLogEventType::AutoModerationUserCommunicationDisabled
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_moderation_rule_trigger_type: Option<String>,
     /// Channel in which the entities were targeted.
     ///
     /// The following events have this option:
     ///
+    /// - [`AuditLogEventType::AutoModerationBlockMessage`]
+    /// - [`AuditLogEventType::AutoModerationFlagToChannel`]
+    /// - [`AuditLogEventType::AutoModerationUserCommunicationDisabled`]
     /// - [`AuditLogEventType::MemberMove`]
     /// - [`AuditLogEventType::MessageDelete`]
     /// - [`AuditLogEventType::MessagePin`]
@@ -21,6 +50,9 @@ pub struct AuditLogOptionalEntryInfo {
     /// - [`AuditLogEventType::StageInstanceDelete`]
     /// - [`AuditLogEventType::StageInstanceUpdate`]
     ///
+    /// [`AuditLogEventType::AutoModerationBlockMessage`]: super::AuditLogEventType::AutoModerationBlockMessage
+    /// [`AuditLogEventType::AutoModerationFlagToChannel`]: super::AuditLogEventType::AutoModerationFlagToChannel
+    /// [`AuditLogEventType::AutoModerationUserCommunicationDisabled`]: super::AuditLogEventType::AutoModerationUserCommunicationDisabled
     /// [`AuditLogEventType::MemberMove`]: super::AuditLogEventType::MemberMove
     /// [`AuditLogEventType::MessageDelete`]: super::AuditLogEventType::MessageDelete
     /// [`AuditLogEventType::MessagePin`]: super::AuditLogEventType::MessagePin


### PR DESCRIPTION
Add `application_commands` to audit log.

Add `AutoModerationFlagToChannel` and `AutoModerationUserCommunicationDisabled` audit log event types.

Add `auto_moderation_rule_name` and `auto_moderation_rule_trigger_type` optional entry info.

Reference: https://github.com/twilight-rs/twilight/issues/1903

Closes: #1903