### PR TITLE
feat(http, model, util): support nsfw commands

### DIFF
--- a/twilight-http/src/request/application/command/create_global_command/chat_input.rs
+++ b/twilight-http/src/request/application/command/create_global_command/chat_input.rs
@@ -35,6 +35,7 @@ pub struct CreateGlobalChatInputCommand<'a> {
     http: &'a Client,
     name: &'a str,
     name_localizations: Option<&'a HashMap<String, String>>,
+    nsfw: Option<bool>,
     options: Option<&'a [CommandOption]>,
 }
 
@@ -58,6 +59,7 @@ impl<'a> CreateGlobalChatInputCommand<'a> {
             http,
             name,
             name_localizations: None,
+            nsfw: None,
             options: None,
         })
     }
@@ -152,6 +154,15 @@ impl<'a> CreateGlobalChatInputCommand<'a> {
         Ok(self)
     }
 
+    /// Set whether the command is age-restricted.
+    ///
+    /// Defaults to not being specified, which uses Discord's default.
+    pub const fn nsfw(mut self, nsfw: bool) -> Self {
+        self.nsfw = Some(nsfw);
+
+        self
+    }
+
     /// Execute the request, returning a future resolving to a [`Response`].
     #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
@@ -188,6 +199,7 @@ impl TryIntoRequest for CreateGlobalChatInputCommand<'_> {
             kind: CommandType::ChatInput,
             name: self.name,
             name_localizations: self.name_localizations,
+            nsfw: self.nsfw,
             options: self.options,
         })
         .map(RequestBuilder::build)

--- a/twilight-http/src/request/application/command/create_global_command/message.rs
+++ b/twilight-http/src/request/application/command/create_global_command/message.rs
@@ -29,6 +29,7 @@ pub struct CreateGlobalMessageCommand<'a> {
     http: &'a Client,
     name: &'a str,
     name_localizations: Option<&'a HashMap<String, String>>,
+    nsfw: Option<bool>,
 }
 
 impl<'a> CreateGlobalMessageCommand<'a> {
@@ -46,6 +47,7 @@ impl<'a> CreateGlobalMessageCommand<'a> {
             http,
             name,
             name_localizations: None,
+            nsfw: None,
         })
     }
 
@@ -89,6 +91,15 @@ impl<'a> CreateGlobalMessageCommand<'a> {
         Ok(self)
     }
 
+    /// Set whether the command is age-restricted.
+    ///
+    /// Defaults to not being specified, which uses Discord's default.
+    pub const fn nsfw(mut self, nsfw: bool) -> Self {
+        self.nsfw = Some(nsfw);
+
+        self
+    }
+
     /// Execute the request, returning a future resolving to a [`Response`].
     #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
@@ -125,6 +136,7 @@ impl TryIntoRequest for CreateGlobalMessageCommand<'_> {
             kind: CommandType::Message,
             name: self.name,
             name_localizations: self.name_localizations,
+            nsfw: self.nsfw,
             options: None,
         })
         .map(RequestBuilder::build)

--- a/twilight-http/src/request/application/command/create_global_command/user.rs
+++ b/twilight-http/src/request/application/command/create_global_command/user.rs
@@ -29,6 +29,7 @@ pub struct CreateGlobalUserCommand<'a> {
     http: &'a Client,
     name: &'a str,
     name_localizations: Option<&'a HashMap<String, String>>,
+    nsfw: Option<bool>,
 }
 
 impl<'a> CreateGlobalUserCommand<'a> {
@@ -46,6 +47,7 @@ impl<'a> CreateGlobalUserCommand<'a> {
             http,
             name,
             name_localizations: None,
+            nsfw: None,
         })
     }
 
@@ -89,6 +91,15 @@ impl<'a> CreateGlobalUserCommand<'a> {
         Ok(self)
     }
 
+    /// Set whether the command is age-restricted.
+    ///
+    /// Defaults to not being specified, which uses Discord's default.
+    pub const fn nsfw(mut self, nsfw: bool) -> Self {
+        self.nsfw = Some(nsfw);
+
+        self
+    }
+
     /// Execute the request, returning a future resolving to a [`Response`].
     #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
@@ -125,6 +136,7 @@ impl TryIntoRequest for CreateGlobalUserCommand<'_> {
             kind: CommandType::User,
             name: self.name,
             name_localizations: self.name_localizations,
+            nsfw: self.nsfw,
             options: None,
         })
         .map(RequestBuilder::build)

--- a/twilight-http/src/request/application/command/create_guild_command/chat_input.rs
+++ b/twilight-http/src/request/application/command/create_guild_command/chat_input.rs
@@ -37,6 +37,7 @@ pub struct CreateGuildChatInputCommand<'a> {
     guild_id: Id<GuildMarker>,
     http: &'a Client,
     name: &'a str,
