### PR TITLE
feat(gateway): conditionally reinsert shard into stream

### DIFF
--- a/twilight-gateway/src/stream.rs
+++ b/twilight-gateway/src/stream.rs
@@ -284,6 +284,9 @@ impl<'a> Stream for ShardMessageStream<'a> {
 /// Note that manually causing the destructor to [not be called] will cause the
 /// shard to not be re-inserted into the stream.
 ///
+/// Shards returning a [fatal error] will not be re-inserted into the stream.
+///
+/// [fatal error]: ReceiveMessageError::is_fatal
 /// [not be called]: std::mem::forget
 pub struct ShardRef<'a> {
     /// List of futures the shard will be re-inserted into when the reference is


### PR DESCRIPTION
Shards returning a fatal error should not be re-inserted into the `ShardList` (as they'll just instantly return the same error again). This is normally achieved by `break`ing on hitting one but since shard's don't have to share the same config, and therefore not all fail at once, some users may wish to continue running the remaining shards (hitting `Poll::Ready(None)` when no shards are left).