### PR TITLE
fix(model)!: add a unknown variant to `PremiumType`

### DIFF
--- a/twilight-model/src/user/premium_type.rs
+++ b/twilight-model/src/user/premium_type.rs
@@ -1,11 +1,34 @@
-use serde_repr::{Deserialize_repr, Serialize_repr};
-#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+use serde::{Deserialize, Serialize};
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
-#[repr(u8)]
+#[serde(from = "u8", into = "u8")]
 pub enum PremiumType {
-    None = 0,
-    NitroClassic = 1,
-    Nitro = 2,
+    None,
+    NitroClassic,
+    Nitro,
+    Unknown(u8)
+}
+
+impl From<u8> for PremiumType {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => PremiumType::None,
+            1 => PremiumType::NitroClassic,
+            2 => PremiumType::Nitro,
+            unknown => PremiumType::Unknown(unknown),
+        }
+    }
+}
+
+impl From<PremiumType> for u8 {
+    fn from(value: PremiumType) -> Self {
+        match value {
+            PremiumType::None => 0,
+            PremiumType::NitroClassic => 1,
+            PremiumType::Nitro => 2,
+            PremiumType::Unknown(unknown) => unknown,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -18,5 +41,6 @@ mod tests {
         serde_test::assert_tokens(&PremiumType::None, &[Token::U8(0)]);
         serde_test::assert_tokens(&PremiumType::NitroClassic, &[Token::U8(1)]);
         serde_test::assert_tokens(&PremiumType::Nitro, &[Token::U8(2)]);
+        serde_test::assert_tokens(&PremiumType::Unknown(42), &[Token::U8(42)]);
     }
 }

--- a/twilight-model/src/user/premium_type.rs
+++ b/twilight-model/src/user/premium_type.rs
@@ -6,7 +6,7 @@ pub enum PremiumType {
     None,
     NitroClassic,
     Nitro,
-    Unknown(u8)
+    Unknown(u8),
 }
 
 impl From<u8> for PremiumType {


### PR DESCRIPTION
This makes the size 2 bytes instead of 1, but it makes it less likely to cause issues with serialization.

--------------------------------
#### For release notes:

Add unknown variant to [`PremiumType`], this is a slight breaking change as the type is no longer `repr(u8)` which means conversions with the `as` keyword is no longer possible. Instead `Into` and `From` should be used instead. ([#1996])


[`PremiumType`]: https://docs.rs/twilight-model/latest/twilight_model/user/enum.PremiumType.html
[#1996]: https://github.com/twilight-rs/twilight/pull/1996