### PR TITLE
docs(gateway): add helpful details for new users

### DIFF
--- a/twilight-gateway/README.md
+++ b/twilight-gateway/README.md
@@ -3,13 +3,13 @@
 [![codecov badge][]][codecov link] [![discord badge][]][discord link] [![github badge][]][github link] [![license badge][]][license link] ![rust badge]
 
 `twilight-gateway` is an implementation of Discord's sharding gateway sessions.
-This is responsible for receiving stateful events in real-time from Discord
-and sending *some* stateful information.
+This is responsible for receiving stateful events in real-time from Discord and
+sending *some* stateful information.
 
 The primary type is the `Shard`, a stateful interface to maintain a Websocket
-connection to Discord's gateway. Much of its functionality can be configured, and
-it's used to receive deserialized gateway event payloads or raw Websocket
-messages, useful for load balancing and microservices.
+connection to Discord's gateway. Much of its functionality can be configured,
+and it's used to receive gateway events or raw Websocket messages, useful for
+load balancing and microservices.
 
 Using the `stream` module, shards can be easily managed in groups.
 
@@ -19,7 +19,6 @@ Using the `stream` module, shards can be easily managed in groups.
   events
 * TLS (mutually exclusive)
   * `native`: platform's native TLS implementation via [`native-tls`]
-    equivalents
   * `rustls-native-roots` (*default*): [`rustls`] using native root certificates
   * `rustls-webpki-roots`: [`rustls`] using [`webpki-roots`] for root
     certificates, useful for `scratch` containers
@@ -30,7 +29,7 @@ Using the `stream` module, shards can be easily managed in groups.
 
 ## Examples
 
-Start a shard and loop over guild and voice state events:
+Create a shard and loop over guild and voice state events:
 
 ```rust,no_run
 use std::env;
@@ -66,6 +65,8 @@ async fn main() -> anyhow::Result<()> {
             },
         };
 
+        // You'd normally want to spawn a new tokio task for each event and
+        // handle the event there to not block the shard.
         tracing::debug!(?event, "received event");
     }
 
@@ -73,7 +74,8 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-Create the recommended number of shards and stream over their events:
+Create the recommended number of shards and run them concurrently through
+`ShardEventStream`:
 
 ```rust,no_run
 use futures::StreamExt;
@@ -105,6 +107,7 @@ async fn main() -> anyhow::Result<()> {
         .await?
         .collect::<Vec<_>>();
 
+    // Create an infinite stream over the shards' events.
     let mut stream = ShardEventStream::new(shards.iter_mut());
 
     while let Some((shard, event)) = stream.next().await {
@@ -121,6 +124,8 @@ async fn main() -> anyhow::Result<()> {
             }
         };
 
+        // You'd normally want to spawn a new tokio task for each event and
+        // handle the event there to not block the shards.
         tracing::debug!(?event, shard = ?shard.id(), "received event");
     }
 
@@ -131,13 +136,11 @@ async fn main() -> anyhow::Result<()> {
 There are a few additional examples located in the
 [repository][github examples link].
 
+[`flate2`]: https://crates.io/crates/flate2
 [`native-tls`]: https://crates.io/crates/native-tls
 [`rustls`]: https://crates.io/crates/rustls
-[`rustls-native-certs`]: https://crates.io/crates/rustls-native-certs
 [`serde_json`]: https://crates.io/crates/serde_json
 [`simd-json`]: https://crates.io/crates/simd-json
-[`tokio-tungstenite`]: https://crates.io/crates/tokio-tungstenite
-[`twilight-http`]: https://twilight-rs.github.io/twilight/twilight_http/index.html
 [`webpki-roots`]: https://crates.io/crates/webpki-roots
 [`zlib-ng`]: https://github.com/zlib-ng/zlib-ng
 [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2

--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -35,6 +35,12 @@ impl Debug for Token {
 /// Configuration used by the shard to identify with the gateway and operate.
 ///
 /// Use [`Config::builder`] to configure a shard's configuration.
+///
+/// May be reused by cloning, also reusing the hidden TLS context---reducing
+/// memory usage. The TLS context may still be reused with an otherwise
+/// different config by turning it into to a [`ConfigBuilder`] through the
+/// [`ConfigBuilder::with_config`] function and then rebuilding it into a new
+/// config.
 #[derive(Clone, Debug)]
 pub struct Config {
     /// Event type flags.

--- a/twilight-gateway/src/connection.rs
+++ b/twilight-gateway/src/connection.rs
@@ -35,10 +35,8 @@ const WEBSOCKET_CONFIG: WebSocketConfig = WebSocketConfig {
 
 /// [`tokio_tungstenite`] library Websocket connection.
 ///
-/// Connections are used by [`Shard`]s when [initially connecting] and when
-/// reconnecting.
+/// Connections are used by [`Shard`]s when reconnecting.
 ///
-/// [initially connecting]: crate::Shard::with_config
 /// [`Shard`]: crate::Shard
 pub type Connection = WebSocketStream<MaybeTlsStream<TcpStream>>;
 

--- a/twilight-gateway/src/stream.rs
+++ b/twilight-gateway/src/stream.rs
@@ -21,10 +21,10 @@
 //!
 //! A multi-threaded executor is able to run tasks in parallel, but splitting
 //! shards across tasks requires channels to communicate between them, for
-//! example, to coordinate shutdowns or to collect all events to a single event
-//! handler task. It is therefore **not** recommended unless required for
-//! performance reasons (a single core should, on a reasonably performant CPU,
-//! be capable of handling tens of thousands of Discord events per second).
+//! example, to coordinate shutdowns. It is therefore **not** recommended unless
+//! required for performance reasons (a single core should, on a reasonably
+//! performant CPU, be capable of handling tens of thousands of Discord events
+//! per second).
 //!
 //! See the [gateway-parallel] example for how to implement this.
 //!


### PR DESCRIPTION
Adds important details to the primary examples. Also extends some details about `Config` and TLS context reuse, `Shard::sender` and the gateway identify queue.
