### PR TITLE
refactor(http): deprecate getreactions::exec

### DIFF
--- a/twilight-http/src/request/channel/reaction/get_reactions.rs
+++ b/twilight-http/src/request/channel/reaction/get_reactions.rs
@@ -85,6 +85,7 @@ impl<'a> GetReactions<'a> {
     }
 
     /// Execute the request, returning a future resolving to a [`Response`].
+    #[deprecated(since = "0.15.1", note = "use `.await` or `into_future` instead")]
     pub fn exec(self) -> ResponseFuture<ListBody<User>> {
         self.into_future()
     }


### PR DESCRIPTION
Deprecate `GetReactions::exec` in favor of its `IntoFuture` implementation. This deprecation was missed in pull request #1898.

Discovered in pull request #2132.