### PR TITLE
feat(model): message type deletable check methods

### DIFF
--- a/twilight-model/src/channel/message/kind.rs
+++ b/twilight-model/src/channel/message/kind.rs
@@ -71,7 +71,7 @@ impl MessageType {
     ///
     /// To check whether a message can be deleted while taking permissions into
     /// account, use
-    /// [`deletable_by_permissions`][`Self::deletable_by_permissions`].
+    /// [`deletable_with_permissions`][`Self::deletable_with_permissions`].
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     pub const fn deletable(self) -> bool {
@@ -251,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    fn deletable_by_type() {
+    fn deletable_with_permissions() {
         assert!(MessageType::AutoModerationAction
             .deletable_with_permissions(Permissions::MANAGE_MESSAGES));
         assert!(!MessageType::AutoModerationAction.deletable_with_permissions(Permissions::empty()));

--- a/twilight-model/src/channel/message/kind.rs
+++ b/twilight-model/src/channel/message/kind.rs
@@ -62,6 +62,7 @@ pub enum MessageType {
 
 impl MessageType {
     /// Whether the message can be deleted, not taking permissions into account.
+    /// Some message types can't be deleted, even by server administrators.
     ///
     /// Some message types can only be deleted with certain permissions. For
     /// example, [`AutoModerationAction`][`Self::AutoModerationAction`] can only
@@ -94,6 +95,7 @@ impl MessageType {
     }
 
     /// Whether the message can be deleted, taking permissions into account.
+    /// Some message types can't be deleted, even by server administrators.
     ///
     /// Some message types can only be deleted with certain permissions. For
     /// example, [`AutoModerationAction`][`Self::AutoModerationAction`] can only
@@ -183,9 +185,8 @@ impl From<MessageType> for u8 {
 
 #[cfg(test)]
 mod tests {
-    use crate::guild::Permissions;
-
     use super::MessageType;
+    use crate::guild::Permissions;
     use serde::{Deserialize, Serialize};
     use serde_test::Token;
     use static_assertions::assert_impl_all;

--- a/twilight-model/src/channel/message/kind.rs
+++ b/twilight-model/src/channel/message/kind.rs
@@ -105,7 +105,7 @@ impl MessageType {
     /// into account, use [`deletable`][`Self::deletable`].
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
-    pub const fn deletable_by_permissions(self, permissions: Permissions) -> bool {
+    pub const fn deletable_with_permissions(self, permissions: Permissions) -> bool {
         let required_permissions = match self {
             Self::AutoModerationAction => Permissions::MANAGE_MESSAGES,
             _ => Permissions::empty(),
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn deletable_by_type() {
         assert!(MessageType::AutoModerationAction
-            .deletable_by_permissions(Permissions::MANAGE_MESSAGES));
-        assert!(!MessageType::AutoModerationAction.deletable_by_permissions(Permissions::empty()));
+            .deletable_with_permissions(Permissions::MANAGE_MESSAGES));
+        assert!(!MessageType::AutoModerationAction.deletable_with_permissions(Permissions::empty()));
     }
 }


### PR DESCRIPTION
Add methods on `MessageType` to determine whether the message can be deleted, as some messages can't be deleted even by server administrators. This uses [the table present on the documentation](https://discord.com/developers/docs/resources/channel#message-object-message-types) for message types. Because this information is documented, we should expose it. Some message types can only be deleted by people with certain documented permissions, which at the moment is only `AUTO_MODERATION_ACTION` which requires the `MANAGE_MESSAGES` permission.

Included are two methods: `deletable` which doesn't check against a set of permissions, and `deletable_by_permissions` which *does* check against a set of permissions. Tests are included (and simplified along with the rest of the tests).

Example:

```rust
use twilight_model::{channel::message::MessageType, guild::Permissions};

assert!(MessageType::Regular.deletable());
assert!(!MessageType::GuildDiscoveryDisqualified.deletable());

// requires the MANAGE_MESSAGES permission, but is in general deletable
assert!(MessageType::AutoModerationAction.deletable());

assert!(!MessageType::AutoModerationAction.deletable_by_permission(Permissions::empty()));
assert!(MessageType::AutoModerationAction.deletable_by_permission(Permissions::MANAGE_MESSAGES));
```