### PR TITLE
feat(gateway)!: mark `Message` exhaustive

### DIFF
--- a/twilight-gateway/src/message.rs
+++ b/twilight-gateway/src/message.rs
@@ -97,7 +97,6 @@ impl<'a> CloseFrame<'a> {
 
 /// Message to send over the connection to the remote.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
 pub enum Message {
     /// Close message with an optional frame including information about the
     /// reason for the close.


### PR DESCRIPTION
The `Message` enum is the subset of the WebSocket message types relevant to end users of the Discord gateway (`binary` frames are converted to `text` frames by shards). It's *highly* unlikely for Discord to expand their use of control frames and even more unlikely for it to use any currently reserved control frames. It is therefore unnecessary to mark `Message` as `#[non_exhaustive]`, especially since it complicates users' code.

This was originally discovered in #2003
