### PR TITLE
refactor(gateway): don't pass `WEBSOCKET_CONFIG` in an `Option`

### DIFF
--- a/twilight-gateway/src/connection.rs
+++ b/twilight-gateway/src/connection.rs
@@ -95,7 +95,7 @@ pub async fn connect(
     let url = ConnectionUrl::new(maybe_gateway_url).to_string();
 
     tracing::debug!(%shard_id, ?url, "shaking hands with remote");
-    let stream = tls.connect(&url, Some(WEBSOCKET_CONFIG)).await?;
+    let stream = tls.connect(&url, WEBSOCKET_CONFIG).await?;
     tracing::debug!(%shard_id, "shook hands with remote");
 
     Ok(stream)

--- a/twilight-gateway/src/tls.rs
+++ b/twilight-gateway/src/tls.rs
@@ -31,10 +31,10 @@ mod r#impl {
     /// Connect to the provided URL without TLS.
     pub async fn connect(
         url: &str,
-        maybe_config: Option<WebSocketConfig>,
+        config: WebSocketConfig,
         _tls: &TlsContainer,
     ) -> Result<Connection, ShardInitializeError> {
-        let (stream, _) = tokio_tungstenite::connect_async_with_config(url, maybe_config)
+        let (stream, _) = tokio_tungstenite::connect_async_with_config(url, Some(config))
             .await
             .map_err(|source| ShardInitializeError {
                 kind: ShardInitializeErrorType::Establishing,
@@ -86,11 +86,11 @@ mod r#impl {
     /// Connect to the provided URL with the underlying TLS connector.
     pub async fn connect(
         url: &str,
-        maybe_config: Option<WebSocketConfig>,
+        config: WebSocketConfig,
         tls: &TlsContainer,
     ) -> Result<Connection, ShardInitializeError> {
         let (stream, _) =
-            tokio_tungstenite::connect_async_tls_with_config(url, maybe_config, tls.connector())
+            tokio_tungstenite::connect_async_tls_with_config(url, Some(config), tls.connector())
                 .await
                 .map_err(|source| ShardInitializeError {
                     kind: ShardInitializeErrorType::Establishing,
@@ -176,11 +176,11 @@ mod r#impl {
     /// Connect to the provided URL with the underlying TLS connector.
     pub async fn connect(
         url: &str,
-        maybe_config: Option<WebSocketConfig>,
+        config: WebSocketConfig,
         tls: &TlsContainer,
     ) -> Result<Connection, ShardInitializeError> {
         let (stream, _) =
-            tokio_tungstenite::connect_async_tls_with_config(url, maybe_config, tls.connector())
+            tokio_tungstenite::connect_async_tls_with_config(url, Some(config), tls.connector())
                 .await
                 .map_err(|source| ShardInitializeError {
                     kind: ShardInitializeErrorType::Establishing,
@@ -302,7 +302,7 @@ impl TlsContainer {
     pub async fn connect(
         &self,
         url: &str,
-        config: Option<WebSocketConfig>,
+        config: WebSocketConfig,
     ) -> Result<Connection, ShardInitializeError> {
         r#impl::connect(url, config, self).await
     }


### PR DESCRIPTION
As the `WebSocketConfig` parameter is always provided, it's confusing to pass it inside of an `Option`.
