### PR TITLE
docs(model): update automod keyword limit

### DIFF
--- a/twilight-model/src/guild/auto_moderation/trigger_type.rs
+++ b/twilight-model/src/guild/auto_moderation/trigger_type.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub enum AutoModerationTriggerType {
     /// Check if content contains words from a user defined list of keywords.
     ///
-    /// Maximum of 3 per guild.
+    /// Maximum of 5 per guild.
     Keyword,
     /// Check if content represents generic spam.
     ///


### PR DESCRIPTION
Update the automod keyword rule limit documentation from 3 to 5.

Part of #2012.