### PR TITLE
feat(http-ratelimiting): add a bucket for global rate limits

### DIFF
--- a/twilight-http-ratelimiting/src/in_memory/bucket.rs
+++ b/twilight-http-ratelimiting/src/in_memory/bucket.rs
@@ -236,7 +236,7 @@ impl BucketQueueTask {
 
             match timeout(Self::WAIT, ticket_headers).await {
                 Ok(Ok(Some(headers))) => {
-                    self.handle_headers(&headers).await;
+                    self.handle_headers(&headers);
                     global_ticket_tx.headers(Some(headers)).ok();
                 }
                 Ok(Ok(None)) => {
@@ -272,7 +272,7 @@ impl BucketQueueTask {
     }
 
     /// Update the bucket's ratelimit state.
-    async fn handle_headers(&self, headers: &RatelimitHeaders) {
+    fn handle_headers(&self, headers: &RatelimitHeaders) {
         let ratelimits = match headers {
             RatelimitHeaders::Present(present) => {
                 Some((present.limit(), present.remaining(), present.reset_after()))

--- a/twilight-http-ratelimiting/src/in_memory/global_bucket.rs
+++ b/twilight-http-ratelimiting/src/in_memory/global_bucket.rs
@@ -1,0 +1,100 @@
+use super::bucket::BucketQueue;
+use crate::RatelimitHeaders;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::Instant;
+
+/// seconds per period
+const PERIOD: u64 = 1;
+/// requests per period
+const REQUESTS: u64 = 50;
+
+/// Global bucket. Keeps track of the global rate limit.
+#[derive(Debug, Clone)]
+pub struct GlobalBucket(Arc<InnerGlobalBucket>);
+
+impl GlobalBucket {
+    /// Queue of global ratelimit requests
+    pub fn queue(&self) -> &BucketQueue {
+        &self.0.queue
+    }
+
+    /// Whether the global ratelimit is exhausted.
+    pub fn is_locked(&self) -> bool {
+        self.0.is_locked.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for GlobalBucket {
+    fn default() -> Self {
+        Self(InnerGlobalBucket::new())
+    }
+}
+
+#[derive(Debug)]
+struct InnerGlobalBucket {
+    pub queue: BucketQueue,
+    /// currently waiting for capacity
+    is_locked: AtomicBool,
+}
+
+impl InnerGlobalBucket {
+    fn new() -> Arc<Self> {
+        let this = Self {
+            queue: Default::default(),
+            is_locked: Default::default(),
+        };
+        let this = Arc::new(this);
+
+        tokio::spawn(run_global_queue_task(this.clone()));
+
+        this
+    }
+}
+
+#[tracing::instrument(name = "background global queue task", skip_all)]
+async fn run_global_queue_task(bucket: Arc<InnerGlobalBucket>) {
+    let mut time = Instant::now();
+
+    while let Some(queue_tx) = bucket.queue.pop().await {
+        wait_if_needed(bucket.as_ref(), &mut time).await;
+
+        let ticket_headers = if let Some(ticket_headers) = queue_tx.available() {
+            ticket_headers
+        } else {
+            continue;
+        };
+
+        if let Ok(Some(RatelimitHeaders::Global(headers))) = ticket_headers.await {
+            tracing::debug!(seconds = headers.retry_after(), "globally ratelimited");
+
+            bucket.is_locked.store(true, Ordering::Release);
+            tokio::time::sleep(Duration::from_secs(headers.retry_after())).await;
+            bucket.is_locked.store(false, Ordering::Release);
+        }
+    }
+}
+
+async fn wait_if_needed(bucket: &InnerGlobalBucket, time: &mut Instant) {
+    let period = Duration::from_secs(PERIOD);
+    let fill_rate = period / REQUESTS as u32;
+
+    let now = Instant::now();
+    // base contingent of 1 period worth of requests
+    let base = now - period;
+    // reset to base if no request came in for long enough
+    if base > *time {
+        *time = base;
+    }
+
+    // we request one request worth of rate limit consumption
+    *time += fill_rate;
+
+    // if time > now, wait until there is capacity available again
+    if *time > now {
+        bucket.is_locked.store(true, Ordering::Release);
+        tokio::time::sleep_until(*time).await;
+        bucket.is_locked.store(false, Ordering::Release);
+    }
+}

--- a/twilight-http-ratelimiting/src/in_memory/mod.rs
+++ b/twilight-http-ratelimiting/src/in_memory/mod.rs
@@ -46,6 +46,19 @@ impl InMemoryRatelimiter {
         Self::default()
     }
 
+    /// Create a new in-memory ratelimiter using custom ratelimit values.
+    ///
+    /// `period` is given in seconds.
+    ///
+    /// `requests` indicates the amount of requests per period.
+    #[must_use]
+    pub fn with_global_ratelimit(period: u64, requests: u32) -> Self {
+        Self {
+            global: GlobalBucket::with_ratelimit(period, requests),
+            ..Self::default()
+        }
+    }
+
     /// Enqueue the [`TicketNotifier`] to the [`Path`]'s [`Bucket`].
     ///
     /// Returns the new [`Bucket`] if none existed.

--- a/twilight-http-ratelimiting/src/in_memory/mod.rs
+++ b/twilight-http-ratelimiting/src/in_memory/mod.rs
@@ -4,7 +4,7 @@ mod bucket;
 mod global_bucket;
 
 use self::bucket::{Bucket, BucketQueueTask};
-pub use self::global_bucket::GlobalBucket;
+pub(crate) use self::global_bucket::GlobalBucket;
 use super::{
     ticket::{self, TicketNotifier},
     Bucket as InfoBucket, Ratelimiter,


### PR DESCRIPTION
This closes #650.

I opted to keep the rate limit trait as is for now, even though `is_globally_locked` is unused.
Additionally, the global rate limiter waits for each request to return before accepting the next request. Since 50/s isn't that many, I wanted to keep it simple. If you disagree, then I would change that.
Lastly, Discord only documents the hardcoded 50 requests per second. Nirn-proxy however seemed to have figured out that big bots have [different global rate limits](https://github.com/germanoeich/nirn-proxy/blob/9711f991e978db820ddb917c498283029b5f360e/lib/discord.go#L178-L181). ~~We discussed this on Discord and decided not to support this due to it not being officially documented.~~ EDIT: It was requested to add the option to instead specify custom ratelimit values manually.