### PR TITLE
build(book): disable playgrounds by default

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -11,3 +11,6 @@ edition = "2021"
 
 [output.html]
 default-theme = "rust"
+
+[output.html.playground]
+runnable = false


### PR DESCRIPTION
Disable playgrounds with the book's examples by default. Playgrounds won't be runnable because almost all examples will depend upon something like the gateway, and the playground wouldn't compile our code examples in the first place.