### PR TITLE
fix(gateway): reset `heartbeat_interval` on disconnect

### DIFF
--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -733,6 +733,7 @@ impl Shard {
             reconnect_attempts: 0,
         };
         self.connection = None;
+        self.heartbeat_interval = None;
 
         if disconnect == Disconnect::InvalidateSession {
             self.session = None;


### PR DESCRIPTION
Fixes the following issue happening:
```terminal
2022-10-29T17:42:05.858258Z DEBUG shard{id=[47, 50]}: twilight_gateway::shard: sending heartbeat sequence=Some(1)
2022-10-29T17:42:05.968093Z DEBUG shard{id=[47, 50]}: twilight_gateway::shard: received heartbeat ack
...
2022-10-29T17:42:46.117107Z DEBUG shard{id=[47, 50]}: twilight_gateway::shard: received reconnect
2022-10-29T17:42:47.118972Z DEBUG shard{id=[47, 50]}:connect: twilight_gateway::connection: shaking hands with gateway url="wss://gateway-us-east1-b.discord.gg/?v=10&encoding=json&compress=zlib-stream"
2022-10-29T17:42:47.522472Z DEBUG shard{id=[47, 50]}:connect: tungstenite::handshake::client: Client handshake done.
2022-10-29T17:42:47.522573Z DEBUG shard{id=[47, 50]}: twilight_gateway::shard: sending heartbeat sequence=Some(1)
2022-10-29T17:42:47.522648Z DEBUG shard{id=[47, 50]}: twilight_gateway::shard: received hello heartbeat_interval=41250
2022-10-29T17:42:47.522685Z DEBUG shard{id=[47, 50]}: twilight_gateway::shard: sending resume
2022-10-29T17:42:47.633194Z  INFO shard{id=[47, 50]}: twilight_gateway::shard: received unrequested heartbeat ack
2022-10-29T17:42:47.638884Z DEBUG shard{id=[47, 50]}: twilight_gateway::shard: received dispatch event_type=RESUMED sequence=2
```

An existing `heartbeat_interval` completed between reconnecting and receiving a `Hello`, which is illegal (and also logged as an unrequested heartbeat ack) since heartbeating should only happen *after* receiving a `Hello` (in this case it was likely fine as Discord had propably sent `Hello` when it received the heartbeat).
