### PR TITLE
feat(model): add `MessageFlags::SUPPRESS_NOTIFICATIONS`

### DIFF
--- a/twilight-http/src/request/channel/message/create_message.rs
+++ b/twilight-http/src/request/channel/message/create_message.rs
@@ -238,9 +238,11 @@ impl<'a> CreateMessage<'a> {
 
     /// Set the message's flags.
     ///
-    /// The only supported flag is [`SUPPRESS_EMBEDS`].
+    /// The only supported flags are [`SUPPRESS_EMBEDS`] and
+    /// [`SUPPRESS_NOTIFICATIONS`].
     ///
     /// [`SUPPRESS_EMBEDS`]: MessageFlags::SUPPRESS_EMBEDS
+    /// [`SUPPRESS_NOTIFICATIONS`]: MessageFlags::SUPPRESS_NOTIFICATIONS
     pub const fn flags(mut self, flags: MessageFlags) -> Self {
         self.fields.flags = Some(flags);
 

--- a/twilight-http/src/request/channel/thread/create_forum_thread/message.rs
+++ b/twilight-http/src/request/channel/thread/create_forum_thread/message.rs
@@ -152,9 +152,11 @@ impl<'a> CreateForumThreadMessage<'a> {
 
     /// Set the message's flags.
     ///
-    /// The only supported flag is [`SUPPRESS_EMBEDS`].
+    /// The only supported flags are [`SUPPRESS_EMBEDS`] and
+    /// [`SUPPRESS_NOTIFICATIONS`].
     ///
     /// [`SUPPRESS_EMBEDS`]: MessageFlags::SUPPRESS_EMBEDS
+    /// [`SUPPRESS_NOTIFICATIONS`]: MessageFlags::SUPPRESS_NOTIFICATIONS
     pub const fn flags(mut self, flags: MessageFlags) -> Self {
         self.0.fields.message.flags = Some(flags);
 

--- a/twilight-model/src/channel/message/flags.rs
+++ b/twilight-model/src/channel/message/flags.rs
@@ -106,6 +106,7 @@ mod tests {
         MessageFlags::FAILED_TO_MENTION_SOME_ROLES_IN_THREAD.bits(),
         1 << 8
     );
+    const_assert_eq!(MessageFlags::SUPPRESS_NOTIFICATIONS.bits(), 1 << 12);
 
     #[test]
     fn serde() {

--- a/twilight-model/src/channel/message/flags.rs
+++ b/twilight-model/src/channel/message/flags.rs
@@ -31,7 +31,7 @@ bitflags! {
         /// This message failed to mention some roles in a thread, which
         /// subsequently failed to add the role's members to the thread.
         const FAILED_TO_MENTION_SOME_ROLES_IN_THREAD  = 1 << 8;
-        /// This message will not trigger push and desktop notifications
+        /// This message will not trigger push and desktop notifications.
         const SUPPRESS_NOTIFICATIONS = 1 << 12;
     }
 }

--- a/twilight-model/src/channel/message/flags.rs
+++ b/twilight-model/src/channel/message/flags.rs
@@ -31,6 +31,8 @@ bitflags! {
         /// This message failed to mention some roles in a thread, which
         /// subsequently failed to add the role's members to the thread.
         const FAILED_TO_MENTION_SOME_ROLES_IN_THREAD  = 1 << 8;
+        /// This message will not trigger push and desktop notifications
+        const SUPPRESS_NOTIFICATIONS = 1 << 12;
     }
 }
 


### PR DESCRIPTION
Adds support for `@silent` messages via the `SUPPRESS_NOTIFICATIONS` flag. 

Closes #2137.