### PR TITLE
feat!(model, gateway): Support the GUILD_AUDIT_LOG_ENTRY_CREATE gateway event

### DIFF
--- a/examples/gateway-metrics.rs
+++ b/examples/gateway-metrics.rs
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let intents =
-        Intents::GUILD_BANS | Intents::GUILD_EMOJIS_AND_STICKERS | Intents::GUILD_MESSAGES;
+        Intents::GUILD_MODERATION | Intents::GUILD_EMOJIS_AND_STICKERS | Intents::GUILD_MESSAGES;
     let (cluster, mut events) = Cluster::new(env::var("DISCORD_TOKEN")?, intents).await?;
     println!("Created cluster");
 

--- a/examples/gateway-shard.rs
+++ b/examples/gateway-shard.rs
@@ -7,7 +7,7 @@ async fn main() -> anyhow::Result<()> {
     // Initialize the tracing subscriber.
     tracing_subscriber::fmt::init();
 
-    let intents = Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES;
+    let intents = Intents::GUILDS | Intents::GUILD_MODERATION;
     let (shard, mut events) = Shard::new(env::var("DISCORD_TOKEN")?, intents);
 
     shard.start().await?;

--- a/twilight-cache-inmemory/src/lib.rs
+++ b/twilight-cache-inmemory/src/lib.rs
@@ -892,6 +892,7 @@ impl UpdateCache for Event {
             | Event::GatewayInvalidateSession(_)
             | Event::GatewayReconnect
             | Event::GiftCodeUpdate
+            | Event::GuildAuditLogEntryCreate(_)
             | Event::GuildIntegrationsUpdate(_)
             | Event::GuildScheduledEventCreate(_)
             | Event::GuildScheduledEventDelete(_)

--- a/twilight-gateway/src/cluster/mod.rs
+++ b/twilight-gateway/src/cluster/mod.rs
@@ -14,8 +14,9 @@
 //! #[tokio::main]
 //! async fn main() -> anyhow::Result<()> {
 //!     let token = env::var("DISCORD_TOKEN")?;
-//!     let intents =
-//!         Intents::GUILD_MODERATION | Intents::GUILD_EMOJIS_AND_STICKERS | Intents::GUILD_MESSAGES;
+//!     let intents = Intents::GUILD_MODERATION
+//!         | Intents::GUILD_EMOJIS_AND_STICKERS
+//!         | Intents::GUILD_MESSAGES;
 //!     let (cluster, mut events) = Cluster::new(token, intents).await?;
 //!     let cluster = Arc::new(cluster);
 //!     cluster.up().await;

--- a/twilight-gateway/src/cluster/mod.rs
+++ b/twilight-gateway/src/cluster/mod.rs
@@ -15,7 +15,7 @@
 //! async fn main() -> anyhow::Result<()> {
 //!     let token = env::var("DISCORD_TOKEN")?;
 //!     let intents =
-//!         Intents::GUILD_BANS | Intents::GUILD_EMOJIS_AND_STICKERS | Intents::GUILD_MESSAGES;
+//!         Intents::GUILD_MODERATION | Intents::GUILD_EMOJIS_AND_STICKERS | Intents::GUILD_MESSAGES;
 //!     let (cluster, mut events) = Cluster::new(token, intents).await?;
 //!     let cluster = Arc::new(cluster);
 //!     cluster.up().await;

--- a/twilight-gateway/src/event.rs
+++ b/twilight-gateway/src/event.rs
@@ -47,6 +47,8 @@ bitflags! {
         const GATEWAY_RECONNECT = 1 << 9;
         /// Gift code sent in a channel has been updated.
         const GIFT_CODE_UPDATE = 1 << 49;
+        /// A audit log entry has been created.
+        const GUILD_AUDIT_LOG_ENTRY_CREATE = 1 << 75;
         /// A guild has been created.
         const GUILD_CREATE = 1 << 10;
         /// A guild has been deleted or the current user has been removed from a guild.
@@ -206,6 +208,7 @@ bitflags! {
             | Self::CHANNEL_DELETE.bits()
             | Self::CHANNEL_PINS_UPDATE.bits()
             | Self::CHANNEL_UPDATE.bits()
+            | Self::GUILD_AUDIT_LOG_ENTRY_CREATE.bits()
             | Self::GUILD_CREATE.bits()
             | Self::GUILD_DELETE.bits()
             | Self::GUILD_UPDATE.bits()
@@ -321,6 +324,7 @@ impl From<EventType> for EventTypeFlags {
             EventType::GatewayInvalidateSession => Self::GATEWAY_INVALIDATE_SESSION,
             EventType::GatewayReconnect => Self::GATEWAY_RECONNECT,
             EventType::GiftCodeUpdate => Self::GIFT_CODE_UPDATE,
+            EventType::GuildAuditLogEntryCreate => Self::GUILD_AUDIT_LOG_ENTRY_CREATE,
             EventType::GuildCreate => Self::GUILD_CREATE,
             EventType::GuildDelete => Self::GUILD_DELETE,
             EventType::GuildEmojisUpdate => Self::GUILD_EMOJIS_UPDATE,

--- a/twilight-gateway/src/event.rs
+++ b/twilight-gateway/src/event.rs
@@ -47,7 +47,7 @@ bitflags! {
         const GATEWAY_RECONNECT = 1 << 9;
         /// Gift code sent in a channel has been updated.
         const GIFT_CODE_UPDATE = 1 << 49;
-        /// A audit log entry has been created.
+        /// An audit log entry has been created.
         const GUILD_AUDIT_LOG_ENTRY_CREATE = 1 << 75;
         /// A guild has been created.
         const GUILD_CREATE = 1 << 10;

--- a/twilight-gateway/src/event.rs
+++ b/twilight-gateway/src/event.rs
@@ -231,7 +231,7 @@ bitflags! {
         /// All [`EventTypeFlags`] in [`Intents::GUILD_MODERATION`].
         ///
         /// [`Intents::GUILD_MODERATION`]: crate::Intents::GUILD_MODERATION
-        const GUILD_MODERATION = Self::BAN_ADD.bits() | Self::BAN_REMOVE.bits() | Self::GUILD_AUDIT_LOG_ENTRY_CREATE.bits()
+        const GUILD_MODERATION = Self::BAN_ADD.bits() | Self::BAN_REMOVE.bits() | Self::GUILD_AUDIT_LOG_ENTRY_CREATE.bits();
         /// All [`EventTypeFlags`] in [`Intents::GUILD_EMOJIS_AND_STICKERS`].
         ///
         /// [`Intents::GUILD_EMOJIS_AND_STICKERS`]: crate::Intents::GUILD_EMOJIS_AND_STICKERS

--- a/twilight-gateway/src/event.rs
+++ b/twilight-gateway/src/event.rs
@@ -208,7 +208,6 @@ bitflags! {
             | Self::CHANNEL_DELETE.bits()
             | Self::CHANNEL_PINS_UPDATE.bits()
             | Self::CHANNEL_UPDATE.bits()
-            | Self::GUILD_AUDIT_LOG_ENTRY_CREATE.bits()
             | Self::GUILD_CREATE.bits()
             | Self::GUILD_DELETE.bits()
             | Self::GUILD_UPDATE.bits()
@@ -227,7 +226,12 @@ bitflags! {
         /// All [`EventTypeFlags`] in [`Intents::GUILD_BANS`].
         ///
         /// [`Intents::GUILD_BANS`]: crate::Intents::GUILD_BANS
-        const GUILD_BANS = Self::BAN_ADD.bits() | Self::BAN_REMOVE.bits();
+        #[deprecated(since = "0.14.2", note = "use the `GUILD_MODERATION` intent instead")]
+        const GUILD_BANS = Self::BAN_ADD.bits() | Self::BAN_REMOVE.bits() | Self::GUILD_AUDIT_LOG_ENTRY_CREATE.bits();
+        /// All [`EventTypeFlags`] in [`Intents::GUILD_MODERATION`].
+        ///
+        /// [`Intents::GUILD_MODERATION`]: crate::Intents::GUILD_MODERATION
+        const GUILD_MODERATION = Self::BAN_ADD.bits() | Self::BAN_REMOVE.bits() | Self::GUILD_AUDIT_LOG_ENTRY_CREATE.bits()
         /// All [`EventTypeFlags`] in [`Intents::GUILD_EMOJIS_AND_STICKERS`].
         ///
         /// [`Intents::GUILD_EMOJIS_AND_STICKERS`]: crate::Intents::GUILD_EMOJIS_AND_STICKERS

--- a/twilight-model/src/gateway/event/dispatch.rs
+++ b/twilight-model/src/gateway/event/dispatch.rs
@@ -26,6 +26,7 @@ pub enum DispatchEvent {
     ChannelUpdate(Box<ChannelUpdate>),
     CommandPermissionsUpdate(CommandPermissionsUpdate),
     GiftCodeUpdate,
+    GuildAuditLogEntryCreate(Box<GuildAuditLogEntryCreate>),
     GuildCreate(Box<GuildCreate>),
     GuildDelete(GuildDelete),
     GuildEmojisUpdate(GuildEmojisUpdate),
@@ -95,6 +96,7 @@ impl DispatchEvent {
             Self::ChannelUpdate(_) => EventType::ChannelUpdate,
             Self::CommandPermissionsUpdate(_) => EventType::CommandPermissionsUpdate,
             Self::GiftCodeUpdate => EventType::GiftCodeUpdate,
+            Self::GuildAuditLogEntryCreate(_) => EventType::GuildAuditLogEntryCreate,
             Self::GuildCreate(_) => EventType::GuildCreate,
             Self::GuildDelete(_) => EventType::GuildDelete,
             Self::GuildEmojisUpdate(_) => EventType::GuildEmojisUpdate,
@@ -167,6 +169,7 @@ impl TryFrom<Event> for DispatchEvent {
             Event::ChannelUpdate(v) => Self::ChannelUpdate(v),
             Event::CommandPermissionsUpdate(v) => Self::CommandPermissionsUpdate(v),
             Event::GiftCodeUpdate => Self::GiftCodeUpdate,
+            Event::GuildAuditLogEntryCreate(v) => Self::GuildAuditLogEntryCreate(v),
             Event::GuildCreate(v) => Self::GuildCreate(v),
             Event::GuildDelete(v) => Self::GuildDelete(v),
             Event::GuildEmojisUpdate(v) => Self::GuildEmojisUpdate(v),
@@ -274,6 +277,9 @@ impl<'de, 'a> DeserializeSeed<'de> for DispatchEventWithTypeDeserializer<'a> {
 
                 DispatchEvent::GiftCodeUpdate
             }
+            "GUILD_AUDIT_LOG_ENTRY_CREATE" => DispatchEvent::GuildAuditLogEntryCreate(Box::new(
+                GuildAuditLogEntryCreate::deserialize(deserializer)?,
+            )),
             "GUILD_BAN_ADD" => DispatchEvent::BanAdd(BanAdd::deserialize(deserializer)?),
             "GUILD_BAN_REMOVE" => DispatchEvent::BanRemove(BanRemove::deserialize(deserializer)?),
             "GUILD_CREATE" => {

--- a/twilight-model/src/gateway/event/kind.rs
+++ b/twilight-model/src/gateway/event/kind.rs
@@ -24,6 +24,7 @@ pub enum EventType {
     GatewayInvalidateSession,
     GatewayReconnect,
     GiftCodeUpdate,
+    GuildAuditLogEntryCreate,
     GuildCreate,
     GuildDelete,
     GuildEmojisUpdate,
@@ -110,6 +111,7 @@ impl EventType {
             Self::ChannelUpdate => Some("CHANNEL_UPDATE"),
             Self::CommandPermissionsUpdate => Some("APPLICATION_COMMAND_PERMISSIONS_UPDATE"),
             Self::GiftCodeUpdate => Some("GIFT_CODE_UPDATE"),
+            Self::GuildAuditLogEntryCreate => Some("GUILD_AUDIT_LOG_ENTRY_CREATE"),
             Self::GuildCreate => Some("GUILD_CREATE"),
             Self::GuildDelete => Some("GUILD_DELETE"),
             Self::GuildEmojisUpdate => Some("GUILD_EMOJIS_UPDATE"),
@@ -186,6 +188,7 @@ impl<'a> TryFrom<&'a str> for EventType {
             "AUTO_MODERATION_RULE_CREATE" => Ok(Self::AutoModerationRuleCreate),
             "AUTO_MODERATION_RULE_DELETE" => Ok(Self::AutoModerationRuleDelete),
             "AUTO_MODERATION_RULE_UPDATE" => Ok(Self::AutoModerationRuleUpdate),
+            "GUILD_AUDIT_LOG_ENTRY_CREATE" => Ok(Self::GuildAuditLogEntryCreate),
             "GUILD_BAN_ADD" => Ok(Self::BanAdd),
             "GUILD_BAN_REMOVE" => Ok(Self::BanRemove),
             "CHANNEL_CREATE" => Ok(Self::ChannelCreate),
@@ -302,6 +305,10 @@ mod tests {
         );
         assert_variant(EventType::GatewayReconnect, "GATEWAY_RECONNECT");
         assert_variant(EventType::GiftCodeUpdate, "GIFT_CODE_UPDATE");
+        assert_variant(
+            EventType::GuildAuditLogEntryCreate,
+            "GUILD_AUDIT_LOG_ENTRY_CREATE",
+        );
         assert_variant(EventType::GuildCreate, "GUILD_CREATE");
         assert_variant(EventType::GuildDelete, "GUILD_DELETE");
         assert_variant(EventType::GuildEmojisUpdate, "GUILD_EMOJIS_UPDATE");

--- a/twilight-model/src/gateway/event/mod.rs
+++ b/twilight-model/src/gateway/event/mod.rs
@@ -60,6 +60,8 @@ pub enum Event {
     GatewayReconnect,
     /// Undocumented event, should be ignored.
     GiftCodeUpdate,
+    /// A audit log entry was created.
+    GuildAuditLogEntryCreate(Box<GuildAuditLogEntryCreate>),
     /// A guild was created.
     GuildCreate(Box<GuildCreate>),
     /// A guild was deleted or the current user was removed from a guild.
@@ -205,6 +207,7 @@ impl Event {
             Event::ChannelDelete(e) => e.0.guild_id,
             Event::ChannelUpdate(e) => e.0.guild_id,
             Event::CommandPermissionsUpdate(e) => Some(e.0.guild_id),
+            Event::GuildAuditLogEntryCreate(e) => e.0.guild_id,
             Event::GuildCreate(e) => Some(e.0.id),
             Event::GuildDelete(e) => Some(e.id),
             Event::GuildEmojisUpdate(e) => Some(e.guild_id),
@@ -292,6 +295,7 @@ impl Event {
             Self::GatewayInvalidateSession(_) => EventType::GatewayInvalidateSession,
             Self::GatewayReconnect => EventType::GatewayReconnect,
             Self::GiftCodeUpdate => EventType::GiftCodeUpdate,
+            Self::GuildAuditLogEntryCreate(_) => EventType::GuildAuditLogEntryCreate,
             Self::GuildCreate(_) => EventType::GuildCreate,
             Self::GuildDelete(_) => EventType::GuildDelete,
             Self::GuildEmojisUpdate(_) => EventType::GuildEmojisUpdate,
@@ -371,6 +375,7 @@ impl From<DispatchEvent> for Event {
             DispatchEvent::ChannelUpdate(v) => Self::ChannelUpdate(v),
             DispatchEvent::CommandPermissionsUpdate(v) => Self::CommandPermissionsUpdate(v),
             DispatchEvent::GiftCodeUpdate => Self::GiftCodeUpdate,
+            DispatchEvent::GuildAuditLogEntryCreate(v) => Self::GuildAuditLogEntryCreate(v),
             DispatchEvent::GuildCreate(v) => Self::GuildCreate(v),
             DispatchEvent::GuildDelete(v) => Self::GuildDelete(v),
             DispatchEvent::GuildEmojisUpdate(v) => Self::GuildEmojisUpdate(v),

--- a/twilight-model/src/gateway/intents.rs
+++ b/twilight-model/src/gateway/intents.rs
@@ -81,7 +81,7 @@ bitflags! {
         ///
         /// [`GUILD_BAN_ADD`]: super::event::Event::BanAdd
         /// [`GUILD_BAN_REMOVE`]: super::event::Event::BanRemove
-        #[deprecated(since = "0.14,2", note = "use the `GUILD_MODERATION` intent instead")]
+        #[deprecated(since = "0.14.2", note = "use the `GUILD_MODERATION` intent instead")]
         const GUILD_BANS = 1 << 2;
         /// Guild moderation intent.
         ///

--- a/twilight-model/src/gateway/intents.rs
+++ b/twilight-model/src/gateway/intents.rs
@@ -81,7 +81,19 @@ bitflags! {
         ///
         /// [`GUILD_BAN_ADD`]: super::event::Event::BanAdd
         /// [`GUILD_BAN_REMOVE`]: super::event::Event::BanRemove
+        #[deprecated(since = "0.14,2", note = "use the `GUILD_MODERATION` intent instead")]
         const GUILD_BANS = 1 << 2;
+        /// Guild moderation intent.
+        ///
+        /// Event(s) received:
+        ///  - [`GUILD_AUDIT_LOG_ENTRY_CREATE`]
+        ///  - [`GUILD_BAN_ADD`]
+        ///  - [`GUILD_BAN_REMOVE`]
+        ///
+        /// [`GUILD_AUDIT_LOG_ENTRY_CREATE`]: super::event::Event::
+        /// [`GUILD_BAN_ADD`]: super::event::Event::BanAdd
+        /// [`GUILD_BAN_REMOVE`]: super::event::Event::BanRemove
+        const GUILD_MODERATION = 1 << 2;
         /// Guild emojis and stickers intent.
         ///
         /// Event(s) received:

--- a/twilight-model/src/gateway/payload/incoming/guild_audit_log_entry_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_audit_log_entry_create.rs
@@ -1,0 +1,20 @@
+use crate::guild::audit_log::AuditLogEntry;
+use serde::{Deserialize, Serialize};
+use std::ops::{Deref, DerefMut};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct GuildAuditLogEntryCreate(pub AuditLogEntry);
+
+impl Deref for GuildAuditLogEntryCreate {
+    type Target = AuditLogEntry;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for GuildAuditLogEntryCreate {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/twilight-model/src/gateway/payload/incoming/guild_audit_log_entry_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_audit_log_entry_create.rs
@@ -2,6 +2,16 @@ use crate::guild::audit_log::AuditLogEntry;
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
+/// The inner value of the [`GuildAuditLogEntryCreate`] variant of the
+/// [`Event`] enum.
+///
+/// It is received when a new audit log entry is created in a
+/// server. The bot needs the [`VIEW_AUDIT_LOG`] permission to receive
+/// the event.
+///
+/// [`GuildAuditLogEntryCreate`]: crate::gateway::event::Event::GuildAuditLogEntryCreate
+/// [`Event`]:crate::gateway::event::Event
+/// [`VIEW_AUDIT_LOG`]: crate::guild::Permissions::VIEW_AUDIT_LOG
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct GuildAuditLogEntryCreate(pub AuditLogEntry);
 

--- a/twilight-model/src/gateway/payload/incoming/mod.rs
+++ b/twilight-model/src/gateway/payload/incoming/mod.rs
@@ -25,6 +25,7 @@ mod channel_delete;
 mod channel_pins_update;
 mod channel_update;
 mod command_permissions_update;
+mod guild_audit_log_entry_create;
 mod guild_create;
 mod guild_delete;
 mod guild_emojis_update;
@@ -80,7 +81,8 @@ pub use self::{
     auto_moderation_rule_update::AutoModerationRuleUpdate, ban_add::BanAdd, ban_remove::BanRemove,
     channel_create::ChannelCreate, channel_delete::ChannelDelete,
     channel_pins_update::ChannelPinsUpdate, channel_update::ChannelUpdate,
-    command_permissions_update::CommandPermissionsUpdate, guild_create::GuildCreate,
+    command_permissions_update::CommandPermissionsUpdate,
+    guild_audit_log_entry_create::GuildAuditLogEntryCreate, guild_create::GuildCreate,
     guild_delete::GuildDelete, guild_emojis_update::GuildEmojisUpdate,
     guild_integrations_update::GuildIntegrationsUpdate,
     guild_scheduled_event_create::GuildScheduledEventCreate,

--- a/twilight-model/src/guild/audit_log/entry.rs
+++ b/twilight-model/src/guild/audit_log/entry.rs
@@ -1,6 +1,6 @@
 use super::{AuditLogChange, AuditLogEventType, AuditLogOptionalEntryInfo};
 use crate::id::{
-    marker::{AuditLogEntryMarker, GenericMarker, UserMarker},
+    marker::{AuditLogEntryMarker, GenericMarker, GuildMarker, UserMarker},
     Id,
 };
 use serde::{Deserialize, Serialize};
@@ -15,6 +15,14 @@ pub struct AuditLogEntry {
     /// List of changes included in the entry.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub changes: Vec<AuditLogChange>,
+    /// ID of the server where the entry was added.
+    ///
+    /// This is **only** availible when receiving the event in
+    /// [GuildAuditLogEntryCreate].
+    ///
+    /// [GuildAuditLogEntryCreate]: crate::gateway::payload::GuildAuditLogEntryCreate
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guild_id: Option<Id<GuildMarker>>,
     /// ID of the entire entry.
     pub id: Id<AuditLogEntryMarker>,
     /// Optional information about the entry.
@@ -74,6 +82,7 @@ mod tests {
                 new: None,
                 old: Some(image_hash::ICON),
             }]),
+            guild_id: None,
             id: Id::new(3),
             options: None,
             reason: Some("some reason".to_owned()),

--- a/twilight-model/src/guild/audit_log/entry.rs
+++ b/twilight-model/src/guild/audit_log/entry.rs
@@ -17,10 +17,10 @@ pub struct AuditLogEntry {
     pub changes: Vec<AuditLogChange>,
     /// ID of the server where the entry was added.
     ///
-    /// This is **only** availible when receiving the event in
-    /// [GuildAuditLogEntryCreate].
+    /// This is **only** available when receiving the event in
+    /// [`GuildAuditLogEntryCreate`].
     ///
-    /// [GuildAuditLogEntryCreate]: crate::gateway::payload::GuildAuditLogEntryCreate
+    /// [`GuildAuditLogEntryCreate`]: crate::gateway::payload::incoming::GuildAuditLogEntryCreate
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<Id<GuildMarker>>,
     /// ID of the entire entry.


### PR DESCRIPTION
This patch also deprecates the `GUILD_BANS` intent in favour of the `GUILD_MODERATION` intent.

This will be marked as draft until the API docs PR is merged.

Note that currently the event needs the `GUILDS` intent though this will change soon.

Closes #2066