### PR TITLE
feat(gateway): heartbeat jitter

### DIFF
--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -19,6 +19,7 @@ version = "0.13.3"
 bitflags = { default-features = false, version = "1" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
 leaky-bucket-lite = { default-features = false, features = ["tokio"], version = "0.5.1" }
+rand = {default-features = false, features = ["std", "std_rng"], version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.5" }

--- a/twilight-gateway/src/future.rs
+++ b/twilight-gateway/src/future.rs
@@ -137,8 +137,12 @@ impl TickHeartbeatFuture {
                     heartbeat_interval.saturating_sub(last_sent.elapsed()),
                 ))),
             },
-            (Some(_), None) => Self {
-                inner: Some(Box::pin(time::sleep(Duration::ZERO))),
+            (Some(heartbeat_interval), None) => Self {
+                // First heartbeat should have some jitter, see
+                // https://discord.com/developers/docs/topics/gateway#heartbeat-interval
+                inner: Some(Box::pin(time::sleep(
+                    heartbeat_interval.mul_f64(rand::random()),
+                ))),
             },
             (None, _) => Self { inner: None },
         }

--- a/twilight-gateway/src/future.rs
+++ b/twilight-gateway/src/future.rs
@@ -75,8 +75,8 @@ impl<'a> NextMessageFuture<'a> {
             channel_receive_future: rx,
             message_future,
             tick_heartbeat_future: TickHeartbeatFuture::new(
-                maybe_last_sent,
                 maybe_heartbeat_interval,
+                maybe_last_sent,
             ),
         }
     }
@@ -130,26 +130,17 @@ pub struct TickHeartbeatFuture {
 impl TickHeartbeatFuture {
     /// Initialize a new unpolled future that will resolve when the next
     /// heartbeat must be sent.
-    pub fn new(
-        maybe_last_sent: Option<Instant>,
-        maybe_heartbeat_interval: Option<Duration>,
-    ) -> Self {
-        let heartbeat_interval = if let Some(heartbeat_interval) = maybe_heartbeat_interval {
-            heartbeat_interval
-        } else {
-            return Self { inner: None };
-        };
-
-        let remaining = if let Some(last_sent) = maybe_last_sent {
-            let time_since = last_sent.elapsed();
-
-            heartbeat_interval.saturating_sub(time_since)
-        } else {
-            Duration::ZERO
-        };
-
-        Self {
-            inner: Some(Box::pin(time::sleep(remaining))),
+    fn new(maybe_heartbeat_interval: Option<Duration>, maybe_last_sent: Option<Instant>) -> Self {
+        match (maybe_heartbeat_interval, maybe_last_sent) {
+            (Some(heartbeat_interval), Some(last_sent)) => Self {
+                inner: Some(Box::pin(time::sleep(
+                    heartbeat_interval.saturating_sub(last_sent.elapsed()),
+                ))),
+            },
+            (Some(_), None) => Self {
+                inner: Some(Box::pin(time::sleep(Duration::ZERO))),
+            },
+            (None, _) => Self { inner: None },
         }
     }
 }

--- a/twilight-gateway/src/future.rs
+++ b/twilight-gateway/src/future.rs
@@ -88,7 +88,7 @@ impl Future for NextMessageFuture<'_> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.as_mut();
 
-        if let Poll::Ready(()) = this.tick_heartbeat_future.poll_unpin(cx) {
+        if this.tick_heartbeat_future.poll_unpin(cx).is_ready() {
             return Poll::Ready(NextMessageFutureOutput::SendHeartbeat);
         }
 


### PR DESCRIPTION
To spread out server load, Discord wants gateway users to randomize the initial heartbeat event time.
See https://discord.com/developers/docs/topics/gateway#heartbeat-interval
