### PR TITLE
docs(model): formatting of discriminator field

### DIFF
--- a/twilight-model/src/user/current_user.rs
+++ b/twilight-model/src/user/current_user.rs
@@ -24,6 +24,13 @@ pub struct CurrentUser {
     pub bot: bool,
     /// Discriminator used to differentiate people with the same username.
     ///
+    /// # Formatting
+    ///
+    /// Because discriminators are stored as an integer they're not in the
+    /// format of Discord user tags due to a lack of padding with zeros. The
+    /// [`discriminator`] method can be used to retrieve a formatter to pad the
+    /// discriminator with zeros.
+    ///
     /// # serde
     ///
     /// The discriminator field can be deserialized from either a string or an
@@ -67,7 +74,8 @@ pub struct CurrentUser {
 }
 
 impl CurrentUser {
-    /// Create a [`Display`] formatter for a user discriminator.
+    /// Create a [`Display`] formatter for a user discriminator that pads the
+    /// discriminator with zeros up to 4 digits.
     ///
     /// [`Display`]: core::fmt::Display
     pub const fn discriminator(&self) -> DiscriminatorDisplay {

--- a/twilight-model/src/user/current_user.rs
+++ b/twilight-model/src/user/current_user.rs
@@ -36,6 +36,8 @@ pub struct CurrentUser {
     /// The discriminator field can be deserialized from either a string or an
     /// integer. The field will always serialize into a string due to that being
     /// the type Discord's API uses.
+    ///
+    /// [`discriminator`]: Self::discriminator
     #[serde(with = "super::discriminator")]
     pub discriminator: u16,
     /// User's email address associated to the account.

--- a/twilight-model/src/user/mod.rs
+++ b/twilight-model/src/user/mod.rs
@@ -131,6 +131,13 @@ pub struct User {
     pub bot: bool,
     /// Discriminator used to differentiate people with the same username.
     ///
+    /// # Formatting
+    ///
+    /// Because discriminators are stored as an integer they're not in the
+    /// format of Discord user tags due to a lack of padding with zeros. The
+    /// [`discriminator`] method can be used to retrieve a formatter to pad the
+    /// discriminator with zeros.
+    ///
     /// # serde
     ///
     /// The discriminator field can be deserialized from either a string or an
@@ -160,7 +167,8 @@ pub struct User {
 }
 
 impl User {
-    /// Create a [`Display`] formatter for a user discriminator.
+    /// Create a [`Display`] formatter for a user discriminator that pads the
+    /// discriminator with zeros up to 4 digits.
     ///
     /// [`Display`]: core::fmt::Display
     pub const fn discriminator(&self) -> DiscriminatorDisplay {

--- a/twilight-model/src/user/mod.rs
+++ b/twilight-model/src/user/mod.rs
@@ -143,6 +143,8 @@ pub struct User {
     /// The discriminator field can be deserialized from either a string or an
     /// integer. The field will always serialize into a string due to that being
     /// the type Discord's API uses.
+    ///
+    /// [`discriminator`]: Self::discriminator
     #[serde(with = "discriminator")]
     pub discriminator: u16,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/user/profile.rs
+++ b/twilight-model/src/user/profile.rs
@@ -30,6 +30,8 @@ pub struct UserProfile {
     /// The discriminator field can be deserialized from either a string or an
     /// integer. The field will always serialize into a string due to that being
     /// the type Discord's API uses.
+    ///
+    /// [`discriminator`]: Self::discriminator
     #[serde(with = "super::discriminator")]
     pub discriminator: u16,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/user/profile.rs
+++ b/twilight-model/src/user/profile.rs
@@ -18,6 +18,13 @@ pub struct UserProfile {
     pub bot: bool,
     /// Discriminator used to differentiate people with the same username.
     ///
+    /// # Formatting
+    ///
+    /// Because discriminators are stored as an integer they're not in the
+    /// format of Discord user tags due to a lack of padding with zeros. The
+    /// [`discriminator`] method can be used to retrieve a formatter to pad the
+    /// discriminator with zeros.
+    ///
     /// # serde
     ///
     /// The discriminator field can be deserialized from either a string or an
@@ -43,7 +50,8 @@ pub struct UserProfile {
 }
 
 impl UserProfile {
-    /// Create a [`Display`] formatter for a user discriminator.
+    /// Create a [`Display`] formatter for a user discriminator that pads the
+    /// discriminator with zeros up to 4 digits.
     ///
     /// [`Display`]: core::fmt::Display
     pub const fn discriminator(&self) -> DiscriminatorDisplay {


### PR DESCRIPTION
Add documentation to the `discriminator` field on user models that, because the discriminator is an integer, it's not acceptable for formatting such as in a user tag, and that the `discriminator` method which returns a formatter for just the use case is preferred.