### PR TITLE
fix(gateway-queue)!: Don't sleep if message is unable to be delivered

### DIFF
--- a/twilight-gateway-queue/src/large_bot_queue.rs
+++ b/twilight-gateway-queue/src/large_bot_queue.rs
@@ -74,8 +74,9 @@ async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
     while let Some(req) = rx.recv().await {
         if let Err(source) = req.send(()) {
             tracing::warn!("skipping, send failed with: {source:?}");
+        } else {
+            sleep(DUR).await;
         }
-        sleep(DUR).await;
     }
 }
 

--- a/twilight-gateway-queue/src/lib.rs
+++ b/twilight-gateway-queue/src/lib.rs
@@ -108,8 +108,9 @@ async fn waiter(mut rx: UnboundedReceiver<Sender<()>>) {
     while let Some(req) = rx.recv().await {
         if let Err(source) = req.send(()) {
             tracing::warn!("skipping, send failed: {source:?}");
+        } else {
+            sleep(DUR).await;
         }
-        sleep(DUR).await;
     }
 }
 


### PR DESCRIPTION
## Description
In twilight-gateway-queue, after waiting, sending a message back over the oneshot Sender if the message will **never** be received. In a correct implementation, this means that the shard holding the receiver that was waiting to identify will never identify, therefore, the queue can immediately send a message to the next shard waiting to tell it to identify straight away.

## Why is this a problem?
When using the [gateway-queue](https://github.com/twilight-rs/gateway-queue) crate, if the client cancels the HTTP request, the server will still keep the request queued and attempt to send a response. If you start a cluster running 100 shards, the queue will instantly have 100 requests waiting. If you then kill and restart the cluster, you will need to wait for the gateway-queue server to work through those 100 dead shards that are already queued, meaning that no shards will be able to start for the next 600 seconds.

## Relevant Documentation
https://docs.rs/tokio/latest/tokio/sync/oneshot/struct.Sender.html#method.send

> A successful send occurs when it is determined that the other end of the channel has not hung up already. An unsuccessful send would be one where the corresponding receiver has already been deallocated. Note that a return value of Err means that the data will never be received, but a return value of Ok does not mean that the data will be received. It is possible for the corresponding receiver to hang up immediately after this function returns Ok.

This means that it is always safe to skip sleeping and immediately send a message to the next shard.

