### PR TITLE
refactor(http): human legible error debug bodies

### DIFF
--- a/twilight-http/src/error.rs
+++ b/twilight-http/src/error.rs
@@ -14,11 +14,11 @@ impl Debug for ParsingError<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         let mut debug = f.debug_struct("Parsing");
 
-        if let Ok(body) = str::from_utf8(self.body) {
-            debug.field("body", &body);
-        } else {
-            debug.field("body", &self.body);
+        if let Ok(body_string) = str::from_utf8(self.body) {
+            debug.field("body_string", &body_string);
         }
+
+        debug.field("body", &self.body);
 
         debug.finish()
     }
@@ -34,12 +34,11 @@ impl Debug for ResponseError<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         let mut debug = f.debug_struct("Response");
 
-        if let Ok(body) = str::from_utf8(self.body) {
-            debug.field("body", &body);
-        } else {
-            debug.field("body", &self.body);
+        if let Ok(body_string) = str::from_utf8(self.body) {
+            debug.field("body_string", &body_string);
         }
 
+        debug.field("body", &self.body);
         debug.field("error", &self.error);
         debug.field("status", &self.status);
 

--- a/twilight-http/src/error.rs
+++ b/twilight-http/src/error.rs
@@ -6,46 +6,7 @@ use std::{
     str,
 };
 
-struct ParsingError<'a> {
-    body: &'a [u8],
-}
-
-impl Debug for ParsingError<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        let mut debug = f.debug_struct("Parsing");
-
-        if let Ok(body_string) = str::from_utf8(self.body) {
-            debug.field("body_string", &body_string);
-        }
-
-        debug.field("body", &self.body);
-
-        debug.finish()
-    }
-}
-
-struct ResponseError<'a> {
-    body: &'a [u8],
-    error: &'a ApiError,
-    status: StatusCode,
-}
-
-impl Debug for ResponseError<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        let mut debug = f.debug_struct("Response");
-
-        if let Ok(body_string) = str::from_utf8(self.body) {
-            debug.field("body_string", &body_string);
-        }
-
-        debug.field("body", &self.body);
-        debug.field("error", &self.error);
-        debug.field("status", &self.status);
-
-        debug.finish()
-    }
-}
-
+#[derive(Debug)]
 pub struct Error {
     pub(super) source: Option<Box<dyn StdError + Send + Sync>>,
     pub(super) kind: ErrorType,
@@ -75,38 +36,6 @@ impl Error {
             kind: ErrorType::Json,
             source: Some(Box::new(source)),
         }
-    }
-}
-
-impl Debug for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        let mut debug = f.debug_struct("Error");
-        debug.field("source", &self.source);
-
-        match &self.kind {
-            ErrorType::Parsing { body } => {
-                debug.field("kind", &ParsingError { body });
-            }
-            ErrorType::Response {
-                body,
-                error,
-                status,
-            } => {
-                debug.field(
-                    "kind",
-                    &ResponseError {
-                        body,
-                        error,
-                        status: *status,
-                    },
-                );
-            }
-            other => {
-                debug.field("kind", other);
-            }
-        }
-
-        debug.finish()
     }
 }
 
@@ -163,7 +92,6 @@ impl StdError for Error {
 }
 
 /// Type of [`Error`] that occurred.
-#[derive(Debug)]
 #[non_exhaustive]
 pub enum ErrorType {
     BuildingRequest,
@@ -196,4 +124,145 @@ pub enum ErrorType {
     /// This can occur if a bot token is invalidated or an access token expires
     /// or is revoked. Recreate the client to configure a new token.
     Unauthorized,
+}
+
+impl Debug for ErrorType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::BuildingRequest => f.write_str("BuildingRequest"),
+            Self::ChunkingResponse => f.write_str("ChunkingResponse"),
+            Self::CreatingHeader { name } => f
+                .debug_struct("CreatingHeader")
+                .field("name", name)
+                .finish(),
+            Self::Json => f.write_str("Json"),
+            Self::Parsing { body } => {
+                let mut debug = f.debug_struct("Parsing");
+
+                if let Ok(body_string) = str::from_utf8(body) {
+                    debug.field("body_string", &body_string);
+                }
+
+                debug.field("body", body).finish()
+            }
+            Self::RatelimiterTicket => f.write_str("RatelimiterTicket"),
+            Self::RequestCanceled => f.write_str("RequestCanceled"),
+            Self::RequestError => f.write_str("RequestError"),
+            Self::RequestTimedOut => f.write_str("RequestTimedOut"),
+            Self::Response {
+                body,
+                error,
+                status,
+            } => {
+                let mut debug = f.debug_struct("Response");
+
+                if let Ok(body_string) = str::from_utf8(body) {
+                    debug.field("body_string", &body_string);
+                }
+
+                debug
+                    .field("body", body)
+                    .field("error", error)
+                    .field("status", status)
+                    .finish()
+            }
+            Self::ServiceUnavailable { response } => f
+                .debug_struct("ServiceUnavailable")
+                .field("response", response)
+                .finish(),
+            Self::Unauthorized => f.write_str("Unauthorized"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ErrorType;
+    use crate::{
+        api_error::{ApiError, GeneralApiError},
+        response::StatusCode,
+    };
+
+    /// Ensure
+    #[test]
+    fn parsing_variant_debug() {
+        let body = br#"{"message": "aaa"#.to_vec();
+
+        let error = ErrorType::Parsing { body };
+
+        assert_eq!(
+            "Parsing {
+    body_string: \"{\\\"message\\\": \\\"aaa\",
+    body: [
+        123,
+        34,
+        109,
+        101,
+        115,
+        115,
+        97,
+        103,
+        101,
+        34,
+        58,
+        32,
+        34,
+        97,
+        97,
+        97,
+    ],
+}",
+            format!("{error:#?}"),
+        );
+    }
+
+    #[test]
+    fn response_variant_debug() {
+        let body = br#"{"message": "aaa"}"#.to_vec();
+
+        let error = ErrorType::Response {
+            body,
+            error: ApiError::General(GeneralApiError {
+                code: 0,
+                message: "401: Unauthorized".to_owned(),
+            }),
+            status: StatusCode::new(401),
+        };
+
+        assert_eq!(
+            "Response {
+    body_string: \"{\\\"message\\\": \\\"aaa\\\"}\",
+    body: [
+        123,
+        34,
+        109,
+        101,
+        115,
+        115,
+        97,
+        103,
+        101,
+        34,
+        58,
+        32,
+        34,
+        97,
+        97,
+        97,
+        34,
+        125,
+    ],
+    error: General(
+        GeneralApiError {
+            code: 0,
+            message: \"401: Unauthorized\",
+        },
+    ),
+    status: StatusCode(
+        401,
+    ),
+}",
+            format!("{error:#?}"),
+        );
+    }
 }


