### PR TITLE
reafactor(model)!: unify event deserialization into one type

### DIFF
--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -856,7 +856,7 @@ impl Shard {
                 })?;
                 tracing::debug!(%event_type, %sequence, "received dispatch");
 
-                match event_type {
+                match event_type.as_ref() {
                     "READY" => {
                         let event = Self::parse_event::<MinimalReady>(event)?;
 

--- a/twilight-model/src/gateway/event/gateway.rs
+++ b/twilight-model/src/gateway/event/gateway.rs
@@ -99,15 +99,16 @@ impl<'a> GatewayEventDeserializer<'a> {
 
     /// Sequence of the payload.
     ///
-    /// May only be available if the deserializer was created from the
-    /// `from_json` function.
+    /// May only be available if the deserializer was created via
+    /// [`from_json`][`Self::from_json`]
     pub const fn sequence(&self) -> Option<u64> {
         self.sequence
     }
 
-    /// Clone the `event_type`.
+    /// Create a deserializer with an owned event type.
     ///
-    /// Use this when using a mutable deserialization library like `simd-json`.
+    /// This is necessary when using a mutable deserialization library such as
+    /// `simd-json`.
     pub fn into_owned(self) -> GatewayEventDeserializer<'static> {
         GatewayEventDeserializer {
             event_type: self

--- a/twilight-model/src/gateway/event/gateway.rs
+++ b/twilight-model/src/gateway/event/gateway.rs
@@ -87,24 +87,6 @@ impl<'a> GatewayEventDeserializer<'a> {
         })
     }
 
-    /// Dispatch event type of the payload.
-    pub fn event_type(&self) -> Option<&str> {
-        self.event_type.as_deref()
-    }
-
-    /// Opcode of the payload.
-    pub const fn op(&self) -> u8 {
-        self.op
-    }
-
-    /// Sequence of the payload.
-    ///
-    /// May only be available if the deserializer was created via
-    /// [`from_json`][`Self::from_json`]
-    pub const fn sequence(&self) -> Option<u64> {
-        self.sequence
-    }
-
     /// Create a deserializer with an owned event type.
     ///
     /// This is necessary when using a mutable deserialization library such as
@@ -123,6 +105,24 @@ impl<'a> GatewayEventDeserializer<'a> {
     #[allow(clippy::missing_const_for_fn)]
     pub fn into_parts(self) -> (u8, Option<u64>, Option<Cow<'a, str>>) {
         (self.op, self.sequence, self.event_type)
+    }
+
+    /// Dispatch event type of the payload.
+    pub fn event_type(&self) -> Option<&str> {
+        self.event_type.as_deref()
+    }
+
+    /// Opcode of the payload.
+    pub const fn op(&self) -> u8 {
+        self.op
+    }
+
+    /// Sequence of the payload.
+    ///
+    /// May only be available if the deserializer was created via
+    /// [`from_json`][`Self::from_json`]
+    pub const fn sequence(&self) -> Option<u64> {
+        self.sequence
     }
 
     fn find_event_type(input: &'a str) -> Option<&'a str> {

--- a/twilight-model/src/gateway/event/mod.rs
+++ b/twilight-model/src/gateway/event/mod.rs
@@ -7,7 +7,7 @@ mod kind;
 
 pub use self::{
     dispatch::{DispatchEvent, DispatchEventWithTypeDeserializer},
-    gateway::{GatewayEvent, GatewayEventDeserializer, GatewayEventDeserializerOwned},
+    gateway::{GatewayEvent, GatewayEventDeserializer},
     kind::EventType,
 };
 


### PR DESCRIPTION
Unifies the awkward `GatewayEventDeserializerOwned` into `GatewayEventDeserializer` by using a `Cow` for the event type.
