### PR TITLE
feat(http-ratelimiting)!: hide `http` dependency

### DIFF
--- a/twilight-http-ratelimiting/Cargo.toml
+++ b/twilight-http-ratelimiting/Cargo.toml
@@ -15,12 +15,12 @@ version = "0.15.0"
 
 [dependencies]
 futures-util = { version = "0.3", default-features = false }
-http = { version = "0.2", default-features = false }
 tokio = { version = "1", default-features = false, features = ["rt", "sync", "time"] }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1.23" }
 
 [dev-dependencies]
 criterion = { default-features = false, version = "0.4" }
+http = { version = "0.2", default-features = false }
 static_assertions = { default-features = false, version = "1.1.0" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
 

--- a/twilight-http-ratelimiting/src/request.rs
+++ b/twilight-http-ratelimiting/src/request.rs
@@ -518,4 +518,13 @@ mod tests {
     }
 
     assert_impl_all!(Method: Clone, Copy, Debug, Eq, PartialEq);
+
+    #[test]
+    fn method_conversions() {
+        assert_eq!("DELETE", Method::Delete.name());
+        assert_eq!("GET", Method::Get.name());
+        assert_eq!("PATCH", Method::Patch.name());
+        assert_eq!("POST", Method::Post.name());
+        assert_eq!("PUT", Method::Put.name());
+    }
 }

--- a/twilight-http-ratelimiting/src/request.rs
+++ b/twilight-http-ratelimiting/src/request.rs
@@ -3,42 +3,44 @@
 //! This module contains the type definitions for parameters
 //! relevant for ratelimiting.
 //!
-//! The [`super::Ratelimiter`] uses [`Path`]s and [`Method`]s to store
-//! and associate buckets with routes.
+//! The [`Ratelimiter`] uses [`Path`]s and [`Method`]s to store and associate
+//! buckets with endpoints.
+//!
+//! [`Ratelimiter`]: super::Ratelimiter
 
-use http::Method as HttpMethod;
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
     str::FromStr,
 };
 
-/// Request method.
+/// HTTP request [method].
+///
+/// [method]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum Method {
-    /// DELETE method.
+    /// Delete a resource.
     Delete,
-    /// GET method.
+    /// Retrieve a resource.
     Get,
-    /// PATCH method.
+    /// Update a resource.
     Patch,
-    /// POST method.
+    /// Create a resource.
     Post,
-    /// PUT method.
+    /// Replace a resource.
     Put,
 }
 
 impl Method {
-    /// Convert the method into the equivalent [`http::Method`].
-    #[must_use]
-    pub const fn to_http(self) -> HttpMethod {
+    /// Name of the method.
+    pub const fn name(self) -> &'static str {
         match self {
-            Self::Delete => HttpMethod::DELETE,
-            Self::Get => HttpMethod::GET,
-            Self::Patch => HttpMethod::PATCH,
-            Self::Post => HttpMethod::POST,
-            Self::Put => HttpMethod::PUT,
+            Method::Delete => "DELETE",
+            Method::Get => "GET",
+            Method::Patch => "PATCH",
+            Method::Post => "POST",
+            Method::Put => "PUT",
         }
     }
 }

--- a/twilight-http-ratelimiting/src/request.rs
+++ b/twilight-http-ratelimiting/src/request.rs
@@ -476,7 +476,6 @@ impl TryFrom<(Method, &str)> for Path {
 mod tests {
     use super::{Path, PathParseError, PathParseErrorType};
     use crate::request::Method;
-    use http::Method as HttpMethod;
     use static_assertions::{assert_fields, assert_impl_all};
     use std::{error::Error, fmt::Debug, hash::Hash, str::FromStr};
 
@@ -519,13 +518,4 @@ mod tests {
     }
 
     assert_impl_all!(Method: Clone, Copy, Debug, Eq, PartialEq);
-
-    #[test]
-    fn method_conversions() {
-        assert_eq!(HttpMethod::DELETE, Method::Delete.to_http());
-        assert_eq!(HttpMethod::GET, Method::Get.to_http());
-        assert_eq!(HttpMethod::PATCH, Method::Patch.to_http());
-        assert_eq!(HttpMethod::POST, Method::Post.to_http());
-        assert_eq!(HttpMethod::PUT, Method::Put.to_http());
-    }
 }

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -2582,7 +2582,7 @@ impl Client {
         let url = format!("{protocol}://{host}/api/v{API_VERSION}/{path}");
         tracing::debug!(?url);
 
-        let mut builder = hyper::Request::builder().method(method.to_http()).uri(&url);
+        let mut builder = hyper::Request::builder().method(method.name()).uri(&url);
 
         if use_authorization_token {
             if let Some(token) = self.token.as_deref() {


### PR DESCRIPTION
The `http` crate was exposed in `Method` for `twilight-http` to use when sending requests. Hyper (the underlying HTTP crate), however, accepts string representations of HTTP methods too, so this PR switches to using that instead.

Closes #1456
