### PR TITLE
refactor: change deny lints to warn

### DIFF
--- a/book/tests/src/lib.rs
+++ b/book/tests/src/lib.rs
@@ -1,3 +1,1 @@
-#![deny(warnings)]
-
 include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));

--- a/twilight-cache-inmemory/src/lib.rs
+++ b/twilight-cache-inmemory/src/lib.rs
@@ -9,8 +9,7 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::unnecessary_wraps,
-    clippy::used_underscore_binding
+    clippy::unnecessary_wraps
 )]
 
 pub mod iter;

--- a/twilight-cache-inmemory/src/lib.rs
+++ b/twilight-cache-inmemory/src/lib.rs
@@ -1,4 +1,6 @@
-#![deny(
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc = include_str!("../README.md")]
+#![warn(
     clippy::missing_const_for_fn,
     clippy::pedantic,
     missing_docs,
@@ -10,8 +12,6 @@
     clippy::unnecessary_wraps,
     clippy::used_underscore_binding
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![doc = include_str!("../README.md")]
 
 pub mod iter;
 pub mod model;

--- a/twilight-cache-inmemory/src/lib.rs
+++ b/twilight-cache-inmemory/src/lib.rs
@@ -1,14 +1,8 @@
 #![deny(
-    clippy::all,
     clippy::missing_const_for_fn,
     clippy::pedantic,
-    future_incompatible,
     missing_docs,
-    nonstandard_style,
-    rust_2018_idioms,
-    rustdoc::broken_intra_doc_links,
-    unsafe_code,
-    unused
+    unsafe_code
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/twilight-gateway-queue/src/lib.rs
+++ b/twilight-gateway-queue/src/lib.rs
@@ -1,15 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(
-    clippy::all,
     clippy::missing_const_for_fn,
     clippy::pedantic,
-    future_incompatible,
     missing_docs,
-    nonstandard_style,
-    rust_2018_idioms,
-    rustdoc::broken_intra_doc_links,
-    unsafe_code,
-    unused
+    unsafe_code
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/twilight-gateway-queue/src/lib.rs
+++ b/twilight-gateway-queue/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![deny(
+#![doc = include_str!("../README.md")]
+#![warn(
     clippy::missing_const_for_fn,
     clippy::pedantic,
     missing_docs,
@@ -11,7 +12,6 @@
     clippy::unnecessary_wraps,
     clippy::used_underscore_binding
 )]
-#![doc = include_str!("../README.md")]
 
 #[cfg(feature = "twilight-http")]
 mod day_limiter;

--- a/twilight-gateway-queue/src/lib.rs
+++ b/twilight-gateway-queue/src/lib.rs
@@ -9,8 +9,7 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::unnecessary_wraps,
-    clippy::used_underscore_binding
+    clippy::unnecessary_wraps
 )]
 
 #[cfg(feature = "twilight-http")]

--- a/twilight-gateway/src/lib.rs
+++ b/twilight-gateway/src/lib.rs
@@ -1,16 +1,10 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(
-    clippy::all,
     clippy::missing_const_for_fn,
     clippy::missing_docs_in_private_items,
     clippy::pedantic,
-    future_incompatible,
     missing_docs,
-    nonstandard_style,
-    rust_2018_idioms,
-    rustdoc::broken_intra_doc_links,
-    unsafe_code,
-    unused
+    unsafe_code
 )]
 #![doc = include_str!("../README.md")]
 #![allow(

--- a/twilight-gateway/src/lib.rs
+++ b/twilight-gateway/src/lib.rs
@@ -10,8 +10,7 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::unnecessary_wraps,
-    clippy::used_underscore_binding
+    clippy::unnecessary_wraps
 )]
 
 pub mod error;

--- a/twilight-gateway/src/lib.rs
+++ b/twilight-gateway/src/lib.rs
@@ -1,12 +1,12 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![deny(
+#![doc = include_str!("../README.md")]
+#![warn(
     clippy::missing_const_for_fn,
     clippy::missing_docs_in_private_items,
     clippy::pedantic,
     missing_docs,
     unsafe_code
 )]
