### PR TITLE
fix(gateway): respect `EventTypeFlags`

### DIFF
--- a/twilight-gateway/src/event.rs
+++ b/twilight-gateway/src/event.rs
@@ -396,13 +396,9 @@ impl TryFrom<(OpCode, Option<&str>)> for EventTypeFlags {
             (OpCode::InvalidSession, _) => Ok(Self::GATEWAY_INVALIDATE_SESSION),
             (OpCode::Hello, _) => Ok(Self::GATEWAY_HELLO),
             (OpCode::HeartbeatAck, _) => Ok(Self::GATEWAY_HEARTBEAT_ACK),
-            (_, Some(event_type)) => {
-                if let Ok(flag) = EventType::try_from(event_type) {
-                    Ok(Self::from(flag))
-                } else {
-                    Err(())
-                }
-            }
+            (_, Some(event_type)) => EventType::try_from(event_type)
+                .map(Self::from)
+                .map_err(|_| ()),
             (_, None) => Err(()),
         }
     }

--- a/twilight-gateway/src/event.rs
+++ b/twilight-gateway/src/event.rs
@@ -2,7 +2,7 @@
 //! event deserialization.
 
 use bitflags::bitflags;
-use twilight_model::gateway::event::EventType;
+use twilight_model::gateway::{event::EventType, OpCode};
 
 bitflags! {
     /// Important optimization for narrowing requested event types.
@@ -382,6 +382,28 @@ impl From<EventType> for EventTypeFlags {
             EventType::VoiceServerUpdate => Self::VOICE_SERVER_UPDATE,
             EventType::VoiceStateUpdate => Self::VOICE_STATE_UPDATE,
             EventType::WebhooksUpdate => Self::WEBHOOKS_UPDATE,
+        }
+    }
+}
+
+impl<'a> TryFrom<(OpCode, Option<&'a str>)> for EventTypeFlags {
+    type Error = ();
+
+    fn try_from((op, event_type): (OpCode, Option<&'a str>)) -> Result<Self, Self::Error> {
+        match (op, event_type) {
+            (OpCode::Heartbeat, _) => Ok(Self::GATEWAY_HEARTBEAT),
+            (OpCode::Reconnect, _) => Ok(Self::GATEWAY_RECONNECT),
+            (OpCode::InvalidSession, _) => Ok(Self::GATEWAY_INVALIDATE_SESSION),
+            (OpCode::Hello, _) => Ok(Self::GATEWAY_HELLO),
+            (OpCode::HeartbeatAck, _) => Ok(Self::GATEWAY_HEARTBEAT_ACK),
+            (_, Some(event_type)) => {
+                if let Ok(flag) = EventType::try_from(event_type) {
+                    Ok(Self::from(flag))
+                } else {
+                    return Err(());
+                }
+            }
+            (_, None) => Err(()),
         }
     }
 }

--- a/twilight-gateway/src/event.rs
+++ b/twilight-gateway/src/event.rs
@@ -386,10 +386,10 @@ impl From<EventType> for EventTypeFlags {
     }
 }
 
-impl<'a> TryFrom<(OpCode, Option<&'a str>)> for EventTypeFlags {
+impl TryFrom<(OpCode, Option<&str>)> for EventTypeFlags {
     type Error = ();
 
-    fn try_from((op, event_type): (OpCode, Option<&'a str>)) -> Result<Self, Self::Error> {
+    fn try_from((op, event_type): (OpCode, Option<&str>)) -> Result<Self, Self::Error> {
         match (op, event_type) {
             (OpCode::Heartbeat, _) => Ok(Self::GATEWAY_HEARTBEAT),
             (OpCode::Reconnect, _) => Ok(Self::GATEWAY_RECONNECT),
@@ -400,7 +400,7 @@ impl<'a> TryFrom<(OpCode, Option<&'a str>)> for EventTypeFlags {
                 if let Ok(flag) = EventType::try_from(event_type) {
                     Ok(Self::from(flag))
                 } else {
-                    return Err(());
+                    Err(())
                 }
             }
             (_, None) => Err(()),

--- a/twilight-gateway/src/json.rs
+++ b/twilight-gateway/src/json.rs
@@ -182,9 +182,8 @@ pub fn parse(
             source: None,
         })?;
 
-    event_types
-        .contains(event_flag)
-        .then(|| {
+    if event_types.contains(event_flag) {
+        Some(
             gateway_deserializer
                 .deserialize(&mut json_deserializer)
                 .map_err(|source| {
@@ -194,9 +193,12 @@ pub fn parse(
                         kind: GatewayEventParsingErrorType::Deserializing,
                         source: Some(Box::new(source)),
                     }
-                })
-        })
+                }),
+        )
         .transpose()
+    } else {
+        Ok(None)
+    }
 }
 
 #[cfg(test)]

--- a/twilight-gateway/src/json.rs
+++ b/twilight-gateway/src/json.rs
@@ -183,19 +183,17 @@ pub fn parse(
         })?;
 
     if event_types.contains(event_flag) {
-        Some(
-            gateway_deserializer
-                .deserialize(&mut json_deserializer)
-                .map_err(|source| {
-                    tracing::error!("invalid JSON: {}", String::from_utf8_lossy(json));
+        gateway_deserializer
+            .deserialize(&mut json_deserializer)
+            .map(Some)
+            .map_err(|source| {
+                tracing::error!("invalid JSON: {}", String::from_utf8_lossy(json));
 
-                    GatewayEventParsingError {
-                        kind: GatewayEventParsingErrorType::Deserializing,
-                        source: Some(Box::new(source)),
-                    }
-                }),
-        )
-        .transpose()
+                GatewayEventParsingError {
+                    kind: GatewayEventParsingErrorType::Deserializing,
+                    source: Some(Box::new(source)),
+                }
+            })
     } else {
         Ok(None)
     }

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -481,7 +481,7 @@ impl Shard {
                 }
             };
 
-            // If event is unwanted loop
+            // loop if event is unwanted
             if let Some(event) = json::parse(self.config.event_types(), &mut bytes)
                 .map_err(ReceiveMessageError::from_json)?
             {

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -472,17 +472,22 @@ impl Shard {
     /// Returns a [`ReceiveMessageErrorType::SendingMessage`] error type if the
     /// shard failed to send a message to the gateway, such as a heartbeat.
     pub async fn next_event(&mut self) -> Result<Event, ReceiveMessageError> {
-        let mut bytes = loop {
-            match self.next_message().await? {
-                Message::Binary(bytes) => break bytes,
-                Message::Text(text) => break text.into_bytes(),
-                _ => continue,
-            }
-        };
+        loop {
+            let mut bytes = loop {
+                match self.next_message().await? {
+                    Message::Binary(bytes) => break bytes,
+                    Message::Text(text) => break text.into_bytes(),
+                    _ => continue,
+                }
+            };
 
-        json::parse(&mut bytes)
-            .map(Event::from)
-            .map_err(ReceiveMessageError::from_json)
+            // If event is unwanted loop
+            if let Some(event) = json::parse(self.config.event_types(), &mut bytes)
+                .map_err(ReceiveMessageError::from_json)?
+            {
+                return Ok(event.into());
+            }
+        }
     }
 
     /// Wait for the next raw message from the websocket connection.


### PR DESCRIPTION
The gateway refactor forgot about this important optimization. It's reimplemented it as an additional loop inside of `next_event` (loop again if the event is unwanted).
