### PR TITLE
docs: add `Intents::MESSAGE_CONTENT` to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ async fn main() -> anyhow::Result<()> {
 
     // A cluster is a manager for multiple shards that by default
     // creates as many shards as Discord recommends.
-    let (cluster, mut events) = Cluster::new(token.to_owned(), Intents::GUILD_MESSAGES).await?;
+    let (cluster, mut events) = Cluster::new(token.to_owned(), Intents::GUILD_MESSAGES | Intents::MESSAGE_CONTENT).await?;
     let cluster = Arc::new(cluster);
 
     // Start up the cluster.

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -65,7 +65,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     // Specify intents requesting events about things like new and updated
     // messages in a guild and direct messages.
-    let intents = Intents::GUILD_MESSAGES | Intents::DIRECT_MESSAGES;
+    let intents = Intents::GUILD_MESSAGES | Intents::DIRECT_MESSAGES | Intents::MESSAGE_CONTENT;
 
     let (cluster, mut events) = Cluster::builder(token.clone(), intents)
         .shard_scheme(scheme)


### PR DESCRIPTION
I have added for the book `Intents::MESSAGE_CONTENT` that the example can work as well