-#![doc = include_str!("../README.md")]
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,

--- a/twilight-http-ratelimiting/src/lib.rs
+++ b/twilight-http-ratelimiting/src/lib.rs
@@ -1,4 +1,5 @@
-#![deny(
+#![doc = include_str!("../README.md")]
+#![warn(
     clippy::missing_const_for_fn,
     clippy::missing_docs_in_private_items,
     clippy::pedantic,
@@ -11,7 +12,6 @@
     clippy::unnecessary_wraps,
     clippy::used_underscore_binding
 )]
-#![doc = include_str!("../README.md")]
 
 pub mod headers;
 pub mod in_memory;

--- a/twilight-http-ratelimiting/src/lib.rs
+++ b/twilight-http-ratelimiting/src/lib.rs
@@ -9,8 +9,7 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::unnecessary_wraps,
-    clippy::used_underscore_binding
+    clippy::unnecessary_wraps
 )]
 
 pub mod headers;

--- a/twilight-http-ratelimiting/src/lib.rs
+++ b/twilight-http-ratelimiting/src/lib.rs
@@ -1,15 +1,9 @@
 #![deny(
-    clippy::all,
     clippy::missing_const_for_fn,
     clippy::missing_docs_in_private_items,
     clippy::pedantic,
-    future_incompatible,
     missing_docs,
-    nonstandard_style,
-    rust_2018_idioms,
-    rustdoc::broken_intra_doc_links,
-    unsafe_code,
-    unused
+    unsafe_code
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/twilight-http/src/lib.rs
+++ b/twilight-http/src/lib.rs
@@ -3,8 +3,7 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::unnecessary_wraps,
-    clippy::used_underscore_binding
+    clippy::unnecessary_wraps
 )]
 
 pub mod api_error;

--- a/twilight-http/src/lib.rs
+++ b/twilight-http/src/lib.rs
@@ -1,11 +1,11 @@
-#![deny(clippy::missing_const_for_fn, clippy::pedantic, unsafe_code)]
+#![doc = include_str!("../README.md")]
+#![warn(clippy::missing_const_for_fn, clippy::pedantic, unsafe_code)]
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
     clippy::unnecessary_wraps,
     clippy::used_underscore_binding
 )]
-#![doc = include_str!("../README.md")]
 
 pub mod api_error;
 pub mod client;

--- a/twilight-http/src/lib.rs
+++ b/twilight-http/src/lib.rs
@@ -1,14 +1,4 @@
-#![deny(
-    clippy::all,
-    clippy::missing_const_for_fn,
-    clippy::pedantic,
-    future_incompatible,
-    nonstandard_style,
-    rust_2018_idioms,
-    rustdoc::broken_intra_doc_links,
-    unsafe_code,
-    unused
-)]
+#![deny(clippy::missing_const_for_fn, clippy::pedantic, unsafe_code)]
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,

--- a/twilight-lavalink/src/lib.rs
+++ b/twilight-lavalink/src/lib.rs
@@ -1,4 +1,6 @@
-#![deny(
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc = include_str!("../README.md")]
+#![warn(
     clippy::missing_const_for_fn,
     clippy::pedantic,
     missing_docs,
@@ -10,8 +12,6 @@
     clippy::unnecessary_wraps,
     clippy::used_underscore_binding
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![doc = include_str!("../README.md")]
 
 pub mod client;
 pub mod model;

--- a/twilight-lavalink/src/lib.rs
+++ b/twilight-lavalink/src/lib.rs
@@ -9,8 +9,7 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::unnecessary_wraps,
-    clippy::used_underscore_binding
+    clippy::unnecessary_wraps
 )]
 
 pub mod client;

--- a/twilight-lavalink/src/lib.rs
+++ b/twilight-lavalink/src/lib.rs
@@ -1,14 +1,8 @@
 #![deny(
-    clippy::all,
     clippy::missing_const_for_fn,
     clippy::pedantic,
-    future_incompatible,
     missing_docs,
