### PR TITLE
<type>(<scope>)<! if breaking>: <short summary>Fix/lavalink rejoin bug

### DIFF
--- a/examples/lavalink-basic-bot.rs
+++ b/examples/lavalink-basic-bot.rs
@@ -53,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
         let lavalink = Lavalink::new(user_id, shard_count);
         lavalink.add(lavalink_host, lavalink_auth).await?;
 
-        let intents = Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES;
+        let intents = Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES | Intents::MESSAGE_CONTENT;
         let (shard, events) = Shard::new(token, intents);
 
         shard.start().await?;

--- a/twilight-lavalink/src/client.rs
+++ b/twilight-lavalink/src/client.rs
@@ -200,6 +200,7 @@ impl Lavalink {
 
                     if e.channel_id.is_none() {
                         self.sessions.remove(&guild_id);
+                        self.server_updates.remove(&guild_id);
                     } else {
                         self.sessions
                             .insert(guild_id, e.session_id.clone().into_boxed_str());


### PR DESCRIPTION
I filed an issue in discord (no responses) then opened up an issue #2021. Ended up tracking down the issue and finding the bug. Not sure when this changed or why it happens. I am assuming discord changed the the incoming API but don't know for sure. It seems that the server update wasn't happening anymore.

Here is the problem. Upon leaving we still thought we had a valid server connection:
```
...
2022-12-31T02:35:02.192442Z DEBUG twilight_lavalink::client: got voice server/state update for Id<GuildMarker>(<REDACTED>): VoiceStateUpdate(VoiceStateUpdate(VoiceState { channel_id: None, deaf: false, guild_id: Some(Id<GuildMarker>(<REDACTED>)), member: Some(Member { avatar: None, communication_disabled_until: None, deaf: false, guild_id: Id<GuildMarker>(<REDACTED>), joined_at: Timestamp(2021-10-26 2:22:56.092), mute: false, nick: None, pending: false, premium_since: None, roles: [Id<RoleMarker>(<REDACTED>)], user: User { accent_color: None, avatar: Some(ImageHash { animated: false, bytes: [83, 191, 122, 60, 67, 133, 129, 52, 69, 146, 38, 233, 145, 250, 124, 56] }), banner: None, bot: true, discriminator: 9293, email: None, flags: None, id: Id<UserMarker>(<REDACTED>), locale: None, mfa_enabled: None, name: "<REDACTED>", premium_type: None, public_flags: Some((empty)), system: None, verified: None } }), mute: false, self_deaf: false, self_mute: false, self_stream: false, self_video: false, session_id: "<REDACTED>", suppress: false, user_id: Id<UserMarker>(<REDACTED>), request_to_speak_timestamp: None }))
2022-12-31T02:35:02.192602Z DEBUG twilight_lavalink::client: guild <REDACTED> is now waiting for other half; got: VoiceServerUpdate { endpoint: Some("us-central2733.discord.media:443"), guild_id: Id<GuildMarker>(<REDACTED>), token: "d2e9631b5ee5372a" }
...
```
The waiting for second half didn't make sense. We didn't have a valid connection.
Then we get this when we try to join:
```
...
2022-12-31T02:35:34.221315Z DEBUG twilight_lavalink::client: got both halves for <REDACTED>: VoiceServerUpdate { endpoint: Some("us-central2733.discord.media:443"), guild_id: Id<GuildMarker>(<REDACTED>), token: "d2e9631b5ee5372a" }; Session ID: "<REDACTED>"
2022-12-31T02:35:34.221376Z DEBUG twilight_lavalink::client: getting player for guild <REDACTED>
2022-12-31T02:35:34.221420Z DEBUG twilight_lavalink::client: sending voice update for guild <REDACTED>: VoiceUpdate { event: VoiceServerUpdate { endpoint: Some("us-central2733.discord.media:443"), guild_id: Id<GuildMarker>(<REDACTED>), token: "d2e9631b5ee5372a" }, guild_id: Id<GuildMarker>(<REDACTED>), op: VoiceUpdate, session_id: "<REDACTED>" }
2022-12-31T02:35:34.221485Z DEBUG twilight_lavalink::player: sending event on guild player <REDACTED>: VoiceUpdate(VoiceUpdate { event: VoiceServerUpdate { endpoint: Some("us-central2733.discord.media:443"), guild_id: Id<GuildMarker>(<REDACTED>), token: "d2e9631b5ee5372a" }, guild_id: Id<GuildMarker>(<REDACTED>), op: VoiceUpdate, session_id: "<REDACTED>" })
2022-12-31T02:35:34.221577Z DEBUG twilight_lavalink::client: sent voice update for guild <REDACTED>
2022-12-31T02:35:34.221685Z DEBUG twilight_lavalink::node: forwarding event to 127.0.0.1:2333: VoiceUpdate(VoiceUpdate { event: VoiceServerUpdate { endpoint: Some("us-central2733.discord.media:443"), guild_id: Id<GuildMarker>(<REDACTED>), token: "d2e9631b5ee5372a" }, guild_id: Id<GuildMarker>(<REDACTED>), op: VoiceUpdate, session_id: "<REDACTED>" })
2022-12-31T02:35:34.363231Z DEBUG twilight_lavalink::client: got voice server/state update for Id<GuildMarker>(<REDACTED>): VoiceServerUpdate(VoiceServerUpdate { endpoint: Some("us-central2733.discord.media:443"), guild_id: Id<GuildMarker>(<REDACTED>), token: "b4cb0bc249036082" })
2022-12-31T02:35:34.363317Z DEBUG twilight_lavalink::client: got both halves for <REDACTED>: VoiceServerUpdate { endpoint: Some("us-central2733.discord.media:443"), guild_id: Id<GuildMarker>(<REDACTED>), token: "b4cb0bc249036082" }; Session ID: "<REDACTED>"
2022-12-31T02:35:34.363359Z DEBUG twilight_lavalink::client: getting player for guild <REDACTED>
2022-12-31T02:35:34.363393Z DEBUG twilight_lavalink::client: sending voice update for guild <REDACTED>: VoiceUpdate { event: VoiceServerUpdate { endpoint: Some("us-central2733.discord.media:443"), guild_id: Id<GuildMarker>(<REDACTED>), token: "b4cb0bc249036082" }, guild_id: Id<GuildMarker>(<REDACTED>), op: VoiceUpdate, session_id: "<REDACTED>" }
2022-12-31T02:35:34.363435Z DEBUG twilight_lavalink::player: sending event on guild player <REDACTED>: VoiceUpdate(VoiceUpdate { event: VoiceServerUpdate { endpoint: Some("us-central2733.discord.media:443"), guild_id: Id<GuildMarker>(<REDACTED>), token: "b4cb0bc249036082" }, guild_id: Id<GuildMarker>(<REDACTED>), op: VoiceUpdate, session_id: "<REDACTED>" })
2022-12-31T02:35:34.363497Z DEBUG twilight_lavalink::client: sent voice update for guild <REDACTED>
2022-12-31T02:35:34.363549Z DEBUG twilight_lavalink::node: forwarding event to 127.0.0.1:2333: VoiceUpdate(VoiceUpdate { event: VoiceServerUpdate { endpoint: Some("us-central2733.discord.media:443"), guild_id: Id<GuildMarker>(<REDACTED>), token: "b4cb0bc249036082" }, guild_id: Id<GuildMarker>(<REDACTED>), op: VoiceUpdate, session_id: "<REDACTED>" })
2022-12-31T02:35:34.473501Z DEBUG twilight_lavalink::node: received message from 127.0.0.1:2333: Text("{\"op\":\"playerUpdate\",\"state\":{\"connected\":true,\"ping\":0,\"time\":1672454134472},\"guildId\":\"<REDACTED>\"}")
2022-12-31T02:35:34.477586Z DEBUG Connection{peer=Client}: h2::codec::framed_read: received frame=Headers { stream_id: StreamId(11), flags: (0x4: END_HEADERS) }
2022-12-31T02:35:34.477753Z DEBUG Connection{peer=Client}: h2::codec::framed_read: received frame=Data { stream_id: StreamId(11) }
2022-12-31T02:35:34.477854Z DEBUG Connection{peer=Client}: h2::codec::framed_read: received frame=Data { stream_id: StreamId(11) }
2022-12-31T02:35:34.477947Z DEBUG Connection{peer=Client}: h2::codec::framed_read: received frame=Data { stream_id: StreamId(11), flags: (0x1: END_STREAM) }
2022-12-31T02:35:34.478376Z DEBUG background queue task{path=ChannelsIdMessages(<REDACTED>)}: twilight_http_ratelimiting::in_memory::bucket: updating bucket path=ChannelsIdMessages(<REDACTED>)
2022-12-31T02:35:34.478419Z DEBUG background queue task{path=ChannelsIdMessages(<REDACTED>)}: twilight_http_ratelimiting::in_memory::bucket: starting to get next in queue path=ChannelsIdMessages(<REDACTED>)
2022-12-31T02:35:34.575247Z DEBUG twilight_lavalink::node: received message from 127.0.0.1:2333: Text("{\"op\":\"event\",\"reason\":\"\",\"code\":1011,\"byRemote\":true,\"type\":\"WebSocketClosedEvent\",\"guildId\":\"<REDACTED>\"}")
2022-12-31T02:35:34.575427Z DEBUG twilight_lavalink::node: received message from 127.0.0.1:2333: Text("{\"op\":\"playerUpdate\",\"state\":{\"connected\":true,\"ping\":0,\"time\":1672454134574},\"guildId\":\"<REDACTED>\"}")
2022-12-31T02:35:35.046279Z DEBUG twilight_lavalink::node: received message from 127.0.0.1:2333: Text("{\"op\":\"event\",\"reason\":\"Session is no longer valid.\",\"code\":4006,\"byRemote\":true,\"type\":\"WebSocketClosedEvent\",\"guildId\":\"<REDACTED>\"}")
2022-12-31T02:35:35.046508Z DEBUG twilight_lavalink::node: received message from 127.0.0.1:2333: Text("{\"op\":\"playerUpdate\",\"state\":{\"connected\":false,\"ping\":0,\"time\":1672454135045},\"guildId\":\"<REDACTED>\"}")
```
As you can see the old token was used and sent to the `lavalink` server. That was the problem and then we sent another updated with the new token but we had the original token in the server. `lavalink` then thought the socket was broken since it wasn't destroyed. 

The old session / token `d2e9631b5ee5372a` vs the new `b4cb0bc249036082`. The leave let the state machine in half set mode where the server had the old token set and we had not received the updated token.