### PR TITLE
fix(gateway): ignore unknown event errors

### DIFF
--- a/twilight-gateway/src/json.rs
+++ b/twilight-gateway/src/json.rs
@@ -22,11 +22,12 @@ use twilight_model::gateway::{
 
 /// Error occurred due to an unknown event and opcode pair.
 #[derive(Debug)]
+#[non_exhaustive]
 pub(crate) struct UnknownEventError {
     /// Event type in the payload.
-    event_type: Option<String>,
+    pub event_type: Option<String>,
     /// Opcode in the payload.
-    opcode: Option<u8>,
+    pub opcode: Option<u8>,
 }
 
 impl Display for UnknownEventError {

--- a/twilight-gateway/src/json.rs
+++ b/twilight-gateway/src/json.rs
@@ -11,10 +11,35 @@ use crate::{
     EventTypeFlags,
 };
 use serde::de::DeserializeSeed;
+use std::{
+    error::Error,
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+};
 use twilight_model::gateway::{
     event::{GatewayEvent, GatewayEventDeserializer},
     OpCode,
 };
+
+/// Error occurred due to an unknown event and opcode pair.
+#[derive(Debug)]
+pub(crate) struct UnknownEventError {
+    /// Event type in the payload.
+    event_type: Option<String>,
+    /// Opcode in the payload.
+    opcode: Option<u8>,
+}
+
+impl Display for UnknownEventError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str("unknown opcode/dispatch event type: ")?;
+        Debug::fmt(&self.opcode, f)?;
+        f.write_str("/")?;
+
+        Debug::fmt(&self.event_type, f)
+    }
+}
+
+impl Error for UnknownEventError {}
 
 /// Parse a JSON encoded event into a gateway event if its type is in
 /// `wanted_event_types`.
@@ -43,7 +68,10 @@ pub fn parse(
         } else {
             return Err(ReceiveMessageError {
                 kind: ReceiveMessageErrorType::Deserializing { event },
-                source: Some("missing opcode".into()),
+                source: Some(Box::new(UnknownEventError {
+                    event_type: None,
+                    opcode: None,
+                })),
             });
         };
 
@@ -54,7 +82,10 @@ pub fn parse(
 
         return Err(ReceiveMessageError {
             kind: ReceiveMessageErrorType::Deserializing { event },
-            source: Some(format!("unknown opcode: {opcode}").into()),
+            source: Some(Box::new(UnknownEventError {
+                event_type: None,
+                opcode: Some(opcode),
+            })),
         });
     };
 
@@ -64,11 +95,14 @@ pub fn parse(
         event_type
     } else {
         let opcode = opcode as u8;
-        let source = format!("unknown opcode/dispatch event type: {opcode}/{event_type:?}");
+        let owned_event_type = event_type.map(ToOwned::to_owned);
 
         return Err(ReceiveMessageError {
             kind: ReceiveMessageErrorType::Deserializing { event },
-            source: Some(source.into()),
+            source: Some(Box::new(UnknownEventError {
+                event_type: owned_event_type,
+                opcode: Some(opcode),
+            })),
         });
     };
 

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -469,6 +469,10 @@ impl Shard {
 
     /// Wait for the next Discord event from the gateway.
     ///
+    /// Events not registered in Twilight are skipped. If you need to receive
+    /// events Twilight doesn't support, use [`next_message`] to receive raw
+    /// payloads.
+    ///
     /// # Errors
     ///
     /// Returns a [`ReceiveMessageErrorType::Compression`] error type if the
@@ -489,6 +493,8 @@ impl Shard {
     ///
     /// Returns a [`ReceiveMessageErrorType::SendingMessage`] error type if the
     /// shard failed to send a message to the gateway, such as a heartbeat.
+    ///
+    /// [`next_message`]: Self::next_message
     pub async fn next_event(&mut self) -> Result<Event, ReceiveMessageError> {
         loop {
             let text = match self.next_message().await? {

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -512,8 +512,8 @@ impl Shard {
                             .and_then(|source| source.downcast_ref::<UnknownEventError>())
                             .is_some();
 
-                        if is_unknown_event {
-                            continue;
+                        if !is_unknown_event {
+                            return Err(source);
                         }
                     }
                 },

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -506,6 +506,9 @@ impl Shard {
                         // Discord has many events that aren't documented, so we
                         // need to skip over errors caused by unknown events or
                         // opcodes.
+                        //
+                        // clippy: the recommendation is to reference the method
+                        // by name with a turbofish, which is invalid syntax
                         #[allow(clippy::redundant_closure_for_method_calls)]
                         let is_unknown_event = source
                             .source()


### PR DESCRIPTION
Ignore errors caused by attempting to parse payloads into events that are unknown to Twilight. Because these are unknown payload types, they couldn't possibly ever produce a parsed event, and therefore it's expected that they fail to deserialize. Because this isn't an *error* in the operation of the shard and is considered a normal operation in the event loop, we should skip over these errors from unknown events. Deserialization error variants can still occur from failing to deserialize *known* event types.