### PR TITLE
docs(gateway): fix `EventTypeFlags` links

### DIFF
--- a/twilight-gateway/src/event.rs
+++ b/twilight-gateway/src/event.rs
@@ -9,8 +9,8 @@ bitflags! {
     /// Specifying event types is an important optimization technique on top of
     /// [`Intents`], which can dramatically decrease processor usage in many
     /// circumstances. While specifying intents are required by Discord and
-    /// allow filtering groups of [`Event`]s, event type flags are a Twilight
-    /// specific technique to filter out individual events from being
+    /// allow filtering groups of [`Event`]s, event type flags are a
+    /// Twilight-specific technique to filter out individual events from being
     /// deserialized at all, effectively discarding them.
     ///
     /// For example, [`Intents::GUILDS`] includes a wide range of events from

--- a/twilight-gateway/src/event.rs
+++ b/twilight-gateway/src/event.rs
@@ -1,5 +1,4 @@
-//! Home of [`EventTypeFlags`], and optimization technique for skipping gateway
-//! event deserialization.
+//! Optimization for skipping deserialization of unwanted events.
 
 use bitflags::bitflags;
 use twilight_model::gateway::{event::EventType, OpCode};
@@ -8,25 +7,27 @@ bitflags! {
     /// Important optimization for narrowing requested event types.
     ///
     /// Specifying event types is an important optimization technique on top of
-    /// [intents], which can dramatically decrease processor usage in many
+    /// [`Intents`], which can dramatically decrease processor usage in many
     /// circumstances. While specifying intents are required by Discord and
-    /// allow filtering groups of [events], event type flags are a
-    /// Twilight-specific technique to filter out individual events from being
-    /// deserialized at all, effectively discarding those events.
+    /// allow filtering groups of [`Event`]s, event type flags are a Twilight
+    /// specific technique to filter out individual events from being
+    /// deserialized at all, effectively discarding them.
     ///
     /// For example, [`Intents::GUILDS`] includes a wide range of events from
-    /// [`GuildCreate`] to [`GuildRoleUpdate`] to [`ChannelPinsUpdate`]. If the
-    /// only events used in this group of events is, say, [`ChannelCreate`] and
-    /// [`GuildRoleCreate`], then the [`CHANNEL_CREATE`] and
-    /// [`GUILD_ROLE_CREATE`] event type flags can be specified in combination
-    /// with that intent. This reduces the events received and deserialized to
-    /// only those events.
+    /// [`GuildCreate`] to [`RoleUpdate`] to [`ChannelPinsUpdate`]. If the only
+    /// events used in this group of events is, say, [`ChannelCreate`] and
+    /// [`RoleCreate`], then the [`CHANNEL_CREATE`][Self::CHANNEL_CREATE] and
+    /// [`ROLE_CREATE`][Self::ROLE_CREATE] event type flags can be specified in
+    /// combination with that intent to only deserialize those events.
     ///
-    /// [`CHANNEL_CREATE`]: Self::CHANNEL_CREATE
-    /// [`GUILD_ROLE_CREATE`]: Self::GUILD_ROLE_CREATE
-    /// [`ChannelCreate`]: twilight_model::gateway::payload::incoming::ChannelCreate
-    /// [`ChannelPinsUpdate`]: twilight_model::gateway::payload::incoming::ChannelPinsUpdate
-    /// [`GuildRoleCreate`]: twilight_model::gateway::payload::incoming::GuildRoleCreate
+    /// [`ChannelCreate`]: twilight_model::gateway::event::Event::ChannelCreate
+    /// [`ChannelPinsUpdate`]: twilight_model::gateway::event::Event::ChannelPinsUpdate
+    /// [`Event`]: twilight_model::gateway::event::Event
+    /// [`GuildCreate`]: twilight_model::gateway::event::Event::GuildCreate
+    /// [`Intents`]: twilight_model::gateway::Intents
+    /// [`Intents::GUILDS`]: twilight_model::gateway::Intents::GUILDS
+    /// [`RoleCreate`]: twilight_model::gateway::event::Event::RoleCreate
+    /// [`RoleUpdate`]: twilight_model::gateway::event::Event::RoleUpdate
     pub struct EventTypeFlags: u128 {
         /// Message has been blocked by AutoMod according to a rule.
         const AUTO_MODERATION_ACTION_EXECUTION = 1 << 71;


### PR DESCRIPTION
Fixes the broken [`EventTypeFlags`](https://docs.rs/twilight-gateway/0.15.0-rc.2/twilight_gateway/struct.EventTypeFlags.html) intralinks and rewords the docs to be slightly more consice.

Moved out of #2024