### PR TITLE
ci: use dtolnay/rust-toolchain master branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install toolchain (${{ env.minrust }})
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.minrust }}
 
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
 
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
 

--- a/.github/workflows/deploy-lib.yml
+++ b/.github/workflows/deploy-lib.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
 


### PR DESCRIPTION
As specified in https://github.com/dtolnay/rust-toolchain/tree/master#inputs, one should not use the @v1 tag (it has not been updated since 15 july https://github.com/dtolnay/rust-toolchain/releases/tag/v1).
