### PR TITLE
Make the bucket struct externally instanciable 

### DIFF
--- a/twilight-http-ratelimiting/src/lib.rs
+++ b/twilight-http-ratelimiting/src/lib.rs
@@ -88,6 +88,19 @@ impl Bucket {
 
         reset_at.checked_duration_since(Instant::now())
     }
+    
+    /// Constructs a new bucket instance
+    #[must_use]
+    pub fn new(
+        limit: u64,
+        remaining: u64,
+        reset_after: Duration,
+        started_at: Option<Instant>,
+    ) -> Self {
+        Self {
+            limit, remaining, reset_after, started_at
+        }
+    }
 }
 
 /// A generic error type that implements [`Error`].


### PR DESCRIPTION
This helps external implementations of the ratelimiter possible;
The trait `Ratelimiter` (twilight-http-ratelimiter/src/lib.rs) requires returning a `GetBucketFuture` which is impossible because there is no way to instantiate a Bucket (all the fields are private)

One way of doing this without patching is using `std::mem::transmute` but it's highly unsafe.