### PR TITLE
docs(model): clarify reaction type unicode values

### DIFF
--- a/twilight-model/src/channel/message/reaction.rs
+++ b/twilight-model/src/channel/message/reaction.rs
@@ -34,7 +34,10 @@ pub enum ReactionType {
         // example if the emoji have been deleted off the guild.
         name: Option<String>,
     },
-    /// Standard [Unicode] emoji.
+    /// Standard [Unicode] emoji value.
+    ///
+    /// Unicode reactions must be specified by their unicode value, and *not*
+    /// their Discord display name. Instead of using "arrow_right", use "➡️".
     ///
     /// [Unicode]: https://unicode.org/emoji/
     Unicode {

--- a/twilight-model/src/channel/message/reaction.rs
+++ b/twilight-model/src/channel/message/reaction.rs
@@ -37,7 +37,7 @@ pub enum ReactionType {
     /// Standard [Unicode] emoji value.
     ///
     /// Unicode reactions must be specified by their unicode value, and *not*
-    /// their Discord display name. Instead of using "arrow_right", use "➡️".
+    /// their Discord display name. Instead of using ":arrow_right:", use "➡️".
     ///
     /// [Unicode]: https://unicode.org/emoji/
     Unicode {


### PR DESCRIPTION
Clarify that the name of a unicode reaction type
(`ReactionType::Unicode`) is the *value* of the unicode emoji and not the Discord display name for the emoji. For example, instead of using a value of "arrow_right", a name of "➡️" must be specified.

Documentation added after a support thread was received in our Discord server:
<https://discord.com/channels/745809834183753828/1075631047871578153>