### PR TITLE
feat(http, model): get current authorization route

### DIFF
--- a/twilight-http-ratelimiting/src/request.rs
+++ b/twilight-http-ratelimiting/src/request.rs
@@ -252,6 +252,8 @@ pub enum Path {
     InvitesCode,
     /// Operating on the user's application information.
     OauthApplicationsMe,
+    /// Operating on the current authorization's information.
+    OauthMe,
     /// Operating on stage instances.
     StageInstances,
     /// Operating on sticker packs.
@@ -425,6 +427,7 @@ impl FromStr for Path {
             ["sticker-packs"] => StickerPacks,
             ["stickers", _] => Stickers,
             ["oauth2", "applications", "@me"] => OauthApplicationsMe,
+            ["oauth2", "@me"] => OauthMe,
             ["users", _] => UsersId,
             ["users", _, "connections"] => UsersIdConnections,
             ["users", _, "channels"] => UsersIdChannels,

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -4,6 +4,7 @@ mod interaction;
 
 pub use self::{builder::ClientBuilder, interaction::InteractionClient};
 
+use crate::request::GetCurrentAuthorizationInformation;
 #[allow(deprecated)]
 use crate::{
     client::connector::Connector,
@@ -649,6 +650,11 @@ impl Client {
         guild_id: Id<GuildMarker>,
     ) -> GetCurrentUserGuildMember<'_> {
         GetCurrentUserGuildMember::new(self, guild_id)
+    }
+
+    /// Get information about the current OAuth authorization.
+    pub const fn current_authorization(&self) -> GetCurrentAuthorizationInformation<'_> {
+        GetCurrentAuthorizationInformation::new(self)
     }
 
     /// Get information about the current bot application.

--- a/twilight-http/src/request/get_current_authorization_information.rs
+++ b/twilight-http/src/request/get_current_authorization_information.rs
@@ -1,0 +1,98 @@
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
+    routing::Route,
+};
+use std::future::IntoFuture;
+use twilight_model::oauth::CurrentAuthorizationInformation;
+
+/// Retrieve information about the current OAuth authorization.
+///
+/// Returns the application's, authorization's, and if applicable the user's
+/// details.
+///
+/// Refer to [Discord Docs/Get Current Authorization Information][1].
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::env;
+/// use twilight_http::Client;
+///
+/// let bearer_token = env::var("BEARER_TOKEN")?;
+///
+/// let client = Client::new(bearer_token);
+/// let response = client.current_authorization().await?;
+/// let authorization = response.model().await?;
+///
+/// println!("Application: {}", authorization.application.name);
+///
+/// if let Some(user) = authorization.user {
+///     println!("User: {}", user.name);
+/// }
+/// # Ok(()) }
+/// ```
+///
+/// [1]: https://discord.com/developers/docs/topics/oauth2#get-current-authorization-information
+#[must_use = "requests must be configured and executed"]
+pub struct GetCurrentAuthorizationInformation<'a> {
+    http: &'a Client,
+}
+
+impl<'a> GetCurrentAuthorizationInformation<'a> {
+    pub(crate) const fn new(http: &'a Client) -> Self {
+        Self { http }
+    }
+}
+
+impl IntoFuture for GetCurrentAuthorizationInformation<'_> {
+    type Output = Result<Response<CurrentAuthorizationInformation>, Error>;
+
+    type IntoFuture = ResponseFuture<CurrentAuthorizationInformation>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
+    }
+}
+
+impl TryIntoRequest for GetCurrentAuthorizationInformation<'_> {
+    fn try_into_request(self) -> Result<Request, Error> {
+        Ok(Request::from_route(
+            &Route::GetCurrentAuthorizationInformation,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GetCurrentAuthorizationInformation;
+    use crate::{client::Client, request::TryIntoRequest};
+    use static_assertions::assert_impl_all;
+    use std::{error::Error, future::IntoFuture};
+    use twilight_http_ratelimiting::{Method, Path};
+
+    assert_impl_all!(GetCurrentAuthorizationInformation<'_>: IntoFuture, Send, Sync, TryIntoRequest);
+
+    #[test]
+    fn get_current_authorization_information() -> Result<(), Box<dyn Error>> {
+        let client = Client::new(String::new());
+        let req = client.current_authorization().try_into_request()?;
+
+        assert!(req.use_authorization_token());
+        assert!(req.body().is_none());
+        assert!(req.form().is_none());
+        assert!(req.headers().is_none());
+        assert_eq!(Method::Get, req.method());
+        assert_eq!(&Path::OauthMe, req.ratelimit_path());
+
+        Ok(())
+    }
+}

--- a/twilight-http/src/request/mod.rs
+++ b/twilight-http/src/request/mod.rs
@@ -9,6 +9,7 @@ pub mod user;
 
 mod audit_reason;
 mod base;
+mod get_current_authorization_information;
 mod get_gateway;
 mod get_gateway_authed;
 mod get_user_application;
@@ -19,6 +20,7 @@ mod try_into_request;
 pub use self::{
     audit_reason::AuditLogReason,
     base::{Request, RequestBuilder},
+    get_current_authorization_information::GetCurrentAuthorizationInformation,
     get_gateway::GetGateway,
     get_gateway_authed::GetGatewayAuthed,
     get_user_application::GetUserApplicationInfo,

--- a/twilight-http/src/request/try_into_request.rs
+++ b/twilight-http/src/request/try_into_request.rs
@@ -86,7 +86,8 @@ mod private {
             GetCurrentUserGuildMember, GetCurrentUserGuilds, GetUser, LeaveGuild,
             UpdateCurrentUser,
         },
-        GetGateway, GetGatewayAuthed, GetUserApplicationInfo, GetVoiceRegions,
+        GetCurrentAuthorizationInformation, GetGateway, GetGatewayAuthed, GetUserApplicationInfo,
+        GetVoiceRegions,
     };
 
     pub trait Sealed {}
@@ -170,6 +171,7 @@ mod private {
     impl Sealed for GetChannelWebhooks<'_> {}
     impl Sealed for GetCommandPermissions<'_> {}
     impl Sealed for GetCurrentUser<'_> {}
+    impl Sealed for GetCurrentAuthorizationInformation<'_> {}
     impl Sealed for GetCurrentUserConnections<'_> {}
     impl Sealed for GetCurrentUserGuildMember<'_> {}
     impl Sealed for GetCurrentUserGuilds<'_> {}

--- a/twilight-http/src/routing.rs
+++ b/twilight-http/src/routing.rs
@@ -433,6 +433,8 @@ pub enum Route<'a> {
         /// The ID of the guild.
         guild_id: u64,
     },
+    /// Route information to get the current OAuth authorization information.
+    GetCurrentAuthorizationInformation,
     /// Route information to get the current user.
     GetCurrentUser,
     /// Route information to get info about application the current bot user belongs to
@@ -1143,6 +1145,7 @@ impl<'a> Route<'a> {
             | Self::GetChannelWebhooks { .. }
             | Self::GetChannels { .. }
             | Self::GetCommandPermissions { .. }
+            | Self::GetCurrentAuthorizationInformation
             | Self::GetCurrentUserApplicationInfo
             | Self::GetCurrentUser
             | Self::GetCurrentUserGuildMember { .. }
@@ -1511,6 +1514,7 @@ impl<'a> Route<'a> {
             | Self::UpdateCommandPermissions { application_id, .. } => {
                 Path::ApplicationGuildCommandId(application_id)
             }
+            Self::GetCurrentAuthorizationInformation => Path::OauthMe,
             Self::GetCurrentUserApplicationInfo => Path::OauthApplicationsMe,
             Self::GetCurrentUser | Self::GetUser { .. } | Self::UpdateCurrentUser => Path::UsersId,
             Self::GetCurrentUserGuildMember { .. } => Path::UsersIdGuildsIdMember,
@@ -2327,6 +2331,7 @@ impl Display for Route<'_> {
 
                 f.write_str("/permissions")
             }
+            Route::GetCurrentAuthorizationInformation => f.write_str("oauth2/@me"),
             Route::GetCurrentUserApplicationInfo => f.write_str("oauth2/applications/@me"),
             Route::GetCurrentUser | Route::UpdateCurrentUser => f.write_str("users/@me"),
             Route::GetCurrentUserGuildMember { guild_id } => {
@@ -3950,6 +3955,12 @@ mod tests {
                 "applications/{APPLICATION_ID}/guilds/{GUILD_ID}/commands/{COMMAND_ID}/permissions"
             )
         );
+    }
+
+    #[test]
+    fn get_current_authorization_info() {
+        let route = Route::GetCurrentAuthorizationInformation;
+        assert_eq!(route.to_string(), "oauth2/@me");
     }
 
     #[test]

--- a/twilight-model/src/oauth/current_authorization_information.rs
+++ b/twilight-model/src/oauth/current_authorization_information.rs
@@ -1,0 +1,158 @@
+use super::Application;
+use crate::{user::User, util::Timestamp};
+use serde::{Deserialize, Serialize};
+
+/// Information about the current OAuth authorization.
+///
+/// Requires authentication with a bearer token to make the request necessary to
+/// retrieve this.
+///
+/// Refer to [Discord Docs/Get Current Authorization Information][1] for more
+/// information.
+///
+/// [1]: https://discord.com/developers/docs/topics/oauth2#get-current-authorization-information
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CurrentAuthorizationInformation {
+    /// Current application.
+    pub application: Application,
+    /// When the access token expires.
+    pub expires: Timestamp,
+    /// List of [scopes] the [`user`] has authorized the [`application`] for.
+    ///
+    /// [`application`]: Self::application
+    /// [`user`]: Self::user
+    /// [scopes]: crate::oauth::scope
+    pub scopes: Vec<String>,
+    /// User who has authorized, if the user has authorized with the
+    /// [`IDENTIFY`] scope.
+    ///
+    /// [`IDENTIFY`]: crate::oauth::scope::IDENTIFY
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<User>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        id::Id,
+        oauth::{scope, Application},
+        test::image_hash,
+        util::{datetime::TimestampParseError, Timestamp},
+    };
+
+    use super::CurrentAuthorizationInformation;
+    use serde::{Deserialize, Serialize};
+    use serde_test::{assert_tokens, Token};
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::fmt::Debug;
+
+    assert_fields!(
+        CurrentAuthorizationInformation: application,
+        expires,
+        scopes,
+        user
+    );
+    assert_impl_all!(
+        CurrentAuthorizationInformation: Clone,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        PartialEq,
+        Send,
+        Serialize,
+        Sync
+    );
+
+    #[test]
+    fn serde() -> Result<(), TimestampParseError> {
+        const DESCRIPTION: &str =
+            "Twilight Sparkle is the central main character of My Little Pony Friendship is Magic.";
+        const NAME: &str = "Twilight Sparkle";
+
+        let value = CurrentAuthorizationInformation {
+            application: Application {
+                bot_public: true,
+                bot_require_code_grant: true,
+                cover_image: None,
+                custom_install_url: None,
+                description: DESCRIPTION.to_owned(),
+                guild_id: None,
+                flags: None,
+                icon: Some(image_hash::ICON),
+                id: Id::new(100_000_000_000_000_000),
+                install_params: None,
+                name: NAME.to_owned(),
+                owner: None,
+                primary_sku_id: None,
+                privacy_policy_url: None,
+                rpc_origins: Vec::new(),
+                slug: None,
+                tags: None,
+                team: None,
+                terms_of_service_url: None,
+                verify_key: "a".to_owned(),
+            },
+            expires: Timestamp::parse("2023-01-09T17:19:44.000000+00:00")?,
+            scopes: Vec::from([scope::APPLICATIONS_COMMANDS_PERMISSIONS_UPDATE.to_owned()]),
+            user: None,
+        };
+
+        assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "CurrentAuthorizationInformation",
+                    len: 3,
+                },
+                Token::Str("application"),
+                Token::Struct {
+                    name: "Application",
+                    len: 15,
+                },
+                Token::Str("bot_public"),
+                Token::Bool(true),
+                Token::Str("bot_require_code_grant"),
+                Token::Bool(true),
+                Token::Str("cover_image"),
+                Token::None,
+                Token::Str("description"),
+                Token::Str(DESCRIPTION),
+                Token::Str("guild_id"),
+                Token::None,
+                Token::Str("flags"),
+                Token::None,
+                Token::Str("icon"),
+                Token::Some,
+                Token::Str(image_hash::ICON_INPUT),
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "Id" },
+                Token::Str("100000000000000000"),
+                Token::Str("name"),
+                Token::Str(NAME),
+                Token::Str("owner"),
+                Token::None,
+                Token::Str("primary_sku_id"),
+                Token::None,
+                Token::Str("rpc_origins"),
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
+                Token::Str("slug"),
+                Token::None,
+                Token::Str("team"),
+                Token::None,
+                Token::Str("verify_key"),
+                Token::Str("a"),
+                Token::StructEnd,
+                Token::Str("expires"),
+                Token::Str("2023-01-09T17:19:44.000000+00:00"),
+                Token::Str("scopes"),
+                Token::Seq { len: Some(1) },
+                Token::Str(scope::APPLICATIONS_COMMANDS_PERMISSIONS_UPDATE),
+                Token::SeqEnd,
+                Token::StructEnd,
+            ],
+        );
+
+        Ok(())
+    }
+}

--- a/twilight-model/src/oauth/mod.rs
+++ b/twilight-model/src/oauth/mod.rs
@@ -11,12 +11,14 @@ pub mod current_application_info {
 
 mod application;
 mod application_flags;
+mod current_authorization_information;
 mod install_params;
 mod partial_application;
 
 pub use self::{
-    application::Application, application_flags::ApplicationFlags, install_params::InstallParams,
-    partial_application::PartialApplication,
+    application::Application, application_flags::ApplicationFlags,
+    current_authorization_information::CurrentAuthorizationInformation,
+    install_params::InstallParams, partial_application::PartialApplication,
 };
 
 #[allow(deprecated)]


### PR DESCRIPTION
Add support for the "Get Current Authorization Information" route, at the endpoint `GET /oauth2/@me`. This endpoint takes a client with a bearer token and fetches the application, when the access token expires, the authorized scopes, and the user that authorized the access token if applicable.

Manually tested using the written example:

```
stdout:
Application: kona
User: team959818497288982639
```

Closes #1643.