### PR TITLE
feat(model): Add Interaction::author

### DIFF
--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -116,7 +116,11 @@ impl Interaction {
     /// [`member`]: Self::member
     /// [`user`]: Self::user
     pub const fn author_id(&self) -> Option<Id<UserMarker>> {
-        Some(self.author()?.id)
+        if let Some(user) = self.author() {
+            Some(user.id)
+        } else {
+            None
+        }
     }
 
     /// The user that invoked the interaction.

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -116,11 +116,7 @@ impl Interaction {
     /// [`member`]: Self::member
     /// [`user`]: Self::user
     pub const fn author_id(&self) -> Option<Id<UserMarker>> {
-        if let Some(user) = self.author() {
-            Some(user.id)
-        } else {
-            None
-        }
+        Some(self.author()?.id)
     }
 
     /// The user that invoked the interaction.

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -116,17 +116,26 @@ impl Interaction {
     /// [`member`]: Self::member
     /// [`user`]: Self::user
     pub const fn author_id(&self) -> Option<Id<UserMarker>> {
-        if let Some(member) = &self.member {
-            if let Some(user) = &member.user {
-                return Some(user.id);
-            }
+        if let Some(user) = self.author() {
+            Some(user.id)
+        } else {
+            None
         }
+    }
 
-        if let Some(user) = &self.user {
-            return Some(user.id);
+    /// The user that invoked the interaction.
+    ///
+    /// This will first check for the [`member`]'s
+    /// [`user`][`PartialMember::user`] and then, if not present, check the
+    /// [`user`].
+    ///
+    /// [`member`]: Self::member
+    /// [`user`]: Self::user
+    pub const fn author(&self) -> Option<&User> {
+        match self.member.as_ref() {
+            Some(member) if member.user.is_some() => member.user.as_ref(),
+            _ => self.user.as_ref(),
         }
-
-        None
     }
 
     /// Whether the interaction was invoked in a DM.


### PR DESCRIPTION
This makes it a lot easier to get user information about the interaction author. For instance, my current bot has this function to get the `Username#Discriminator` tag of a user:

```rs
fn get_tag(event: &Interaction) -> String {
    event
        .user
        .as_ref()
        .or(event.member.as_ref().and_then(|m| m.user.as_ref()))
        .map(|user| format!("{}#{}", user.name, user.discriminator()))
        .expect("Could not resolve user for event!")
}
```

With this new method, I can do this much simpler:

```rs
fn get_tag(event: &Interaction) -> String {
    event
        .author()
        .map(|user| format!("{}#{}", user.name, user.discriminator()))
        .expect("Could not resolve user for event!")
}
```