### PR TITLE
feat(gateway): zombie connection detection

### DIFF
--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -728,10 +728,29 @@ impl Shard {
     }
 
     /// Send a heartbeat, optionally overriding the session's sequence.
+    ///
+    /// Closes the connection and resumes if previous sent heartbeat never got
+    /// a reply.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called without an `override_sequence` and without having
+    /// received an [`OpCode::Hello`] event.
     async fn heartbeat(&mut self, override_sequence: Option<u64>) -> Result<(), SendError> {
-        let session_sequence = self.session.as_ref().map(Session::sequence);
+        let is_first_heartbeat = self.heartbeat_interval.is_some() && self.latency.sent().is_none();
 
-        if let Some(sequence) = override_sequence.or(session_sequence) {
+        // Discord never replied to the last heartbeat, connection is failed or
+        // "zombied", see
+        // https://discord.com/developers/docs/topics/gateway#heartbeat-interval-example-heartbeat-ack
+        if !is_first_heartbeat && self.latency().received().is_none() {
+            tracing::warn!("connection failed or \"zombied\"");
+            self.session = self.close(CloseFrame::RESUME).await?;
+            self.disconnect(Disconnect::Resume);
+        } else {
+            let sequence = override_sequence
+                .or(self.session.as_ref().map(Session::sequence))
+                .unwrap();
+
             let command = Heartbeat::new(sequence);
             self.command(&command).await?;
 


### PR DESCRIPTION
Adds detection for failed or "zombied" connections and handles them by closing the connection and attempting to resume.
