### PR TITLE
refactor(model): abstract null boolean visitor

### DIFF
--- a/twilight-model/src/guild/role_tags.rs
+++ b/twilight-model/src/guild/role_tags.rs
@@ -34,11 +34,11 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn bot() {
+    fn role_tags_all() {
         let tags = RoleTags {
             bot_id: Some(Id::new(1)),
             integration_id: Some(Id::new(2)),
-            premium_subscriber: false,
+            premium_subscriber: true,
         };
 
         serde_test::assert_tokens(
@@ -46,7 +46,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "RoleTags",
-                    len: 2,
+                    len: 3,
                 },
                 Token::Str("bot_id"),
                 Token::Some,
@@ -56,26 +56,6 @@ mod tests {
                 Token::Some,
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("2"),
-                Token::StructEnd,
-            ],
-        );
-    }
-
-    #[test]
-    fn premium_subscriber() {
-        let tags = RoleTags {
-            bot_id: None,
-            integration_id: None,
-            premium_subscriber: true,
-        };
-
-        serde_test::assert_tokens(
-            &tags,
-            &[
-                Token::Struct {
-                    name: "RoleTags",
-                    len: 1,
-                },
                 Token::Str("premium_subscriber"),
                 Token::None,
                 Token::StructEnd,
@@ -83,11 +63,11 @@ mod tests {
         );
     }
 
-    /// Test that if all fields are None and the optional null fields are false,
-    /// then serialize back into the source payload (where all fields are not
+    /// Test that if all fields are None and `premium_subscriber` is false, then
+    /// serialize back into the source payload (where all fields are not
     /// present).
     #[test]
-    fn none() {
+    fn role_tags_none() {
         let tags = RoleTags {
             bot_id: None,
             integration_id: None,

--- a/twilight-model/src/guild/role_tags.rs
+++ b/twilight-model/src/guild/role_tags.rs
@@ -7,51 +7,6 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-/// The role tags' `premium_subscriber` field is tricky. It's an optional null.
-///
-/// If the field is present, then the value is null, meaning that the role is a
-/// premium subscriber. If the field is not present, it means that the role is
-/// *not* a premium subscriber.
-mod premium_subscriber {
-    use serde::{
-        de::{Deserializer, Error as DeError, Visitor},
-        ser::Serializer,
-    };
-    use std::fmt::{Formatter, Result as FmtResult};
-
-    struct PremiumSubscriberVisitor;
-
-    impl<'de> Visitor<'de> for PremiumSubscriberVisitor {
-        type Value = bool;
-
-        fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
-            f.write_str("null")
-        }
-
-        fn visit_none<E: DeError>(self) -> Result<Self::Value, E> {
-            Ok(true)
-        }
-
-        // `visit_none` is used by `serde_json` when a present `null` value is
-        // encountered, but other implementations - such as `simd_json` - may
-        // use `visit_unit` instead.
-        fn visit_unit<E: DeError>(self) -> Result<Self::Value, E> {
-            Ok(true)
-        }
-    }
-
-    // Clippy will say this bool can be taken by value, but we need it to be
-    // passed by reference because that's what serde does.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn serialize<S: Serializer>(_: &bool, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_none()
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<bool, D::Error> {
-        deserializer.deserialize_option(PremiumSubscriberVisitor)
-    }
-}
-
 /// Tags that a [`Role`] has.
 ///
 /// [`Role`]: super::Role
@@ -64,7 +19,11 @@ pub struct RoleTags {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub integration_id: Option<Id<IntegrationMarker>>,
     /// Whether this is the guild's premium subscriber role.
-    #[serde(default, skip_serializing_if = "is_false", with = "premium_subscriber")]
+    #[serde(
+        default,
+        skip_serializing_if = "is_false",
+        with = "crate::visitor::null_boolean"
+    )]
     pub premium_subscriber: bool,
 }
 
@@ -75,11 +34,11 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn role_tags_all() {
+    fn bot() {
         let tags = RoleTags {
             bot_id: Some(Id::new(1)),
             integration_id: Some(Id::new(2)),
-            premium_subscriber: true,
+            premium_subscriber: false,
         };
 
         serde_test::assert_tokens(
@@ -87,7 +46,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "RoleTags",
-                    len: 3,
+                    len: 2,
                 },
                 Token::Str("bot_id"),
                 Token::Some,
@@ -97,6 +56,26 @@ mod tests {
                 Token::Some,
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("2"),
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn premium_subscriber() {
+        let tags = RoleTags {
+            bot_id: None,
+            integration_id: None,
+            premium_subscriber: true,
+        };
+
+        serde_test::assert_tokens(
+            &tags,
+            &[
+                Token::Struct {
+                    name: "RoleTags",
+                    len: 1,
+                },
                 Token::Str("premium_subscriber"),
                 Token::None,
                 Token::StructEnd,
@@ -104,11 +83,11 @@ mod tests {
         );
     }
 
-    /// Test that if all fields are None and `premium_subscriber` is false, then
-    /// serialize back into the source payload (where all fields are not
+    /// Test that if all fields are None and the optional null fields are false,
+    /// then serialize back into the source payload (where all fields are not
     /// present).
     #[test]
-    fn role_tags_none() {
+    fn none() {
         let tags = RoleTags {
             bot_id: None,
             integration_id: None,

--- a/twilight-model/src/visitor.rs
+++ b/twilight-model/src/visitor.rs
@@ -5,6 +5,53 @@ use std::{
     marker::PhantomData,
 };
 
+/// Deserializers for optional nullable fields.
+///
+/// Some booleans in the Discord API are null when true, and not present when
+/// false. `serde` doesn't have a way of natively handling this, so we need some
+/// custom (de)serialization magic. [`RoleTags`] in particular has these fields.
+///
+/// [`RoleTags`]: crate::guild::RoleTags
+pub mod null_boolean {
+    use serde::{
+        de::{Deserializer, Error as DeError, Visitor},
+        ser::Serializer,
+    };
+    use std::fmt::{Formatter, Result as FmtResult};
+
+    struct NullBooleanVisitor;
+
+    impl<'de> Visitor<'de> for NullBooleanVisitor {
+        type Value = bool;
+
+        fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+            f.write_str("null")
+        }
+
+        fn visit_none<E: DeError>(self) -> Result<Self::Value, E> {
+            Ok(true)
+        }
+
+        // `visit_none` is used by `serde_json` when a present `null` value is
+        // encountered, but other implementations - such as `simd_json` - may
+        // use `visit_unit` instead.
+        fn visit_unit<E: DeError>(self) -> Result<Self::Value, E> {
+            Ok(true)
+        }
+    }
+
+    // Clippy will say this bool can be taken by value, but we need it to be
+    // passed by reference because that's what serde does.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn serialize<S: Serializer>(_: &bool, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_none()
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<bool, D::Error> {
+        deserializer.deserialize_option(NullBooleanVisitor)
+    }
+}
+
 pub struct U16EnumVisitor<'a> {
     description: &'a str,
     phantom: PhantomData<u16>,


### PR DESCRIPTION
Abstract the `RoleTags::premium_subscriber` null boolean visitor to the visitor module. Work is being done on adding a new field that functions exactly like `RoleTags::premium_subscriber`, where a missing field means false and a null value means true. It's best to abstract the visitor built for the field so it can be re-used elsewhere.