### PR TITLE
refactor(http)!: replace `ListBody` with `Vec`

### DIFF
--- a/twilight-http/src/client/interaction.rs
+++ b/twilight-http/src/client/interaction.rs
@@ -40,7 +40,7 @@ use twilight_model::{
 ///
 /// let interaction_client = client.interaction(application_id);
 ///
-/// let commands = interaction_client.global_commands().await?.models().await?;
+/// let commands = interaction_client.global_commands().await?.model().await?;
 ///
 /// println!("there are {} global commands", commands.len());
 /// # Ok(()) }

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -289,7 +289,7 @@ impl Client {
     ///     .interaction(application_id)
     ///     .global_commands()
     ///     .await?
-    ///     .models()
+    ///     .model()
     ///     .await?;
     ///
     /// println!("there are {} global commands", commands.len());
@@ -2412,7 +2412,7 @@ impl Client {
     /// let client = Client::new("my token".to_owned());
     ///
     /// let guild_id = Id::new(1);
-    /// let stickers = client.guild_stickers(guild_id).await?.models().await?;
+    /// let stickers = client.guild_stickers(guild_id).await?.model().await?;
     ///
     /// println!("{}", stickers.len());
     /// # Ok(()) }

--- a/twilight-http/src/request/application/command/get_global_commands.rs
+++ b/twilight-http/src/request/application/command/get_global_commands.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -39,9 +39,9 @@ impl<'a> GetGlobalCommands<'a> {
 }
 
 impl IntoFuture for GetGlobalCommands<'_> {
-    type Output = Result<Response<ListBody<Command>>, Error>;
+    type Output = Result<Response<Vec<Command>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Command>>;
+    type IntoFuture = ResponseFuture<Vec<Command>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/application/command/get_guild_command_permissions.rs
+++ b/twilight-http/src/request/application/command/get_guild_command_permissions.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -37,9 +37,9 @@ impl<'a> GetGuildCommandPermissions<'a> {
 }
 
 impl IntoFuture for GetGuildCommandPermissions<'_> {
-    type Output = Result<Response<ListBody<GuildCommandPermissions>>, Error>;
+    type Output = Result<Response<Vec<GuildCommandPermissions>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<GuildCommandPermissions>>;
+    type IntoFuture = ResponseFuture<Vec<GuildCommandPermissions>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/application/command/get_guild_commands.rs
+++ b/twilight-http/src/request/application/command/get_guild_commands.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -48,9 +48,9 @@ impl<'a> GetGuildCommands<'a> {
 }
 
 impl IntoFuture for GetGuildCommands<'_> {
-    type Output = Result<Response<ListBody<Command>>, Error>;
+    type Output = Result<Response<Vec<Command>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Command>>;
+    type IntoFuture = ResponseFuture<Vec<Command>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/application/command/set_global_commands.rs
+++ b/twilight-http/src/request/application/command/set_global_commands.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -43,9 +43,9 @@ impl<'a> SetGlobalCommands<'a> {
 }
 
 impl IntoFuture for SetGlobalCommands<'_> {
-    type Output = Result<Response<ListBody<Command>>, Error>;
+    type Output = Result<Response<Vec<Command>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Command>>;
+    type IntoFuture = ResponseFuture<Vec<Command>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/application/command/set_guild_commands.rs
+++ b/twilight-http/src/request/application/command/set_guild_commands.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -49,9 +49,9 @@ impl<'a> SetGuildCommands<'a> {
 }
 
 impl IntoFuture for SetGuildCommands<'_> {
-    type Output = Result<Response<ListBody<Command>>, Error>;
+    type Output = Result<Response<Vec<Command>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Command>>;
+    type IntoFuture = ResponseFuture<Vec<Command>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/application/command/update_command_permissions.rs
+++ b/twilight-http/src/request/application/command/update_command_permissions.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -64,9 +64,9 @@ impl<'a> UpdateCommandPermissions<'a> {
 }
 
 impl IntoFuture for UpdateCommandPermissions<'_> {
-    type Output = Result<Response<ListBody<CommandPermission>>, Error>;
+    type Output = Result<Response<Vec<CommandPermission>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<CommandPermission>>;
+    type IntoFuture = ResponseFuture<Vec<CommandPermission>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/channel/get_pins.rs
+++ b/twilight-http/src/request/channel/get_pins.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,9 +25,9 @@ impl<'a> GetPins<'a> {
 }
 
 impl IntoFuture for GetPins<'_> {
-    type Output = Result<Response<ListBody<Message>>, Error>;
+    type Output = Result<Response<Vec<Message>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Message>>;
+    type IntoFuture = ResponseFuture<Vec<Message>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/channel/invite/get_channel_invites.rs
+++ b/twilight-http/src/request/channel/invite/get_channel_invites.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -30,9 +30,9 @@ impl<'a> GetChannelInvites<'a> {
 }
 
 impl IntoFuture for GetChannelInvites<'_> {
-    type Output = Result<Response<ListBody<Invite>>, Error>;
+    type Output = Result<Response<Vec<Invite>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Invite>>;
+    type IntoFuture = ResponseFuture<Vec<Invite>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/channel/message/get_channel_messages.rs
+++ b/twilight-http/src/request/channel/message/get_channel_messages.rs
@@ -3,7 +3,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -127,9 +127,9 @@ impl<'a> GetChannelMessages<'a> {
 }
 
 impl IntoFuture for GetChannelMessages<'_> {
-    type Output = Result<Response<ListBody<Message>>, Error>;
+    type Output = Result<Response<Vec<Message>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Message>>;
+    type IntoFuture = ResponseFuture<Vec<Message>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/twilight-http/src/request/channel/message/get_channel_messages_configured.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -80,9 +80,9 @@ impl<'a> GetChannelMessagesConfigured<'a> {
 }
 
 impl IntoFuture for GetChannelMessagesConfigured<'_> {
-    type Output = Result<Response<ListBody<Message>>, Error>;
+    type Output = Result<Response<Vec<Message>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Message>>;
+    type IntoFuture = ResponseFuture<Vec<Message>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/channel/reaction/get_reactions.rs
+++ b/twilight-http/src/request/channel/reaction/get_reactions.rs
@@ -3,7 +3,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -88,9 +88,9 @@ impl<'a> GetReactions<'a> {
 }
 
 impl IntoFuture for GetReactions<'_> {
-    type Output = Result<Response<ListBody<User>>, Error>;
+    type Output = Result<Response<Vec<User>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<User>>;
+    type IntoFuture = ResponseFuture<Vec<User>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/channel/thread/get_thread_members.rs
+++ b/twilight-http/src/request/channel/thread/get_thread_members.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -85,9 +85,9 @@ impl<'a> GetThreadMembers<'a> {
 }
 
 impl IntoFuture for GetThreadMembers<'_> {
-    type Output = Result<Response<ListBody<ThreadMember>>, Error>;
+    type Output = Result<Response<Vec<ThreadMember>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<ThreadMember>>;
+    type IntoFuture = ResponseFuture<Vec<ThreadMember>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/channel/webhook/get_channel_webhooks.rs
+++ b/twilight-http/src/request/channel/webhook/get_channel_webhooks.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,9 +25,9 @@ impl<'a> GetChannelWebhooks<'a> {
 }
 
 impl IntoFuture for GetChannelWebhooks<'_> {
-    type Output = Result<Response<ListBody<Webhook>>, Error>;
+    type Output = Result<Response<Vec<Webhook>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Webhook>>;
+    type IntoFuture = ResponseFuture<Vec<Webhook>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/get_voice_regions.rs
+++ b/twilight-http/src/request/get_voice_regions.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -21,9 +21,9 @@ impl<'a> GetVoiceRegions<'a> {
 }
 
 impl IntoFuture for GetVoiceRegions<'_> {
-    type Output = Result<Response<ListBody<VoiceRegion>>, Error>;
+    type Output = Result<Response<Vec<VoiceRegion>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<VoiceRegion>>;
+    type IntoFuture = ResponseFuture<Vec<VoiceRegion>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/auto_moderation/get_guild_auto_moderation_rules.rs
+++ b/twilight-http/src/request/guild/auto_moderation/get_guild_auto_moderation_rules.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -29,9 +29,9 @@ impl<'a> GetGuildAutoModerationRules<'a> {
 }
 
 impl IntoFuture for GetGuildAutoModerationRules<'_> {
-    type Output = Result<Response<ListBody<AutoModerationRule>>, Error>;
+    type Output = Result<Response<Vec<AutoModerationRule>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<AutoModerationRule>>;
+    type IntoFuture = ResponseFuture<Vec<AutoModerationRule>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/ban/get_bans.rs
+++ b/twilight-http/src/request/guild/ban/get_bans.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -42,7 +42,7 @@ struct GetBansFields {
 /// let user_id = Id::new(2);
 ///
 /// let response = client.bans(guild_id).after(user_id).limit(25).await?;
-/// let bans = response.models().await?;
+/// let bans = response.model().await?;
 ///
 /// for ban in bans {
 ///     println!("{} was banned for: {:?}", ban.user.name, ban.reason);
@@ -122,9 +122,9 @@ impl<'a> GetBans<'a> {
 }
 
 impl IntoFuture for GetBans<'_> {
-    type Output = Result<Response<ListBody<Ban>>, Error>;
+    type Output = Result<Response<Vec<Ban>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Ban>>;
+    type IntoFuture = ResponseFuture<Vec<Ban>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/emoji/get_emojis.rs
+++ b/twilight-http/src/request/guild/emoji/get_emojis.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -43,9 +43,9 @@ impl<'a> GetEmojis<'a> {
 }
 
 impl IntoFuture for GetEmojis<'_> {
-    type Output = Result<Response<ListBody<Emoji>>, Error>;
+    type Output = Result<Response<Vec<Emoji>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Emoji>>;
+    type IntoFuture = ResponseFuture<Vec<Emoji>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/get_guild_channels.rs
+++ b/twilight-http/src/request/guild/get_guild_channels.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,9 +25,9 @@ impl<'a> GetGuildChannels<'a> {
 }
 
 impl IntoFuture for GetGuildChannels<'_> {
-    type Output = Result<Response<ListBody<Channel>>, Error>;
+    type Output = Result<Response<Vec<Channel>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Channel>>;
+    type IntoFuture = ResponseFuture<Vec<Channel>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/get_guild_invites.rs
+++ b/twilight-http/src/request/guild/get_guild_invites.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -29,9 +29,9 @@ impl<'a> GetGuildInvites<'a> {
 }
 
 impl IntoFuture for GetGuildInvites<'_> {
-    type Output = Result<Response<ListBody<Invite>>, Error>;
+    type Output = Result<Response<Vec<Invite>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Invite>>;
+    type IntoFuture = ResponseFuture<Vec<Invite>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/get_guild_voice_regions.rs
+++ b/twilight-http/src/request/guild/get_guild_voice_regions.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -27,9 +27,9 @@ impl<'a> GetGuildVoiceRegions<'a> {
 }
 
 impl IntoFuture for GetGuildVoiceRegions<'_> {
-    type Output = Result<Response<ListBody<VoiceRegion>>, Error>;
+    type Output = Result<Response<Vec<VoiceRegion>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<VoiceRegion>>;
+    type IntoFuture = ResponseFuture<Vec<VoiceRegion>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/get_guild_webhooks.rs
+++ b/twilight-http/src/request/guild/get_guild_webhooks.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,9 +25,9 @@ impl<'a> GetGuildWebhooks<'a> {
 }
 
 impl IntoFuture for GetGuildWebhooks<'_> {
-    type Output = Result<Response<ListBody<Webhook>>, Error>;
+    type Output = Result<Response<Vec<Webhook>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Webhook>>;
+    type IntoFuture = ResponseFuture<Vec<Webhook>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/integration/get_guild_integrations.rs
+++ b/twilight-http/src/request/guild/integration/get_guild_integrations.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -28,9 +28,9 @@ impl<'a> GetGuildIntegrations<'a> {
 }
 
 impl IntoFuture for GetGuildIntegrations<'_> {
-    type Output = Result<Response<ListBody<GuildIntegration>>, Error>;
+    type Output = Result<Response<Vec<GuildIntegration>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<GuildIntegration>>;
+    type IntoFuture = ResponseFuture<Vec<GuildIntegration>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/member/get_guild_members.rs
+++ b/twilight-http/src/request/guild/member/get_guild_members.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -99,9 +99,9 @@ impl<'a> GetGuildMembers<'a> {
 }
 
 impl IntoFuture for GetGuildMembers<'_> {
-    type Output = Result<Response<ListBody<Member>>, Error>;
+    type Output = Result<Response<Vec<Member>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Member>>;
+    type IntoFuture = ResponseFuture<Vec<Member>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/member/search_guild_members.rs
+++ b/twilight-http/src/request/guild/member/search_guild_members.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -88,9 +88,9 @@ impl<'a> SearchGuildMembers<'a> {
 }
 
 impl IntoFuture for SearchGuildMembers<'_> {
-    type Output = Result<Response<ListBody<Member>>, Error>;
+    type Output = Result<Response<Vec<Member>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Member>>;
+    type IntoFuture = ResponseFuture<Vec<Member>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/role/get_guild_roles.rs
+++ b/twilight-http/src/request/guild/role/get_guild_roles.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,9 +25,9 @@ impl<'a> GetGuildRoles<'a> {
 }
 
 impl IntoFuture for GetGuildRoles<'_> {
-    type Output = Result<Response<ListBody<Role>>, Error>;
+    type Output = Result<Response<Vec<Role>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Role>>;
+    type IntoFuture = ResponseFuture<Vec<Role>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/role/update_role_positions.rs
+++ b/twilight-http/src/request/guild/role/update_role_positions.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -39,9 +39,9 @@ impl<'a> UpdateRolePositions<'a> {
 }
 
 impl IntoFuture for UpdateRolePositions<'_> {
-    type Output = Result<Response<ListBody<Role>>, Error>;
+    type Output = Result<Response<Vec<Role>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Role>>;
+    type IntoFuture = ResponseFuture<Vec<Role>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/sticker/get_guild_stickers.rs
+++ b/twilight-http/src/request/guild/sticker/get_guild_stickers.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -24,7 +24,7 @@ use twilight_model::{
 /// let client = Client::new("my token".to_owned());
 ///
 /// let guild_id = Id::new(1);
-/// let stickers = client.guild_stickers(guild_id).await?.models().await?;
+/// let stickers = client.guild_stickers(guild_id).await?.model().await?;
 ///
 /// println!("{}", stickers.len());
 /// # Ok(()) }
@@ -41,9 +41,9 @@ impl<'a> GetGuildStickers<'a> {
 }
 
 impl IntoFuture for GetGuildStickers<'_> {
-    type Output = Result<Response<ListBody<Sticker>>, Error>;
+    type Output = Result<Response<Vec<Sticker>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Sticker>>;
+    type IntoFuture = ResponseFuture<Vec<Sticker>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/scheduled_event/get_guild_scheduled_event_users.rs
+++ b/twilight-http/src/request/scheduled_event/get_guild_scheduled_event_users.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -121,9 +121,9 @@ impl<'a> GetGuildScheduledEventUsers<'a> {
 }
 
 impl IntoFuture for GetGuildScheduledEventUsers<'_> {
-    type Output = Result<Response<ListBody<GuildScheduledEventUser>>, Error>;
+    type Output = Result<Response<Vec<GuildScheduledEventUser>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<GuildScheduledEventUser>>;
+    type IntoFuture = ResponseFuture<Vec<GuildScheduledEventUser>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/scheduled_event/get_guild_scheduled_events.rs
+++ b/twilight-http/src/request/scheduled_event/get_guild_scheduled_events.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -37,9 +37,9 @@ impl<'a> GetGuildScheduledEvents<'a> {
 }
 
 impl IntoFuture for GetGuildScheduledEvents<'_> {
-    type Output = Result<Response<ListBody<GuildScheduledEvent>>, Error>;
+    type Output = Result<Response<Vec<GuildScheduledEvent>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<GuildScheduledEvent>>;
+    type IntoFuture = ResponseFuture<Vec<GuildScheduledEvent>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/template/get_templates.rs
+++ b/twilight-http/src/request/template/get_templates.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,9 +25,9 @@ impl<'a> GetTemplates<'a> {
 }
 
 impl IntoFuture for GetTemplates<'_> {
-    type Output = Result<Response<ListBody<Template>>, Error>;
+    type Output = Result<Response<Vec<Template>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Template>>;
+    type IntoFuture = ResponseFuture<Vec<Template>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/user/get_current_user_connections.rs
+++ b/twilight-http/src/request/user/get_current_user_connections.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -23,9 +23,9 @@ impl<'a> GetCurrentUserConnections<'a> {
 }
 
 impl IntoFuture for GetCurrentUserConnections<'_> {
-    type Output = Result<Response<ListBody<Connection>>, Error>;
+    type Output = Result<Response<Vec<Connection>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Connection>>;
+    type IntoFuture = ResponseFuture<Vec<Connection>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/user/get_current_user_guilds.rs
+++ b/twilight-http/src/request/user/get_current_user_guilds.rs
@@ -2,7 +2,7 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -106,9 +106,9 @@ impl<'a> GetCurrentUserGuilds<'a> {
 }
 
 impl IntoFuture for GetCurrentUserGuilds<'_> {
-    type Output = Result<Response<ListBody<CurrentUserGuild>>, Error>;
+    type Output = Result<Response<Vec<CurrentUserGuild>>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<CurrentUserGuild>>;
+    type IntoFuture = ResponseFuture<Vec<CurrentUserGuild>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/response/marker.rs
+++ b/twilight-http/src/response/marker.rs
@@ -7,8 +7,6 @@
 //! [`DeleteRole`]: super::super::request::guild::role::DeleteRole
 //! [`Response`]: super::Response
 
-use std::marker::PhantomData;
-
 /// Marker that a response has no body. Responses with this marker can't be
 /// deserialized.
 ///
@@ -20,22 +18,11 @@ use std::marker::PhantomData;
 #[non_exhaustive]
 pub struct EmptyBody;
 
-/// Marker that a response has a list of something.
-///
-/// May be used via the [`Response::models`].
-///
-/// [`Response::models`]: super::Response::<ListBody<T>>::models
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ListBody<T> {
-    phantom: PhantomData<T>,
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{EmptyBody, ListBody};
+    use super::EmptyBody;
     use static_assertions::assert_impl_all;
     use std::fmt::Debug;
 
     assert_impl_all!(EmptyBody: Clone, Debug, Eq, PartialEq, Send, Sync);
-    assert_impl_all!(ListBody<String>: Clone, Debug, Eq, PartialEq, Send, Sync);
 }


### PR DESCRIPTION
Since there's no need for any special `Vec<T>` handling, this PR removes the `ListBody<T>` marker type.

Together with #2083 this PR leaves only the `EmptyBody` marker, after which the `marker` module could become private, exporting `EmptyBody` directly in the `request` module.

Somewhat dependent upon #2083

# TODO

- [x] Create a deprecated `models` method notifying users to switching to `model`