### PR TITLE
feat(http,model,util,validate)!: use `Cow<'a, [u8]>` for attachments

### DIFF
--- a/examples/model-webhook-slash.rs
+++ b/examples/model-webhook-slash.rs
@@ -25,12 +25,12 @@ static PUB_KEY: Lazy<PublicKey> = Lazy::new(|| {
 ///
 /// Responses are made by giving a function that takes a Interaction and returns
 /// a InteractionResponse or a error.
-async fn interaction_handler<F>(
+async fn interaction_handler<'a, F>(
     req: Request<Body>,
     f: impl Fn(Box<CommandData>) -> F,
 ) -> anyhow::Result<Response<Body>>
 where
-    F: Future<Output = anyhow::Result<InteractionResponse>>,
+    F: Future<Output = anyhow::Result<InteractionResponse<'a>>>,
 {
     // Check that the method used is a POST, all other methods are not allowed.
     if req.method() != Method::POST {
@@ -133,7 +133,7 @@ where
 
 /// Interaction handler that matches on the name of the interaction that
 /// have been dispatched from Discord.
-async fn handler(data: Box<CommandData>) -> anyhow::Result<InteractionResponse> {
+async fn handler<'a>(data: Box<CommandData>) -> anyhow::Result<InteractionResponse<'a>> {
     match data.name.as_ref() {
         "vroom" => vroom(data).await,
         "debug" => debug(data).await,
@@ -142,7 +142,7 @@ async fn handler(data: Box<CommandData>) -> anyhow::Result<InteractionResponse> 
 }
 
 /// Example of a handler that returns the formatted version of the interaction.
-async fn debug(data: Box<CommandData>) -> anyhow::Result<InteractionResponse> {
+async fn debug<'a>(data: Box<CommandData>) -> anyhow::Result<InteractionResponse<'a>> {
     Ok(InteractionResponse {
         kind: InteractionResponseType::ChannelMessageWithSource,
         data: Some(InteractionResponseData {
@@ -153,7 +153,7 @@ async fn debug(data: Box<CommandData>) -> anyhow::Result<InteractionResponse> {
 }
 
 /// Example of interaction that responds with a message saying "Vroom vroom".
-async fn vroom(_: Box<CommandData>) -> anyhow::Result<InteractionResponse> {
+async fn vroom<'a>(_: Box<CommandData>) -> anyhow::Result<InteractionResponse<'a>> {
     Ok(InteractionResponse {
         kind: InteractionResponseType::ChannelMessageWithSource,
         data: Some(InteractionResponseData {

--- a/twilight-http/src/client/interaction.rs
+++ b/twilight-http/src/client/interaction.rs
@@ -81,7 +81,7 @@ impl<'a> InteractionClient<'a> {
         &'a self,
         interaction_id: Id<InteractionMarker>,
         interaction_token: &'a str,
-        response: &'a InteractionResponse,
+        response: &'a InteractionResponse<'_>,
     ) -> CreateResponse<'a> {
         CreateResponse::new(self.client, interaction_id, interaction_token, response)
     }

--- a/twilight-http/src/request/application/interaction/create_followup.rs
+++ b/twilight-http/src/request/application/interaction/create_followup.rs
@@ -128,7 +128,7 @@ impl<'a> CreateFollowup<'a> {
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
-        attachments: &'a [Attachment],
+        attachments: &'a [Attachment<'_>],
     ) -> Result<Self, MessageValidationError> {
         attachments.iter().try_for_each(validate_attachment)?;
 

--- a/twilight-http/src/request/application/interaction/create_response.rs
+++ b/twilight-http/src/request/application/interaction/create_response.rs
@@ -17,7 +17,7 @@ use twilight_model::{
 pub struct CreateResponse<'a> {
     interaction_id: Id<InteractionMarker>,
     interaction_token: &'a str,
-    response: &'a InteractionResponse,
+    response: &'a InteractionResponse<'a>,
     http: &'a Client,
 }
 
@@ -26,7 +26,7 @@ impl<'a> CreateResponse<'a> {
         http: &'a Client,
         interaction_id: Id<InteractionMarker>,
         interaction_token: &'a str,
-        response: &'a InteractionResponse,
+        response: &'a InteractionResponse<'_>,
     ) -> Self {
         Self {
             interaction_id,

--- a/twilight-http/src/request/application/interaction/update_followup.rs
+++ b/twilight-http/src/request/application/interaction/update_followup.rs
@@ -140,7 +140,7 @@ impl<'a> UpdateFollowup<'a> {
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
-        attachments: &'a [Attachment],
+        attachments: &'a [Attachment<'_>],
     ) -> Result<Self, MessageValidationError> {
         attachments.iter().try_for_each(validate_attachment)?;
 

--- a/twilight-http/src/request/application/interaction/update_response.rs
+++ b/twilight-http/src/request/application/interaction/update_response.rs
@@ -137,7 +137,7 @@ impl<'a> UpdateResponse<'a> {
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
-        attachments: &'a [Attachment],
+        attachments: &'a [Attachment<'_>],
     ) -> Result<Self, MessageValidationError> {
         attachments.iter().try_for_each(validate_attachment)?;
 

--- a/twilight-http/src/request/attachment.rs
+++ b/twilight-http/src/request/attachment.rs
@@ -6,7 +6,7 @@ use twilight_model::{
 };
 
 pub struct AttachmentManager<'a> {
-    files: Vec<&'a Attachment>,
+    files: Vec<&'a Attachment<'a>>,
     ids: Vec<Id<AttachmentMarker>>,
 }
 
@@ -54,7 +54,7 @@ impl<'a> AttachmentManager<'a> {
     }
 
     #[must_use = "has no effect if not built into a Form"]
-    pub fn set_files(mut self, files: Vec<&'a Attachment>) -> Self {
+    pub fn set_files(mut self, files: Vec<&'a Attachment<'a>>) -> Self {
         self.files = files;
 
         self

--- a/twilight-http/src/request/channel/message/create_message.rs
+++ b/twilight-http/src/request/channel/message/create_message.rs
@@ -135,7 +135,7 @@ impl<'a> CreateMessage<'a> {
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
-        attachments: &'a [Attachment],
+        attachments: &'a [Attachment<'_>],
     ) -> Result<Self, MessageValidationError> {
         attachments.iter().try_for_each(validate_attachment)?;
 

--- a/twilight-http/src/request/channel/message/update_message.rs
+++ b/twilight-http/src/request/channel/message/update_message.rs
@@ -144,7 +144,7 @@ impl<'a> UpdateMessage<'a> {
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
-        attachments: &'a [Attachment],
+        attachments: &'a [Attachment<'a>],
     ) -> Result<Self, MessageValidationError> {
         attachments.iter().try_for_each(validate_attachment)?;
 

--- a/twilight-http/src/request/channel/webhook/execute_webhook.rs
+++ b/twilight-http/src/request/channel/webhook/execute_webhook.rs
@@ -145,7 +145,7 @@ impl<'a> ExecuteWebhook<'a> {
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
-        attachments: &'a [Attachment],
+        attachments: &'a [Attachment<'_>],
     ) -> Result<Self, MessageValidationError> {
         attachments.iter().try_for_each(validate_attachment)?;
 

--- a/twilight-http/src/request/channel/webhook/update_webhook_message.rs
+++ b/twilight-http/src/request/channel/webhook/update_webhook_message.rs
@@ -136,7 +136,7 @@ impl<'a> UpdateWebhookMessage<'a> {
     /// [`AttachmentFilename`]: twilight_validate::message::MessageValidationErrorType::AttachmentFilename
     pub fn attachments(
         mut self,
-        attachments: &'a [Attachment],
+        attachments: &'a [Attachment<'_>],
     ) -> Result<Self, MessageValidationError> {
         attachments.iter().try_for_each(validate_attachment)?;
 

--- a/twilight-model/src/http/attachment.rs
+++ b/twilight-model/src/http/attachment.rs
@@ -1,5 +1,7 @@
 //! Models used when sending attachments to Discord.
 
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
 /// Attachments used in messages.
@@ -25,14 +27,14 @@ use serde::{Deserialize, Serialize};
 /// attachment.description("Raw data about Twilight Sparkle".to_owned());
 /// ```
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct Attachment {
+pub struct Attachment<'a> {
     /// Description of the attachment, useful for screen readers and users
     /// requiring alt text.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Content of the file.
     #[serde(skip)]
-    pub file: Vec<u8>,
+    pub file: Cow<'a, [u8]>,
     /// Name of the file.
     ///
     /// Examples may be "twilight_sparkle.png", "cat.jpg", or "logs.txt".
@@ -46,7 +48,7 @@ pub struct Attachment {
     pub id: u64,
 }
 
-impl Attachment {
+impl<'a> Attachment<'a> {
     /// Create an attachment from a filename and bytes.
     ///
     /// # Examples
@@ -62,7 +64,7 @@ impl Attachment {
     ///
     /// let attachment = Attachment::from_bytes(filename, file_content, id);
     /// ```
-    pub const fn from_bytes(filename: String, file: Vec<u8>, id: u64) -> Self {
+    pub const fn from_bytes(filename: String, file: Cow<'a, [u8]>, id: u64) -> Self {
         Self {
             description: None,
             file,

--- a/twilight-model/src/http/interaction.rs
+++ b/twilight-model/src/http/interaction.rs
@@ -14,7 +14,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 ///
 /// [Discord Docs/Interaction Object]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct InteractionResponse {
+pub struct InteractionResponse<'a> {
     /// Type of the response.
     #[serde(rename = "type")]
     pub kind: InteractionResponseType,
@@ -31,18 +31,18 @@ pub struct InteractionResponse {
     /// [`Modal`]: InteractionResponseType::Modal
     /// [`UpdateMessage`]: InteractionResponseType::UpdateMessage
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<InteractionResponseData>,
+    pub data: Option<InteractionResponseData<'a>>,
 }
 
 /// Data included in an interaction response.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct InteractionResponseData {
+pub struct InteractionResponseData<'a> {
     /// Allowed mentions of the response.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_mentions: Option<AllowedMentions>,
     /// List of attachments on the response.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub attachments: Option<Vec<Attachment>>,
+    pub attachments: Option<Vec<Attachment<'a>>>,
     /// List of autocomplete alternatives.
     ///
     /// Can only be used with
@@ -126,7 +126,7 @@ mod tests {
         tts
     );
     assert_impl_all!(
-        InteractionResponseData: Clone,
+        InteractionResponseData<'_>: Clone,
         Debug,
         Deserialize<'static>,
         PartialEq,
@@ -187,7 +187,7 @@ mod tests {
             data: Some(InteractionResponseData {
                 attachments: Some(Vec::from([Attachment {
                     description: None,
-                    file: "file data".into(),
+                    file: "file data".as_bytes().into(),
                     filename: "filename.jpg".into(),
                     id: 1,
                 }])),

--- a/twilight-util/src/builder/interaction_response_data.rs
+++ b/twilight-util/src/builder/interaction_response_data.rs
@@ -35,9 +35,9 @@ use twilight_model::{
 /// ```
 #[derive(Clone, Debug)]
 #[must_use = "builders have no effect if unused"]
-pub struct InteractionResponseDataBuilder(InteractionResponseData);
+pub struct InteractionResponseDataBuilder<'a>(InteractionResponseData<'a>);
 
-impl InteractionResponseDataBuilder {
+impl<'a> InteractionResponseDataBuilder<'a> {
     /// Create a new builder to construct an [`InteractionResponseData`].
     pub const fn new() -> Self {
         Self(InteractionResponseData {
@@ -57,7 +57,7 @@ impl InteractionResponseDataBuilder {
     /// Consume the builder, returning an [`InteractionResponseData`].
     #[allow(clippy::missing_const_for_fn)]
     #[must_use = "builders have no effect if unused"]
-    pub fn build(self) -> InteractionResponseData {
+    pub fn build(self) -> InteractionResponseData<'a> {
         self.0
     }
 
@@ -74,7 +74,7 @@ impl InteractionResponseDataBuilder {
     /// Set the attachments of the message.
     ///
     /// Defaults to [`None`].
-    pub fn attachments(mut self, attachments: impl IntoIterator<Item = Attachment>) -> Self {
+    pub fn attachments(mut self, attachments: impl IntoIterator<Item = Attachment<'a>>) -> Self {
         self.0.attachments = Some(attachments.into_iter().collect());
 
         self
@@ -161,7 +161,7 @@ impl InteractionResponseDataBuilder {
     }
 }
 
-impl Default for InteractionResponseDataBuilder {
+impl<'a> Default for InteractionResponseDataBuilder<'a> {
     fn default() -> Self {
         Self::new()
     }
@@ -178,7 +178,7 @@ mod tests {
     };
 
     assert_impl_all!(
-        InteractionResponseDataBuilder: Clone,
+        InteractionResponseDataBuilder<'_>: Clone,
         Debug,
         Default,
         Send,

--- a/twilight-validate/src/message.rs
+++ b/twilight-validate/src/message.rs
@@ -199,7 +199,7 @@ pub enum MessageValidationErrorType {
 ///
 /// [`AttachmentDescriptionTooLarge`]: MessageValidationErrorType::AttachmentDescriptionTooLarge
 /// [`AttachmentFilename`]: MessageValidationErrorType::AttachmentFilename
-pub fn attachment(attachment: &Attachment) -> Result<(), MessageValidationError> {
+pub fn attachment(attachment: &Attachment<'_>) -> Result<(), MessageValidationError> {
     attachment_filename(&attachment.filename)?;
 
     if let Some(description) = &attachment.description {


### PR DESCRIPTION
Instead of taking `&'a [u8]` for attachments, which could cause lifetime issues when using functions like `fn create_attachment<'a>() -> Attachment<'a>`, `Cow<'a, u8>` can be used to support both creating attachments from owned and borrowed bytes.

This is a followup idea to: https://github.com/twilight-rs/twilight/pull/1886