### PR TITLE
fix: clippy 1.65 lints round 2

### DIFF
--- a/twilight-cache-inmemory/src/event/voice_state.rs
+++ b/twilight-cache-inmemory/src/event/voice_state.rs
@@ -326,7 +326,7 @@ mod tests {
             self_mute: false,
             self_stream: false,
             self_video: false,
-            session_id: "".to_owned(),
+            session_id: String::new(),
             suppress: false,
             token: None,
             user_id: Id::new(3),

--- a/twilight-http/src/request/guild/create_guild/builder.rs
+++ b/twilight-http/src/request/guild/create_guild/builder.rs
@@ -826,7 +826,7 @@ mod tests {
     #[test]
     fn voice_fields() {
         assert!(matches!(
-            VoiceFieldsBuilder::new("".to_owned()).unwrap_err().kind(),
+            VoiceFieldsBuilder::new(String::new()).unwrap_err().kind(),
             VoiceFieldsErrorType::NameTooShort { name }
             if name.is_empty()
         ));
@@ -865,7 +865,7 @@ mod tests {
     #[test]
     fn text_fields() {
         assert!(matches!(
-            TextFieldsBuilder::new("".to_owned()).unwrap_err().kind(),
+            TextFieldsBuilder::new(String::new()).unwrap_err().kind(),
             TextFieldsErrorType::NameTooShort { name }
             if name.is_empty()
         ));
@@ -900,7 +900,7 @@ mod tests {
     #[test]
     fn category_fields() {
         assert!(matches!(
-            CategoryFieldsBuilder::new("".to_owned()).unwrap_err().kind(),
+            CategoryFieldsBuilder::new(String::new()).unwrap_err().kind(),
             CategoryFieldsErrorType::NameTooShort { name }
             if name.is_empty()
         ));

--- a/twilight-http/src/request/guild/get_guild_prune_count.rs
+++ b/twilight-http/src/request/guild/get_guild_prune_count.rs
@@ -100,7 +100,7 @@ mod tests {
     #[test]
     fn days() {
         fn days_valid(days: u16) -> bool {
-            let client = Client::new("".to_owned());
+            let client = Client::new(String::new());
             let count = GetGuildPruneCount::new(&client, Id::new(1));
             let days_result = count.days(days);
             days_result.is_ok()


### PR DESCRIPTION
This was somehow missed in the previous Rust 1.65 Clippy fix PR (#1985).
