### PR TITLE
refactor(http): remove get automod rule reasons

### DIFF
--- a/twilight-http/src/request/guild/auto_moderation/get_auto_moderation_rule.rs
+++ b/twilight-http/src/request/guild/auto_moderation/get_auto_moderation_rule.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, Request, TryIntoRequest},
+    request::{Request, TryIntoRequest},
     response::{Response, ResponseFuture},
     routing::Route,
 };
@@ -24,7 +24,6 @@ pub struct GetAutoModerationRule<'a> {
     auto_moderation_rule_id: Id<AutoModerationRuleMarker>,
     guild_id: Id<GuildMarker>,
     http: &'a Client,
-    reason: Option<&'a str>,
 }
 
 impl<'a> GetAutoModerationRule<'a> {
@@ -37,7 +36,6 @@ impl<'a> GetAutoModerationRule<'a> {
             auto_moderation_rule_id,
             guild_id,
             http,
-            reason: None,
         }
     }
 
@@ -65,17 +63,10 @@ impl IntoFuture for GetAutoModerationRule<'_> {
 
 impl TryIntoRequest for GetAutoModerationRule<'_> {
     fn try_into_request(self) -> Result<Request, Error> {
-        let mut request = Request::builder(&Route::GetAutoModerationRule {
+        Ok(Request::builder(&Route::GetAutoModerationRule {
             auto_moderation_rule_id: self.auto_moderation_rule_id.get(),
             guild_id: self.guild_id.get(),
-        });
-
-        if let Some(reason) = self.reason {
-            let header = request::audit_header(reason)?;
-
-            request = request.headers(header);
-        }
-
-        Ok(request.build())
+        })
+        .build())
     }
 }


### PR DESCRIPTION
Remove reasons from being internally stored on the `GetAutoModerationRule` request. Because this was never exposed and in practice never used we can remove it due to the endpoint not supporting it.

Surfaced in the original PR adding the request, #1846.