### PR TITLE
fix(http): resolve new clippy lints

### DIFF
--- a/twilight-http/src/routing.rs
+++ b/twilight-http/src/routing.rs
@@ -3108,10 +3108,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!(
-                "applications/{application_id}/commands?with_localizations=true",
-                application_id = APPLICATION_ID
-            )
+            format!("applications/{APPLICATION_ID}/commands?with_localizations=true")
         );
 
         let route = Route::GetGlobalCommands {
@@ -3163,9 +3160,7 @@ mod tests {
         assert_eq!(
             route.to_string(),
             format!(
-                "applications/{application_id}/guilds/{guild_id}/commands?with_localizations=true",
-                application_id = APPLICATION_ID,
-                guild_id = GUILD_ID
+                "applications/{APPLICATION_ID}/guilds/{GUILD_ID}/commands?with_localizations=true"
             )
         );
 


### PR DESCRIPTION
This fixes some clippy errors that seem to have been introduced in the latest rust updates.