### PR TITLE
book(lavalink): sync TLS docs with gateway

### DIFF
--- a/book/src/chapter_1_crates/section_3_gateway.md
+++ b/book/src/chapter_1_crates/section_3_gateway.md
@@ -32,15 +32,6 @@ In addition to enabling the feature, you will need to add the following to your
 rustflags = ["-C", "target-cpu=native"]
 ```
 
-### Metrics
-
-The `metrics` feature provides metrics information via the [`metrics`] crate.
-Some of the metrics logged are counters about received event counts and their
-types and gauges about the capacity and efficiency of the inflater of each
-shard.
-
-This is disabled by default.
-
 ### TLS
 
 `twilight-gateway` has features to enable [`tokio-tungstenite`]'s TLS features.
@@ -135,10 +126,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 [cmake]: https://cmake.org/
 [flate2]: https://github.com/alexcrichton/flate2-rs
 [zlib-ng]: https://github.com/zlib-ng/zlib-ng
-[`async-tungstenite`]: https://crates.io/crates/async-tungstenite
 [`hyper-rustls`]: https://crates.io/crates/hyper-rustls
 [`hyper-tls`]: https://crates.io/crates/hyper-tls
 [`metrics`]: https://crates.io/crates/metrics
 [`serde_json`]: https://crates.io/crates/serde_json
 [`simd-json`]: https://crates.io/crates/simd-json
-[`twilight-http`]: ./section_2_http.md
+[`tokio-tungstenite`]: https://crates.io/crates/tokio-tungstenite

--- a/book/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
+++ b/book/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
@@ -19,22 +19,28 @@ This is enabled by default.
 
 ### TLS
 
-`twilight-lavalink` has features to enable [`async-tungstenite`]'s TLS features.
-These features are mutually exclusive.
-
-`rustls` is enabled by default.
+`twilight-lavalink` has features to enable [`tokio-tungstenite`]'s TLS features.
+These features are mutually exclusive. `rustls-native-roots` is enabled by
+default.
 
 #### Native
 
-The `native` feature enables [`async-tungstenite`]'s `tokio-native-tls` feature.
-This will use native TLS support, for example OpenSSL on Linux.
+The `native` feature enables [`tokio-tungstenite`]'s `native-tls` feature.
 
 #### RusTLS
 
-The `rustls` feature enables [`async-tungstenite`]'s `tokio-rustls` which uses
-the [RusTLS] crate as the TLS backend.
+RusTLS allows specifying from where certificate roots are retrieved from.
+
+##### Native roots
+The `rustls-native-roots` feature enables [`tokio-tungstenite`]'s
+`rustls-tls-native-roots` feature.
 
 This is enabled by default.
+
+##### Web PKI roots
+
+The `rustls-webpki-roots` feature enables [`tokio-tungstenite`]'s
+`rustls-tls-webpki-roots` feature.
 
 ## Examples
 
@@ -104,4 +110,4 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 [model]: ../section_1_model.html
 [node]: https://twilight-rs.github.io/twilight/twilight_lavalink/node/struct.Node.html
 [process]: https://twilight-rs.github.io/twilight/twilight_lavalink/client/struct.Lavalink.html#method.process
-[`async-tungstenite`]: https://crates.io/crates/async-tungstenite
+[`tokio-tungstenite`]: https://crates.io/crates/tokio-tungstenite


### PR DESCRIPTION
The book's TLS docs for Twilight-lavalink incorrectly mention `async-tungstenite` as the WebSocket library instead of `tokio-tungstenite`. This PR, like #1982 for the gateway, corrects this. Additionally I removed the mention of the gateway's metric feature (removed in #1993).
