### PR TITLE
fix(gateway): reset `resume_gateway_url` on reconnect failure and invalidated sessions

### DIFF
--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -934,7 +934,6 @@ impl Shard {
                     close_code,
                     reconnect_attempts: reconnect_attempts + 1,
                 };
-
                 self.resume_gateway_url = None;
 
                 ReceiveMessageError::from_reconnect(source)

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -732,6 +732,7 @@ impl Shard {
         if disconnect == Disconnect::InvalidateSession {
             tracing::debug!(shard_id = %self.id(), "session invalidated");
             self.session = None;
+            self.resume_gateway_url = None;
         }
     }
 
@@ -933,6 +934,8 @@ impl Shard {
                     close_code,
                     reconnect_attempts: reconnect_attempts + 1,
                 };
+
+                self.resume_gateway_url = None;
 
                 ReceiveMessageError::from_reconnect(source)
             })?;


### PR DESCRIPTION
The `resume_gateway_url` is recieved in `Ready` events, but should not be re-used if reconnecting to this URL fails or if the `Shard`'s session was invalidated.
See https://discord.com/developers/docs/topics/gateway
