### PR TITLE
docs(http): updating command perms requires oauth

### DIFF
--- a/twilight-http/src/client/interaction.rs
+++ b/twilight-http/src/client/interaction.rs
@@ -332,6 +332,9 @@ impl<'a> InteractionClient<'a> {
     /// This overwrites the command permissions so the full set of permissions
     /// have to be sent every time.
     ///
+    /// This request requires that the client was configured with an OAuth Bearer
+    /// token.
+    ///
     /// # Errors
     ///
     /// Returns an error of type [`PermissionsCountInvalid`] if the permissions

--- a/twilight-http/src/request/application/command/update_command_permissions.rs
+++ b/twilight-http/src/request/application/command/update_command_permissions.rs
@@ -25,10 +25,11 @@ struct UpdateCommandPermissionsFields<'a> {
 
 /// Update command permissions for a single command in a guild.
 ///
-/// # Note:
+/// Note that this overwrites the command permissions, so the full set of
+/// permissions has to be sent every time.
 ///
-/// This overwrites the command permissions so the full set of permissions
-/// have to be sent every time.
+/// This request requires that the client was configured with an OAuth Bearer
+/// token.
 #[must_use = "requests must be configured and executed"]
 pub struct UpdateCommandPermissions<'a> {
     application_id: Id<ApplicationMarker>,


### PR DESCRIPTION
Add documentation on `InteractionClient::update_command_permissions` and `UpdateCommandPermissions` that an OAuth Bearer token is required to use the endpoint.

Closes #1740.