### PR TITLE
ci: speedup & reduce cache storage

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install cargo-minimal-versions
         uses: taiki-e/install-action@cargo-minimal-versions
 
-      - run: cargo minimal-versions check --all-features --all-targets
+      - run: cargo minimal-versions check --all-features
 
   # Check documentation
   build-docs:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -156,7 +156,7 @@ jobs:
         run: cargo nextest --config-file ${{ github.workspace }}/nextest.toml run --profile ci --workspace --exclude book
 
       - name: Run doctests
-        run: cargo test --doc
+        run: cargo test --doc --workspace --exclude book
 
   feature-combinations:
     name: Feature combinations

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      # Necessary for minimal-versions
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
       - name: Retrieve rust-version
         run: echo rust-version=$(awk '/rust-version/{print $NF}' Cargo.toml | tr -d '"') >> $GITHUB_ENV
 
@@ -41,7 +45,13 @@ jobs:
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"
 
-      - run: cargo check --all-features --all-targets
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Install cargo-minimal-versions
+        uses: taiki-e/install-action@cargo-minimal-versions
+
+      - run: cargo minimal-versions check --all-features --all-targets
 
   # Check documentation
   build-docs:
@@ -119,33 +129,6 @@ jobs:
 
       - name: Check code formatting
         run: cargo fmt --all -- --check --unstable-features --config format_code_in_doc_comments=true
-
-  min-vers:
-    name: Minimal crate versions
-    needs: [MSRV]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Add problem matchers
-        run: echo "::add-matcher::.github/rust.json"
-
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-
-      - name: Install cargo-minimal-versions
-        uses: taiki-e/install-action@cargo-minimal-versions
-
-      - name: Check minimal versions
-        run: cargo minimal-versions check
 
   # Tests
   test:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      # Necessary for minimal-versions
-      - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
       - name: Retrieve rust-version
         run: echo rust-version=$(awk '/rust-version/{print $NF}' Cargo.toml | tr -d '"') >> $GITHUB_ENV
 
@@ -45,13 +41,7 @@ jobs:
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"
 
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-
-      - name: Install cargo-minimal-versions
-        uses: taiki-e/install-action@cargo-minimal-versions
-
-      - run: cargo minimal-versions check --all-features
+      - run: cargo check --all-features --all-targets
 
   # Check documentation
   build-docs:
@@ -129,6 +119,33 @@ jobs:
 
       - name: Check code formatting
         run: cargo fmt --all -- --check --unstable-features --config format_code_in_doc_comments=true
+
+  min-vers:
+    name: Minimal crate versions
+    needs: [MSRV]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Add problem matchers
+        run: echo "::add-matcher::.github/rust.json"
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Install cargo-minimal-versions
+        uses: taiki-e/install-action@cargo-minimal-versions
+
+      - name: Check minimal versions
+        run: cargo minimal-versions check
 
   # Tests
   test:

--- a/twilight-cache-inmemory/Cargo.toml
+++ b/twilight-cache-inmemory/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 version = "0.15.0"
 
 [dependencies]
-bitflags = { default-features = false, version = "1" }
+bitflags = { default-features = false, version = "1.3" }
 dashmap = { default-features = false, version = "5.3" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.0" }

--- a/twilight-cache-inmemory/Cargo.toml
+++ b/twilight-cache-inmemory/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 version = "0.15.0"
 
 [dependencies]
-bitflags = { default-features = false, version = "1.3" }
+bitflags = { default-features = false, version = "1" }
 dashmap = { default-features = false, version = "5.3" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.0" }


### PR DESCRIPTION
Twilight's CI cache regurarely exceeds the maximum provided 10GB storage by GitHub, discarding the oldest caches. The resulting cache misses increases our CI time and wastes GitHub's resources.

By inlining the min-vers CI job into MSRV we reduce it's risk of becoming stale (running dependant jobs quicker) as the dependencies are frozen and also remove an almost duplicate 300MB cache.
By excluding the book from the doctest CI no longer needs to recompile Twilight due to the book's dependencies and this should also reduce this job's cache size.
