### PR TITLE
refactor(model): rename `GatewayClose` to `WebsocketClose`

### DIFF
--- a/twilight-cache-inmemory/src/lib.rs
+++ b/twilight-cache-inmemory/src/lib.rs
@@ -897,6 +897,8 @@ impl UpdateCache for Event {
             Event::UserUpdate(v) => c.update(v),
             Event::VoiceStateUpdate(v) => c.update(v.deref()),
             // Ignored events.
+            #[allow(deprecated)]
+            Event::GatewayClose(_) => {}
             Event::AutoModerationActionExecution(_)
             | Event::AutoModerationRuleCreate(_)
             | Event::AutoModerationRuleDelete(_)
@@ -904,7 +906,6 @@ impl UpdateCache for Event {
             | Event::BanAdd(_)
             | Event::BanRemove(_)
             | Event::CommandPermissionsUpdate(_)
-            | Event::GatewayClose(_)
             | Event::GatewayHeartbeat(_)
             | Event::GatewayHeartbeatAck
             | Event::GatewayHello(_)
@@ -926,7 +927,8 @@ impl UpdateCache for Event {
             | Event::ThreadMemberUpdate(_)
             | Event::TypingStart(_)
             | Event::VoiceServerUpdate(_)
-            | Event::WebhooksUpdate(_) => {}
+            | Event::WebhooksUpdate(_)
+            | Event::WebsocketClose(_) => {}
         }
     }
 }

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -492,7 +492,7 @@ impl Shard {
     pub async fn next_event(&mut self) -> Result<Event, ReceiveMessageError> {
         loop {
             match self.next_message().await? {
-                Message::Close(frame) => return Ok(Event::GatewayClose(frame)),
+                Message::Close(frame) => return Ok(Event::WebsocketClose(frame)),
                 Message::Text(event) => {
                     if let Some(event) = json::parse(event, self.config.event_types())? {
                         return Ok(event.into());

--- a/twilight-model/src/gateway/event/mod.rs
+++ b/twilight-model/src/gateway/event/mod.rs
@@ -46,6 +46,7 @@ pub enum Event {
     CommandPermissionsUpdate(CommandPermissionsUpdate),
     /// Close message with an optional frame including information about the
     /// reason for the close.
+    #[deprecated(since = "0.15.1", note = "renamed to WebsocketClose")]
     GatewayClose(Option<CloseFrame<'static>>),
     /// A heartbeat was sent to or received from the gateway.
     GatewayHeartbeat(u64),
@@ -169,6 +170,9 @@ pub enum Event {
     VoiceStateUpdate(Box<VoiceStateUpdate>),
     /// A webhook was updated.
     WebhooksUpdate(WebhooksUpdate),
+    /// Close message with an optional frame including information about the
+    /// reason for the close.
+    WebsocketClose(Option<CloseFrame<'static>>),
 }
 
 impl Event {
@@ -235,8 +239,9 @@ impl Event {
             Event::VoiceServerUpdate(e) => Some(e.guild_id),
             Event::VoiceStateUpdate(e) => e.0.guild_id,
             Event::WebhooksUpdate(e) => Some(e.guild_id),
+            #[allow(deprecated)]
+            Event::GatewayClose(_) => None,
             Event::ChannelPinsUpdate(_)
-            | Event::GatewayClose(_)
             | Event::GatewayHeartbeat(_)
             | Event::GatewayHeartbeatAck
             | Event::GatewayHello(_)
@@ -250,7 +255,8 @@ impl Event {
             | Event::Ready(_)
             | Event::Resumed
             | Event::ThreadMemberUpdate(_)
-            | Event::UserUpdate(_) => None,
+            | Event::UserUpdate(_)
+            | Event::WebsocketClose(_) => None,
         }
     }
 
@@ -267,6 +273,7 @@ impl Event {
             Self::ChannelPinsUpdate(_) => EventType::ChannelPinsUpdate,
             Self::ChannelUpdate(_) => EventType::ChannelUpdate,
             Self::CommandPermissionsUpdate(_) => EventType::CommandPermissionsUpdate,
+            #[allow(deprecated)]
             Self::GatewayClose(_) => EventType::GatewayClose,
             Self::GatewayHeartbeat(_) => EventType::GatewayHeartbeat,
             Self::GatewayHeartbeatAck => EventType::GatewayHeartbeatAck,
@@ -326,6 +333,7 @@ impl Event {
             Self::VoiceServerUpdate(_) => EventType::VoiceServerUpdate,
             Self::VoiceStateUpdate(_) => EventType::VoiceStateUpdate,
             Self::WebhooksUpdate(_) => EventType::WebhooksUpdate,
+            Self::WebsocketClose(_) => EventType::GatewayClose,
         }
     }
 }


### PR DESCRIPTION
The name `GatewayClose` is unfortunately confusing as it could be misconstrued as being equivalent to the old `Event::ShardDisconnect` variant. The `WebsocketClose` variant name better documents the fact that it's chiefly about the *websocket connection* closing. This can imply that the "gateway" is closing too (if sent by cloudflare/discord), but it can also mean that the "gateway" was already closed (if the shard initiated the websocket close) and that it merely closes the websocket connection.

This is a semi-breaking change as `Shard::next_event` no longer returns `Event::GatewayClose`, but since the old variant is marked as deprecated, producing a warning on use, users should not be affected by this.
