### PR TITLE
feat(model, validate, cache)!: Add new select components

### DIFF
--- a/twilight-cache-inmemory/src/event/member.rs
+++ b/twilight-cache-inmemory/src/event/member.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use std::borrow::Cow;
 use twilight_model::{
-    application::interaction::application_command::InteractionMember,
+    application::interaction::resolved::InteractionMember,
     gateway::payload::incoming::{MemberAdd, MemberChunk, MemberRemove, MemberUpdate},
     guild::{Member, PartialMember},
     id::{

--- a/twilight-cache-inmemory/src/model/member.rs
+++ b/twilight-cache-inmemory/src/model/member.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use twilight_model::{
-    application::interaction::application_command::InteractionMember,
+    application::interaction::resolved::InteractionMember,
     guild::{Member, PartialMember},
     id::{
         marker::{GuildMarker, RoleMarker, UserMarker},

--- a/twilight-model/src/application/interaction/application_command/mod.rs
+++ b/twilight-model/src/application/interaction/application_command/mod.rs
@@ -3,15 +3,11 @@
 //! [`ApplicationCommand`]: crate::application::interaction::InteractionType::ApplicationCommand
 
 mod option;
-mod resolved;
 
-pub use self::{
-    option::{CommandDataOption, CommandOptionValue},
-    resolved::{CommandInteractionDataResolved, InteractionChannel, InteractionMember},
-};
+pub use self::option::{CommandDataOption, CommandOptionValue};
 
 use crate::{
-    application::command::CommandType,
+    application::{command::CommandType, interaction::resolved::InteractionDataResolved},
     id::{
         marker::{CommandMarker, GenericMarker, GuildMarker},
         Id,
@@ -44,7 +40,7 @@ pub struct CommandData {
     pub options: Vec<CommandDataOption>,
     /// Resolved data from the interaction's options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub resolved: Option<CommandInteractionDataResolved>,
+    pub resolved: Option<InteractionDataResolved>,
     /// If this is a user or message command, the ID of the targeted user/message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_id: Option<Id<GenericMarker>>,

--- a/twilight-model/src/application/interaction/message_component.rs
+++ b/twilight-model/src/application/interaction/message_component.rs
@@ -23,9 +23,9 @@ pub struct MessageComponentInteractionData {
     pub component_type: ComponentType,
     /// Values selected by the user.
     ///
-    /// Only used for [`SelectMenu`] components.
+    /// Only used for [`StringSelectMenu`] components.
     ///
-    /// [`SelectMenu`]: ComponentType::SelectMenu
+    /// [`StringSelectMenu`]: ComponentType::StringSelectMenu
     #[serde(default)]
     pub values: Vec<String>,
 }

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -7,6 +7,7 @@
 pub mod application_command;
 pub mod message_component;
 pub mod modal;
+pub mod resolved;
 
 mod interaction_type;
 
@@ -404,7 +405,7 @@ pub enum InteractionData {
     /// Data received for the [`MessageComponent`] interaction type.
     ///
     /// [`MessageComponent`]: InteractionType::MessageComponent
-    MessageComponent(MessageComponentInteractionData),
+    MessageComponent(Box<MessageComponentInteractionData>),
     /// Data received for the [`ModalSubmit`] interaction type.
     ///
     /// [`ModalSubmit`]: InteractionType::ModalSubmit
@@ -414,10 +415,8 @@ pub enum InteractionData {
 #[cfg(test)]
 mod tests {
     use super::{
-        application_command::{
-            CommandData, CommandDataOption, CommandInteractionDataResolved, CommandOptionValue,
-            InteractionMember,
-        },
+        application_command::{CommandData, CommandDataOption, CommandOptionValue},
+        resolved::{InteractionDataResolved, InteractionMember},
         Interaction, InteractionData, InteractionType,
     };
     use crate::{
@@ -449,7 +448,7 @@ mod tests {
                     name: "member".into(),
                     value: CommandOptionValue::User(Id::new(600)),
                 }]),
-                resolved: Some(CommandInteractionDataResolved {
+                resolved: Some(InteractionDataResolved {
                     attachments: HashMap::new(),
                     channels: HashMap::new(),
                     members: IntoIterator::into_iter([(
@@ -578,7 +577,7 @@ mod tests {
                 Token::Str("resolved"),
                 Token::Some,
                 Token::Struct {
-                    name: "CommandInteractionDataResolved",
+                    name: "InteractionDataResolved",
                     len: 2,
                 },
                 Token::Str("members"),

--- a/twilight-model/src/application/interaction/resolved.rs
+++ b/twilight-model/src/application/interaction/resolved.rs
@@ -11,14 +11,13 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::HashMap;
 
-/// Resolved mentioned resources.
+/// Resolved resources.
 ///
 /// See [Discord Docs/Resolved Data Structure].
 ///
-/// [`ApplicationCommand`]: crate::application::interaction::InteractionType::ApplicationCommand
 /// [Discord Docs/Resolved Data Structure]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct CommandInteractionDataResolved {
+pub struct InteractionDataResolved {
     /// Map of resolved attachments.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub attachments: HashMap<Id<AttachmentMarker>, Attachment>,
@@ -93,7 +92,7 @@ pub struct InteractionMember {
 
 #[cfg(test)]
 mod tests {
-    use super::{CommandInteractionDataResolved, InteractionChannel, InteractionMember};
+    use super::{InteractionChannel, InteractionDataResolved, InteractionMember};
     use crate::{
         channel::{
             message::{
@@ -117,7 +116,7 @@ mod tests {
         let joined_at = Timestamp::from_str("2021-08-10T12:18:37.000000+00:00")?;
         let timestamp = Timestamp::from_str("2020-02-02T02:02:02.020000+00:00")?;
 
-        let value = CommandInteractionDataResolved {
+        let value = InteractionDataResolved {
             attachments: IntoIterator::into_iter([(
                 Id::new(400),
                 Attachment {
@@ -272,7 +271,7 @@ mod tests {
             &value,
             &[
                 Token::Struct {
-                    name: "CommandInteractionDataResolved",
+                    name: "InteractionDataResolved",
                     len: 6,
                 },
                 Token::Str("attachments"),

--- a/twilight-model/src/channel/message/component/channel_select.rs
+++ b/twilight-model/src/channel/message/component/channel_select.rs
@@ -1,0 +1,49 @@
+use crate::channel::ChannelType;
+
+/// Dropdown-style [`Component`] that renders belew messages with pre-populated channel data.
+///
+/// [`Component`]: super::Component
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ChannelSelectMenu {
+    /// List of channel types for the select menu to show
+    ///
+    /// [`ChannelType`]: ChannelType
+    pub channel_types: Option<Vec<ChannelType>>,
+    /// Developer defined identifier.
+    pub custom_id: String,
+    /// Whether the select menu is disabled.
+    ///
+    /// Defaults to `false`.
+    pub disabled: bool,
+    /// Maximum number of options that may be chosen.
+    pub max_values: Option<u8>,
+    /// Minimum number of options that must be chosen.
+    pub min_values: Option<u8>,
+    /// Custom placeholder text if no option is selected.
+    pub placeholder: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_fields!(
+        ChannelSelectMenu: channel_types,
+        custom_id,
+        disabled,
+        max_values,
+        min_values,
+        placeholder
+    );
+    assert_impl_all!(
+        ChannelSelectMenu: Clone,
+        Debug,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Sync
+    );
+}

--- a/twilight-model/src/channel/message/component/kind.rs
+++ b/twilight-model/src/channel/message/component/kind.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// Type of [`Component`].
 ///
-/// Refer to [Discord Docs/Component Types]
+/// See [Discord Docs/Component Types]
 ///
 /// [`Component`]: super::Component
 /// [Discord Docs/Component Types]: https://discord.com/developers/docs/interactions/message-components#component-object-component-types

--- a/twilight-model/src/channel/message/component/kind.rs
+++ b/twilight-model/src/channel/message/component/kind.rs
@@ -3,7 +3,10 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// Type of [`Component`].
 ///
+/// Refer to [Discord Docs/Component Types]
+///
 /// [`Component`]: super::Component
+/// [Discord Docs/Component Types]: https://discord.com/developers/docs/interactions/message-components#component-object-component-types
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
@@ -16,14 +19,30 @@ pub enum ComponentType {
     ///
     /// [`Button`]: super::Button
     Button,
-    /// Component is an [`SelectMenu`].
+    /// Component is an [`StringSelectMenu`].
     ///
-    /// [`SelectMenu`]: super::SelectMenu
-    SelectMenu,
+    /// [`StringSelectMenu`]: super::StringSelectMenu
+    StringSelectMenu,
     /// Component is an [`TextInput`].
     ///
     /// [`TextInput`]: super::TextInput
     TextInput,
+    /// Component is an [`TypeSelectMenu`]
+    ///
+    /// [`TypeSelectMenu`]: super::TypeSelectMenu
+    UserSelectMenu,
+    /// Component is an [`RoleSelectMenu`]
+    ///
+    /// [`RoleSelectMenu`]: super::TypeSelectMenu
+    RoleSelectMenu,
+    /// Component is an [`MentionableSelectMenu`]
+    ///
+    /// [`MentionableSelectMenu`]: super::TypeSelectMenu
+    MentionableSelectMenu,
+    /// Component is an [`ChannelSelectMenu`]
+    ///
+    /// [`ChannelSelectMenu`]: super::ChannelSelectMenu
+    ChannelSelectMenu,
     /// Variant value is unknown to the library.
     Unknown(u8),
 }
@@ -33,8 +52,12 @@ impl From<u8> for ComponentType {
         match value {
             1 => ComponentType::ActionRow,
             2 => ComponentType::Button,
-            3 => ComponentType::SelectMenu,
+            3 => ComponentType::StringSelectMenu,
             4 => ComponentType::TextInput,
+            5 => ComponentType::UserSelectMenu,
+            6 => ComponentType::RoleSelectMenu,
+            7 => ComponentType::MentionableSelectMenu,
+            8 => ComponentType::ChannelSelectMenu,
             unknown => ComponentType::Unknown(unknown),
         }
     }
@@ -45,8 +68,12 @@ impl From<ComponentType> for u8 {
         match value {
             ComponentType::ActionRow => 1,
             ComponentType::Button => 2,
-            ComponentType::SelectMenu => 3,
+            ComponentType::StringSelectMenu => 3,
             ComponentType::TextInput => 4,
+            ComponentType::UserSelectMenu => 5,
+            ComponentType::RoleSelectMenu => 6,
+            ComponentType::MentionableSelectMenu => 7,
+            ComponentType::ChannelSelectMenu => 8,
             ComponentType::Unknown(unknown) => unknown,
         }
     }
@@ -72,8 +99,12 @@ impl ComponentType {
         match self {
             Self::ActionRow => "ActionRow",
             Self::Button => "Button",
-            Self::SelectMenu => "SelectMenu",
+            Self::StringSelectMenu => "StringSelectMenu",
             Self::TextInput => "TextInput",
+            Self::UserSelectMenu => "UserSelectMenu",
+            Self::RoleSelectMenu => "RoleSelectMenu",
+            Self::MentionableSelectMenu => "MentionableSelectMenu",
+            Self::ChannelSelectMenu => "ChannelSelectMenu",
             Self::Unknown(_) => "Unknown",
         }
     }
@@ -110,8 +141,12 @@ mod tests {
     fn variants() {
         serde_test::assert_tokens(&ComponentType::ActionRow, &[Token::U8(1)]);
         serde_test::assert_tokens(&ComponentType::Button, &[Token::U8(2)]);
-        serde_test::assert_tokens(&ComponentType::SelectMenu, &[Token::U8(3)]);
+        serde_test::assert_tokens(&ComponentType::StringSelectMenu, &[Token::U8(3)]);
         serde_test::assert_tokens(&ComponentType::TextInput, &[Token::U8(4)]);
+        serde_test::assert_tokens(&ComponentType::UserSelectMenu, &[Token::U8(5)]);
+        serde_test::assert_tokens(&ComponentType::RoleSelectMenu, &[Token::U8(6)]);
+        serde_test::assert_tokens(&ComponentType::MentionableSelectMenu, &[Token::U8(7)]);
+        serde_test::assert_tokens(&ComponentType::ChannelSelectMenu, &[Token::U8(8)]);
         serde_test::assert_tokens(&ComponentType::Unknown(99), &[Token::U8(99)]);
     }
 
@@ -119,8 +154,15 @@ mod tests {
     fn names() {
         assert_eq!("ActionRow", ComponentType::ActionRow.name());
         assert_eq!("Button", ComponentType::Button.name());
-        assert_eq!("SelectMenu", ComponentType::SelectMenu.name());
+        assert_eq!("StringSelectMenu", ComponentType::StringSelectMenu.name());
         assert_eq!("TextInput", ComponentType::TextInput.name());
+        assert_eq!("UserSelectMenu", ComponentType::UserSelectMenu.name());
+        assert_eq!("RoleSelectMenu", ComponentType::RoleSelectMenu.name());
+        assert_eq!(
+            "MentionableSelectMenu",
+            ComponentType::MentionableSelectMenu.name()
+        );
+        assert_eq!("ChannelSelectMenu", ComponentType::ChannelSelectMenu.name());
         assert_eq!("Unknown", ComponentType::Unknown(99).name());
     }
 }

--- a/twilight-model/src/channel/message/component/kind.rs
+++ b/twilight-model/src/channel/message/component/kind.rs
@@ -27,9 +27,9 @@ pub enum ComponentType {
     ///
     /// [`TextInput`]: super::TextInput
     TextInput,
-    /// Component is an [`TypeSelectMenu`]
+    /// Component is an [`UserSelectMenu`]
     ///
-    /// [`TypeSelectMenu`]: super::TypeSelectMenu
+    /// [`UserSelectMenu`]: super::TypeSelectMenu
     UserSelectMenu,
     /// Component is an [`RoleSelectMenu`]
     ///

--- a/twilight-model/src/channel/message/component/string_select.rs
+++ b/twilight-model/src/channel/message/component/string_select.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Component`]: super::Component
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct SelectMenu {
+pub struct StringSelectMenu {
     /// Developer defined identifier.
     pub custom_id: String,
     /// Whether the select menu is disabled.
@@ -17,14 +17,14 @@ pub struct SelectMenu {
     /// Minimum number of options that must be chosen.
     pub min_values: Option<u8>,
     /// List of available choices.
-    pub options: Vec<SelectMenuOption>,
+    pub options: Vec<StringSelectMenuOption>,
     /// Custom placeholder text if no option is selected.
     pub placeholder: Option<String>,
 }
 
-/// Dropdown options that are part of [`SelectMenu`].
+/// Dropdown options that are part of [`StringSelectMenu`].
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct SelectMenuOption {
+pub struct StringSelectMenuOption {
     /// Whether the option will be selected by default.
     #[serde(default)]
     pub default: bool,
@@ -48,17 +48,25 @@ mod tests {
     use std::{fmt::Debug, hash::Hash};
 
     assert_fields!(
-        SelectMenu: custom_id,
+        StringSelectMenu: custom_id,
         disabled,
         max_values,
         min_values,
         options,
         placeholder
     );
-    assert_impl_all!(SelectMenu: Clone, Debug, Eq, Hash, PartialEq, Send, Sync);
+    assert_impl_all!(
+        StringSelectMenu: Clone,
+        Debug,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Sync
+    );
 
     assert_impl_all!(
-        SelectMenuOption: Clone,
+        StringSelectMenuOption: Clone,
         Debug,
         Deserialize<'static>,
         Eq,
@@ -68,5 +76,11 @@ mod tests {
         Serialize,
         Sync
     );
-    assert_fields!(SelectMenuOption: default, description, emoji, label, value);
+    assert_fields!(
+        StringSelectMenuOption: default,
+        description,
+        emoji,
+        label,
+        value
+    );
 }

--- a/twilight-model/src/channel/message/component/type_select.rs
+++ b/twilight-model/src/channel/message/component/type_select.rs
@@ -1,0 +1,42 @@
+/// Dropdown-style [`Component`] that renders belew messages with pre-populated data.
+///
+/// [`Component`]: super::Component
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct TypeSelectMenu {
+    /// Developer defined identifier.
+    pub custom_id: String,
+    /// Whether the select menu is disabled.
+    ///
+    /// Defaults to `false`.
+    pub disabled: bool,
+    /// Maximum number of options that may be chosen.
+    pub max_values: Option<u8>,
+    /// Minimum number of options that must be chosen.
+    pub min_values: Option<u8>,
+    /// Custom placeholder text if no option is selected.
+    pub placeholder: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use static_assertions::{assert_fields, assert_impl_all};
+    use std::{fmt::Debug, hash::Hash};
+
+    assert_fields!(
+        TypeSelectMenu: custom_id,
+        disabled,
+        max_values,
+        min_values,
+        placeholder
+    );
+    assert_impl_all!(
+        TypeSelectMenu: Clone,
+        Debug,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Sync
+    );
+}

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -1139,13 +1139,14 @@ mod tests {
             app_permissions: Some(Permissions::SEND_MESSAGES),
             application_id: Id::new(1),
             channel_id: Some(Id::new(2)),
-            data: Some(InteractionData::MessageComponent(
+            data: Some(InteractionData::MessageComponent(Box::new(
                 MessageComponentInteractionData {
                     custom_id: String::from("Click"),
                     component_type: ComponentType::Button,
                     values: Vec::new(),
+                    resolved: None,
                 },
-            )),
+            ))),
             guild_id: Some(Id::new(3)),
             guild_locale: None,
             id: Id::new(4),

--- a/twilight-validate/src/component.rs
+++ b/twilight-validate/src/component.rs
@@ -46,8 +46,8 @@ pub const COMPONENT_CUSTOM_ID_LENGTH: usize = 100;
 /// [1]: https://discord.com/developers/docs/interactions/message-components#component-object-component-structure
 pub const COMPONENT_BUTTON_LABEL_LENGTH: usize = 80;
 
-/// Maximum number of [`SelectMenuOption`]s that can be chosen in a
-/// [`SelectMenu`].
+/// Maximum number of [`StringSelectMenuOption`]s that can be chosen in a
+/// [`StringSelectMenu`].
 ///
 /// This is defined in Dicsord's documentation, per
 /// [Discord Docs/Select Menu][1].
@@ -55,8 +55,8 @@ pub const COMPONENT_BUTTON_LABEL_LENGTH: usize = 80;
 /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure
 pub const SELECT_MAXIMUM_VALUES_LIMIT: usize = 25;
 
-/// Minimum number of [`SelectMenuOption`]s that can be chosen in a
-/// [`SelectMenu`].
+/// Minimum number of [`StringSelectMenuOption`]s that can be chosen in a
+/// [`StringSelectMenu`].
 ///
 /// This is defined in Dicsord's documentation, per
 /// [Discord Docs/Select Menu][1].
@@ -64,8 +64,8 @@ pub const SELECT_MAXIMUM_VALUES_LIMIT: usize = 25;
 /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure
 pub const SELECT_MAXIMUM_VALUES_REQUIREMENT: usize = 1;
 
-/// Maximum number of [`SelectMenuOption`]s that must be chosen in a
-/// [`SelectMenu`].
+/// Maximum number of [`StringSelectMenuOption`]s that must be chosen in a
+/// [`StringSelectMenu`].
 ///
 /// This is defined in Dicsord's documentation, per
 /// [Discord Docs/Select Menu][1].
@@ -73,7 +73,7 @@ pub const SELECT_MAXIMUM_VALUES_REQUIREMENT: usize = 1;
 /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure
 pub const SELECT_MINIMUM_VALUES_LIMIT: usize = 25;
 
-/// Maximum number of [`SelectMenuOption`]s in a [`SelectMenu`].
+/// Maximum number of [`StringSelectMenuOption`]s in a [`StringSelectMenu`].
 ///
 /// This is defined in Discord's documentation, per
 /// [Discord Docs/Select Menu][1].
@@ -81,7 +81,7 @@ pub const SELECT_MINIMUM_VALUES_LIMIT: usize = 25;
 /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-menu-structure
 pub const STRING_SELECT_OPTION_COUNT: usize = 25;
 
-/// Maximum length of a [`SelectMenuOption::description`] in codepoints.
+/// Maximum length of a [`StringSelectMenuOption::description`] in codepoints.
 ///
 /// This is defined in Discord's documentation, per
 /// [Discord Docs/Select Menu Option][1].
@@ -89,7 +89,7 @@ pub const STRING_SELECT_OPTION_COUNT: usize = 25;
 /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
 pub const STRING_SELECT_OPTION_DESCRIPTION_LENGTH: usize = 100;
 
-/// Maximum length of a [`SelectMenuOption::label`] in codepoints.
+/// Maximum length of a [`StringSelectMenuOption::label`] in codepoints.
 ///
 /// This is defined in Discord's documentation, per
 /// [Discord Docs/Select Menu Option][1].
@@ -97,7 +97,7 @@ pub const STRING_SELECT_OPTION_DESCRIPTION_LENGTH: usize = 100;
 /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
 pub const STRING_SELECT_OPTION_LABEL_LENGTH: usize = 100;
 
-/// Maximum length of a [`SelectMenuOption::value`] in codepoints.
+/// Maximum length of a [`StringSelectMenuOption::value`] in codepoints.
 ///
 /// This is defined in Discord's documentation, per
 /// [Discord Docs/Select Menu Option][1].
@@ -105,7 +105,11 @@ pub const STRING_SELECT_OPTION_LABEL_LENGTH: usize = 100;
 /// [1]: https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure
 pub const STRING_SELECT_OPTION_VALUE_LENGTH: usize = 100;
 
-/// Maximum length of a [`SelectMenu::placeholder`] in codepoints.
+/// Maximum length of a Select Menu's placeholder in codepoints.
+/// 
+/// [`ChannelSelectMenu::placeholder`]
+/// [`StringSelectMenu::placeholder`]
+/// [`TypeSelectMenu::placeholder`]
 ///
 /// This is defined in Discord's documentation, per
 /// [Discord Docs/Select Menu][1].
@@ -502,7 +506,7 @@ pub fn component(component: &Component) -> Result<(), ComponentValidationError> 
 /// Refer to [`button`] for potential errors when validating a button in the
 /// action row.
 ///
-/// Refer to [`select_menu`] for potential errors when validating a select menu
+/// Refer to [`string_select_menu`] for potential errors when validating a select menu
 /// in the action row.
 ///
 /// Refer to [`text_input`] for potential errors when validating a text input in
@@ -566,6 +570,7 @@ pub fn action_row(action_row: &ActionRow) -> Result<(), ComponentValidationError
 /// [`ComponentLabelLength`]: ComponentValidationErrorType::ComponentLabelLength
 /// [`SelectMaximumValuesCount`]: ComponentValidationErrorType::SelectMaximumValuesCount
 /// [`SelectMinimumValuesCount`]: ComponentValidationErrorType::SelectMinimumValuesCount
+/// [`SelectPlaceholderLength`]: ComponentValidationErrorType::SelectPlaceholderLength
 pub fn channel_select_menu(
     select_menu: &ChannelSelectMenu,
 ) -> Result<(), ComponentValidationError> {
@@ -680,7 +685,7 @@ pub fn button(button: &Button) -> Result<(), ComponentValidationError> {
 /// [`StringSelectOptionDescriptionLength`]: ComponentValidationErrorType::StringSelectOptionDescriptionLength
 /// [`StringSelectOptionLabelLength`]: ComponentValidationErrorType::StringSelectOptionLabelLength
 /// [`StringSelectOptionValueLength`]: ComponentValidationErrorType::StringSelectOptionValueLength
-/// [`StringSelectPlaceholderLength`]: ComponentValidationErrorType::SelectPlaceholderLength
+/// [`SelectPlaceholderLength`]: ComponentValidationErrorType::SelectPlaceholderLength
 pub fn string_select_menu(select_menu: &StringSelectMenu) -> Result<(), ComponentValidationError> {
     self::component_custom_id(&select_menu.custom_id)?;
     self::component_select_options(&select_menu.options)?;
@@ -733,6 +738,7 @@ pub fn string_select_menu(select_menu: &StringSelectMenu) -> Result<(), Componen
 /// [`ComponentLabelLength`]: ComponentValidationErrorType::ComponentLabelLength
 /// [`SelectMaximumValuesCount`]: ComponentValidationErrorType::SelectMaximumValuesCount
 /// [`SelectMinimumValuesCount`]: ComponentValidationErrorType::SelectMinimumValuesCount
+/// [`SelectPlaceholderLength`]: ComponentValidationErrorType::SelectPlaceholderLength
 pub fn type_select_menu(select_menu: &TypeSelectMenu) -> Result<(), ComponentValidationError> {
     self::component_custom_id(&select_menu.custom_id)?;
 


### PR DESCRIPTION
Adds support for new select components in twilight-model and the twilight-validation crates. See [Discord changelog](https://discord.com/developers/docs/change-log#new-select-menu-components).

I believe that I have included all the necessary changes relating to them but it is possible I missed something. 

Not sure if this is how you guys want them implemented. Just let me know or someone else can take it over if you'd like 😄 

### Breaking changes
- Renames SelectMenu to StringSelectMenu (Struct & component enum variant)
- Renames SelectMenuOption to StringSelectMenuOption
- Renames CommandInteractionDataResolved to InteractionDataResolved

We don't need to rename these and I can revert them back **but** I do think it's a good change to make since it clarifies exactly what can be done with them. Discord documentation also refers to them as such. 

### Additions
I added a TypeSelectMenu since 3 (user, mentionable, & role) of the 4 new selects use the same data structure. Not sure if this should be named something else. 

Channel selects got their own type, ChannelSelectMenu, which lets you filter which channels are shown by setting channel_types.

### Tests
Added and updated a few tests but likely need to add some more. Just not sure what you want specifically tested. I did manually test with one of my bots & they do work. 
