### PR TITLE
build: remove keys with default value

### DIFF
--- a/book/tests/Cargo.toml
+++ b/book/tests/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 authors.workspace = true
-build = "build.rs"
 edition.workspace = true
 name = "book"
 version = "0.0.0"

--- a/twilight-cache-inmemory/Cargo.toml
+++ b/twilight-cache-inmemory/Cargo.toml
@@ -2,7 +2,6 @@
 authors.workspace = true
 categories = ["caching"]
 description = "In-process-memory based cache for the Twilight ecosystem."
-documentation = "https://docs.rs/twilight-cache-inmemory"
 edition.workspace = true
 homepage = "https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html"
 include.workspace = true
@@ -10,7 +9,6 @@ keywords = ["discord", "discord-api", "twilight"]
 license.workspace = true
 name = "twilight-cache-inmemory"
 publish = true
-readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 version = "0.13.0"

--- a/twilight-gateway-queue/Cargo.toml
+++ b/twilight-gateway-queue/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 authors.workspace = true
 description = "Discord Gateway connection queue implementation for the Twilight ecosystem."
-documentation = "https://docs.rs/twilight-gateway-queue"
 edition.workspace = true
 homepage = "https://twilight.rs/"
 include.workspace = true
@@ -9,7 +8,6 @@ keywords = ["discord", "discord-api", "twilight"]
 license.workspace = true
 name = "twilight-gateway-queue"
 publish = true
-readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 version = "0.13.1"

--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -2,7 +2,6 @@
 authors.workspace = true
 categories = ["api-bindings", "asynchronous", "web-programming::websocket"]
 description = "Discord Gateway implementation for the Twilight ecosystem."
-documentation = "https://docs.rs/twilight-gateway"
 edition.workspace = true
 homepage = "https://twilight.rs/chapter_1_crates/section_3_gateway.html"
 include.workspace = true
@@ -10,7 +9,6 @@ keywords = ["discord", "discord-api", "twilight"]
 license.workspace = true
 name = "twilight-gateway"
 publish = true
-readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 version = "0.13.3"

--- a/twilight-http-ratelimiting/Cargo.toml
+++ b/twilight-http-ratelimiting/Cargo.toml
@@ -2,7 +2,6 @@
 authors.workspace = true
 categories = ["api-bindings", "asynchronous"]
 description = "Discord REST API ratelimiter implementations for the Twilight ecosystem."
-documentation = "https://docs.rs/twilight-http-ratelimiting"
 edition.workspace = true
 homepage = "https://twilight.rs/"
 include.workspace = true
@@ -10,7 +9,6 @@ keywords = ["discord", "discord-api", "twilight"]
 license.workspace = true
 name = "twilight-http-ratelimiting"
 publish = true
-readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 version = "0.13.2"

--- a/twilight-http/Cargo.toml
+++ b/twilight-http/Cargo.toml
@@ -2,7 +2,6 @@
 authors.workspace = true
 categories = ["api-bindings", "asynchronous", "web-programming::http-client"]
 description = "Discord REST API client for the Twilight ecosystem."
-documentation = "https://docs.rs/twilight-http"
 edition.workspace = true
 homepage = "https://twilight.rs/chapter_1_crates/section_2_http.html"
 include.workspace = true
@@ -10,7 +9,6 @@ keywords = ["discord", "discord-api", "twilight"]
 license.workspace = true
 name = "twilight-http"
 publish = true
-readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 version = "0.13.2"

--- a/twilight-lavalink/Cargo.toml
+++ b/twilight-lavalink/Cargo.toml
@@ -2,7 +2,6 @@
 authors.workspace = true
 categories = ["api-bindings", "asynchronous", "web-programming::http-client", "web-programming::websocket"]
 description = "Lavalink client for the Twilight ecosystem."
-documentation = "https://docs.rs/twilight-lavalink"
 edition.workspace = true
 homepage = "https://twilight.rs/chapter_1_crates/section_8_first_party/section_3_lavalink.html"
 include.workspace = true
