### PR TITLE
fix(http): create auto moderation type field name

### DIFF
--- a/twilight-http/src/request/guild/auto_moderation/create_auto_moderation_rule.rs
+++ b/twilight-http/src/request/guild/auto_moderation/create_auto_moderation_rule.rs
@@ -25,6 +25,7 @@ use twilight_validate::request::{
 #[derive(Serialize)]
 struct CreateAutoModerationRuleFieldsAction {
     /// Type of action.
+    #[serde(rename = "type")]
     pub kind: AutoModerationActionType,
     /// Additional metadata needed during execution for this specific action
     /// type.


### PR DESCRIPTION
Fix the name of the CreateAutoModerationRule field body's `type` field from `kind` by putting a `#[serde(rename = "type")]` on it.

API docs:
<https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-auto-moderation-action-structure>

Closes #2092.