### PR DESCRIPTION
Manually implement Debug for `twilight_http::error::ErrorType`, providing custom implementations for some error types that contain HTTP body bytes so they can be converted to strings.

Old debug message (reformatted for PR readability):

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error {
    source: None,
    kind: Response {
        body: [
            123, 34, 99, 111, 100, 101, 34, 58, 32, 53, 48, 48, 51, 53, 44, 32,
            34, 101, 114, 114, 111, 114, 115, 34, 58, 32, 123, 34, 111, 112,
            116, 105, 111, 110, 115, 34, 58, 32, 123, 34, 49, 34, 58, 32, 123,
            34, 95, 101, 114, 114, 111, 114, 115, 34, 58, 32, 91, 123, 34, 99,
            111, 100, 101, 34, 58, 32, 34, 65, 80, 80, 76, 73, 67, 65, 84, 73,
            79, 78, 95, 67, 79, 77, 77, 65, 78, 68, 95, 79, 80, 84, 73, 79, 78,
            83, 95, 78, 65, 77, 69, 95, 73, 78, 86, 65, 76, 73, 68, 34, 44, 32,
            34, 109, 101, 115, 115, 97, 103, 101, 34, 58, 32, 34, 79, 112, 116,
            105, 111, 110, 32, 110, 97, 109, 101, 32, 97, 32, 105, 115, 32, 97,
            108, 114, 101, 97, 100, 121, 32, 117, 115, 101, 100, 32, 105, 110,
            32, 116, 104, 101, 115, 101, 32, 111, 112, 116, 105, 111, 110, 115,
            34, 125, 93, 125, 125, 125, 44, 32, 34, 109, 101, 115, 115, 97, 103,
            101, 34, 58, 32, 34, 73, 110, 118, 97, 108, 105, 100, 32, 70, 111,
            114, 109, 32, 66, 111, 100, 121, 34, 125
        ],
        error: General(GeneralApiError {
            code: 50035,
            message: "Invalid Form Body"
        }),
        status: StatusCode(400)
    }
}', examples/http-get-message.rs:66:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

New debug message (reformatted string body for PR readability):

```

thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error {
    source: None,
    kind: Response {
        body_string: "{
            \"code\": 50035,
            \"errors\": {
                \"options\": {
                    \"1\": {
                        \"_errors\": [{
                            \"code\": \"APPLICATION_COMMAND_OPTIONS_NAME_INVALID\",
                            \"message\": \"Option name a is already used in these options\"
                        }]
                    }
                }
            },
            \"message\": \"Invalid Form Body\"
        }",
        body: [
            123, 34, 99, 111, 100, 101, 34, 58, 32, 53, 48, 48, 51, 53, 44, 32,
            34, 101, 114, 114, 111, 114, 115, 34, 58, 32, 123, 34, 111, 112,
            116, 105, 111, 110, 115, 34, 58, 32, 123, 34, 49, 34, 58, 32, 123,
            34, 95, 101, 114, 114, 111, 114, 115, 34, 58, 32, 91, 123, 34, 99,
            111, 100, 101, 34, 58, 32, 34, 65, 80, 80, 76, 73, 67, 65, 84, 73,
            79, 78, 95, 67, 79, 77, 77, 65, 78, 68, 95, 79, 80, 84, 73, 79, 78,
            83, 95, 78, 65, 77, 69, 95, 73, 78, 86, 65, 76, 73, 68, 34, 44, 32,
            34, 109, 101, 115, 115, 97, 103, 101, 34, 58, 32, 34, 79, 112, 116,
            105, 111, 110, 32, 110, 97, 109, 101, 32, 97, 32, 105, 115, 32, 97,
            108, 114, 101, 97, 100, 121, 32, 117, 115, 101, 100, 32, 105, 110,
            32, 116, 104, 101, 115, 101, 32, 111, 112, 116, 105, 111, 110, 115,
            34, 125, 93, 125, 125, 125, 44, 32, 34, 109, 101, 115, 115, 97, 103,
            101, 34, 58, 32, 34, 73, 110, 118, 97, 108, 105, 100, 32, 70, 111,
            114, 109, 32, 66, 111, 100, 121, 34, 125
        ],
        error: General(GeneralApiError {
            code: 50035,
            message: "Invalid Form Body"
        }),
        status: StatusCode(400)
    }
}', examples/http-get-message.rs:66:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```