### PR TITLE
ci: bump book-test checkout workflow version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -205,7 +205,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Left out of #1722 due to the book being inlined after the fact.
