### PR TITLE
refactor(gateway)!: touch up `Latency`

### DIFF
--- a/twilight-gateway/src/latency.rs
+++ b/twilight-gateway/src/latency.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 /// [`Shard`]'s gateway connection latency.
 ///
 /// Measures the difference between sending a heartbeat and receiving an
-/// acknowledgement, also known as a heartbeat period. Sprious heartbeat
+/// acknowledgement, also known as a heartbeat period. Spurious heartbeat
 /// acknowledgements are ignored.
 ///
 /// May be obtained via [`Shard::latency`].

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -869,7 +869,7 @@ impl Shard {
         // The ratelimiter reserves capacity for heartbeat messages.
         self.send_unratelimited(message).await?;
 
-        self.latency.track_sent();
+        self.latency.record_sent();
 
         Ok(())
     }
@@ -1000,7 +1000,7 @@ impl Shard {
                 let requested = self.latency.received().is_none() && self.latency.sent().is_some();
                 if requested {
                     tracing::debug!("received heartbeat ack");
-                    self.latency.track_received();
+                    self.latency.record_received();
                 } else {
                     tracing::info!("received unrequested heartbeat ack");
                 }


### PR DESCRIPTION
Redoes a lot of documentation to be more consistent and clearer. Also extends the testing of `Latency::record_received`.

Breaking change: renames `Latency::heartbeats` to `Latency::periods`.
