### PR TITLE
perf(gateway): defer creating `Deserializer` until checking event is wanted

### DIFF
--- a/twilight-gateway/src/json.rs
+++ b/twilight-gateway/src/json.rs
@@ -32,16 +32,15 @@ pub fn parse(
     let gateway_deserializer =
         GatewayEventDeserializer::from_json(&json).expect("Shard::process asserted valid opcode");
 
-    let opcode = match OpCode::from(gateway_deserializer.op()) {
-        Some(opcode) => opcode,
-        None => {
-            let opcode = gateway_deserializer.op();
+    let opcode = if let Some(opcode) = OpCode::from(gateway_deserializer.op()) {
+        opcode
+    } else {
+        let opcode = gateway_deserializer.op();
 
-            return Err(ReceiveMessageError {
-                kind: ReceiveMessageErrorType::Deserializing { event: json },
-                source: Some(format!("unknown opcode: {opcode}").into()),
-            });
-        }
+        return Err(ReceiveMessageError {
+            kind: ReceiveMessageErrorType::Deserializing { event: json },
+            source: Some(format!("unknown opcode: {opcode}").into()),
+        });
     };
 
     let event_type = gateway_deserializer.event_type();

--- a/twilight-gateway/src/json.rs
+++ b/twilight-gateway/src/json.rs
@@ -46,17 +46,16 @@ pub fn parse(
 
     let event_type = gateway_deserializer.event_type();
 
-    let event_flag = match EventTypeFlags::try_from((opcode, event_type)) {
-        Ok(event_flag) => event_flag,
-        Err(_) => {
-            let opcode = opcode as u8;
-            let source = format!("unknown opcode/dispatch event type: {opcode}/{event_type:?}");
+    let event_flag = if let Ok(event_flag) = EventTypeFlags::try_from((opcode, event_type)) {
+        event_flag
+    } else {
+        let opcode = opcode as u8;
+        let source = format!("unknown opcode/dispatch event type: {opcode}/{event_type:?}");
 
-            return Err(ReceiveMessageError {
-                kind: ReceiveMessageErrorType::Deserializing { event: json },
-                source: Some(source.into()),
-            });
-        }
+        return Err(ReceiveMessageError {
+            kind: ReceiveMessageErrorType::Deserializing { event: json },
+            source: Some(source.into()),
+        });
     };
 
     if event_types.contains(event_flag) {

--- a/twilight-gateway/src/json.rs
+++ b/twilight-gateway/src/json.rs
@@ -11,7 +11,6 @@ use crate::{
     EventTypeFlags,
 };
 use serde::de::DeserializeSeed;
-use std::str;
 use twilight_model::gateway::{
     event::{GatewayEvent, GatewayEventDeserializer},
     OpCode,
@@ -30,18 +29,44 @@ pub fn parse(
     event_types: EventTypeFlags,
     json: String,
 ) -> Result<Option<GatewayEvent>, ReceiveMessageError> {
-    #[cfg_attr(not(feature = "simd-json"), allow(unused_mut))]
-    let mut bytes = json.into_bytes();
-    let json = str::from_utf8(&bytes).unwrap();
-
     let gateway_deserializer =
-        GatewayEventDeserializer::from_json(json).expect("Shard::process asserted valid opcode");
+        GatewayEventDeserializer::from_json(&json).expect("Shard::process asserted valid opcode");
 
-    #[cfg(feature = "simd-json")]
-    let (gateway_deserializer, mut json_deserializer) = {
+    let opcode = match OpCode::from(gateway_deserializer.op()) {
+        Some(opcode) => opcode,
+        None => {
+            let opcode = gateway_deserializer.op();
+
+            return Err(ReceiveMessageError {
+                kind: ReceiveMessageErrorType::Deserializing { event: json },
+                source: Some(format!("unknown opcode: {opcode}").into()),
+            });
+        }
+    };
+
+    let event_type = gateway_deserializer.event_type();
+
+    let event_flag = match EventTypeFlags::try_from((opcode, event_type)) {
+        Ok(event_flag) => event_flag,
+        Err(_) => {
+            let opcode = opcode as u8;
+            let source = format!("unknown opcode/dispatch event type: {opcode}/{event_type:?}");
+
+            return Err(ReceiveMessageError {
+                kind: ReceiveMessageErrorType::Deserializing { event: json },
+                source: Some(source.into()),
+            });
+        }
+    };
+
+    if event_types.contains(event_flag) {
+        #[cfg(feature = "simd-json")]
         let gateway_deserializer = gateway_deserializer.into_owned();
+        #[cfg(feature = "simd-json")]
+        let mut bytes = json.into_bytes();
 
-        let json_deserializer = match simd_json::Deserializer::from_slice(&mut bytes) {
+        #[cfg(feature = "simd-json")]
+        let mut json_deserializer = match simd_json::Deserializer::from_slice(&mut bytes) {
             Ok(deserializer) => deserializer,
             Err(source) => {
                 return Err(ReceiveMessageError {
@@ -53,51 +78,18 @@ pub fn parse(
             }
         };
 
-        (gateway_deserializer, json_deserializer)
-    };
+        #[cfg(not(feature = "simd-json"))]
+        let mut json_deserializer = serde_json::Deserializer::from_str(&json);
 
-    #[cfg(not(feature = "simd-json"))]
-    let mut json_deserializer = serde_json::Deserializer::from_str(json);
-
-    let opcode = match OpCode::from(gateway_deserializer.op()) {
-        Some(opcode) => opcode,
-        None => {
-            return Err(ReceiveMessageError {
-                kind: ReceiveMessageErrorType::Deserializing {
-                    event: String::from_utf8_lossy(&bytes).into_owned(),
-                },
-                source: Some(format!("unknown opcode: {}", gateway_deserializer.op()).into()),
-            })
-        }
-    };
-
-    let event_type = gateway_deserializer.event_type();
-
-    let event_flag = match EventTypeFlags::try_from((opcode, event_type)) {
-        Ok(event_flag) => event_flag,
-        Err(_) => {
-            return Err(ReceiveMessageError {
-                kind: ReceiveMessageErrorType::Deserializing {
-                    event: String::from_utf8_lossy(&bytes).into_owned(),
-                },
-                source: Some(
-                    format!(
-                        "unknown opcode/dispatch event type: {}/{event_type:?}",
-                        opcode as u8
-                    )
-                    .into(),
-                ),
-            })
-        }
-    };
-
-    if event_types.contains(event_flag) {
         gateway_deserializer
             .deserialize(&mut json_deserializer)
             .map(Some)
             .map_err(|source| ReceiveMessageError {
                 kind: ReceiveMessageErrorType::Deserializing {
+                    #[cfg(feature = "simd-json")]
                     event: String::from_utf8_lossy(&bytes).into_owned(),
+                    #[cfg(not(feature = "simd-json"))]
+                    event: json,
                 },
                 source: Some(Box::new(source)),
             })


### PR DESCRIPTION
Most events entering `parse` are thrown out due to users' `EventTypeFlags` not wanting them. This PR tries to optimize this path by deferring the creation of the deserializer until the `EventTypeFlags` check.

Moved out of #2024
