### PR TITLE
refactor(gateway)!: reuse queue by default in `create_*` functions

### DIFF
--- a/twilight-gateway/README.md
+++ b/twilight-gateway/README.md
@@ -77,7 +77,7 @@ Create the recommended number of shards and stream over their events:
 
 ```rust,no_run
 use futures::StreamExt;
-use std::{collections::HashMap, env};
+use std::env;
 use twilight_gateway::{
     stream::{self, ShardEventStream},
     Config, Intents,

--- a/twilight-gateway/README.md
+++ b/twilight-gateway/README.md
@@ -90,7 +90,7 @@ async fn main() -> anyhow::Result<()> {
 
     let token = env::var("DISCORD_TOKEN")?;
     let client = Client::new(token.clone());
-    let config = Config::new(token.clone(), Intents::GUILDS);
+    let config = Config::new(token, Intents::GUILDS);
 
     let mut shards = stream::create_recommended(&client, config, |_, builder| builder.build())
         .await?

--- a/twilight-gateway/README.md
+++ b/twilight-gateway/README.md
@@ -77,9 +77,8 @@ Create the recommended number of shards and stream over their events:
 
 ```rust,no_run
 use futures::StreamExt;
-use std::{collections::HashMap, env, sync::Arc};
+use std::{collections::HashMap, env};
 use twilight_gateway::{
-    queue::LocalQueue,
     stream::{self, ShardEventStream},
     Config, Intents,
 };
@@ -91,17 +90,9 @@ async fn main() -> anyhow::Result<()> {
 
     let token = env::var("DISCORD_TOKEN")?;
     let client = Client::new(token.clone());
+    let config = Config::new(token.clone(), Intents::GUILDS);
 
-    let queue = Arc::new(LocalQueue::new());
-    // Callback to create a config for each shard, useful for when not all shards
-    // have the same configuration, such as for per-shard presences.
-    let config_callback = |_| {
-        Config::builder(token.clone(), Intents::GUILDS)
-            .queue(queue.clone())
-            .build()
-    };
-
-    let mut shards = stream::create_recommended(&client, config_callback)
+    let mut shards = stream::create_recommended(&client, config, |_, builder| builder.build())
         .await?
         .collect::<Vec<_>>();
 

--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -149,14 +149,6 @@ impl Config {
         &self.token.inner
     }
 
-    /// Set the TLS container for the configuration.
-    ///
-    /// This is necessary for sharing a TLS container across configurations.
-    #[allow(clippy::missing_const_for_fn)]
-    pub(crate) fn set_tls(&mut self, tls: TlsContainer) {
-        self.tls = tls;
-    }
-
     /// Session information to resume a shard on initialization.
     pub(crate) fn take_session(&mut self) -> Option<Session> {
         self.session.take()

--- a/twilight-gateway/src/stream.rs
+++ b/twilight-gateway/src/stream.rs
@@ -32,10 +32,7 @@
 //! [gateway-parallel]: https://github.com/twilight-rs/twilight/blob/main/examples/gateway-parallel.rs
 //! [session queue]: crate::queue
 
-use crate::{
-    error::ReceiveMessageError, message::Message, tls::TlsContainer, Config, ConfigBuilder, Shard,
-    ShardId,
-};
+use crate::{error::ReceiveMessageError, message::Message, Config, ConfigBuilder, Shard, ShardId};
 use futures_util::{
     future::BoxFuture,
     stream::{FuturesUnordered, Stream, StreamExt},
@@ -393,7 +390,7 @@ pub fn create_bucket<F: Fn(ShardId, ConfigBuilder) -> Config>(
     bucket_id: u64,
     concurrency: u64,
     total: u64,
-    mut config: Config,
+    config: Config,
     per_shard_config: F,
 ) -> impl Iterator<Item = Shard> {
     assert!(bucket_id < total, "bucket id must be less than the total");
@@ -403,7 +400,6 @@ pub fn create_bucket<F: Fn(ShardId, ConfigBuilder) -> Config>(
     );
 
     let concurrency = concurrency.try_into().unwrap();
-    config.set_tls(TlsContainer::new().unwrap());
 
     (bucket_id..total).step_by(concurrency).map(move |index| {
         let id = ShardId::new(index, total);
@@ -449,11 +445,10 @@ pub fn create_bucket<F: Fn(ShardId, ConfigBuilder) -> Config>(
 pub fn create_range<F: Fn(ShardId, ConfigBuilder) -> Config>(
     range: impl RangeBounds<u64>,
     total: u64,
-    mut config: Config,
+    config: Config,
     per_shard_config: F,
 ) -> impl Iterator<Item = Shard> {
     let range = calculate_range(range, total);
-    config.set_tls(TlsContainer::new().unwrap());
 
     range.map(move |index| {
         let id = ShardId::new(index, total);

--- a/twilight-gateway/src/stream.rs
+++ b/twilight-gateway/src/stream.rs
@@ -1,11 +1,10 @@
 //! Utilities for managing collections of shards.
 //!
 //! Multiple shards may easily be created at once, with a per shard config
-//! created from a `Fn(ShardId) -> Config` closure, with the help of the
-//! `create_` set of functions. These functions will also reuse shards' TLS
-//! context, something otherwise achieved by cloning an existing [`Config`], but
-//! will not by default set a shared [session queue] (see
-//! [`ConfigBuilder::queue`]).
+//! created from a `Fn(ShardId, ConfigBuilder) -> Config` closure, with the help
+//! of the `create_` set of functions. These functions will reuse shards'
+//! TLS context and [session queue], something otherwise achieved by cloning an
+//! existing [`Config`].
 //!
 //! # Concurrency
 //!
@@ -353,8 +352,8 @@ struct NextItemOutput<'a, Item> {
 
 /// Create a single bucket's worth of shards.
 ///
-/// Passing a primary config is required to ensure shared queue functionality.
-/// Further customization may be performed in the callback.
+/// Passing a primary config is required. Further customization of this config
+/// may be performed in the callback.
 ///
 /// # Examples
 ///
@@ -411,8 +410,8 @@ pub fn create_bucket<F: Fn(ShardId, ConfigBuilder) -> Config>(
 
 /// Create a range of shards.
 ///
-/// Passing a primary config is required to ensure shared queue functionality.
-/// Further customization may be performed in the callback.
+/// Passing a primary config is required. Further customization of this config
+/// may be performed in the callback.
 ///
 /// # Examples
 ///
@@ -460,8 +459,8 @@ pub fn create_range<F: Fn(ShardId, ConfigBuilder) -> Config>(
 
 /// Create a range of shards from Discord's recommendation.
 ///
-/// Passing a primary config is required to ensure shared queue functionality.
-/// Further customization may be performed in the callback.
+/// Passing a primary config is required. Further customization of this config
+/// may be performed in the callback.
 ///
 /// Internally calls [`create_range`] with the values from [`GetGatewayAuthed`].
 ///


### PR DESCRIPTION
Instead of removing these functions entirely, accept a primary `Config`, which is then subsequently optionally modified in the callback. The default config creates the default queue, which is then cloned and re-built before it passed to each shard. It also re-uses the TLS container.

Alternative to #2090.