-    nonstandard_style,
-    rust_2018_idioms,
-    rustdoc::broken_intra_doc_links,
-    unsafe_code,
-    unused
+    unsafe_code
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/twilight-mention/src/lib.rs
+++ b/twilight-mention/src/lib.rs
@@ -1,4 +1,5 @@
-#![deny(
+#![doc = include_str!("../README.md")]
+#![warn(
     clippy::missing_const_for_fn,
     clippy::pedantic,
     missing_docs,
@@ -10,7 +11,6 @@
     clippy::unnecessary_wraps,
     clippy::used_underscore_binding
 )]
-#![doc = include_str!("../README.md")]
 
 pub mod fmt;
 pub mod parse;

--- a/twilight-mention/src/lib.rs
+++ b/twilight-mention/src/lib.rs
@@ -8,8 +8,7 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::unnecessary_wraps,
-    clippy::used_underscore_binding
+    clippy::unnecessary_wraps
 )]
 
 pub mod fmt;

--- a/twilight-mention/src/lib.rs
+++ b/twilight-mention/src/lib.rs
@@ -1,14 +1,8 @@
 #![deny(
-    clippy::all,
     clippy::missing_const_for_fn,
     clippy::pedantic,
-    future_incompatible,
     missing_docs,
-    nonstandard_style,
-    rust_2018_idioms,
-    rustdoc::broken_intra_doc_links,
-    unsafe_code,
-    unused
+    unsafe_code
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/twilight-model/src/channel/message/mod.rs
+++ b/twilight-model/src/channel/message/mod.rs
@@ -1,5 +1,5 @@
 //! Textual user communication method.
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 pub mod component;
 pub mod embed;

--- a/twilight-model/src/guild/auto_moderation/mod.rs
+++ b/twilight-model/src/guild/auto_moderation/mod.rs
@@ -8,7 +8,7 @@
 //! trigger. For example, if a user tries to send a message which contains a
 //! certain keyword, a rule can trigger and block the message before it is sent.
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 mod action;
 mod event_type;

--- a/twilight-model/src/lib.rs
+++ b/twilight-model/src/lib.rs
@@ -1,5 +1,5 @@
-#![deny(clippy::missing_const_for_fn, clippy::pedantic, unsafe_code)]
 #![doc = include_str!("../README.md")]
+#![warn(clippy::missing_const_for_fn, clippy::pedantic, unsafe_code)]
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,

--- a/twilight-model/src/lib.rs
+++ b/twilight-model/src/lib.rs
@@ -3,8 +3,7 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::semicolon_if_nothing_returned,
-    clippy::used_underscore_binding
+    clippy::semicolon_if_nothing_returned
 )]
 
 pub mod application;

--- a/twilight-model/src/lib.rs
+++ b/twilight-model/src/lib.rs
@@ -1,14 +1,4 @@
-#![deny(
-    clippy::all,
-    clippy::missing_const_for_fn,
-    clippy::pedantic,
-    future_incompatible,
-    nonstandard_style,
-    rust_2018_idioms,
-    rustdoc::broken_intra_doc_links,
-    unsafe_code,
-    unused
-)]
+#![deny(clippy::missing_const_for_fn, clippy::pedantic, unsafe_code)]
 #![doc = include_str!("../README.md")]
 #![allow(
     clippy::module_name_repetitions,

--- a/twilight-model/src/util/datetime/mod.rs
+++ b/twilight-model/src/util/datetime/mod.rs
@@ -32,7 +32,7 @@
 //! # Ok(()) }
 //! ```
 
-#![deny(clippy::missing_docs_in_private_items)]
+#![warn(clippy::missing_docs_in_private_items)]
 
 mod display;
 mod error;

--- a/twilight-model/src/voice/mod.rs
+++ b/twilight-model/src/voice/mod.rs
@@ -1,5 +1,5 @@
 //! Voice connection and gateway definitions.
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 mod close_code;
 mod opcode;

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -1,4 +1,5 @@
-#![deny(
+#![doc = include_str!("../README.md")]
+#![warn(
     clippy::missing_const_for_fn,
     clippy::missing_docs_in_private_items,
     clippy::pedantic,
