### PR TITLE
refactor(cache): remove redundant `guild_members` insertions

### DIFF
--- a/twilight-cache-inmemory/src/event/member.rs
+++ b/twilight-cache-inmemory/src/event/member.rs
@@ -110,12 +110,6 @@ impl UpdateCache for MemberAdd {
         }
 
         cache.cache_member(self.guild_id, self.0.clone());
-
-        cache
-            .guild_members
-            .entry(self.guild_id)
-            .or_default()
-            .insert(self.0.user.id);
     }
 }
 
@@ -130,8 +124,6 @@ impl UpdateCache for MemberChunk {
         }
 
         cache.cache_members(self.guild_id, self.members.clone());
-        let mut guild = cache.guild_members.entry(self.guild_id).or_default();
-        guild.extend(self.members.iter().map(|member| member.user.id));
     }
 }
 


### PR DESCRIPTION
`cache.cache_member` already performs the insertion into `guild_members`, so both of these insertions seem to be redundant

discussed on discord here: https://discord.com/channels/745809834183753828/1020062771703980133/1068756194606465115