### PR TITLE
docs(model): activity timestamp integer values

### DIFF
--- a/twilight-model/src/gateway/presence/activity.rs
+++ b/twilight-model/src/gateway/presence/activity.rs
@@ -15,7 +15,8 @@ pub struct Activity {
     pub assets: Option<ActivityAssets>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub buttons: Vec<ActivityButton>,
-    // Introduced with custom statuses.
+    /// Unix timestamp of when the activity was added to the user's session, in
+    /// milliseconds.
     pub created_at: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<String>,
@@ -23,7 +24,6 @@ pub struct Activity {
     pub emoji: Option<ActivityEmoji>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub flags: Option<ActivityFlags>,
-    // Introduced with custom statuses.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/gateway/presence/activity_timestamps.rs
+++ b/twilight-model/src/gateway/presence/activity_timestamps.rs
@@ -2,8 +2,10 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ActivityTimestamps {
+    /// Unix time of when the activity started, in milliseconds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end: Option<u64>,
+    /// Unix time of when the activity ends, in milliseconds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start: Option<u64>,
 }


### PR DESCRIPTION
Document that the integer values of `Activity::created_at` and `ActivityTimestamps`' `end` and `start` fields are the Unix timestamp in milliseconds.

Closes #1958.