### PR TITLE
test(model): add real-world role tag tests

### DIFF
--- a/twilight-model/src/guild/role_tags.rs
+++ b/twilight-model/src/guild/role_tags.rs
@@ -75,11 +75,11 @@ mod tests {
     use serde_test::Token;
 
     #[test]
-    fn role_tags_all() {
+    fn bot() {
         let tags = RoleTags {
             bot_id: Some(Id::new(1)),
             integration_id: Some(Id::new(2)),
-            premium_subscriber: true,
+            premium_subscriber: false,
         };
 
         serde_test::assert_tokens(
@@ -87,7 +87,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "RoleTags",
-                    len: 3,
+                    len: 2,
                 },
                 Token::Str("bot_id"),
                 Token::Some,
@@ -97,6 +97,26 @@ mod tests {
                 Token::Some,
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("2"),
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn premium_subscriber() {
+        let tags = RoleTags {
+            bot_id: None,
+            integration_id: None,
+            premium_subscriber: true,
+        };
+
+        serde_test::assert_tokens(
+            &tags,
+            &[
+                Token::Struct {
+                    name: "RoleTags",
+                    len: 1,
+                },
                 Token::Str("premium_subscriber"),
                 Token::None,
                 Token::StructEnd,
@@ -104,11 +124,11 @@ mod tests {
         );
     }
 
-    /// Test that if all fields are None and `premium_subscriber` is false, then
-    /// serialize back into the source payload (where all fields are not
+    /// Test that if all fields are None and the optional null fields are false,
+    /// then serialize back into the source payload (where all fields are not
     /// present).
     #[test]
-    fn role_tags_none() {
+    fn none() {
         let tags = RoleTags {
             bot_id: None,
             integration_id: None,


### PR DESCRIPTION
The tests used for Role Tags weren't sets of role tags one would find in the real world. In particular, the test for "all" role tag fields can't happen because bots can't be premium subscribers. To fix this there are now three tests: one for bots, one for premium subscribers, and one for no role tags.