### PR TITLE
docs(gateway): record error source in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,10 @@ async fn main() -> anyhow::Result<()> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;

--- a/book/src/chapter_1_crates/section_3_gateway.md
+++ b/book/src/chapter_1_crates/section_3_gateway.md
@@ -98,7 +98,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;

--- a/book/src/chapter_1_crates/section_4_cache_inmemory.md
+++ b/book/src/chapter_1_crates/section_4_cache_inmemory.md
@@ -25,7 +25,10 @@ loop {
     let event = match shard.next_event().await {
         Ok(event) => event,
         Err(source) => {
-            tracing::warn!(?source, "error receiving event");
+            tracing::warn!(
+                source = &source as &dyn std::error::Error,
+                "error receiving event"
+            );
 
             if source.is_fatal() {
                 break;

--- a/book/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
+++ b/book/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
@@ -72,7 +72,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -77,7 +77,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;

--- a/examples/gateway-intents.rs
+++ b/examples/gateway-intents.rs
@@ -14,7 +14,10 @@ async fn main() -> anyhow::Result<()> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;

--- a/examples/gateway-metrics.rs
+++ b/examples/gateway-metrics.rs
@@ -31,7 +31,10 @@ async fn main() -> anyhow::Result<()> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;

--- a/examples/gateway-request-members.rs
+++ b/examples/gateway-request-members.rs
@@ -17,7 +17,10 @@ async fn main() -> anyhow::Result<()> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;

--- a/examples/gateway-reshard.rs
+++ b/examples/gateway-reshard.rs
@@ -57,7 +57,10 @@ async fn gateway_runner(client: Arc<Client>, mut shards: Vec<Shard>) {
         let event = match stream.next().await {
             Some((_, Ok(event))) => event,
             Some((_, Err(source))) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;
@@ -112,7 +115,10 @@ async fn reshard(
     while !identified.iter().all(|&shard| shard) {
         match stream.next().await {
             Some((_, Err(source))) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     // When returning `None` `reshard` will be called again,

--- a/examples/gateway-shard.rs
+++ b/examples/gateway-shard.rs
@@ -13,7 +13,10 @@ async fn main() -> anyhow::Result<()> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;

--- a/examples/lavalink-basic-bot.rs
+++ b/examples/lavalink-basic-bot.rs
@@ -72,7 +72,10 @@ async fn main() -> anyhow::Result<()> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;

--- a/twilight-cache-inmemory/README.md
+++ b/twilight-cache-inmemory/README.md
@@ -52,7 +52,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;

--- a/twilight-gateway/README.md
+++ b/twilight-gateway/README.md
@@ -54,7 +54,10 @@ async fn main() -> anyhow::Result<()> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 // If the error is fatal, as may be the case for invalid
                 // authentication or intents, then break out of the loop to
@@ -101,7 +104,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (shard, event) = match stream.next().await {
             Some((shard, Ok(event))) => (shard, event),
             Some((shard, Err(source))) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -271,7 +271,10 @@ struct MinimalReady {
 ///     let event = match shard.next_event().await {
 ///         Ok(event) => event,
 ///         Err(source) => {
-///             tracing::warn!(?source, "error receiving event");
+///             tracing::warn!(
+///                 source = &source as &dyn std::error::Error,
+///                 "error receiving event"
+///             );
 ///
 ///             if source.is_fatal() {
 ///                 break;

--- a/twilight-gateway/src/stream.rs
+++ b/twilight-gateway/src/stream.rs
@@ -113,7 +113,10 @@ pub enum StartRecommendedErrorType {
 ///     let (shard, event) = match stream.next().await {
 ///         Some((shard, Ok(event))) => (shard, event),
 ///         Some((shard, Err(source))) => {
-///             tracing::warn!(?source, "error receiving event");
+///             tracing::warn!(
+///                 source = &source as &dyn std::error::Error,
+///                 "error receiving event"
+///             );
 ///
 ///             if source.is_fatal() {
 ///                 break;

--- a/twilight-lavalink/README.md
+++ b/twilight-lavalink/README.md
@@ -91,7 +91,10 @@ async fn main() -> anyhow::Result<()> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;

--- a/twilight-standby/README.md
+++ b/twilight-standby/README.md
@@ -90,7 +90,10 @@ async fn main() -> anyhow::Result<()> {
         let event = match shard.next_event().await {
             Ok(event) => event,
             Err(source) => {
-                tracing::warn!(?source, "error receiving event");
+                tracing::warn!(
+                    source = &source as &dyn std::error::Error,
+                    "error receiving event"
+                );
 
                 if source.is_fatal() {
                     break;


### PR DESCRIPTION
`Value` (required to record variables in events) has no `impl<T: Error> Value for T`, but does have a `impl Value for dyn Error` implementation. ~~Recording values as `Error` exposes the error source in recorded events, which includes context.~~

It's important to use this for all public examples in Twilight since users will base their code on them, and not including error sources will lead to frustration when debugging.