+    nsfw: Option<bool>,
     name_localizations: Option<&'a HashMap<String, String>>,
     options: Option<&'a [CommandOption]>,
 }
@@ -62,6 +63,7 @@ impl<'a> CreateGuildChatInputCommand<'a> {
             http,
             name,
             name_localizations: None,
+            nsfw: None,
             options: None,
         })
     }
@@ -147,6 +149,15 @@ impl<'a> CreateGuildChatInputCommand<'a> {
         Ok(self)
     }
 
+    /// Set whether the command is age-restricted.
+    ///
+    /// Defaults to not being specified, which uses Discord's default.
+    pub const fn nsfw(mut self, nsfw: bool) -> Self {
+        self.nsfw = Some(nsfw);
+
+        self
+    }
+
     /// Execute the request, returning a future resolving to a [`Response`].
     #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<Command> {
@@ -184,6 +195,7 @@ impl TryIntoRequest for CreateGuildChatInputCommand<'_> {
             kind: CommandType::ChatInput,
             name: self.name,
             name_localizations: self.name_localizations,
+            nsfw: self.nsfw,
             options: self.options,
         })
         .map(RequestBuilder::build)

--- a/twilight-http/src/request/application/command/create_guild_command/message.rs
+++ b/twilight-http/src/request/application/command/create_guild_command/message.rs
@@ -32,6 +32,7 @@ pub struct CreateGuildMessageCommand<'a> {
     http: &'a Client,
     name: &'a str,
     name_localizations: Option<&'a HashMap<String, String>>,
+    nsfw: Option<bool>,
 }
 
 impl<'a> CreateGuildMessageCommand<'a> {
@@ -50,6 +51,7 @@ impl<'a> CreateGuildMessageCommand<'a> {
             http,
             name,
             name_localizations: None,
+            nsfw: None,
         })
     }
 
@@ -82,6 +84,15 @@ impl<'a> CreateGuildMessageCommand<'a> {
         self.name_localizations = Some(localizations);
 
         Ok(self)
+    }
+
+    /// Set whether the command is age-restricted.
+    ///
+    /// Defaults to not being specified, which uses Discord's default.
+    pub const fn nsfw(mut self, nsfw: bool) -> Self {
+        self.nsfw = Some(nsfw);
+
+        self
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
@@ -121,6 +132,7 @@ impl TryIntoRequest for CreateGuildMessageCommand<'_> {
             kind: CommandType::Message,
             name: self.name,
             name_localizations: self.name_localizations,
+            nsfw: self.nsfw,
             options: None,
         })
         .map(RequestBuilder::build)

--- a/twilight-http/src/request/application/command/create_guild_command/user.rs
+++ b/twilight-http/src/request/application/command/create_guild_command/user.rs
@@ -32,6 +32,7 @@ pub struct CreateGuildUserCommand<'a> {
     http: &'a Client,
     name: &'a str,
     name_localizations: Option<&'a HashMap<String, String>>,
+    nsfw: Option<bool>,
 }
 
 impl<'a> CreateGuildUserCommand<'a> {
@@ -50,6 +51,7 @@ impl<'a> CreateGuildUserCommand<'a> {
             http,
             name,
             name_localizations: None,
+            nsfw: None,
         })
     }
 
@@ -82,6 +84,15 @@ impl<'a> CreateGuildUserCommand<'a> {
         self.name_localizations = Some(localizations);
 
         Ok(self)
+    }
+
+    /// Set whether the command is age-restricted.
+    ///
+    /// Defaults to not being specified, which uses Discord's default.
+    pub const fn nsfw(mut self, nsfw: bool) -> Self {
+        self.nsfw = Some(nsfw);
+
+        self
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
@@ -121,6 +132,7 @@ impl TryIntoRequest for CreateGuildUserCommand<'_> {
             kind: CommandType::User,
             name: self.name,
             name_localizations: self.name_localizations,
+            nsfw: self.nsfw,
             options: None,
         })
         .map(RequestBuilder::build)

--- a/twilight-http/src/request/application/command/mod.rs
+++ b/twilight-http/src/request/application/command/mod.rs
@@ -54,6 +54,8 @@ struct CommandBorrowed<'a> {
     pub name: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name_localizations: Option<&'a HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nsfw: Option<bool>,
     #[serde(default)]
     pub options: Option<&'a [CommandOption]>,
 }
@@ -92,6 +94,7 @@ mod tests {
                 "en-US".to_owned(),
                 "command name".to_owned(),
             )])),
+            nsfw: Some(true),
             options: Vec::new(),
             version: Id::new(1),
         };
@@ -105,6 +108,7 @@ mod tests {
             kind: CommandType::ChatInput,
             name: &command.name,
             name_localizations: command.name_localizations.as_ref(),
+            nsfw: command.nsfw,
             options: Some(&command.options),
         };
     }

