### PR TITLE
refactor(gateway)!: touch up errors

### DIFF
--- a/twilight-gateway/src/channel.rs
+++ b/twilight-gateway/src/channel.rs
@@ -68,11 +68,8 @@ impl MessageSender {
     /// Returns a [`SendErrorType::Sending`] error type if the message could
     /// not be sent over the websocket. This indicates the shard is either
     /// currently restarting or closed and will restart.
-    ///
-    /// Returns a [`SendErrorType::Serializing`] error type if the provided
-    /// command failed to serialize.
     pub fn command(&self, command: &impl Command) -> Result<(), SendError> {
-        let message = command::prepare(command)?;
+        let message = command::prepare(command);
 
         self.send(message)
     }

--- a/twilight-gateway/src/command.rs
+++ b/twilight-gateway/src/command.rs
@@ -2,11 +2,7 @@
 //!
 //! [`Shard::command`]: crate::Shard::command
 
-use crate::{
-    error::{SendError, SendErrorType},
-    json,
-    message::Message,
-};
+use crate::{json, message::Message};
 use twilight_model::gateway::payload::outgoing::{
     identify::Identify, resume::Resume, Heartbeat, RequestGuildMembers, UpdatePresence,
     UpdateVoiceState,
@@ -55,18 +51,10 @@ impl Command for UpdatePresence {}
 impl Command for UpdateVoiceState {}
 
 /// Prepare a command for sending by serializing it and creating a message.
-///
-/// # Errors
-///
-/// Returns a [`SendErrorType::Serializing`] error type if the provided value
-/// failed to serialize into JSON.
-pub fn prepare(command: &impl Command) -> Result<Message, SendError> {
+pub fn prepare(command: &impl Command) -> Message {
     json::to_vec(command)
         .map(Message::Binary)
-        .map_err(|source| SendError {
-            source: Some(Box::new(source)),
-            kind: SendErrorType::Serializing,
-        })
+        .expect("command's serialize impl never errors")
 }
 
 #[cfg(test)]
@@ -74,7 +62,6 @@ mod tests {
     use super::Command;
     use crate::message::Message;
     use static_assertions::assert_impl_all;
-    use std::error::Error;
     use twilight_model::gateway::payload::outgoing::{
         identify::Identify, resume::Resume, Heartbeat, RequestGuildMembers, UpdatePresence,
         UpdateVoiceState,
@@ -88,13 +75,11 @@ mod tests {
     assert_impl_all!(UpdateVoiceState: Command);
 
     #[test]
-    fn prepare() -> Result<(), Box<dyn Error>> {
+    fn prepare() {
         let heartbeat = Heartbeat::new(30_000);
-        let bytes = serde_json::to_vec(&heartbeat)?;
-        let message = super::prepare(&heartbeat)?;
+        let bytes = serde_json::to_vec(&heartbeat).unwrap();
+        let message = super::prepare(&heartbeat);
 
         assert_eq!(message, Message::Binary(bytes));
-
-        Ok(())
     }
 }

--- a/twilight-gateway/src/error.rs
+++ b/twilight-gateway/src/error.rs
@@ -236,8 +236,8 @@ pub enum ReceiveMessageErrorType {
     FatallyClosed {
         /// Close code of the close message.
         ///
-        /// The close code may be able to parse into [`CloseCode`] if it's a
-        /// known close code. Unknown close codes are considered fatal.
+        /// The close code may be able to parse into [`CloseCode`] if it is
+        /// known. Unknown close codes are considered fatal.
         close_code: u16,
     },
     /// Processing the message failed.

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -612,12 +612,9 @@ impl Shard {
     /// not be sent over the websocket. This indicates the shard is either
     /// currently restarting or closed and will restart.
     ///
-    /// Returns a [`SendErrorType::Serializing`] error type if the provided
-    /// command failed to serialize.
-    ///
     /// [`send`]: Self::send
     pub async fn command(&mut self, command: &impl Command) -> Result<(), SendError> {
-        let message = command::prepare(command)?;
+        let message = command::prepare(command);
 
         self.send(message).await
     }


### PR DESCRIPTION
This PR does some light changes on `SendError` and `ReceiveMessageError`.
1. removes the `Result` return type on `command::prepare` and the associated `SendErrorType::Serializing` variant as serializing `Command` will never fail (breaking).
2. always includes the close code's integer representation for `ReceiveMessageErrorType::FatallyClosed`'s `Display` implementation as user's may prefer it over the name, and it's tedious to manually map the name to an integer.
