### PR TITLE
refactor: update dependencies

### DIFF
--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -20,7 +20,7 @@ rand = { default-features = false, features = ["std", "std_rng"], version = "0.8
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.8" }
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.17" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.18" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-gateway-queue = { default-features = false, path = "../twilight-gateway-queue", version = "0.15.0-rc.1" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.0-rc.1" }
@@ -32,7 +32,7 @@ twilight-model = { default-features = false, path = "../twilight-model", version
 # https://github.com/alexcrichton/flate2-rs/issues/217
 flate2 = { default-features = false, optional = true, version = "1.0.24" }
 twilight-http = { default-features = false, optional = true, path = "../twilight-http", version = "0.15.0-rc.1" }
-simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = ">=0.4, <0.7" }
+simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = ">=0.4, <0.8" }
 
 # TLS libraries
 # They are needed to track what is used in tokio-tungstenite

--- a/twilight-http-ratelimiting/Cargo.toml
+++ b/twilight-http-ratelimiting/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "1", default-features = false, features = ["rt", "sync", "ti
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1.23" }
 
 [dev-dependencies]
-criterion = { default-features = false, version = "0.3" }
+criterion = { default-features = false, version = "0.4" }
 static_assertions = { default-features = false, version = "1.1.0" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
 

--- a/twilight-http/Cargo.toml
+++ b/twilight-http/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.15.0-rc.1"
 hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
 hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.23" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
-hyper-trust-dns = { default-features = false, optional = true, version = "0.4" }
+hyper-trust-dns = { default-features = false, optional = true, version = "0.5" }
 percent-encoding = { default-features = false, version = "2" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1" }
@@ -30,7 +30,7 @@ twilight-validate = { default-features = false, path = "../twilight-validate", v
 
 # Optional dependencies.
 brotli = { default-features = false, features = ["std"], optional = true, version = "3.0.0" }
-simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = ">=0.4, <0.7" }
+simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = ">=0.4, <0.8" }
 
 [features]
 default = ["decompression", "rustls-native-roots"]

--- a/twilight-lavalink/Cargo.toml
+++ b/twilight-lavalink/Cargo.toml
@@ -20,7 +20,7 @@ http = { default-features = false, version = "0.2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["macros", "net", "rt", "sync", "time"], version = "1.0" }
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.17" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.18" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.0-rc.1" }
 

--- a/twilight-lavalink/src/node.rs
+++ b/twilight-lavalink/src/node.rs
@@ -655,7 +655,13 @@ async fn reconnect(
 
 async fn backoff(
     config: &NodeConfig,
-) -> Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response<()>), NodeError> {
+) -> Result<
+    (
+        WebSocketStream<MaybeTlsStream<TcpStream>>,
+        Response<Option<Vec<u8>>>,
+    ),
+    NodeError,
+> {
     let mut seconds = 1;
 
     loop {

--- a/twilight-mention/Cargo.toml
+++ b/twilight-mention/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.15.0-rc.1"
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.0-rc.1" }
 
 [dev-dependencies]
-criterion = { default-features = false, version = "0.3" }
+criterion = { default-features = false, version = "0.4" }
 static_assertions = { default-features = false, version = "1" }
 
 [[bench]]

--- a/twilight-model/Cargo.toml
+++ b/twilight-model/Cargo.toml
@@ -21,7 +21,7 @@ time = { default-features = false, features = ["parsing", "std"], version = "0.3
 tracing = { default-features = false, version = "0.1.16" }
 
 [dev-dependencies]
-criterion = { default-features = false, version = "0.3" }
+criterion = { default-features = false, version = "0.4" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 serde_test = { default-features = false, version = "1" }
 static_assertions = { default-features = false, version = "1.0" }


### PR DESCRIPTION
Update all crates' dependencies, which includes updated dependencies for `gateway`, `http-ratelimiting`, `http`, `lavalink`, `mention`, and `model`.