### PR TITLE
fix(http)!: require privacy_level in `CreateGuildScheduledEvent`

### DIFF
--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -105,6 +105,7 @@ use twilight_model::{
         },
         Id,
     },
+    scheduled_event::PrivacyLevel,
 };
 use twilight_validate::{
     channel::ChannelValidationError, request::ValidationError, sticker::StickerValidationError,
@@ -2139,8 +2140,9 @@ impl Client {
     pub const fn create_guild_scheduled_event(
         &self,
         guild_id: Id<GuildMarker>,
+        privacy_level: PrivacyLevel,
     ) -> CreateGuildScheduledEvent<'_> {
-        CreateGuildScheduledEvent::new(self, guild_id)
+        CreateGuildScheduledEvent::new(self, guild_id, privacy_level)
     }
 
     /// Get a scheduled event in a guild.

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -2086,7 +2086,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// use twilight_model::{id::Id, util::Timestamp};
+    /// use twilight_model::{id::Id, scheduled_event::PrivacyLevel, util::Timestamp};
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("token".to_owned());
@@ -2095,7 +2095,7 @@ impl Client {
     /// let garfield_start_time = Timestamp::parse("2022-01-01T14:00:00+00:00")?;
     ///
     /// client
-    ///     .create_guild_scheduled_event(guild_id)
+    ///     .create_guild_scheduled_event(guild_id, PrivacyLevel::GuildOnly)
     ///     .stage_instance(
     ///         channel_id,
     ///         "Garfield Appreciation Hour",
@@ -2111,7 +2111,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use twilight_http::Client;
-    /// use twilight_model::{id::Id, util::Timestamp};
+    /// use twilight_model::{id::Id, scheduled_event::PrivacyLevel, util::Timestamp};
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = Client::new("token".to_owned());
@@ -2120,7 +2120,7 @@ impl Client {
     /// let garfield_con_end_time = Timestamp::parse("2022-01-06T17:00:00+00:00")?;
     ///
     /// client
-    ///     .create_guild_scheduled_event(guild_id)
+    ///     .create_guild_scheduled_event(guild_id, PrivacyLevel::GuildOnly)
     ///     .external(
     ///         "Garfield Con 2022",
     ///         "Baltimore Convention Center",

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
@@ -66,7 +66,7 @@ struct CreateGuildScheduledEventFields<'a> {
 ///
 /// ```no_run
 /// # use twilight_http::Client;
-/// use twilight_model::{id::Id, util::Timestamp};
+/// use twilight_model::{id::Id, scheduled_event::PrivacyLevel, util::Timestamp};
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let client = Client::new("token".to_owned());
@@ -75,7 +75,7 @@ struct CreateGuildScheduledEventFields<'a> {
 /// let garfield_start_time = Timestamp::parse("2022-01-01T14:00:00+00:00")?;
 ///
 /// client
-///     .create_guild_scheduled_event(guild_id)
+///     .create_guild_scheduled_event(guild_id, PrivacyLevel::GuildOnly)
 ///     .stage_instance(
 ///         channel_id,
 ///         "Garfield Appreciation Hour",
@@ -91,7 +91,7 @@ struct CreateGuildScheduledEventFields<'a> {
 ///
 /// ```no_run
 /// # use twilight_http::Client;
-/// use twilight_model::{id::Id, util::Timestamp};
+/// use twilight_model::{id::Id, scheduled_event::PrivacyLevel, util::Timestamp};
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let client = Client::new("token".to_owned());
@@ -100,7 +100,7 @@ struct CreateGuildScheduledEventFields<'a> {
 /// let garfield_con_end_time = Timestamp::parse("2022-01-06T17:00:00+00:00")?;
 ///
 /// client
-///     .create_guild_scheduled_event(guild_id)
+///     .create_guild_scheduled_event(guild_id, PrivacyLevel::GuildOnly)
 ///     .external(
 ///         "Garfield Con 2022",
 ///         "Baltimore Convention Center",

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
@@ -125,7 +125,11 @@ pub struct CreateGuildScheduledEvent<'a> {
 }
 
 impl<'a> CreateGuildScheduledEvent<'a> {
-    pub(crate) const fn new(http: &'a Client, guild_id: Id<GuildMarker>) -> Self {
+    pub(crate) const fn new(
+        http: &'a Client,
+        guild_id: Id<GuildMarker>,
+        privacy_level: PrivacyLevel,
+    ) -> Self {
         Self {
             guild_id,
             http,
@@ -136,7 +140,7 @@ impl<'a> CreateGuildScheduledEvent<'a> {
                 entity_type: None,
                 image: None,
                 name: None,
-                privacy_level: None,
+                privacy_level: Some(privacy_level),
                 scheduled_end_time: None,
                 scheduled_start_time: None,
             },


### PR DESCRIPTION
Previously, the request builder would fail to add a value for `privacy_level` at all. This ensures that it is set in the first place.

Fixes #1960.

This request could be further refactored to include `name` in the initial builder call, but that's for another pr. 
