### PR TITLE
fix(gateway): don't panic on zombied connection

### DIFF
--- a/twilight-gateway/src/latency.rs
+++ b/twilight-gateway/src/latency.rs
@@ -43,7 +43,7 @@ impl Latency {
         }
     }
 
-    /// The average latency over the lifetime of the shard.
+    /// The average latency over all recorded ones.
     ///
     /// For example, a reasonable value for this may be between 10 to 100
     /// milliseconds depending on the network connection and physical location.

--- a/twilight-gateway/src/latency.rs
+++ b/twilight-gateway/src/latency.rs
@@ -55,7 +55,7 @@ impl Latency {
         self.total_duration.checked_div(self.heartbeats)
     }
 
-    /// The total number of heartbeats that have been sent over the lifetime of the shard.
+    /// The total number of heartbeats that have been received.
     pub const fn heartbeats(&self) -> u32 {
         self.heartbeats
     }

--- a/twilight-gateway/src/latency.rs
+++ b/twilight-gateway/src/latency.rs
@@ -43,7 +43,7 @@ impl Latency {
         }
     }
 
-    /// The average latency over all recorded ones.
+    /// The average latency over all recorded heartbeats.
     ///
     /// For example, a reasonable value for this may be between 10 to 100
     /// milliseconds depending on the network connection and physical location.

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -322,6 +322,11 @@ pub struct Shard {
     /// ID of the shard.
     id: ShardId,
     /// Recent heartbeat latency statistics.
+    ///
+    /// The latency is reset on receiving [`GatewayEvent::Hello`] as the host
+    /// may have changed, and therefore invalidated previous latency statistic.
+    ///
+    /// [`GatewayEvent::Hello`]: twilight_model::gateway::event::GatewayEvent::Hello
     latency: Latency,
     /// Command ratelimiter, if it was enabled via
     /// [`Config::ratelimit_messages`].

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -324,7 +324,7 @@ pub struct Shard {
     /// Recent heartbeat latency statistics.
     ///
     /// The latency is reset on receiving [`GatewayEvent::Hello`] as the host
-    /// may have changed, and therefore invalidated previous latency statistic.
+    /// may have changed and invalidating previous latency statistic.
     ///
     /// [`GatewayEvent::Hello`]: twilight_model::gateway::event::GatewayEvent::Hello
     latency: Latency,

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -900,7 +900,7 @@ impl Shard {
                 self.heartbeat_interval = Some(interval);
 
                 // Reset `Latency` since the shard might have connected to a new
-                // remote, invalidating its records.
+                // remote which invalidates the recorded latencies.
                 self.latency = Latency::new();
 
                 if self.session.is_none() {

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -878,7 +878,9 @@ impl Shard {
                 }
             }
             Some(OpCode::Heartbeat) => {
-                self.heartbeat(self.session().map(Session::sequence))
+                let event = Self::parse_event(buffer)?;
+
+                self.heartbeat(Some(event.data))
                     .await
                     .map_err(ProcessError::from_send)?;
             }

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -324,7 +324,7 @@ pub struct Shard {
     /// Recent heartbeat latency statistics.
     ///
     /// The latency is reset on receiving [`GatewayEvent::Hello`] as the host
-    /// may have changed and invalidating previous latency statistic.
+    /// may have changed, invalidating previous latency statistic.
     ///
     /// [`GatewayEvent::Hello`]: twilight_model::gateway::event::GatewayEvent::Hello
     latency: Latency,

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -878,9 +878,7 @@ impl Shard {
                 }
             }
             Some(OpCode::Heartbeat) => {
-                let event = Self::parse_event(buffer)?;
-
-                self.heartbeat(Some(event.data))
+                self.heartbeat(self.session().map(Session::sequence))
                     .await
                     .map_err(ProcessError::from_send)?;
             }


### PR DESCRIPTION
I encountered this panic during normal operation:
```
2022-10-21T15:29:41.171756Z DEBUG shard{id=[0, 1]}: twilight_gateway::shard: sending heartbeat sequence=Some(11)
2022-10-21T15:29:41.284294Z DEBUG shard{id=[0, 1]}: twilight_gateway::shard: received heartbeat ack
2022-10-21T15:30:22.421292Z DEBUG shard{id=[0, 1]}: twilight_gateway::shard: sending heartbeat sequence=Some(11)
2022-10-21T15:30:27.519472Z DEBUG shard{id=[0, 1]}: twilight_gateway::shard: received websocket close message
2022-10-21T15:30:28.521889Z DEBUG shard{id=[0, 1]}:connect: twilight_gateway::connection: shaking hands with remote url="wss://gateway-us-east1-c.discord.gg/?v=10&encoding=json&compress=zlib-stream"
2022-10-21T15:30:28.691873Z DEBUG shard{id=[0, 1]}:connect: tungstenite::handshake::client: Client handshake done.    
2022-10-21T15:30:28.692110Z DEBUG shard{id=[0, 1]}: twilight_gateway::shard: sending resume
2022-10-21T15:30:28.693228Z DEBUG shard{id=[0, 1]}: twilight_gateway::shard: received hello heartbeat_interval=41250
2022-10-21T15:30:28.804870Z DEBUG shard{id=[0, 1]}: twilight_gateway::shard: received dispatch event_type=RESUMED sequence=12
2022-10-21T15:30:35.246260Z  INFO shard{id=[0, 1]}: twilight_gateway::shard: connection is failed or "zombied"
thread 'main' panicked at 'connected', /twilight/twilight-gateway/src/shard.rs:495:42
stack backtrace:
   0: rust_begin_unwind
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/panicking.rs:142:14
   2: core::panicking::panic_display
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/panicking.rs:72:5
   3: core::panicking::panic_str
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/panicking.rs:56:5
   4: core::option::expect_failed
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/option.rs:1874:5
   5: core::option::Option<T>::expect
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/option.rs:738:21
   6: twilight_gateway::shard::Shard::next_message::{{closure}}::{{closure}}
             at /twilight/twilight-gateway/src/shard.rs:495:17
   7: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/future/mod.rs:91:19
   8: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
             at /tracing-0.1.37/src/instrument.rs:272:9
   9: twilight_gateway::shard::Shard::next_message::{{closure}}
             at /twilight/twilight-gateway/src/shard.rs:472:5
  10: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/future/mod.rs:91:19
  11: twilight_gateway::shard::Shard::next_event::{{closure}}
             at /twilight/twilight-gateway/src/shard.rs:440:42
```

The error chain is as follows:
1. Last sent heartbeat never got a response
2. Received close message
3. Sucessfully reconnected and resumed
4. Wanted to send a new heartbeat, but last one never got a response, so the shard is zombied
5. Set `Shard::connection` to `None` (in `Shard::disconnect`)
6. Returned from `Shard::heartbeat` (in `Shard::next_message`)
7. Looped to recreate and await `NextMessageFuture`
8. Panic due to `Shard::connection` being `None`.

There are two bugs:
1. The shard incorrectly assessed that the connection was zombied
2. The shard recreated `NextMessageFuture` instead of reconnecting after encountering a zombied connection.

This PR fixes 1. by reseting `Shard::latency` on receiving `Hello` and 2. by moving the zombie logic out of `Shard::heartbeat` and directly into `Shard::next_message`.

Notably upon receiving `Heartbeat` the shard will now call `Shard::heartbeat` without first checking if the connection is zombied, but I think this still follows the gateway specification as it states that a heartbeat should be sent back immediately:
> Upon receiving the event, your app should immediately send back another Heartbeat event without waiting the remainder of the current interval.