### PR TITLE
fix(gateway)!: heartbeat with a `null` sequence until a session is initialized

### DIFF
--- a/twilight-gateway/src/channel.rs
+++ b/twilight-gateway/src/channel.rs
@@ -114,7 +114,7 @@ mod tests {
         assert!(channel.rx_mut().try_recv().is_err());
 
         let request = RequestGuildMembers::builder(Id::new(1)).query("", None);
-        let heartbeat = Heartbeat::new(30_000);
+        let heartbeat = Heartbeat::new(Some(30_000));
         let heartbeat_bytes = serde_json::to_vec(&heartbeat)?;
         assert!(sender.command(&request).is_ok());
         assert!(sender

--- a/twilight-gateway/src/command.rs
+++ b/twilight-gateway/src/command.rs
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn prepare() -> Result<(), Box<dyn Error>> {
-        let heartbeat = Heartbeat::new(30_000);
+        let heartbeat = Heartbeat::new(Some(30_000));
         let bytes = serde_json::to_vec(&heartbeat)?;
         let message = super::prepare(&heartbeat)?;
 

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -736,7 +736,7 @@ impl Shard {
     }
 
     /// Send a heartbeat with an optional sequence number that should be
-    /// [`None`] if the shard has not received any events yet.
+    /// [`None`] if the shard has not yet received a dispatch event.
     ///
     /// Closes the connection and resumes if previous sent heartbeat never got
     /// a reply.

--- a/twilight-model/src/gateway/payload/outgoing/heartbeat.rs
+++ b/twilight-model/src/gateway/payload/outgoing/heartbeat.rs
@@ -3,12 +3,12 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Heartbeat {
-    pub d: u64,
+    pub d: Option<u64>,
     pub op: OpCode,
 }
 
 impl Heartbeat {
-    pub const fn new(seq: u64) -> Self {
+    pub const fn new(seq: Option<u64>) -> Self {
         Self {
             d: seq,
             op: OpCode::Heartbeat,


### PR DESCRIPTION
#1934 accidentally assumed that the heartbeat sequence is known when heartbeating starts.
`Shards` will now send `null` as the heartbeat sequence until they receives their first sequence in the `Ready` event.

`Shard`s would before #1934 and this PR not send Heartbeats *at all* until it had received a `Ready` event (after identifying).

## Breaking change

`Heartbeat`'s sequence is now optional.