### PR TITLE
refactor(model)!: redo `gateway::OpCode`

### DIFF
--- a/twilight-gateway/src/json.rs
+++ b/twilight-gateway/src/json.rs
@@ -170,11 +170,10 @@ pub fn parse(
         (gateway_deserializer, json_deserializer)
     };
 
-    let opcode =
-        OpCode::try_from(gateway_deserializer.op()).map_err(|_| GatewayEventParsingError {
-            kind: GatewayEventParsingErrorType::PayloadInvalid,
-            source: None,
-        })?;
+    let opcode = OpCode::from(gateway_deserializer.op()).ok_or(GatewayEventParsingError {
+        kind: GatewayEventParsingErrorType::PayloadInvalid,
+        source: None,
+    })?;
 
     let event_flag = EventTypeFlags::try_from((opcode, gateway_deserializer.event_type_ref()))
         .map_err(|_| GatewayEventParsingError {

--- a/twilight-model/src/gateway/event/gateway.rs
+++ b/twilight-model/src/gateway/event/gateway.rs
@@ -317,7 +317,7 @@ impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
         })?;
 
         Ok(match op {
-            OpCode::Event => {
+            OpCode::Dispatch => {
                 let t = self
                     .2
                     .ok_or_else(|| DeError::custom("event type not provided beforehand"))?;
@@ -421,9 +421,6 @@ impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
             OpCode::PresenceUpdate => {
                 return Err(DeError::unknown_variant("PresenceUpdate", VALID_OPCODES))
             }
-            OpCode::VoiceServerPing => {
-                return Err(DeError::unknown_variant("VoiceServerPing", VALID_OPCODES))
-            }
             OpCode::VoiceStateUpdate => {
                 return Err(DeError::unknown_variant("VoiceStateUpdate", VALID_OPCODES))
             }
@@ -463,7 +460,7 @@ impl Serialize for GatewayEvent {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         const fn opcode(gateway_event: &GatewayEvent) -> OpCode {
             match gateway_event {
-                GatewayEvent::Dispatch(_, _) => OpCode::Event,
+                GatewayEvent::Dispatch(_, _) => OpCode::Dispatch,
                 GatewayEvent::Heartbeat(_) => OpCode::Heartbeat,
                 GatewayEvent::HeartbeatAck => OpCode::HeartbeatAck,
                 GatewayEvent::Hello(_) => OpCode::Hello,
@@ -857,7 +854,7 @@ mod tests {
                 Token::Str("s"),
                 Token::U64(2_048),
                 Token::Str("op"),
-                Token::U8(OpCode::Event as u8),
+                Token::U8(OpCode::Dispatch as u8),
                 Token::Str("d"),
                 Token::Struct {
                     name: "RoleDelete",

--- a/twilight-model/src/gateway/opcode.rs
+++ b/twilight-model/src/gateway/opcode.rs
@@ -47,7 +47,8 @@ pub enum OpCode {
 }
 
 impl OpCode {
-    /// Try to match an integer value to a opcode, returning [`None`] if no match is found.
+    /// Try to match an integer value to an opcode, returning [`None`] if no
+    /// match is found.
     pub const fn from(code: u8) -> Option<Self> {
         Some(match code {
             0 => Self::Dispatch,

--- a/twilight-model/src/gateway/opcode.rs
+++ b/twilight-model/src/gateway/opcode.rs
@@ -4,8 +4,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 ///
 /// The documentation is written from a client's perspective.
 ///
-/// [`PresenceUpdate`], [`RequestGuildMembers`], and [`VoiceStateUpdate`] are not requiried for
-/// establishing or maintaining a gateway connection.
+/// [`PresenceUpdate`], [`RequestGuildMembers`], and [`VoiceStateUpdate`] are
+/// not requiried for establishing or maintaining a gateway connection.
 ///
 /// [`PresenceUpdate`]: Self::PresenceUpdate
 /// [`RequestGuildMembers`]: Self::RequestGuildMembers
@@ -20,7 +20,8 @@ pub enum OpCode {
     ///
     /// [`DispatchEvent`]: super::event::DispatchEvent
     Dispatch = 0,
-    /// Periodically sent to maintain the connection and may be received to immediately request one.
+    /// Periodically sent to maintain the connection and may be received to
+    /// immediately request one.
     Heartbeat = 1,
     /// Start a new session.
     Identify = 2,

--- a/twilight-model/src/gateway/opcode.rs
+++ b/twilight-model/src/gateway/opcode.rs
@@ -48,7 +48,7 @@ pub enum OpCode {
 
 impl OpCode {
     /// Try to match an integer value to a opcode, returning [`None`] if no match is found.
-    pub fn from(code: u8) -> Option<Self> {
+    pub const fn from(code: u8) -> Option<Self> {
         Some(match code {
             0 => Self::Dispatch,
             1 => Self::Heartbeat,

--- a/twilight-model/src/gateway/opcode.rs
+++ b/twilight-model/src/gateway/opcode.rs
@@ -1,54 +1,67 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-/// Gateway opcodes.
+/// Gateway event opcodes.
+///
+/// The documentation is written from a client's perspective.
+///
+/// [`PresenceUpdate`], [`RequestGuildMembers`], and [`VoiceStateUpdate`] are not requiried for
+/// establishing or maintaining a gateway connection.
+///
+/// [`PresenceUpdate`]: Self::PresenceUpdate
+/// [`RequestGuildMembers`]: Self::RequestGuildMembers
+/// [`VoiceStateUpdate`]: Self::VoiceStateUpdate
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum OpCode {
-    /// An event was received.
-    Event = 0,
-    /// Fired periodically to keep connection alive.
+    /// [`DispatchEvent`] and sequence number.
+    ///
+    /// Will only be received after establishing a session.
+    ///
+    /// [`DispatchEvent`]: super::event::DispatchEvent
+    Dispatch = 0,
+    /// Periodically sent to maintain the connection and may be received to immediately request one.
     Heartbeat = 1,
     /// Start a new session.
     Identify = 2,
-    /// Update the client's presence information.
+    /// Request to update the client's presence.
     PresenceUpdate = 3,
-    /// Join, leave or move between voice channels.
+    /// Request to join, leave or move between voice channels.
     VoiceStateUpdate = 4,
-    /// Voice ping checking. This opcode is deprecated.
-    VoiceServerPing = 5,
-    /// Resume a previously disconnected session.
+    /// Resume a previously disconnected session, skipping over [`Identify`].
+    ///
+    /// [`Identify`]: Self::Identify
     Resume = 6,
-    /// Received to indicate a reconnect is required.
+    /// Indicates that a reconnect is required.
     Reconnect = 7,
     /// Request a list of members for a guild.
     RequestGuildMembers = 8,
     /// Received when the session is invalidated.
     InvalidSession = 9,
-    /// Received after connecting, contains heartbeat interval.
+    /// Received after connecting, contains the heartbeat interval.
     Hello = 10,
-    /// Received in response to a heartbeat.
+    /// Received in response to sending a [`Heartbeat`].
+    ///
+    /// [`Heartbeat`]: Self::Heartbeat
     HeartbeatAck = 11,
 }
 
-impl TryFrom<u8> for OpCode {
-    type Error = u8;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        Ok(match value {
-            0 => Self::Event,
+impl OpCode {
+    /// Try to match an integer value to a opcode, returning [`None`] if no match is found.
+    pub fn from(code: u8) -> Option<Self> {
+        Some(match code {
+            0 => Self::Dispatch,
             1 => Self::Heartbeat,
             2 => Self::Identify,
             3 => Self::PresenceUpdate,
             4 => Self::VoiceStateUpdate,
-            5 => Self::VoiceServerPing,
             6 => Self::Resume,
             7 => Self::Reconnect,
             8 => Self::RequestGuildMembers,
             9 => Self::InvalidSession,
             10 => Self::Hello,
             11 => Self::HeartbeatAck,
-            other => return Err(other),
+            _ => return None,
         })
     }
 }
@@ -71,17 +84,15 @@ mod tests {
         Send,
         Serialize,
         Sync,
-        TryFrom<u8>
     );
 
     #[test]
     fn variants() {
-        serde_test::assert_tokens(&OpCode::Event, &[Token::U8(0)]);
+        serde_test::assert_tokens(&OpCode::Dispatch, &[Token::U8(0)]);
         serde_test::assert_tokens(&OpCode::Heartbeat, &[Token::U8(1)]);
         serde_test::assert_tokens(&OpCode::Identify, &[Token::U8(2)]);
         serde_test::assert_tokens(&OpCode::PresenceUpdate, &[Token::U8(3)]);
         serde_test::assert_tokens(&OpCode::VoiceStateUpdate, &[Token::U8(4)]);
-        serde_test::assert_tokens(&OpCode::VoiceServerPing, &[Token::U8(5)]);
         serde_test::assert_tokens(&OpCode::Resume, &[Token::U8(6)]);
         serde_test::assert_tokens(&OpCode::Reconnect, &[Token::U8(7)]);
         serde_test::assert_tokens(&OpCode::RequestGuildMembers, &[Token::U8(8)]);

--- a/twilight-model/src/gateway/opcode.rs
+++ b/twilight-model/src/gateway/opcode.rs
@@ -16,7 +16,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 pub enum OpCode {
     /// [`DispatchEvent`] and sequence number.
     ///
-    /// Will only be received after establishing a session.
+    /// Will only be received after establishing or resuming a session.
     ///
     /// [`DispatchEvent`]: super::event::DispatchEvent
     Dispatch = 0,


### PR DESCRIPTION
* Renames `OpCode::Event` to `OpCode::Dispatch`
* Replaces the `TryFrom<u8>` impl with a `from(u8) -> Option<Self>` method
* Removes the deprecated and undocumented `OpCode::VoiceServerPing` variant
* Extends the `OpCode` documentation
