### PR TITLE
fix(validate): properly validate context menu commands

### DIFF
--- a/twilight-validate/src/command.rs
+++ b/twilight-validate/src/command.rs
@@ -237,12 +237,10 @@ pub fn command(value: &Command) -> Result<(), CommandValidationError> {
                 self::description(description)?;
             }
         }
-    } else {
-        if description.len() != 0 {
-            return Err(CommandValidationError {
-                kind: CommandValidationErrorType::DescriptionInvalid,
-            });
-        }
+    } else if !description.is_empty() {
+        return Err(CommandValidationError {
+            kind: CommandValidationErrorType::DescriptionInvalid,
+        });
     };
 
     if let Some(name_localizations) = name_localizations {

--- a/twilight-validate/src/command.rs
+++ b/twilight-validate/src/command.rs
@@ -230,13 +230,20 @@ pub fn command(value: &Command) -> Result<(), CommandValidationError> {
         ..
     } = value;
 
-    self::description(description)?;
-
-    if let Some(description_localizations) = description_localizations {
-        for description in description_localizations.values() {
-            self::description(description)?;
+    if *kind == CommandType::ChatInput {
+        self::description(description)?;
+        if let Some(description_localizations) = description_localizations {
+            for description in description_localizations.values() {
+                self::description(description)?;
+            }
         }
-    }
+    } else {
+        if description.len() != 0 {
+            return Err(CommandValidationError {
+                kind: CommandValidationErrorType::DescriptionInvalid,
+            });
+        }
+    };
 
     if let Some(name_localizations) = name_localizations {
         for name in name_localizations.values() {
@@ -527,13 +534,19 @@ mod tests {
 
         assert!(command(&valid_command).is_ok());
 
-        let invalid_command = Command {
+        let invalid_message_command = Command {
             description: "c".repeat(101),
             name: "d".repeat(33),
+            ..valid_command.clone()
+        };
+
+        assert!(command(&invalid_message_command).is_err());
+        let invalid_context_menu_command = Command {
+            description: String::new(),
             ..valid_command
         };
 
-        assert!(command(&invalid_command).is_err());
+        assert!(command(&invalid_context_menu_command).is_err());
     }
 
     #[test]

--- a/twilight-validate/src/command.rs
+++ b/twilight-validate/src/command.rs
@@ -537,10 +537,19 @@ mod tests {
             name: "d".repeat(33),
             ..valid_command.clone()
         };
-
         assert!(command(&invalid_message_command).is_err());
-        let invalid_context_menu_command = Command {
+
+        let valid_context_menu_command = Command {
             description: String::new(),
+            kind: CommandType::Message,
+            ..valid_command.clone()
+        };
+
+        assert!(command(&valid_context_menu_command).is_ok());
+
+        let invalid_context_menu_command = Command {
+            description: "example description".to_string(),
+            kind: CommandType::Message,
             ..valid_command
         };
 


### PR DESCRIPTION
This is an issue i ran into, and was mildly inconvenienced by. It could be done in a more compartmentalized way, but it would be a breaking change and wouldn't really create any illumination.