### PR TITLE
feat(http, validate)!: channel user limits

### DIFF
--- a/twilight-http/src/request/channel/update_channel.rs
+++ b/twilight-http/src/request/channel/update_channel.rs
@@ -18,7 +18,7 @@ use twilight_model::{
 use twilight_validate::{
     channel::{
         bitrate as validate_bitrate, forum_topic as validate_forum_topic, name as validate_name,
-        topic as validate_topic, ChannelValidationError,
+        topic as validate_topic, user_limit as validate_user_limit, ChannelValidationError,
     },
     request::{audit_reason as validate_audit_reason, ValidationError},
 };
@@ -334,11 +334,18 @@ impl<'a> UpdateChannel<'a> {
     /// Set to 0 for no limit. Limit can otherwise be between 1 and 99
     /// inclusive. See [Discord Docs/Modify Channel].
     ///
+    /// # Errors
+    ///
+    /// Returns an error of type [`UserLimitInvalid`] if the bitrate is invalid.
+    ///
     /// [Discord Docs/Modify Channel]: https://discord.com/developers/docs/resources/channel#modify-channel-json-params-guild-channel
-    pub const fn user_limit(mut self, user_limit: u16) -> Self {
+    /// [`UserLimitInvalid`]: twilight_validate::channel::ChannelValidationErrorType::UserLimitInvalid
+    pub fn user_limit(mut self, user_limit: u16) -> Result<Self, ChannelValidationError> {
+        validate_user_limit(user_limit)?;
+
         self.fields.user_limit = Some(user_limit);
 
-        self
+        Ok(self)
     }
 
     /// Set the [`VideoQualityMode`] for the voice channel.

--- a/twilight-validate/src/channel.rs
+++ b/twilight-validate/src/channel.rs
@@ -248,7 +248,7 @@ pub fn topic(value: impl AsRef<str>) -> Result<(), ChannelValidationError> {
 
 /// Ensure a channel's user limit is correct.
 ///
-/// Must be at least 99.
+/// Must be at most 99.
 ///
 /// # Errors
 ///

--- a/twilight-validate/src/channel.rs
+++ b/twilight-validate/src/channel.rs
@@ -24,6 +24,9 @@ pub const CHANNEL_RATE_LIMIT_PER_USER_MAX: u16 = 21_600;
 /// Maximum length of a channel's topic.
 pub const CHANNEL_TOPIC_LENGTH_MAX: usize = 1024;
 
+/// Maximum user limit of an audio channel.
+pub const CHANNEL_USER_LIMIT_MAX: u16 = 99;
+
 /// Returned when the channel can not be updated as configured.
 #[derive(Debug)]
 pub struct ChannelValidationError {
@@ -79,6 +82,11 @@ impl Display for ChannelValidationError {
 
                 f.write_str(" is not a thread")
             }
+            ChannelValidationErrorType::UserLimitInvalid => {
+                f.write_str("user limit is greater than ")?;
+
+                Display::fmt(&CHANNEL_USER_LIMIT_MAX, f)
+            }
         }
     }
 }
@@ -108,6 +116,8 @@ pub enum ChannelValidationErrorType {
         /// Provided type.
         kind: ChannelType,
     },
+    /// User limit is greater than 99.
+    UserLimitInvalid,
 }
 
 /// Ensure a channel's bitrate is collect.
@@ -236,6 +246,25 @@ pub fn topic(value: impl AsRef<str>) -> Result<(), ChannelValidationError> {
     }
 }
 
+/// Ensure a channel's user limit is correct.
+///
+/// Must be at least 99.
+///
+/// # Errors
+///
+/// Returns an error of type [`UserLimitInvalid`] if the UserLimit is invalid.
+///
+/// [`UserLimitInvalid`]: ChannelValidationErrorType::BitrateInvalid
+pub const fn user_limit(value: u16) -> Result<(), ChannelValidationError> {
+    if value <= CHANNEL_USER_LIMIT_MAX {
+        Ok(())
+    } else {
+        Err(ChannelValidationError {
+            kind: ChannelValidationErrorType::UserLimitInvalid,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -280,5 +309,15 @@ mod tests {
         assert!(topic("a".repeat(1_024)).is_ok());
 
         assert!(topic("a".repeat(1_025)).is_err());
+    }
+
+    #[test]
+    fn user_limit() {
+        assert!(super::user_limit(0).is_ok());
+        assert!(super::user_limit(99).is_ok());
+        assert!(matches!(
+            super::user_limit(100).unwrap_err().kind(),
+            ChannelValidationErrorType::UserLimitInvalid
+        ));
     }
 }

--- a/twilight-validate/src/channel.rs
+++ b/twilight-validate/src/channel.rs
@@ -252,7 +252,7 @@ pub fn topic(value: impl AsRef<str>) -> Result<(), ChannelValidationError> {
 ///
 /// # Errors
 ///
-/// Returns an error of type [`UserLimitInvalid`] if the UserLimit is invalid.
+/// Returns an error of type [`UserLimitInvalid`] if the user limit is invalid.
 ///
 /// [`UserLimitInvalid`]: ChannelValidationErrorType::BitrateInvalid
 pub const fn user_limit(value: u16) -> Result<(), ChannelValidationError> {


### PR DESCRIPTION
Validate channel `user_limit` fields on `UpdateChannel` and `CreateGuildChannel`, introducing a new `user_limit` function in `twilight_validate::channel`.

Part of #1477.