@@ -10,7 +9,6 @@ keywords = ["discord", "discord-api", "lavalink", "twilight"]
 license.workspace = true
 name = "twilight-lavalink"
 publish = true
-readme = "README.md"
 rust-version.workspace = true
 repository.workspace = true
 version = "0.13.2"

--- a/twilight-mention/Cargo.toml
+++ b/twilight-mention/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 authors.workspace = true
 description = "Utilities for working with mentions in the Twilight ecosystem."
-documentation = "https://docs.rs/twilight-mention"
 edition.workspace = true
 homepage = "https://twilight.rs/chapter_1_crates/section_8_first_party/section_2_mention.html"
 include.workspace = true
@@ -9,7 +8,6 @@ keywords = ["twilight"]
 license.workspace = true
 name = "twilight-mention"
 publish = true
-readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 version = "0.13.0"

--- a/twilight-model/Cargo.toml
+++ b/twilight-model/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 authors.workspace = true
 description = "Discord API models for the Twilight ecosystem."
-documentation = "https://docs.rs/twilight-model"
 edition.workspace = true
 homepage = "https://twilight.rs/chapter_1_crates/section_1_model.html"
 include.workspace = true
@@ -9,7 +8,6 @@ keywords = ["discord", "discord-api", "twilight"]
 license.workspace = true
 name = "twilight-model"
 publish = true
-readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 version = "0.13.5"

--- a/twilight-standby/Cargo.toml
+++ b/twilight-standby/Cargo.toml
@@ -2,7 +2,6 @@
 authors.workspace = true
 categories = ["asynchronous"]
 description = "Utility to filter wait for filtered incoming events for the Twilight ecosystem."
-documentation = "https://docs.rs/twilight-standby"
 edition.workspace = true
 homepage = "https://twilight.rs/chapter_1_crates/section_6_standby.html"
 include.workspace = true
@@ -10,7 +9,6 @@ keywords = ["discord", "discord-api", "twilight"]
 license.workspace = true
 name = "twilight-standby"
 publish = true
-readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 version = "0.13.2"

--- a/twilight-util/Cargo.toml
+++ b/twilight-util/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 authors.workspace = true
 description = "Miscellaneous utilities for Twilight."
-documentation = "https://docs.rs/twilight-util"
 edition.workspace = true
 homepage = "https://twilight.rs"
 include.workspace = true
@@ -9,7 +8,6 @@ keywords = ["discord", "discord-api", "twilight"]
 license.workspace = true
 name = "twilight-util"
 publish = true
-readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 version = "0.13.3"

--- a/twilight-validate/Cargo.toml
+++ b/twilight-validate/Cargo.toml
@@ -2,7 +2,6 @@
 authors.workspace = true
 categories = ["api-bindings"]
 description = "Functions and constants for validating request parameters"
-documentation = "https://docs.rs/twilight-validate"
 edition.workspace = true
 homepage = "https://twilight.rs/"
 include.workspace = true
@@ -10,7 +9,6 @@ keywords = ["discord", "discord-api", "twilight"]
 license.workspace = true
 name = "twilight-validate"
 publish = true
-readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 version = "0.13.1"

--- a/twilight/Cargo.toml
+++ b/twilight/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 authors.workspace = true
 description = "Advertisement crate for the twilight ecosystem; please use the individual crates instead."
-documentation = "https://docs.rs/twilight"
 edition.workspace = true
 homepage = "https://twilight.rs"
 include.workspace = true
@@ -9,7 +8,6 @@ keywords = ["discord", "discord-api", "twilight"]
 license.workspace = true
 name = "twilight"
 publish = true
-readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 version = "0.13.0"


### PR DESCRIPTION
## Problem
Specifying default manifest values[^1] is confusing as they're usually only specified when the default is overwritten.

## Solution
Removes default manifest values from all `Cargo.toml` files.

[^1]: https://doc.rust-lang.org/cargo/reference/manifest.html