--- a/twilight-http/src/request/application/command/update_global_command.rs
+++ b/twilight-http/src/request/application/command/update_global_command.rs
@@ -22,6 +22,8 @@ struct UpdateGlobalCommandFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    nsfw: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     options: Option<&'a [CommandOption]>,
 }
 
@@ -51,6 +53,7 @@ impl<'a> UpdateGlobalCommand<'a> {
             fields: UpdateGlobalCommandFields {
                 description: None,
                 name: None,
+                nsfw: None,
                 options: None,
             },
             http,
@@ -74,6 +77,13 @@ impl<'a> UpdateGlobalCommand<'a> {
     /// Edit the command options of the command.
     pub const fn command_options(mut self, options: &'a [CommandOption]) -> Self {
         self.fields.options = Some(options);
+
+        self
+    }
+
+    /// Edit whether the command is age-restricted.
+    pub const fn nsfw(mut self, nsfw: bool) -> Self {
+        self.fields.nsfw = Some(nsfw);
 
         self
     }

--- a/twilight-http/src/request/application/command/update_guild_command.rs
+++ b/twilight-http/src/request/application/command/update_guild_command.rs
@@ -22,6 +22,8 @@ struct UpdateGuildCommandFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    nsfw: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     options: Option<&'a [CommandOption]>,
 }
 
@@ -53,6 +55,7 @@ impl<'a> UpdateGuildCommand<'a> {
             fields: UpdateGuildCommandFields {
                 description: None,
                 name: None,
+                nsfw: None,
                 options: None,
             },
             guild_id,
@@ -77,6 +80,13 @@ impl<'a> UpdateGuildCommand<'a> {
     /// Edit the command options of the command.
     pub const fn command_options(mut self, options: &'a [CommandOption]) -> Self {
         self.fields.options = Some(options);
+
+        self
+    }
+
+    /// Edit whether the command is age-restricted.
+    pub const fn nsfw(mut self, nsfw: bool) -> Self {
+        self.fields.nsfw = Some(nsfw);
 
         self
     }

--- a/twilight-model/src/application/command/mod.rs
+++ b/twilight-model/src/application/command/mod.rs
@@ -83,6 +83,11 @@ pub struct Command {
     /// [Discord Docs/Localization]: https://discord.com/developers/docs/interactions/application-commands#localization
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name_localizations: Option<HashMap<String, String>>,
+    /// Whether the command is age-restricted.
+    ///
+    /// Defaults to false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nsfw: Option<bool>,
     #[serde(default)]
     pub options: Vec<CommandOption>,
     /// Autoincrementing version identifier.
@@ -116,6 +121,7 @@ mod tests {
             kind: CommandType::ChatInput,
             name: "test command".into(),
             name_localizations: Some(HashMap::from([("en-US".into(), "test command".into())])),
+            nsfw: None,
             options: Vec::from([CommandOption {
                 autocomplete: None,
                 channel_types: None,

--- a/twilight-util/src/builder/command.rs
+++ b/twilight-util/src/builder/command.rs
@@ -75,6 +75,7 @@ impl CommandBuilder {
             kind,
             name: name.into(),
             name_localizations: None,
+            nsfw: None,
             options: Vec::new(),
             version: Id::new(1),
         })
@@ -172,6 +173,15 @@ impl CommandBuilder {
 
     fn _option(mut self, option: CommandOption) -> Self {
         self.0.options.push(option);
+
+        self
+    }
+
+    /// Set whether the command is age-restricted.
+    ///
+    /// Defaults to not being specified, which uses Discord's default.
+    pub const fn nsfw(mut self, nsfw: bool) -> Self {
+        self.0.nsfw = Some(nsfw);
 
         self
     }
@@ -1408,6 +1418,7 @@ mod tests {
                 "Get or edit permissions for a user or a role",
                 CommandType::ChatInput,
             )
+            .nsfw(true)
             .option(
                 SubCommandGroupBuilder::new("user", "Get or edit permissions for a user")
                     .subcommands([
@@ -1458,6 +1469,7 @@ mod tests {
             kind: CommandType::ChatInput,
             name: String::from("permissions"),
             name_localizations: None,
+            nsfw: Some(true),
             description_localizations: None,
             options: Vec::from([
                 CommandOption {

--- a/twilight-validate/src/command.rs
+++ b/twilight-validate/src/command.rs
@@ -520,6 +520,7 @@ mod tests {
             kind: CommandType::ChatInput,
             name: "b".repeat(32),
             name_localizations: Some(HashMap::from([("en-US".to_string(), "b".repeat(32))])),
+            nsfw: None,
             options: Vec::new(),
             version: Id::new(4),
         };


### PR DESCRIPTION
Support age-restricted commands via the new `nsfw` field on commands, which is an optional boolean. Adds NSFW setters to guild/global command create and update HTTP builders and to the util crate's command builder.

Closes #2011.