### PR TITLE
feat(model): rename certified moderator to alumni

### DIFF
--- a/twilight-model/src/user/flags.rs
+++ b/twilight-model/src/user/flags.rs
@@ -30,8 +30,11 @@ bitflags! {
         const VERIFIED_BOT = 1 << 16;
         /// Early verified bot developer.
         const VERIFIED_DEVELOPER = 1 << 17;
-        /// Discord certified moderator.
+        /// Moderator Programs Alumni
+        #[deprecated(since = "0.14.0", note = "use `MODERATOR_PROGRAMS_ALUMNI`")]
         const CERTIFIED_MODERATOR = 1 << 18;
+        /// Moderator Programs Alumni
+        const MODERATOR_PROGRAMS_ALUMNI = 1 << 18;
         /// Bot uses only HTTP interactions and is shown in the online member
         /// list.
         const BOT_HTTP_INTERACTIONS = 1 << 19;


### PR DESCRIPTION
Rename the `CERTIFIED_MODERATOR` user flag to `MODERATOR_PROGRAMS_ALUMNI`, deprecating `CERTIFIED_MODERATOR`.

Closes #2008.

<img width="595" alt="Screenshot 2022-12-27 at 20 18 41" src="https://user-images.githubusercontent.com/57759500/209767316-f9ef9aae-8373-4466-9024-f15aaadc4fe8.png">
