### PR TITLE
refactor!(model, cache, gateway): Make `Presence::guild_id` an `Option`

### DIFF
--- a/twilight-cache-inmemory/src/event/presence.rs
+++ b/twilight-cache-inmemory/src/event/presence.rs
@@ -34,7 +34,11 @@ impl UpdateCache for PresenceUpdate {
 
         let presence = CachedPresence::from_model(self.0.clone());
 
-        cache.cache_presence(self.guild_id, presence);
+        // Presence updates should always contain a guild ID as per the API docs.
+        cache.cache_presence(
+            self.guild_id.expect("Presence update without guild id"),
+            presence,
+        );
     }
 }
 
@@ -54,7 +58,7 @@ mod tests {
     fn presence_update() {
         let cache = InMemoryCache::new();
 
-        let guild_id = Id::new(1);
+        let guild_id = Some(Id::new(1));
         let user_id = Id::new(1);
 
         let payload = PresenceUpdate(Presence {
@@ -74,7 +78,7 @@ mod tests {
         assert_eq!(1, cache.guild_presences.len());
         assert!(cache
             .guild_presences
-            .get(&guild_id)
+            .get(&guild_id.unwrap())
             .unwrap()
             .contains(&user_id));
     }

--- a/twilight-cache-inmemory/src/model/presence.rs
+++ b/twilight-cache-inmemory/src/model/presence.rs
@@ -14,7 +14,7 @@ use twilight_model::{
 pub struct CachedPresence {
     pub(crate) activities: Vec<Activity>,
     pub(crate) client_status: ClientStatus,
-    pub(crate) guild_id: Id<GuildMarker>,
+    pub(crate) guild_id: Option<Id<GuildMarker>>,
     pub(crate) status: Status,
     pub(crate) user_id: Id<UserMarker>,
 }
@@ -31,7 +31,7 @@ impl CachedPresence {
     }
 
     /// ID of the guild.
-    pub const fn guild_id(&self) -> Id<GuildMarker> {
+    pub const fn guild_id(&self) -> Option<Id<GuildMarker>> {
         self.guild_id
     }
 

--- a/twilight-model/src/channel/thread/member.rs
+++ b/twilight-model/src/channel/thread/member.rs
@@ -1,8 +1,8 @@
 use crate::{
-    gateway::presence::{Presence, PresenceIntermediary},
+    gateway::presence::Presence,
     guild::Member,
     id::{
-        marker::{ChannelMarker, GuildMarker, UserMarker},
+        marker::{ChannelMarker, UserMarker},
         Id,
     },
     util::Timestamp,
@@ -22,38 +22,6 @@ pub struct ThreadMember {
     pub presence: Option<Presence>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_id: Option<Id<UserMarker>>,
-}
-
-/// Version of [`ThreadMember`], but without a guild ID in the
-/// [`Self::member`] field.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
-pub(crate) struct ThreadMemberIntermediary {
-    // Values currently unknown and undocumented.
-    pub flags: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<Id<ChannelMarker>>,
-    pub join_timestamp: Timestamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub member: Option<Member>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub presence: Option<PresenceIntermediary>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_id: Option<Id<UserMarker>>,
-}
-
-impl ThreadMemberIntermediary {
-    /// Inject a guild ID into a thread member intermediary
-    pub fn into_thread_member(self, guild_id: Id<GuildMarker>) -> ThreadMember {
-        let presence = self.presence.map(|p| p.into_presence(guild_id));
-        ThreadMember {
-            flags: self.flags,
-            id: self.id,
-            join_timestamp: self.join_timestamp,
-            member: self.member,
-            presence,
-            user_id: self.user_id,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/twilight-model/src/gateway/event/mod.rs
+++ b/twilight-model/src/gateway/event/mod.rs
@@ -214,7 +214,7 @@ impl Event {
             Event::MemberRemove(e) => Some(e.guild_id),
             Event::MemberUpdate(e) => Some(e.guild_id),
             Event::MessageCreate(e) => e.0.guild_id,
-            Event::PresenceUpdate(e) => Some(e.0.guild_id),
+            Event::PresenceUpdate(e) => e.0.guild_id,
             Event::ReactionAdd(e) => e.0.guild_id,
             Event::ReactionRemove(e) => e.0.guild_id,
             Event::ReactionRemoveAll(e) => e.guild_id,

--- a/twilight-model/src/gateway/payload/incoming/thread_members_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/thread_members_update.rs
@@ -1,17 +1,13 @@
 use crate::{
-    channel::thread::member::{ThreadMember, ThreadMemberIntermediary},
+    channel::thread::member::ThreadMember,
     id::{
         marker::{ChannelMarker, GuildMarker, UserMarker},
         Id,
     },
 };
-use serde::{
-    de::{value::MapAccessDeserializer, MapAccess, Visitor},
-    Deserialize, Deserializer, Serialize,
-};
-use std::fmt::{Formatter, Result as FmtResult};
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ThreadMembersUpdate {
     /// List of thread members.
     ///
@@ -28,60 +24,6 @@ pub struct ThreadMembersUpdate {
     pub member_count: i32,
     #[serde(default)]
     pub removed_member_ids: Vec<Id<UserMarker>>,
-}
-
-impl<'de> Deserialize<'de> for ThreadMembersUpdate {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        deserializer.deserialize_map(ThreadMembersUpdateVisitor)
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
-struct ThreadMembersUpdateIntermediary {
-    /// ThreadMembers without the guild ID.
-    #[serde(default)]
-    pub added_members: Vec<ThreadMemberIntermediary>,
-    pub guild_id: Id<GuildMarker>,
-    pub id: Id<ChannelMarker>,
-    pub member_count: i32,
-    #[serde(default)]
-    pub removed_member_ids: Vec<Id<UserMarker>>,
-}
-
-impl ThreadMembersUpdateIntermediary {
-    fn into_thread_members_update(self) -> ThreadMembersUpdate {
-        let guild_id = self.guild_id;
-        let added_members = self
-            .added_members
-            .into_iter()
-            .map(|tm| tm.into_thread_member(guild_id))
-            .collect();
-
-        ThreadMembersUpdate {
-            added_members,
-            guild_id,
-            id: self.id,
-            member_count: self.member_count,
-            removed_member_ids: self.removed_member_ids,
-        }
-    }
-}
-
-struct ThreadMembersUpdateVisitor;
-
-impl<'de> Visitor<'de> for ThreadMembersUpdateVisitor {
-    type Value = ThreadMembersUpdate;
-
-    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_str("struct ThreadMembersUpdate")
-    }
-
-    fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
-        let deser = MapAccessDeserializer::new(map);
-        let update = ThreadMembersUpdateIntermediary::deserialize(deser)?;
-
-        Ok(update.into_thread_members_update())
-    }
 }
 
 #[cfg(test)]
@@ -170,7 +112,7 @@ mod tests {
                 mobile: None,
                 web: None,
             },
-            guild_id: Id::new(2),
+            guild_id: Some(Id::new(2)),
             status: Status::Online,
             user: UserOrId::UserId { id: Id::new(3) },
         };

--- a/twilight-model/src/guild/mod.rs
+++ b/twilight-model/src/guild/mod.rs
@@ -57,7 +57,6 @@ pub use self::{
     verification_level::VerificationLevel, widget::GuildWidget,
 };
 
-use super::gateway::presence::PresenceListDeserializer;
 use crate::{
     channel::{message::sticker::Sticker, Channel, StageInstance},
     gateway::presence::Presence,
@@ -250,7 +249,7 @@ impl<'de> Deserialize<'de> for Guild {
                 let mut premium_progress_bar_enabled = None;
                 let mut premium_subscription_count = None::<Option<_>>;
                 let mut premium_tier = None;
-                let mut presences = None;
+                let mut presences = None::<Vec<Presence>>;
                 let mut public_updates_channel_id = None::<Option<_>>;
                 let mut roles = None;
                 let mut splash = None::<Option<_>>;
@@ -525,9 +524,7 @@ impl<'de> Deserialize<'de> for Guild {
                                 return Err(DeError::duplicate_field("presences"));
                             }
 
-                            let deserializer = PresenceListDeserializer::new(Id::new(1));
-
-                            presences = Some(map.next_value_seed(deserializer)?);
+                            presences = Some(map.next_value()?);
                         }
                         Field::PublicUpdatesChannelId => {
                             if public_updates_channel_id.is_some() {
@@ -753,7 +750,7 @@ impl<'de> Deserialize<'de> for Guild {
                 }
 
                 for presence in &mut presences {
-                    presence.guild_id = id;
+                    presence.guild_id = Some(id);
                 }
 
                 for thread in &mut threads {


### PR DESCRIPTION
As outlined in [discord](https://discord.com/channels/745809834183753828/1071506807941505044), this PR makes `Presence::guild_id` an option. This is being done for various reasons.

The first reason is for future-proofing against API changes. `Presence` isn't an explicitly defined structure in the API, but rather something that is the return value of a gateway event. Despite this, it does show up in other areas of the API. As of making this PR there isn't any situations where we receive a presence and have no knowledge of the guild id. However, as the field itself isn't always required to be sent with presences, the API may not always give twilight `guild_id`s with presences as it's not required to. 

Secondly, is to work towards removing manually deserializers. See #1364