### PR TITLE
fix(model)!: flatten `DefaultReaction` and `ForumTag`

### DIFF
--- a/twilight-model/src/channel/forum.rs
+++ b/twilight-model/src/channel/forum.rs
@@ -85,7 +85,7 @@ mod tests {
 
     #[test]
     fn forum_tag() {
-        let with_emoji_id = ForumTag {
+        let value = ForumTag {
             emoji_id: Some(EMOJI_ID),
             emoji_name: None,
             id: TAG_ID,
@@ -94,7 +94,7 @@ mod tests {
         };
 
         serde_test::assert_tokens(
-            &with_emoji_id,
+            &value,
             &[
                 Token::Struct {
                     name: "ForumTag",
@@ -104,36 +104,6 @@ mod tests {
                 Token::Some,
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("1"),
-                Token::Str("emoji_name"),
-                Token::None,
-                Token::Str("id"),
-                Token::NewtypeStruct { name: "Id" },
-                Token::Str("2"),
-                Token::Str("moderated"),
-                Token::Bool(false),
-                Token::Str("name"),
-                Token::Str("other"),
-                Token::StructEnd,
-            ],
-        );
-
-        let without_emoji = ForumTag {
-            emoji_id: None,
-            emoji_name: None,
-            id: TAG_ID,
-            moderated: false,
-            name: "other".into(),
-        };
-
-        serde_test::assert_tokens(
-            &without_emoji,
-            &[
-                Token::Struct {
-                    name: "ForumTag",
-                    len: 5,
-                },
-                Token::Str("emoji_id"),
-                Token::None,
                 Token::Str("emoji_name"),
                 Token::None,
                 Token::Str("id"),

--- a/twilight-model/src/channel/forum.rs
+++ b/twilight-model/src/channel/forum.rs
@@ -2,74 +2,54 @@ use crate::id::{
     marker::{EmojiMarker, TagMarker},
     Id,
 };
-use serde::{
-    de::{Deserializer, Error as DeError},
-    ser::{SerializeStruct, Serializer},
-    Deserialize, Serialize,
-};
+use serde::{Deserialize, Serialize};
 
+/// Emoji to use as the default way to react to a forum post.
+///
+/// Exactly one of `emoji_id` and `emoji_name` must be set.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct DefaultReaction {
-    #[serde(flatten)]
-    pub emoji: ForumReaction,
+    /// ID of custom guild emoji.
+    ///
+    /// Conflicts with `emoji_name`.
+    pub emoji_id: Option<Id<EmojiMarker>>,
+    /// Unicode emoji character.
+    ///
+    /// Conflicts with `emoji_id`.
+    pub emoji_name: Option<String>,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum ForumReaction {
-    EmojiId(Id<EmojiMarker>),
-    EmojiName(String),
-}
-
-impl<'de> Deserialize<'de> for ForumReaction {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let internal = InternalForumReaction::deserialize(deserializer)?;
-        match (internal.emoji_id, internal.emoji_name) {
-            (None, Some(name)) => Ok(Self::EmojiName(name)),
-            (Some(id), None) => Ok(Self::EmojiId(id)),
-            _ => Err(DeError::custom("too few or many fields")),
-        }
-    }
-}
-
-impl Serialize for ForumReaction {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut state = serializer.serialize_struct("ForumReaction", 2)?;
-
-        match self {
-            Self::EmojiId(id) => {
-                state.serialize_field("emoji_id", &Some(id))?;
-                state.serialize_field("emoji_name", &None::<()>)?;
-            }
-            Self::EmojiName(name) => {
-                state.serialize_field("emoji_id", &None::<()>)?;
-                state.serialize_field("emoji_name", &Some(name))?;
-            }
-        }
-
-        state.end()
-    }
-}
-
-/// Helper struct for [`ForumReaction`]'s deserialization implementation.
-#[derive(Deserialize)]
-#[serde(rename = "ForumReaction")]
-struct InternalForumReaction {
-    emoji_id: Option<Id<EmojiMarker>>,
-    emoji_name: Option<String>,
-}
-
+/// Tag that is able to be applied to a thread in a [`GuildForum`] [`Channel`].
+///
+/// May at most contain one of `emoji_id` and `emoji_name`.
+///
+/// [`Channel`]: super::Channel
+/// [`GuildForum`]: super::ChannelType::GuildForum
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ForumTag {
-    #[serde(flatten)]
-    pub emoji: ForumReaction,
+    /// ID of custom guild emoji.
+    ///
+    /// Conflicts with `emoji_name`.
+    pub emoji_id: Option<Id<EmojiMarker>>,
+    /// Unicode emoji character.
+    ///
+    /// Conflicts with `emoji_name`.
+    pub emoji_name: Option<String>,
+    /// ID of the tag.
     pub id: Id<TagMarker>,
+    /// Whether the tag can only be added or removed by [`Member`]s with the
+    /// [`MANAGE_THREADS`] permission.
+    ///
+    /// [`MANAGE_THREADS`]: crate::guild::Permissions::MANAGE_THREADS
+    /// [`Member`]: crate::guild::Member
     pub moderated: bool,
+    /// Name of the tag (0--20 characters).
     pub name: String,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{DefaultReaction, ForumReaction, ForumTag};
+    use super::{DefaultReaction, ForumTag};
     use crate::id::{
         marker::{EmojiMarker, TagMarker},
         Id,
@@ -82,38 +62,44 @@ mod tests {
     #[test]
     fn default_reaction() {
         let value = DefaultReaction {
-            emoji: ForumReaction::EmojiName("name".into()),
+            emoji_id: None,
+            emoji_name: Some("name".to_owned()),
         };
 
-        // justification for `Token::Map`: https://github.com/serde-rs/serde/issues/1346#issuecomment-451715157
         serde_test::assert_tokens(
             &value,
             &[
-                Token::Map { len: None },
+                Token::Struct {
+                    name: "DefaultReaction",
+                    len: 2,
+                },
                 Token::Str("emoji_id"),
                 Token::None,
                 Token::Str("emoji_name"),
                 Token::Some,
                 Token::Str("name"),
-                Token::MapEnd,
+                Token::StructEnd,
             ],
         );
     }
 
     #[test]
     fn forum_tag() {
-        let value = ForumTag {
-            emoji: ForumReaction::EmojiId(EMOJI_ID),
+        let with_emoji_id = ForumTag {
+            emoji_id: Some(EMOJI_ID),
+            emoji_name: None,
             id: TAG_ID,
             moderated: false,
             name: "other".into(),
         };
 
-        // justification for `Token::Map`: https://github.com/serde-rs/serde/issues/1346#issuecomment-451715157
         serde_test::assert_tokens(
-            &value,
+            &with_emoji_id,
             &[
-                Token::Map { len: None },
+                Token::Struct {
+                    name: "ForumTag",
+                    len: 5,
+                },
                 Token::Str("emoji_id"),
                 Token::Some,
                 Token::NewtypeStruct { name: "Id" },
@@ -127,7 +113,37 @@ mod tests {
                 Token::Bool(false),
                 Token::Str("name"),
                 Token::Str("other"),
-                Token::MapEnd,
+                Token::StructEnd,
+            ],
+        );
+
+        let without_emoji = ForumTag {
+            emoji_id: None,
+            emoji_name: None,
+            id: TAG_ID,
+            moderated: false,
+            name: "other".into(),
+        };
+
+        serde_test::assert_tokens(
+            &without_emoji,
+            &[
+                Token::Struct {
+                    name: "ForumTag",
+                    len: 5,
+                },
+                Token::Str("emoji_id"),
+                Token::None,
+                Token::Str("emoji_name"),
+                Token::None,
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "Id" },
+                Token::Str("2"),
+                Token::Str("moderated"),
+                Token::Bool(false),
+                Token::Str("name"),
+                Token::Str("other"),
+                Token::StructEnd,
             ],
         );
     }

--- a/twilight-model/src/channel/forum.rs
+++ b/twilight-model/src/channel/forum.rs
@@ -3,7 +3,9 @@ use crate::id::{
     Id,
 };
 use serde::{
-    de::Error as DeError, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
+    de::{Deserializer, Error as DeError},
+    ser::{SerializeStruct, Serializer},
+    Deserialize, Serialize,
 };
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/twilight-model/src/channel/forum.rs
+++ b/twilight-model/src/channel/forum.rs
@@ -2,25 +2,58 @@ use crate::id::{
     marker::{EmojiMarker, TagMarker},
     Id,
 };
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::Error as DeError, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
+};
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct DefaultReaction {
-    #[serde(flatten)]
-    emoji: ForumReaction,
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ForumReaction {
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum DefaultReaction {
     EmojiId(Id<EmojiMarker>),
     EmojiName(String),
+}
+
+impl<'de> Deserialize<'de> for DefaultReaction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let internal = InternalDefaultReaction::deserialize(deserializer)?;
+        match (internal.emoji_id, internal.emoji_name) {
+            (None, Some(name)) => Ok(Self::EmojiName(name)),
+            (Some(id), None) => Ok(Self::EmojiId(id)),
+            _ => Err(DeError::custom("too few or many fields")),
+        }
+    }
+}
+
+impl Serialize for DefaultReaction {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut state = serializer.serialize_struct("DefaultReaction", 2)?;
+
+        match self {
+            DefaultReaction::EmojiId(id) => {
+                state.serialize_field("emoji_id", &Some(id))?;
+                state.serialize_field("emoji_name", &None::<()>)?;
+            }
+            DefaultReaction::EmojiName(name) => {
+                state.serialize_field("emoji_id", &None::<()>)?;
+                state.serialize_field("emoji_name", &Some(name))?;
+            }
+        }
+
+        state.end()
+    }
+}
+
+/// Helper struct for [`DefaultReaction`]'s deserialization implementation.
+#[derive(Deserialize)]
+#[serde(rename = "DefaultReaction")]
+struct InternalDefaultReaction {
+    emoji_id: Option<Id<EmojiMarker>>,
+    emoji_name: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ForumTag {
     #[serde(flatten)]
-    pub emoji: ForumReaction,
+    pub emoji: DefaultReaction,
     pub id: Id<TagMarker>,
     pub moderated: bool,
     pub name: String,
@@ -28,7 +61,7 @@ pub struct ForumTag {
 
 #[cfg(test)]
 mod tests {
-    use super::{DefaultReaction, ForumReaction, ForumTag};
+    use super::{DefaultReaction, ForumTag};
     use crate::id::{
         marker::{EmojiMarker, TagMarker},
         Id,
@@ -40,18 +73,21 @@ mod tests {
 
     #[test]
     fn default_reaction() {
-        let value = DefaultReaction {
-            emoji: ForumReaction::EmojiName("name".into()),
-        };
+        let value = DefaultReaction::EmojiName("name".into());
 
-        // justification for `Token::Map`: https://github.com/serde-rs/serde/issues/1346#issuecomment-451715157
         serde_test::assert_tokens(
             &value,
             &[
-                Token::Map { len: None },
+                Token::Struct {
+                    name: "DefaultReaction",
+                    len: 2,
+                },
+                Token::Str("emoji_id"),
+                Token::None,
                 Token::Str("emoji_name"),
+                Token::Some,
                 Token::Str("name"),
-                Token::MapEnd,
+                Token::StructEnd,
             ],
         );
     }
@@ -59,20 +95,22 @@ mod tests {
     #[test]
     fn forum_tag() {
         let value = ForumTag {
-            emoji: ForumReaction::EmojiId(EMOJI_ID),
+            emoji: DefaultReaction::EmojiId(EMOJI_ID),
             id: TAG_ID,
             moderated: false,
             name: "other".into(),
         };
 
-        // justification for `Token::Map`: https://github.com/serde-rs/serde/issues/1346#issuecomment-451715157
         serde_test::assert_tokens(
             &value,
             &[
                 Token::Map { len: None },
                 Token::Str("emoji_id"),
+                Token::Some,
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("1"),
+                Token::Str("emoji_name"),
+                Token::None,
                 Token::Str("id"),
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("2"),


### PR DESCRIPTION
Fixes #1977 by flattening `DefaultReaction` and `ForumTag` and documenting invariants, as they would otherwise need custom deserializers and serializers.
Also fixes `DefaultReaction`'s fields to now be public.