@@ -11,7 +12,6 @@
     clippy::unnecessary_wraps,
     clippy::used_underscore_binding
 )]
-#![doc = include_str!("../README.md")]
 
 pub mod future;
 

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -1,15 +1,9 @@
 #![deny(
-    clippy::all,
     clippy::missing_const_for_fn,
     clippy::missing_docs_in_private_items,
     clippy::pedantic,
-    future_incompatible,
     missing_docs,
-    nonstandard_style,
-    rust_2018_idioms,
-    rustdoc::broken_intra_doc_links,
-    unsafe_code,
-    unused
+    unsafe_code
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -9,8 +9,7 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::unnecessary_wraps,
-    clippy::used_underscore_binding
+    clippy::unnecessary_wraps
 )]
 
 pub mod future;

--- a/twilight-util/src/lib.rs
+++ b/twilight-util/src/lib.rs
@@ -9,8 +9,7 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::unnecessary_wraps,
-    clippy::used_underscore_binding
+    clippy::unnecessary_wraps
 )]
 
 #[cfg(feature = "builder")]

--- a/twilight-util/src/lib.rs
+++ b/twilight-util/src/lib.rs
@@ -1,4 +1,6 @@
-#![deny(
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc = include_str!("../README.md")]
+#![warn(
     clippy::missing_const_for_fn,
     clippy::pedantic,
     missing_docs,
@@ -10,8 +12,6 @@
     clippy::unnecessary_wraps,
     clippy::used_underscore_binding
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![doc = include_str!("../README.md")]
 
 #[cfg(feature = "builder")]
 pub mod builder;

--- a/twilight-util/src/lib.rs
+++ b/twilight-util/src/lib.rs
@@ -1,14 +1,8 @@
 #![deny(
-    clippy::all,
     clippy::missing_const_for_fn,
     clippy::pedantic,
-    future_incompatible,
     missing_docs,
-    nonstandard_style,
-    rust_2018_idioms,
-    rustdoc::broken_intra_doc_links,
-    unsafe_code,
-    unused
+    unsafe_code
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/twilight-validate/src/lib.rs
+++ b/twilight-validate/src/lib.rs
@@ -1,4 +1,5 @@
-#![deny(
+#![doc = include_str!("../README.md")]
+#![warn(
     clippy::missing_const_for_fn,
     clippy::missing_docs_in_private_items,
     clippy::pedantic,
@@ -11,7 +12,6 @@
     clippy::unnecessary_wraps,
     clippy::used_underscore_binding
 )]
-#![doc = include_str!("../README.md")]
 
 pub mod channel;
 pub mod command;

--- a/twilight-validate/src/lib.rs
+++ b/twilight-validate/src/lib.rs
@@ -9,8 +9,7 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::unnecessary_wraps,
-    clippy::used_underscore_binding
+    clippy::unnecessary_wraps
 )]
 
 pub mod channel;

--- a/twilight-validate/src/lib.rs
+++ b/twilight-validate/src/lib.rs
@@ -1,15 +1,9 @@
 #![deny(
-    clippy::all,
     clippy::missing_const_for_fn,
     clippy::missing_docs_in_private_items,
     clippy::pedantic,
-    future_incompatible,
     missing_docs,
-    nonstandard_style,
-    rust_2018_idioms,
-    rustdoc::broken_intra_doc_links,
-    unsafe_code,
-    unused
+    unsafe_code
 )]
 #![allow(
     clippy::module_name_repetitions,


### PR DESCRIPTION
Development of Twilight is somewhat tedious due to warning lints failing compilations of WIP changes. We should instead only fail builds once we submit them to a PR, i.e. fail in CI.
This PR removes the deny by default lints and warns on the remaining one's. Additionally I removed an uncessary allow by default `unused_underscore_binding` lint (useful when `tracing` was optional)

Suggested in https://github.com/twilight-rs/twilight/discussions/1644#discussioncomment-4583127
