### PR TITLE
docs(lavalink): minor fix in example

### DIFF
--- a/examples/lavalink-basic-bot.rs
+++ b/examples/lavalink-basic-bot.rs
@@ -79,7 +79,7 @@ async fn main() -> anyhow::Result<()> {
                 continue;
             }
 
-            match msg.content.split_once(' ').map(|x| x.0) {
+            match msg.content.split_whitespace().next() {
                 Some("!join") => spawn(join(msg.0, Arc::clone(&state))),
                 Some("!leave") => spawn(leave(msg.0, Arc::clone(&state))),
                 Some("!pause") => spawn(pause(msg.0, Arc::clone(&state))),


### PR DESCRIPTION
In `.split_once()` examples:
```
assert_eq!("cfg".split_once('='), None);
assert_eq!("cfg=foo".split_once('='), Some(("cfg", "foo")));
```
so
`!join *anything*` → works
`!join` → matches to default