### PR TITLE
docs(gateway): touch up `ShardId` and add section about receiving events

### DIFF
--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -26,11 +26,11 @@ use twilight_model::gateway::{
 ///
 /// > `number = (guild_id >> 22) % total`.
 ///
-/// The total number of shards is in other words unrelated to the value of
-/// `total`, which is only used to specify the share of events that the shard
-/// will receive. This formula is independently calculated for all shards, which
-/// means that events may be duplicated or lost if it's determined that an event
-/// should be sent to multiple or no shard.
+/// `total` is in other words unrelated to the total number of shards and is
+/// only used to specify the share of events a shard will receive. The formula
+/// is independently calculated for all shards, which means that events may be
+/// duplicated or lost if it's determined that an event should be sent to
+/// multiple or no shard.
 ///
 /// It may be helpful to visualize the logic in code:
 ///

--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -15,12 +15,14 @@ use twilight_model::gateway::{
 ///
 /// Incoming events are split by their originating guild and are received by the
 /// shard with the id calculated from the following formula:
-/// `number = (guild_id >> 22) % total`. `total` does not therefore need to be
-/// the actual total number of shards and is only used to specify the share of
-/// events the shard will receive (note that a shard may maximally be connected
-/// to 2500 guilds). This formula is independently calculated for all shards,
-/// which means that events may be duplicated or lost if it's determined that an
-/// event should be sent to multiple or no shard.
+///
+/// > `number = (guild_id >> 22) % total`.
+///
+/// The total number of shards is in other words unrelated to the value of
+/// `total`, which is only used to specify the share of events that the shard
+/// will receive. This formula is independently calculated for all shards, which
+/// means that events may be duplicated or lost if it's determined that an event
+/// should be sent to multiple or no shard.
 ///
 /// It may be helpful to visualize the logic in code:
 ///

--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -13,6 +13,14 @@ use twilight_model::gateway::{
 
 /// [`Shard`] identifier to calculate if it receivies a given event.
 ///
+/// A shard ID consist of two fields: `number` and `total`. These values do not
+/// need to be unique, and are used by Discord for calculating which events to
+/// send to which shard. Shards should in general share the same `total` value
+/// and have an unique `number` value, but users may deviate from this when
+/// resharding/migrating to a new set of shards.
+///
+/// # Advanced use
+///
 /// Incoming events are split by their originating guild and are received by the
 /// shard with the id calculated from the following formula:
 ///

--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -83,10 +83,6 @@ impl ShardId {
     }
 
     /// Create a new shard identifier if the shard indexes are valid.
-    ///
-    /// Non panicking version of [`new`].
-    ///
-    /// [`new`]: Self::new
     pub const fn new_checked(number: u64, total: u64) -> Option<Self> {
         if total > 0 && number < total {
             Some(Self { number, total })
@@ -420,7 +416,7 @@ impl ConfigBuilder {
     ///     )?)
     ///     .build();
     ///
-    /// let shard = Shard::with_config(ShardId::ONE, config);
+    /// let shard = Shard::with_config(ShardId::ONE, config).await?;
     /// # Ok(()) }
     /// ```
     #[allow(clippy::missing_const_for_fn)]

--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -46,7 +46,10 @@ use twilight_model::gateway::{
 /// }
 /// ```
 ///
+/// See [Discord Docs/Sharding].
+///
 /// [`shard`]: crate::Shard
+/// [Discord Docs/Sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ShardId {
     /// Number of the shard, 0-indexed.

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -224,6 +224,11 @@ struct MinimalReady {
 /// sessions with the ratelimit. Refer to Discord's [documentation][docs:shards]
 /// on shards to have a better understanding of what they are.
 ///
+/// # Sharding
+///
+/// Bots in more than 2500 guilds must run multiple shards with different
+/// [`ShardId`]s, which is easiest done by using items in the [`stream`] module.
+///
 /// # Sending shard commands in different tasks
 ///
 /// Because a shard itself can't be used in multiple tasks it's not possible to
@@ -280,9 +285,10 @@ struct MinimalReady {
 /// # Ok(()) }
 /// ```
 ///
-/// [`queue`]: crate::queue
 /// [docs:shards]: https://discord.com/developers/docs/topics/gateway#sharding
 /// [gateway commands]: Shard::command
+/// [`stream`]: crate::stream
+/// [`queue`]: crate::queue
 #[derive(Debug)]
 pub struct Shard {
     /// Abstraction to decompress Websocket messages, if compression is enabled.


### PR DESCRIPTION
The official docs on the effects of `shard_id` and `num_shards` is terrible, so this PR adds a lot of documentation to `ShardId` explaining its nuances.
