### PR TITLE
docs(model): remove link to member module

### DIFF
--- a/twilight-model/src/guild/mod.rs
+++ b/twilight-model/src/guild/mod.rs
@@ -3,9 +3,6 @@
 //! [`Guild`]s allow, for example, assigning [`Role`]s to [`Member`]s to limit
 //! their [`Permissions`] globally, or per [`Channel`].
 //!
-//! Advanced user's may look inside the [`member`] module for custom
-//! [`Member`] deserializers.
-//!
 //! [`User`]: super::user::User
 
 pub mod audit_log;


### PR DESCRIPTION
Remove a link to the `member` module from the `guild` module-level documentation. This link should have been removed in pull request #2083 due to the module being made private but was missed.