### PR TITLE
fix(gateway)!: correct command ratelimiter

### DIFF
--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -48,7 +48,7 @@ anyhow = { default-features = false, features = ["std"], version = "1" }
 futures = { default-features = false, version = "0.3" }
 serde_test = { default-features = false, version = "1.0.136" }
 static_assertions = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.12" }
+tokio = { default-features = false, features = ["macros", "rt-multi-thread", "test-util"], version = "1.12" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log"], version = "0.3" }
 
 [features]

--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -48,7 +48,7 @@ anyhow = { default-features = false, features = ["std"], version = "1" }
 futures = { default-features = false, version = "0.3" }
 serde_test = { default-features = false, version = "1.0.136" }
 static_assertions = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["macros", "rt-multi-thread", "test-util"], version = "1.12" }
+tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.12" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log"], version = "0.3" }
 
 [features]

--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -18,7 +18,6 @@ version = "0.13.2"
 [dependencies]
 bitflags = { default-features = false, version = "1" }
 futures-util = { default-features = false, features = ["std"], version = "0.3" }
-leaky-bucket-lite = { default-features = false, features = ["tokio"], version = "0.5.1" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.5" }

--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -49,7 +49,7 @@ anyhow = { default-features = false, features = ["std"], version = "1" }
 futures = { default-features = false, version = "0.3" }
 serde_test = { default-features = false, version = "1.0.136" }
 static_assertions = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.12" }
+tokio = { default-features = false, features = ["macros", "rt-multi-thread", "test-util"], version = "1.12" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log"], version = "0.3" }
 
 [features]

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -1,12 +1,17 @@
 //! Ratelimiter on the user's ability to [send messages].
 //!
+//! See <https://discord.com/developers/docs/topics/gateway#rate-limiting>
+//!
 //! [send messages]: crate::Shard::send
 
 use leaky_bucket_lite::LeakyBucket;
 use std::time::{Duration, Instant};
 
-/// Interval of how often the ratelimit bucket resets, in milliseconds.
-const RESET_DURATION_MILLISECONDS: u64 = 60_000;
+/// Number of commands allowed in a given [`RESET_PERIOD`].
+const COMMANDS_PER_RESET: u32 = 120;
+
+/// Duration until the ratelimit bucket resets.
+const RESET_PERIOD: Duration = Duration::from_secs(60);
 
 /// Ratelimiter for sending commands over the gateway to Discord.
 #[derive(Debug)]
@@ -17,21 +22,15 @@ pub struct CommandRatelimiter {
 
 impl CommandRatelimiter {
     /// Create a new ratelimiter.
-    pub(crate) fn new(heartbeat_interval: u64) -> Self {
-        /// Interval of how often to refill the bucket.
-        const REFILL_INTERVAL: Duration = Duration::from_millis(RESET_DURATION_MILLISECONDS);
-
-        // Number of commands allotted to the user per reset period.
-        let commands_allotted = u32::from(available_commands_per_interval(heartbeat_interval));
-
-        let bucket = LeakyBucket::builder()
-            .max(commands_allotted)
-            .tokens(commands_allotted)
-            .refill_interval(REFILL_INTERVAL)
-            .refill_amount(commands_allotted)
-            .build();
-
-        Self { bucket }
+    pub(crate) fn new() -> Self {
+        Self {
+            bucket: LeakyBucket::builder()
+                .max(COMMANDS_PER_RESET)
+                .tokens(COMMANDS_PER_RESET)
+                .refill_interval(RESET_PERIOD)
+                .refill_amount(COMMANDS_PER_RESET)
+                .build(),
+        }
     }
 
     /// Current number of commands that are still available within the interval.
@@ -55,60 +54,6 @@ impl CommandRatelimiter {
     }
 }
 
-/// Calculate the number of commands to allot in a given reset period while
-/// taking the heartbeat interval into account.
-///
-/// This is reserving twice as much as needed for heartbeats, to account for
-/// Discord sending us a heartbeat and expecting a heartbeat in response.
-///
-/// For example, when the heartbeat interval is 42500 milliseconds then 116
-/// commands will be allotted per reset period.
-fn available_commands_per_interval(heartbeat_interval: u64) -> u8 {
-    /// Number of commands to reserve per reset. This number is a bit
-    /// high because the heartbeat interval may be anything, so we're
-    /// just being cautious here.
-    const ALLOT_ON_FAIL: u8 = COMMANDS_PER_RESET - 10;
-
-    /// Number of commands allowed in a given reset period.
-    ///
-    /// API documentation with details:
-    /// <https://discord.com/developers/docs/topics/gateway#rate-limiting>
-    const COMMANDS_PER_RESET: u8 = 120;
-
-    // Guard against the interval being 0, in which case we can default.
-    if heartbeat_interval == 0 {
-        return ALLOT_ON_FAIL;
-    }
-
-    let mut heartbeats = RESET_DURATION_MILLISECONDS / heartbeat_interval;
-    let remainder = RESET_DURATION_MILLISECONDS % heartbeat_interval;
-
-    // If we have a remainder then we reserve an additional heartbeat.
-    //
-    // If there is a remainder per reset then in theory we could allot one less
-    // command for heartbeating variably every number of resets, but it's best
-    // to be cautious and keep it simple.
-    if remainder > 0 {
-        heartbeats = heartbeats.saturating_add(1);
-    }
-
-    // Convert the heartbeats to a u8. The number of heartbeats **should** never
-    // be above `u8::MAX`, so the error pattern branch should never be reached.
-    let heartbeats_converted = if let Ok(value) = heartbeats.try_into() {
-        value
-    } else {
-        tracing::warn!(
-            default=ALLOT_ON_FAIL,
-            %heartbeats,
-            "heartbeats > u8 max; defaulting",
-        );
-
-        ALLOT_ON_FAIL
-    };
-
-    COMMANDS_PER_RESET.saturating_sub(heartbeats_converted * 2)
-}
-
 #[cfg(test)]
 mod tests {
     use super::CommandRatelimiter;
@@ -116,12 +61,4 @@ mod tests {
     use std::fmt::Debug;
 
     assert_impl_all!(CommandRatelimiter: Debug, Send, Sync);
-
-    #[test]
-    fn available_commands_per_interval() {
-        assert_eq!(118, super::available_commands_per_interval(60_000));
-        assert_eq!(116, super::available_commands_per_interval(42_500));
-        assert_eq!(116, super::available_commands_per_interval(30_000));
-        assert_eq!(114, super::available_commands_per_interval(29_999));
-    }
 }

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -76,7 +76,7 @@ mod tests {
         assert!(ratelimiter.available() == 0);
 
         time::pause();
-        // Should not refill untill RESET_PERIOD has passed.
+        // Should not refill until RESET_PERIOD has passed.
         time::advance(RESET_PERIOD - Duration::from_secs(1)).await;
         assert!(ratelimiter.available() == 0);
 

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -7,11 +7,11 @@
 use leaky_bucket_lite::LeakyBucket;
 use std::time::{Duration, Instant};
 
-/// Number of commands allowed in a given [`RESET_PERIOD`].
+/// Number of commands allowed in a given [`RESET_DURATION`].
 const COMMANDS_PER_RESET: u32 = 120;
 
 /// Duration until the ratelimit bucket resets.
-const RESET_PERIOD: Duration = Duration::from_secs(60);
+const RESET_DURATION: Duration = Duration::from_secs(60);
 
 /// Ratelimiter for sending commands over the gateway to Discord.
 #[derive(Debug)]
@@ -22,13 +22,15 @@ pub struct CommandRatelimiter {
 
 impl CommandRatelimiter {
     /// Create a new ratelimiter.
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(heartbeat_interval: u64) -> Self {
+        let allotted = nonreserved_commands_per_reset(Duration::from_millis(heartbeat_interval));
+
         Self {
             bucket: LeakyBucket::builder()
-                .max(COMMANDS_PER_RESET)
-                .tokens(COMMANDS_PER_RESET)
-                .refill_interval(RESET_PERIOD)
-                .refill_amount(COMMANDS_PER_RESET)
+                .max(allotted)
+                .tokens(allotted)
+                .refill_interval(RESET_DURATION)
+                .refill_amount(allotted)
                 .build(),
         }
     }
@@ -54,51 +56,90 @@ impl CommandRatelimiter {
     }
 }
 
+/// Calculate the number of non reserved commands for heartbeating (which skips
+/// the ratelimiter) in a given [`RESET_DURATION`].
+///
+/// Reserves capacity for twice the amount of heartbeats to account for Discord
+/// absurdly sending [`OpCode::Heartbeat`]s when the gateway is ratelimited
+/// (which requires the gateway to immediately send a heartbeat back).
+///
+/// [`OpCode::Heartbeat`]: twilight_model::gateway::OpCode::Heartbeat
+fn nonreserved_commands_per_reset(heartbeat_interval: Duration) -> u32 {
+    /// Guard against faulty gateway implementations sending absurdly low
+    /// heartbeat intervals by maximally reserving 10 heartbeats per
+    /// [`RESET_DURATION`].
+    const MAX_NONRESERVED_COMMANDS_PER_RESET: u32 = COMMANDS_PER_RESET - 10;
+
+    // Round up to be on the safe side.
+    let reserved_heartbeats =
+        (RESET_DURATION.as_secs_f32() / heartbeat_interval.as_secs_f32()).ceil();
+
+    COMMANDS_PER_RESET
+        .saturating_sub(reserved_heartbeats as u32 * 2)
+        .max(MAX_NONRESERVED_COMMANDS_PER_RESET)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{CommandRatelimiter, COMMANDS_PER_RESET, RESET_PERIOD};
+    use super::{nonreserved_commands_per_reset, CommandRatelimiter, RESET_DURATION};
     use static_assertions::assert_impl_all;
     use std::{fmt::Debug, time::Duration};
     use tokio::time;
 
     assert_impl_all!(CommandRatelimiter: Debug, Send, Sync);
 
-    #[tokio::test(start_paused = true)]
-    async fn ratelimiter_refills() {
-        let ratelimiter = CommandRatelimiter::new();
+    #[test]
+    fn commands_per_interval() {
+        assert_eq!(118, nonreserved_commands_per_reset(Duration::from_secs(60)));
+        assert_eq!(
+            116,
+            nonreserved_commands_per_reset(Duration::from_millis(42_500))
+        );
+        assert_eq!(116, nonreserved_commands_per_reset(Duration::from_secs(30)));
+        assert_eq!(
+            114,
+            nonreserved_commands_per_reset(Duration::from_millis(29_999))
+        );
+    }
 
-        assert!(ratelimiter.available() == COMMANDS_PER_RESET);
-        for _ in 0..COMMANDS_PER_RESET {
+    #[tokio::test(start_paused = true)]
+    async fn ratelimiter_specification() {
+        let ratelimiter = CommandRatelimiter::new(RESET_DURATION.as_millis().try_into().unwrap());
+
+        let commands_per_reset: u32 = nonreserved_commands_per_reset(RESET_DURATION);
+
+        assert!(ratelimiter.available() == commands_per_reset);
+        for _ in 0..commands_per_reset {
             ratelimiter.acquire_one().await;
         }
         assert!(ratelimiter.available() == 0);
 
         // Should not refill until RESET_PERIOD has passed.
-        time::advance(RESET_PERIOD - Duration::from_secs(1)).await;
+        time::advance(RESET_DURATION - Duration::from_secs(1)).await;
         assert!(ratelimiter.available() == 0);
 
         // All should be refilled.
         time::advance(Duration::from_secs(1)).await;
-        assert!(ratelimiter.available() == COMMANDS_PER_RESET);
+        assert!(ratelimiter.available() == commands_per_reset);
 
-        for _ in 0..COMMANDS_PER_RESET / 2 {
+        for _ in 0..commands_per_reset / 2 {
             ratelimiter.acquire_one().await;
         }
-        assert!(ratelimiter.available() == COMMANDS_PER_RESET / 2);
+        assert!(ratelimiter.available() == commands_per_reset / 2);
 
-        time::advance(RESET_PERIOD / 2).await;
+        time::advance(RESET_DURATION / 2).await;
 
-        for _ in 0..COMMANDS_PER_RESET / 2 {
+        for _ in 0..commands_per_reset / 2 {
             ratelimiter.acquire_one().await;
         }
         assert!(ratelimiter.available() == 0);
 
         // Half should be refilled.
-        time::advance(RESET_PERIOD / 2).await;
-        assert!(ratelimiter.available() == COMMANDS_PER_RESET / 2);
+        time::advance(RESET_DURATION / 2).await;
+        assert!(ratelimiter.available() == commands_per_reset / 2);
 
         // All should be refilled.
-        time::advance(RESET_PERIOD / 2).await;
-        assert!(ratelimiter.available() == COMMANDS_PER_RESET);
+        time::advance(RESET_DURATION / 2).await;
+        assert!(ratelimiter.available() == commands_per_reset);
     }
 }

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -71,12 +71,12 @@ fn nonreserved_commands_per_reset(heartbeat_interval: Duration) -> u32 {
     const MAX_NONRESERVED_COMMANDS_PER_RESET: u32 = COMMANDS_PER_RESET - 10;
 
     // Round up to be on the safe side.
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     let reserved_heartbeats =
-        (RESET_DURATION.as_secs_f32() / heartbeat_interval.as_secs_f32()).ceil();
+        (RESET_DURATION.as_secs_f32() / heartbeat_interval.as_secs_f32()).ceil() as u32;
 
-    #[allow(clippy::cast_sign_loss)]
     COMMANDS_PER_RESET
-        .saturating_sub(reserved_heartbeats as u32 * 2)
+        .saturating_sub(reserved_heartbeats * 2)
         .max(MAX_NONRESERVED_COMMANDS_PER_RESET)
 }
 

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -74,6 +74,7 @@ fn nonreserved_commands_per_reset(heartbeat_interval: Duration) -> u32 {
     let reserved_heartbeats =
         (RESET_DURATION.as_secs_f32() / heartbeat_interval.as_secs_f32()).ceil();
 
+    #[allow(clippy::cast_sign_loss)]
     COMMANDS_PER_RESET
         .saturating_sub(reserved_heartbeats as u32 * 2)
         .max(MAX_NONRESERVED_COMMANDS_PER_RESET)

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -82,6 +82,6 @@ mod tests {
 
         // Should now be refilled.
         time::advance(Duration::from_secs(1)).await;
-        assert!(ratelimiter.available() == 120);
+        assert!(ratelimiter.available() == COMMANDS_PER_RESET);
     }
 }

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -61,7 +61,7 @@ impl CommandRatelimiter {
 }
 
 /// Guard around the ratelimit permit. As long as this is held one command is
-/// guarenteed to not be ratelimited.
+/// guaranteed to not be ratelimited.
 ///
 /// Because this hold a shared reference to [`Semaphore`],
 /// [`CommandRatelimiter`] will only be dropped after the last guard has been

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -108,7 +108,7 @@ impl Drop for RatelimiterGuard {
 /// [`OpCode::Heartbeat`]: twilight_model::gateway::OpCode::Heartbeat
 fn nonreserved_commands_per_reset(heartbeat_interval: Duration) -> u8 {
     /// Guard against faulty gateway implementations sending absurdly low
-    /// heartbeat intervals by maximally reserving 10 heartbeats per
+    /// heartbeat intervals by maximally reserving some number of heartbeats per
     /// [`RESET_DURATION`].
     const MAX_NONRESERVED_COMMANDS_PER_RESET: u8 = COMMANDS_PER_RESET - 10;
 
@@ -132,7 +132,7 @@ mod tests {
     assert_impl_all!(CommandRatelimiter: Debug, Send, Sync);
 
     #[test]
-    fn commands_per_interval() {
+    fn nonreserved_commands() {
         assert_eq!(118, nonreserved_commands_per_reset(Duration::from_secs(60)));
         assert_eq!(
             116,
@@ -145,6 +145,7 @@ mod tests {
         );
     }
 
+    // Divide into two tests as they take one minute each to finish.
     #[tokio::test]
     async fn ratelimiter_specification_1() {
         let ratelimiter = CommandRatelimiter::new(RESET_DURATION.as_millis().try_into().unwrap());

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -853,7 +853,7 @@ impl Shard {
 
                 self.heartbeat(Some(event.data))
                     .await
-                    .map_err(ProcessError::from_send)?
+                    .map_err(ProcessError::from_send)?;
             }
             Ok(OpCode::HeartbeatAck) => {
                 self.latency.track_received();

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -657,7 +657,7 @@ impl Shard {
     /// [was enabled]: crate::ConfigBuilder::ratelimit_messages
     pub async fn send(&mut self, message: Message) -> Result<(), SendError> {
         if let Some(ref ratelimiter) = self.ratelimiter {
-            ratelimiter.acquire_one().await;
+            ratelimiter.acquire().await;
         }
 
         self.send_direct(message).await


### PR DESCRIPTION
Discord may send `Heartbeat` requests that must immediately make the shard send a `Heartbeat` back, this can only be solved by reserving capacity. The current ratelimiter API does also not allow for background `Heartbeat` events to take priority over user sendable commands, so the easiest solution is to reserve capacity for them and have them skip the ratelimiter too (the `Ratelimiter::new` method assigns enough reserved capacity for both `Heartbeat` situations).
TODO:
- [x] Document Discord sending `Heartbeat` events even when the Shard is ratelimited, forcing it to reserve capacity
- [x] Have outgoing heartbeats skip the ratelimiter
- [x] Make the ratelimiter pass the tests asserting it following the specification (dropped the dependecy on `leaky-bucket-lite` by using a `Semaphore` and an async drop hack)
- [x] Tests shouldn't take 1 minute to complete and should be consistent (fixed by calling `task::yield_now` multiple times after `time::advance`, this is likely using unstable tokio behaviour)
## Breaking change
The `CommandRatelimiter::next_refill` method is removed.