### PR TITLE
docs(gateway): all event types can be excluded

### DIFF
--- a/twilight-gateway/src/event.rs
+++ b/twilight-gateway/src/event.rs
@@ -20,6 +20,13 @@ bitflags! {
     /// [`ROLE_CREATE`][Self::ROLE_CREATE] event type flags can be specified in
     /// combination with that intent to only deserialize those events.
     ///
+    /// Selected event types only affect the events returned by [`Shard`]s.
+    /// Events necessary for maintaining the connection to Discord, such as
+    /// [`GATEWAY_HEARTBEAT`][`Self::GATEWAY_HEARTBEAT`] and
+    /// [`GATEWAY_HELLO`][`Self::GATEWAY_HELLO`], can safely be excluded and
+    /// won't cause the operation of shards to fail, because shards will always
+    /// parse portions of necessary events.
+    ///
     /// [`ChannelCreate`]: twilight_model::gateway::event::Event::ChannelCreate
     /// [`ChannelPinsUpdate`]: twilight_model::gateway::event::Event::ChannelPinsUpdate
     /// [`Event`]: twilight_model::gateway::event::Event


### PR DESCRIPTION
Add a piece of documentation to `EventTypeFlags` to clarify that all events can be excluded from a selection of flags because shards will always parse portions of events necessary for maintaining gateway connections.

Documentation added after a support thread was received in our Discord server:
<https://discord.com/channels/745809834183753828/1075585618953908344>