### PR TITLE
docs(gateway): don't build all features on docs.rs

### DIFF
--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -58,5 +58,4 @@ zlib-simd = ["dep:flate2", "flate2?/zlib-ng"]
 zlib-stock = ["dep:flate2", "flate2?/zlib"]
 
 [package.metadata.docs.rs]
-all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
The RC's [build failed], so this is the workaround I can think of. 

[build failed]: https://docs.rs/crate/twilight-gateway/0.15.0-rc.1/builds/716646