### PR TITLE
feat(gateway)!: add `Event::GatewayClose` variant

### DIFF
--- a/examples/gateway-parallel.rs
+++ b/examples/gateway-parallel.rs
@@ -8,10 +8,9 @@ use futures_util::{future::join_all, StreamExt};
 use std::{env, iter, sync::Arc, thread};
 use tokio::{signal, sync::watch, task::JoinSet};
 use twilight_gateway::{
-    message::CloseFrame,
     queue::LocalQueue,
     stream::{self, ShardEventStream},
-    Config, Intents, Shard,
+    CloseFrame, Config, Intents, Shard,
 };
 use twilight_http::Client;
 

--- a/twilight-cache-inmemory/src/lib.rs
+++ b/twilight-cache-inmemory/src/lib.rs
@@ -886,6 +886,7 @@ impl UpdateCache for Event {
             | Event::BanAdd(_)
             | Event::BanRemove(_)
             | Event::CommandPermissionsUpdate(_)
+            | Event::GatewayClose(_)
             | Event::GatewayHeartbeat(_)
             | Event::GatewayHeartbeatAck
             | Event::GatewayHello(_)

--- a/twilight-gateway/src/event.rs
+++ b/twilight-gateway/src/event.rs
@@ -325,6 +325,7 @@ impl From<EventType> for EventTypeFlags {
             EventType::ChannelPinsUpdate => Self::CHANNEL_PINS_UPDATE,
             EventType::ChannelUpdate => Self::CHANNEL_UPDATE,
             EventType::CommandPermissionsUpdate => Self::COMMAND_PERMISSIONS_UPDATE,
+            EventType::GatewayClose => Self::empty(),
             EventType::GatewayHeartbeat => Self::GATEWAY_HEARTBEAT,
             EventType::GatewayHeartbeatAck => Self::GATEWAY_HEARTBEAT_ACK,
             EventType::GatewayHello => Self::GATEWAY_HELLO,

--- a/twilight-gateway/src/lib.rs
+++ b/twilight-gateway/src/lib.rs
@@ -21,7 +21,6 @@
 )]
 
 pub mod error;
-pub mod message;
 pub mod stream;
 
 mod channel;
@@ -34,6 +33,7 @@ mod future;
 mod inflater;
 mod json;
 mod latency;
+mod message;
 mod ratelimiter;
 mod session;
 mod shard;
@@ -45,13 +45,14 @@ pub use self::{
     config::{Config, ConfigBuilder, ShardId},
     event::EventTypeFlags,
     latency::Latency,
+    message::Message,
     ratelimiter::CommandRatelimiter,
     session::Session,
     shard::{ConnectionStatus, Shard},
 };
 #[cfg(any(feature = "zlib-stock", feature = "zlib-simd"))]
 pub use inflater::Inflater;
-pub use twilight_model::gateway::Intents;
+pub use twilight_model::gateway::{CloseFrame, Intents};
 
 #[doc(no_inline)]
 pub use twilight_gateway_queue as queue;

--- a/twilight-gateway/src/message.rs
+++ b/twilight-gateway/src/message.rs
@@ -1,4 +1,4 @@
-//! Send raw websocket messages over the websocket.
+//! Raw websocket message.
 //!
 //! This is mostly equivalent to the underlying websocket library's message, but
 //! this intermediary exists to prevent exposing it in the public API. Messages
@@ -6,94 +6,11 @@
 //! input will not be checked and will be passed directly to the underlying
 //! websocket library.
 
-use std::borrow::Cow;
 use tokio_tungstenite::tungstenite::{
     protocol::{frame::coding::CloseCode, CloseFrame as TungsteniteCloseFrame},
     Message as TungsteniteMessage,
 };
