### PR TITLE
perf(cache): replace hashmap .iter().find() with .get()

### DIFF
--- a/twilight-cache-inmemory/src/event/interaction.rs
+++ b/twilight-cache-inmemory/src/event/interaction.rs
@@ -39,11 +39,9 @@ impl UpdateCache for InteractionCreate {
 
                     // This should always match, because resolved members
                     // are guaranteed to have a matching resolved user
-                    if let Some((&id, member)) =
-                        &resolved.members.iter().find(|(&id, _)| id == u.id)
-                    {
+                    if let Some(member) = &resolved.members.get(&u.id) {
                         if let Some(guild_id) = self.guild_id {
-                            cache.cache_borrowed_interaction_member(guild_id, member, id);
+                            cache.cache_borrowed_interaction_member(guild_id, member, u.id);
                         }
                     }
                 }


### PR DESCRIPTION
Replace an instance of finding a HashMap value by key through an iterator with `HashMap::get`.