### PR TITLE
fix(http): return `Message` from `UpdateWebhookMessage`

### DIFF
--- a/twilight-http/src/request/channel/webhook/update_webhook_message.rs
+++ b/twilight-http/src/request/channel/webhook/update_webhook_message.rs
@@ -7,13 +7,16 @@ use crate::{
         attachment::{AttachmentManager, PartialAttachment},
         Nullable, Request, TryIntoRequest,
     },
-    response::{marker::EmptyBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
 use std::future::IntoFuture;
 use twilight_model::{
-    channel::message::{AllowedMentions, Component, Embed},
+    channel::{
+        message::{AllowedMentions, Component, Embed},
+        Message,
+    },
     http::attachment::Attachment,
     id::{
         marker::{AttachmentMarker, ChannelMarker, MessageMarker, WebhookMarker},
@@ -317,15 +320,15 @@ impl<'a> UpdateWebhookMessage<'a> {
 
     /// Execute the request, returning a future resolving to a [`Response`].
     #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
-    pub fn exec(self) -> ResponseFuture<EmptyBody> {
+    pub fn exec(self) -> ResponseFuture<Message> {
         self.into_future()
     }
 }
 
 impl IntoFuture for UpdateWebhookMessage<'_> {
-    type Output = Result<Response<EmptyBody>, Error>;
+    type Output = Result<Response<Message>, Error>;
 
-    type IntoFuture = ResponseFuture<EmptyBody>;
+    type IntoFuture = ResponseFuture<Message>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;


### PR DESCRIPTION
Aligns the return value with the one [documented](https://discord.com/developers/docs/resources/webhook#edit-webhook-message).

Closes #2052
