### PR TITLE
docs: standardize examples

### DIFF
--- a/book/src/chapter_1_crates/section_3_gateway.md
+++ b/book/src/chapter_1_crates/section_3_gateway.md
@@ -88,18 +88,17 @@ the dependency tree it will make use of that instead of [zlib-ng].
 Starting a `Shard` and printing the contents of new messages as they come in:
 
 ```rust,no_run
-use std::{env, error::Error};
+use std::env;
 use twilight_gateway::{Config, Intents, Shard, ShardId};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
-    // Initialize the tracing subscriber.
+async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let token = env::var("DISCORD_TOKEN")?;
+
     let config = Config::new(token, Intents::GUILD_MESSAGES);
     let mut shard = Shard::new(ShardId::ONE, config);
-    tracing::info!("created shard");
 
     loop {
         let event = match shard.next_event().await {

--- a/book/src/chapter_1_crates/section_4_cache_inmemory.md
+++ b/book/src/chapter_1_crates/section_4_cache_inmemory.md
@@ -10,7 +10,7 @@ Process new messages that come over a shard into the cache:
 
 ```rust,no_run
 # #[tokio::main]
-# async fn main() -> Result<(), Box<dyn std::error::Error>> {
+# async fn main() -> anyhow::Result<()> {
 use std::env;
 use twilight_cache_inmemory::InMemoryCache;
 use twilight_gateway::{Config, Intents, Shard, ShardId};

--- a/book/tests/Cargo.toml
+++ b/book/tests/Cargo.toml
@@ -5,6 +5,7 @@ name = "book"
 version = "0.0.0"
 
 [dependencies]
+anyhow = { default-features = false, features = ["std"], version = "1.0.50" }
 futures = { version = "0.3", default-features = false }
 skeptic = "0.13.5"
 twilight-gateway = { path = "../../twilight-gateway" }

--- a/examples/gateway-parallel.rs
+++ b/examples/gateway-parallel.rs
@@ -15,6 +15,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let token = env::var("DISCORD_TOKEN")?;
+
     let client = Client::new(token.clone());
 
     let config = Config::new(token, Intents::GUILDS);

--- a/examples/gateway-request-members.rs
+++ b/examples/gateway-request-members.rs
@@ -4,7 +4,6 @@ use twilight_model::{gateway::payload::outgoing::RequestGuildMembers, id::Id};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Initialize the tracing subscriber.
     tracing_subscriber::fmt::init();
 
     let token = env::var("DISCORD_TOKEN")?;

--- a/examples/gateway-reshard.rs
+++ b/examples/gateway-reshard.rs
@@ -9,10 +9,10 @@ use twilight_http::Client;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Initialize the tracing subscriber.
     tracing_subscriber::fmt::init();
 
     let token = env::var("DISCORD_TOKEN")?;
+
     let client = Arc::new(Client::new(token.clone()));
 
     let config = Config::new(token, Intents::GUILD_MESSAGES | Intents::MESSAGE_CONTENT);

--- a/twilight-cache-inmemory/Cargo.toml
+++ b/twilight-cache-inmemory/Cargo.toml
@@ -23,6 +23,7 @@ twilight-model = { default-features = false, path = "../twilight-model", version
 twilight-util = { default-features = false, features = ["permission-calculator"], optional = true, path = "../twilight-util", version = "0.15.0-rc.1" }
 
 [dev-dependencies]
+anyhow = { default-features = false, features = ["std"], version = "1" }
 futures = { default-features = false, version = "0.3" }
 static_assertions = { default-features = false, version = "1" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }

--- a/twilight-cache-inmemory/README.md
+++ b/twilight-cache-inmemory/README.md
@@ -33,16 +33,16 @@ Refer to the `permission` module for more documentation.
 Update a cache with events that come in through the gateway:
 
 ```rust,no_run
-use std::{env, error::Error};
+use std::env;
 use twilight_cache_inmemory::InMemoryCache;
 use twilight_gateway::{Config, Intents, Shard, ShardId};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
-    // Initialize the tracing subscriber.
+async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let token = env::var("DISCORD_TOKEN")?;
+
     let config = Config::new(token, Intents::GUILD_MESSAGES);
     let mut shard = Shard::new(ShardId::ONE, config);
 

--- a/twilight-gateway/README.md
+++ b/twilight-gateway/README.md
@@ -35,7 +35,6 @@ use twilight_gateway::{Config, Intents, Shard, ShardId};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Initialize the tracing subscriber.
     tracing_subscriber::fmt::init();
 
     let token = env::var("DISCORD_TOKEN")?;
@@ -84,6 +83,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 
     let token = env::var("DISCORD_TOKEN")?;
+
     let client = Client::new(token.clone());
 
     let config = Config::new(token, Intents::GUILDS);

--- a/twilight-standby/Cargo.toml
+++ b/twilight-standby/Cargo.toml
@@ -24,4 +24,5 @@ twilight-model = { default-features = false, path = "../twilight-model", version
 anyhow = { default-features = false, features = ["std"], version = "1" }
 static_assertions = { default-features = false, version = "1" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
+tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log"], version = "0.3" }
 twilight-gateway = { default-features = false, features = ["rustls-native-roots"], path = "../twilight-gateway" }

--- a/twilight-standby/README.md
+++ b/twilight-standby/README.md
@@ -78,6 +78,8 @@ use twilight_standby::Standby;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
     let token = env::var("DISCORD_TOKEN")?;
 
     let config = Config::new(token, Intents::GUILD_MESSAGES | Intents::GUILD_MESSAGE_REACTIONS);


### PR DESCRIPTION
Standardizes all examples to have the same style, declaration of items, and retrieval of Discord token.

Split out of #2090