-
-/// Information about a [close message].
-///
-/// A close frame can be constructed via [`CloseFrame::new`]. A default close
-/// frame for causing a [full session disconnect] and for
-/// [causing a session resume] are provided.
-///
-/// [causing a session resume]: CloseFrame::RESUME
-/// [close message]: Message::Close
-/// [full session disconnect]: CloseFrame::NORMAL
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub struct CloseFrame<'a> {
-    /// Reason for the close.
-    code: u16,
-    /// Textual representation of the reason the connection is being closed.
-    reason: Cow<'a, str>,
-}
-
-impl<'a> CloseFrame<'a> {
-    /// Normal close code indicating the shard will not be reconnecting soon.
-    ///
-    /// Sending [`Message::Close`] with this frame will cause Discord to
-    /// invalidate your session. If you intend to resume your session soon,
-    /// use [`RESUME`].
-    ///
-    /// [`RESUME`]: Self::RESUME
-    pub const NORMAL: Self = Self::new(1000, "closing connection");
-
-    /// Close code indicating the shard will be reconnecting soon.
-    ///
-    /// Sending [`Message::Close`] with this frame will cause Discord to keep
-    /// your session alive. If you **don't** intend to resume your session soon,
-    /// use [`NORMAL`].
-    ///
-    /// [`NORMAL`]: Self::NORMAL
-    pub const RESUME: Self = Self::new(4000, "resuming connection");
-
-    /// Construct a close frame from a code and a reason why.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use twilight_gateway::message::CloseFrame;
-    ///
-    /// let frame = CloseFrame::new(1000, "reason here");
-    ///
-    /// assert_eq!(1000, frame.code());
-    /// assert_eq!("reason here", frame.reason());
-    /// ```
-    pub const fn new(code: u16, reason: &'a str) -> Self {
-        Self {
-            code,
-            reason: Cow::Borrowed(reason),
-        }
-    }
-
-    /// Close code of the frame.
-    pub const fn code(&self) -> u16 {
-        self.code
-    }
-
-    /// Reason for the close.
-    pub fn reason(&self) -> &str {
-        self.reason.as_ref()
-    }
-
-    /// Convert a `tungstenite` close frame into a `twilight` close frame.
-    pub(crate) fn from_tungstenite(tungstenite: TungsteniteCloseFrame<'a>) -> Self {
-        Self {
-            code: u16::from(tungstenite.code),
-            reason: tungstenite.reason,
-        }
-    }
-
-    /// Convert a `twilight` close frame into a `tungstenite` close frame.
-    pub(crate) fn into_tungstenite(self) -> TungsteniteCloseFrame<'a> {
-        TungsteniteCloseFrame {
-            code: CloseCode::from(self.code),
-            reason: self.reason,
-        }
-    }
-}
+use twilight_model::gateway::CloseFrame;
 
 /// Message to send over the connection to the remote.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -112,11 +29,10 @@ impl Message {
     /// message.
     pub(crate) fn from_tungstenite(tungstenite: TungsteniteMessage) -> Option<Self> {
         match tungstenite {
-            TungsteniteMessage::Close(maybe_close) => {
-                let close = maybe_close.map(CloseFrame::from_tungstenite);
-
-                Some(Self::Close(close))
-            }
+            TungsteniteMessage::Close(frame) => Some(Self::Close(frame.map(|frame| CloseFrame {
+                code: frame.code.into(),
+                reason: frame.reason,
+            }))),
             TungsteniteMessage::Text(string) => Some(Self::Text(string)),
             TungsteniteMessage::Binary(_)
             | TungsteniteMessage::Frame(_)
@@ -129,8 +45,11 @@ impl Message {
     /// message.
     pub(crate) fn into_tungstenite(self) -> TungsteniteMessage {
         match self {
-            Self::Close(close) => {
-                TungsteniteMessage::Close(close.map(CloseFrame::into_tungstenite))
+            Self::Close(frame) => {
+                TungsteniteMessage::Close(frame.map(|frame| TungsteniteCloseFrame {
+                    code: CloseCode::from(frame.code),
+                    reason: frame.reason,
+                }))
             }
             Self::Text(string) => TungsteniteMessage::Text(string),
         }
@@ -139,16 +58,9 @@ impl Message {
 
 #[cfg(test)]
 mod tests {
-    use super::{CloseFrame, Message};
+    use super::Message;
     use static_assertions::assert_impl_all;
     use std::fmt::Debug;
 
-    assert_impl_all!(
-        CloseFrame<'_>:
-        Clone,
-        Debug,
-        Eq,
-        PartialEq,
-    );
     assert_impl_all!(Message: Clone, Debug, Eq, PartialEq);
 }

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -701,10 +701,7 @@ impl Shard {
     /// ```no_run
     /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use std::{borrow::Cow, env};
-    /// use twilight_gateway::{
-    ///     message::{CloseFrame, Message},
-    ///     Intents, Shard, ShardId,
-    /// };
+    /// use twilight_gateway::{CloseFrame, Intents, Message, Shard, ShardId};
     ///
     /// let token = env::var("DISCORD_TOKEN")?;
     /// let mut shard = Shard::new(ShardId::ONE, token, Intents::GUILDS);
@@ -788,10 +785,7 @@ impl Shard {
     /// # use twilight_gateway::{Intents, Shard, ShardId};
     /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let mut shard = Shard::new(ShardId::ONE, String::new(), Intents::empty());
-    /// use twilight_gateway::{
-    ///     error::ReceiveMessageErrorType,
-    ///     message::{CloseFrame, Message},
-    /// };
+    /// use twilight_gateway::{error::ReceiveMessageErrorType, CloseFrame, Message};
     ///
     /// shard.close(CloseFrame::NORMAL).await?;
     ///

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -68,10 +68,9 @@ use crate::{
     future::{self, NextMessageFuture, NextMessageFutureOutput},
     json,
     latency::Latency,
-    message::{CloseFrame, Message},
     ratelimiter::CommandRatelimiter,
     session::Session,
-    Config, ShardId,
+    Config, Message, ShardId,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::{de::DeserializeOwned, Deserialize};
@@ -92,7 +91,7 @@ use twilight_model::gateway::{
             Heartbeat, Identify, Resume,
         },
     },
-    CloseCode, Intents, OpCode,
+    CloseCode, CloseFrame, Intents, OpCode,
 };
 
 /// Who initiated the closing of the websocket connection.
@@ -463,7 +462,7 @@ impl Shard {
     pub async fn next_event(&mut self) -> Result<Event, ReceiveMessageError> {
         loop {
             match self.next_message().await? {
-                Message::Close(_) => {}
+                Message::Close(frame) => return Ok(Event::GatewayClose(frame)),
                 Message::Text(json) => {
                     if let Some(event) = json::parse(self.config.event_types(), json)? {
                         return Ok(event.into());
@@ -618,7 +617,7 @@ impl Shard {
                 // Don't run `disconnect` if we initiated the close.
                 if !self.status.is_disconnected() {
                     self.disconnect(CloseInitiator::Gateway(
-                        frame.as_ref().map(CloseFrame::code),
+                        frame.as_ref().map(|frame| frame.code),
                     ));
                 }
             }
@@ -823,7 +822,7 @@ impl Shard {
         &mut self,
         close_frame: CloseFrame<'static>,
     ) -> Result<Option<Session>, SendError> {
-        let close_code = close_frame.code();
+        let close_code = close_frame.code;
 
         tracing::debug!(frame = ?close_frame, "sending websocket close message");
         let message = Message::Close(Some(close_frame));

--- a/twilight-model/src/gateway/event/kind.rs
+++ b/twilight-model/src/gateway/event/kind.rs
@@ -18,6 +18,7 @@ pub enum EventType {
     ChannelUpdate,
     #[serde(rename = "APPLICATION_COMMAND_PERMISSIONS_UPDATE")]
     CommandPermissionsUpdate,
+    GatewayClose,
     GatewayHeartbeat,
     GatewayHeartbeatAck,
     GatewayHello,
@@ -154,7 +155,8 @@ impl EventType {
             Self::VoiceServerUpdate => Some("VOICE_SERVER_UPDATE"),
             Self::VoiceStateUpdate => Some("VOICE_STATE_UPDATE"),
             Self::WebhooksUpdate => Some("WEBHOOKS_UPDATE"),
-            Self::GatewayHeartbeat
+            Self::GatewayClose
+            | Self::GatewayHeartbeat
             | Self::GatewayHeartbeatAck
             | Self::GatewayHello
             | Self::GatewayInvalidateSession
@@ -279,6 +281,7 @@ mod tests {
             EventType::CommandPermissionsUpdate,
             "APPLICATION_COMMAND_PERMISSIONS_UPDATE",
         );
+        assert_variant(EventType::GatewayClose, "GATEWAY_CLOSE");
         assert_variant(EventType::GatewayHeartbeat, "GATEWAY_HEARTBEAT");
         assert_variant(EventType::GatewayHeartbeatAck, "GATEWAY_HEARTBEAT_ACK");
         assert_variant(EventType::GatewayHello, "GATEWAY_HELLO");

--- a/twilight-model/src/gateway/event/mod.rs
+++ b/twilight-model/src/gateway/event/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
     kind::EventType,
 };
 
-use super::payload::incoming::*;
+use super::{payload::incoming::*, CloseFrame};
 use crate::id::{marker::GuildMarker, Id};
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
@@ -44,6 +44,9 @@ pub enum Event {
     ChannelUpdate(Box<ChannelUpdate>),
     /// A command's permissions were updated.
     CommandPermissionsUpdate(CommandPermissionsUpdate),
+    /// Close message with an optional frame including information about the
+    /// reason for the close.
+    GatewayClose(Option<CloseFrame<'static>>),
     /// A heartbeat was sent to or received from the gateway.
     GatewayHeartbeat(u64),
     /// A heartbeat acknowledgement was received from the gateway.
@@ -230,6 +233,7 @@ impl Event {
             Event::VoiceStateUpdate(e) => e.0.guild_id,
             Event::WebhooksUpdate(e) => Some(e.guild_id),
             Event::ChannelPinsUpdate(_)
+            | Event::GatewayClose(_)
             | Event::GatewayHeartbeat(_)
             | Event::GatewayHeartbeatAck
             | Event::GatewayHello(_)
@@ -260,6 +264,7 @@ impl Event {
             Self::ChannelPinsUpdate(_) => EventType::ChannelPinsUpdate,
             Self::ChannelUpdate(_) => EventType::ChannelUpdate,
             Self::CommandPermissionsUpdate(_) => EventType::CommandPermissionsUpdate,
+            Self::GatewayClose(_) => EventType::GatewayClose,
             Self::GatewayHeartbeat(_) => EventType::GatewayHeartbeat,
             Self::GatewayHeartbeatAck => EventType::GatewayHeartbeatAck,
             Self::GatewayHello(_) => EventType::GatewayHello,

--- a/twilight-model/src/gateway/frame.rs
+++ b/twilight-model/src/gateway/frame.rs
@@ -50,8 +50,8 @@ impl<'a> CloseFrame<'a> {
     ///
     /// let frame = CloseFrame::new(1000, "reason here");
     ///
-    /// assert_eq!(1000, frame.code());
-    /// assert_eq!("reason here", frame.reason());
+    /// assert_eq!(1000, frame.code);
+    /// assert_eq!("reason here", frame.reason);
     /// ```
     pub const fn new(code: u16, reason: &'a str) -> Self {
         Self {

--- a/twilight-model/src/gateway/frame.rs
+++ b/twilight-model/src/gateway/frame.rs
@@ -1,0 +1,77 @@
+//! Raw Websocket frame.
+//!
+//! This is mostly equivalent to the underlying websocket library's message, but
+//! this intermediary exists to prevent exposing it in the public API. Messages
+//! constructed are equivalent to what the underlying library will receive. The
+//! input will not be checked and will be passed directly to the underlying
+//! websocket library.
+
+use std::borrow::Cow;
+
+/// Information about a close message.
+///
+/// A close frame can be constructed via [`CloseFrame::new`]. A default close
+/// frame for causing a [full session disconnect] and for
+/// [causing a session resume] are provided.
+///
+/// [causing a session resume]: CloseFrame::RESUME
+/// [full session disconnect]: CloseFrame::NORMAL
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CloseFrame<'a> {
+    /// Reason for the close.
+    pub code: u16,
+    /// Textual representation of the reason the connection is being closed.
+    pub reason: Cow<'a, str>,
+}
+
+impl<'a> CloseFrame<'a> {
+    /// Normal close code indicating the shard will not be reconnecting soon.
+    ///
+    /// This frame will cause Discord to invalidate your session. If you intend
+    /// to resume your session soon, use [`RESUME`].
+    ///
+    /// [`RESUME`]: Self::RESUME
+    pub const NORMAL: Self = Self::new(1000, "closing connection");
+
+    /// Close code indicating the shard will be reconnecting soon.
+    ///
+    /// This frame will cause Discord to keep your session alive. If you
+    /// **don't** intend to resume your session soon, use [`NORMAL`].
+    ///
+    /// [`NORMAL`]: Self::NORMAL
+    pub const RESUME: Self = Self::new(4000, "resuming connection");
+
+    /// Construct a close frame from a code and a reason why.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use twilight_model::gateway::CloseFrame;
+    ///
+    /// let frame = CloseFrame::new(1000, "reason here");
+    ///
+    /// assert_eq!(1000, frame.code());
+    /// assert_eq!("reason here", frame.reason());
+    /// ```
+    pub const fn new(code: u16, reason: &'a str) -> Self {
+        Self {
+            code,
+            reason: Cow::Borrowed(reason),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CloseFrame;
+    use static_assertions::assert_impl_all;
+    use std::fmt::Debug;
+
+    assert_impl_all!(
+        CloseFrame<'_>:
+        Clone,
+        Debug,
+        Eq,
+        PartialEq,
+    );
+}

--- a/twilight-model/src/gateway/mod.rs
+++ b/twilight-model/src/gateway/mod.rs
@@ -4,6 +4,7 @@ pub mod payload;
 pub mod presence;
 
 mod close_code;
+mod frame;
 mod intents;
 mod opcode;
 mod reaction;
@@ -11,6 +12,7 @@ mod session_start_limit;
 
 pub use self::{
     close_code::{CloseCode, CloseCodeConversionError},
+    frame::CloseFrame,
     intents::Intents,
     opcode::OpCode,
     reaction::GatewayReaction,


### PR DESCRIPTION
Adds a sought after equivalent of `Message::Close` to the `Event` enum, avoiding users having to reimplement `Shard::next_event` themselves just for handling closes.

The `CloseFrame`'s fields are now public and it's no longer marked as non-exhaustive.