### PR TITLE
fix(model): signed channel member counts

### DIFF
--- a/twilight-model/src/channel/mod.rs
+++ b/twilight-model/src/channel/mod.rs
@@ -578,7 +578,9 @@ mod tests {
                 presence: None,
                 user_id: Some(Id::new(5)),
             }),
-            member_count: Some(50),
+            // Old threads can have negative member counts, so we need to ensure
+            // we keep negative member counts around.
+            member_count: Some(-1),
             message_count: Some(50),
             name: Some("privatethread".into()),
             newly_created: Some(true),
@@ -623,7 +625,7 @@ mod tests {
                 },
                 "default_auto_archive_duration": 60,
                 "invitable": true,
-                "member_count": 50,
+                "member_count": -1,
                 "message_count": 50,
                 "name": "privatethread",
                 "newly_created": true,

--- a/twilight-model/src/channel/mod.rs
+++ b/twilight-model/src/channel/mod.rs
@@ -119,7 +119,7 @@ pub struct Channel {
     /// At most a value of 50 is provided although the real number may be
     /// higher.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub member_count: Option<i32>,
+    pub member_count: Option<i8>,
     /// Number of messages in the channel.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_count: Option<u32>,

--- a/twilight-model/src/channel/mod.rs
+++ b/twilight-model/src/channel/mod.rs
@@ -119,7 +119,7 @@ pub struct Channel {
     /// At most a value of 50 is provided although the real number may be
     /// higher.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub member_count: Option<u8>,
+    pub member_count: Option<i32>,
     /// Number of messages in the channel.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_count: Option<u32>,
@@ -401,7 +401,7 @@ mod tests {
                 presence: None,
                 user_id: Some(Id::new(5)),
             }),
-            member_count: Some(50_u8),
+            member_count: Some(50),
             message_count: Some(50),
             name: Some("newsthread".into()),
             newly_created: Some(true),
@@ -489,7 +489,7 @@ mod tests {
                 presence: None,
                 user_id: Some(Id::new(5)),
             }),
-            member_count: Some(50_u8),
+            member_count: Some(50),
             message_count: Some(50),
             name: Some("publicthread".into()),
             newly_created: Some(true),
@@ -578,7 +578,7 @@ mod tests {
                 presence: None,
                 user_id: Some(Id::new(5)),
             }),
-            member_count: Some(50_u8),
+            member_count: Some(50),
             message_count: Some(50),
             name: Some("privatethread".into()),
             newly_created: Some(true),


### PR DESCRIPTION
Thread channels that haven't been updated in a while can have negative member counts, so we need to make `Channel::member_count` signed so channels and guilds correctly deserialize.