### PR TITLE
feat(model)!: reduce size of gateway REST API models

### DIFF
--- a/book/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
+++ b/book/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
@@ -32,6 +32,7 @@ The `native` feature enables [`tokio-tungstenite`]'s `native-tls` feature.
 RusTLS allows specifying from where certificate roots are retrieved from.
 
 ##### Native roots
+
 The `rustls-native-roots` feature enables [`tokio-tungstenite`]'s
 `rustls-tls-native-roots` feature.
 
@@ -63,7 +64,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let token = env::var("DISCORD_TOKEN")?;
     let lavalink_host = SocketAddr::from_str(&env::var("LAVALINK_HOST")?)?;
     let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
-    let shard_count = 1_u64;
+    let shard_count = 1_u32;
 
     let http = HttpClient::new(token.clone());
     let user_id = http.current_user().await?.model().await?.id;
@@ -103,7 +104,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
 *crates.io*: <https://crates.io/crates/twilight-lavalink>
 
-[RusTLS]: https://crates.io/crates/rustls
 [Lavalink]: https://github.com/freyacodes/Lavalink
 [client]: https://twilight-rs.github.io/twilight/twilight_lavalink/client/struct.Lavalink.html
 [gateway]: ../section_3_gateway.html

--- a/examples/lavalink-basic-bot.rs
+++ b/examples/lavalink-basic-bot.rs
@@ -44,7 +44,7 @@ async fn main() -> anyhow::Result<()> {
         let token = env::var("DISCORD_TOKEN")?;
         let lavalink_host = SocketAddr::from_str(&env::var("LAVALINK_HOST")?)?;
         let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
-        let shard_count = 1u64;
+        let shard_count = 1u32;
 
         let http = HttpClient::new(token.clone());
         let user_id = http.current_user().await?.model().await?.id;

--- a/twilight-gateway-queue/src/day_limiter.rs
+++ b/twilight-gateway-queue/src/day_limiter.rs
@@ -52,8 +52,8 @@ pub(crate) struct DayLimiterInner {
     pub http: Arc<Client>,
     pub last_check: Instant,
     pub next_reset: Duration,
-    pub total: u64,
-    pub current: u64,
+    pub total: u16,
+    pub current: u16,
 }
 
 impl DayLimiter {
@@ -99,7 +99,7 @@ impl DayLimiter {
             if let Ok(res) = lock.http.gateway().authed().await {
                 if let Ok(info) = res.model().await {
                     let last_check = Instant::now();
-                    let next_reset = Duration::from_millis(info.session_start_limit.remaining);
+                    let next_reset = Duration::from_millis(info.session_start_limit.reset_after);
 
                     tracing::info!("next session start limit reset in: {next_reset:.2?}");
 

--- a/twilight-gateway-queue/src/large_bot_queue.rs
+++ b/twilight-gateway-queue/src/large_bot_queue.rs
@@ -84,9 +84,9 @@ impl Queue for LargeBotQueue {
     /// Request to be able to identify with the gateway. This will place this
     /// request behind all other requests, and the returned future will resolve
     /// once the request has been completed.
-    fn request(&'_ self, shard_id: [u64; 2]) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+    fn request(&'_ self, shard_id: [u32; 2]) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         #[allow(clippy::cast_possible_truncation)]
-        let bucket = (shard_id[0] % (self.buckets.len() as u64)) as usize;
+        let bucket = (shard_id[0] % (self.buckets.len() as u32)) as usize;
         let (tx, rx) = oneshot::channel();
 
         Box::pin(async move {

--- a/twilight-gateway-queue/src/lib.rs
+++ b/twilight-gateway-queue/src/lib.rs
@@ -55,7 +55,7 @@ pub trait Queue: Debug + Send + Sync {
     ///
     /// The returned future must resolve only when the shard can initiate the
     /// session.
-    fn request<'a>(&'a self, shard_id: [u64; 2]) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+    fn request<'a>(&'a self, shard_id: [u32; 2]) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 }
 
 /// A local, in-process implementation of a [`Queue`] which manages the
@@ -118,7 +118,7 @@ impl Queue for LocalQueue {
     /// Request to be able to identify with the gateway. This will place this
     /// request behind all other requests, and the returned future will resolve
     /// once the request has been completed.
-    fn request(&'_ self, [id, total]: [u64; 2]) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+    fn request(&'_ self, [id, total]: [u32; 2]) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
             let (tx, rx) = oneshot::channel();
 
@@ -142,7 +142,7 @@ impl Queue for LocalQueue {
 pub struct NoOpQueue;
 
 impl Queue for NoOpQueue {
-    fn request(&'_ self, [_id, _total]: [u64; 2]) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+    fn request(&'_ self, [_id, _total]: [u32; 2]) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(future::ready(()))
     }
 }

--- a/twilight-gateway/src/stream.rs
+++ b/twilight-gateway/src/stream.rs
@@ -386,19 +386,19 @@ struct NextItemOutput<'a, Item> {
 /// Panics if loading TLS certificates fails.
 #[track_caller]
 pub fn create_bucket<F: Fn(ShardId, ConfigBuilder) -> Config>(
-    bucket_id: u64,
-    concurrency: u64,
-    total: u64,
+    bucket_id: u32,
+    concurrency: u8,
+    total: u32,
     config: Config,
     per_shard_config: F,
 ) -> impl Iterator<Item = Shard> {
     assert!(bucket_id < total, "bucket id must be less than the total");
     assert!(
-        concurrency < total,
+        (u32::from(concurrency)) < total,
         "concurrency must be less than the total"
     );
 
-    let concurrency = concurrency.try_into().unwrap();
+    let concurrency = concurrency.into();
 
     (bucket_id..total).step_by(concurrency).map(move |index| {
         let id = ShardId::new(index, total);
@@ -442,8 +442,8 @@ pub fn create_bucket<F: Fn(ShardId, ConfigBuilder) -> Config>(
 /// Panics if loading TLS certificates fails.
 #[track_caller]
 pub fn create_range<F: Fn(ShardId, ConfigBuilder) -> Config>(
-    range: impl RangeBounds<u64>,
-    total: u64,
+    range: impl RangeBounds<u32>,
+    total: u32,
     config: Config,
     per_shard_config: F,
 ) -> impl Iterator<Item = Shard> {
@@ -505,7 +505,7 @@ pub async fn create_recommended<F: Fn(ShardId, ConfigBuilder) -> Config>(
 ///
 /// Panics if `start >= total` or if `end > total`, where `start` and `end`
 /// refer to `range`'s start and end.
-fn calculate_range(range: impl RangeBounds<u64>, total: u64) -> Range<u64> {
+fn calculate_range(range: impl RangeBounds<u32>, total: u32) -> Range<u32> {
     // 0, or the provided start bound (inclusive).
     let start = match range.start_bound() {
         Bound::Excluded(from) => *from + 1,

--- a/twilight-lavalink/README.md
+++ b/twilight-lavalink/README.md
@@ -76,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
     let token = env::var("DISCORD_TOKEN")?;
     let lavalink_host = SocketAddr::from_str(&env::var("LAVALINK_HOST")?)?;
     let lavalink_auth = env::var("LAVALINK_AUTHORIZATION")?;
-    let shard_count = 1u64;
+    let shard_count = 1u32;
 
     let http = HttpClient::new(token.clone());
     let user_id = http.current_user().await?.model().await?.id;

--- a/twilight-lavalink/src/client.rs
+++ b/twilight-lavalink/src/client.rs
@@ -100,7 +100,7 @@ pub struct Lavalink {
     nodes: DashMap<SocketAddr, Arc<Node>>,
     players: PlayerManager,
     resume: Option<Resume>,
-    shard_count: u64,
+    shard_count: u32,
     user_id: Id<UserMarker>,
     server_updates: DashMap<Id<GuildMarker>, VoiceServerUpdate>,
     sessions: DashMap<Id<GuildMarker>, Box<str>>,
@@ -118,7 +118,7 @@ impl Lavalink {
     ///
     /// [`add`]: Self::add
     /// [`new_with_resume`]: Self::new_with_resume
-    pub fn new(user_id: Id<UserMarker>, shard_count: u64) -> Self {
+    pub fn new(user_id: Id<UserMarker>, shard_count: u32) -> Self {
         Self::_new_with_resume(user_id, shard_count, None)
     }
 
@@ -131,13 +131,13 @@ impl Lavalink {
     /// [`new`]: Self::new
     pub fn new_with_resume(
         user_id: Id<UserMarker>,
-        shard_count: u64,
+        shard_count: u32,
         resume: impl Into<Option<Resume>>,
     ) -> Self {
         Self::_new_with_resume(user_id, shard_count, resume.into())
     }
 
-    fn _new_with_resume(user_id: Id<UserMarker>, shard_count: u64, resume: Option<Resume>) -> Self {
+    fn _new_with_resume(user_id: Id<UserMarker>, shard_count: u32, resume: Option<Resume>) -> Self {
         Self {
             nodes: DashMap::new(),
             players: PlayerManager::new(),
@@ -381,13 +381,13 @@ impl Lavalink {
     ///
     /// This map should be small or empty, and if it isn't, then it needs to be
     /// cleared out anyway.
-    fn clear_shard_states(&self, shard_id: u64) {
-        let shard_count = self.shard_count;
+    fn clear_shard_states(&self, shard_id: u32) {
+        let shard_count = u64::from(self.shard_count);
 
         self.server_updates
-            .retain(|k, _| (k.get() >> 22) % shard_count != shard_id);
+            .retain(|k, _| (k.get() >> 22) % shard_count != u64::from(shard_id));
         self.sessions
-            .retain(|k, _| (k.get() >> 22) % shard_count != shard_id);
+            .retain(|k, _| (k.get() >> 22) % shard_count != u64::from(shard_id));
     }
 }
 

--- a/twilight-model/src/gateway/connection_info/bot_connection_info.rs
+++ b/twilight-model/src/gateway/connection_info/bot_connection_info.rs
@@ -8,7 +8,7 @@ pub struct BotConnectionInfo {
     /// Current session availability and session connection concurrency limits.
     pub session_start_limit: SessionStartLimit,
     /// Recommended shard count to use.
-    pub shards: u64,
+    pub shards: u32,
     /// URL to the gateway.
     pub url: String,
 }
@@ -44,16 +44,16 @@ mod tests {
                     len: 4,
                 },
                 Token::Str("max_concurrency"),
-                Token::U64(16),
+                Token::U8(16),
                 Token::Str("remaining"),
-                Token::U64(998),
+                Token::U16(998),
                 Token::Str("reset_after"),
                 Token::U64(84_686_789),
                 Token::Str("total"),
-                Token::U64(1000),
+                Token::U16(1000),
                 Token::StructEnd,
                 Token::Str("shards"),
-                Token::U64(3),
+                Token::U32(3),
                 Token::Str("url"),
                 Token::Str("wss://gateway.discord.gg"),
                 Token::StructEnd,

--- a/twilight-model/src/gateway/id.rs
+++ b/twilight-model/src/gateway/id.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
-    num::NonZeroU64,
+    num::NonZeroU32,
 };
 
 pub struct ShardIdParseError {
@@ -51,9 +51,9 @@ pub enum ShardIdParseErrorType {
     /// ShardId's number was greater or equal to its total.
     NumberGreaterOrEqualTotal {
         /// Value of number.
-        number: u64,
+        number: u32,
         /// Value of total.
-        total: u64,
+        total: u32,
     },
 }
 
@@ -92,12 +92,12 @@ pub enum ShardIdParseErrorType {
 ///
 /// [Discord Docs/Sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-#[serde(try_from = "[u64; 2]", into = "[u64; 2]")]
+#[serde(try_from = "[u32; 2]", into = "[u32; 2]")]
 pub struct ShardId {
     /// Number of the shard, 0-indexed.
-    number: u64,
+    number: u32,
     /// Total number of shards used by the bot, 1-indexed.
-    total: NonZeroU64,
+    total: NonZeroU32,
 }
 
 impl ShardId {
@@ -127,9 +127,9 @@ impl ShardId {
     ///
     /// Panics if the shard number is greater than or equal to the total number
     /// of shards.
-    pub const fn new(number: u64, total: u64) -> Self {
+    pub const fn new(number: u32, total: u32) -> Self {
         assert!(number < total, "number must be less than total");
-        if let Some(total) = NonZeroU64::new(total) {
+        if let Some(total) = NonZeroU32::new(total) {
             Self { number, total }
         } else {
             panic!("unreachable: total is at least 1")
@@ -138,12 +138,12 @@ impl ShardId {
 
     /// Create a new shard identifier if the shard indexes are valid.
     #[allow(clippy::missing_panics_doc)]
-    pub const fn new_checked(number: u64, total: u64) -> Option<Self> {
+    pub const fn new_checked(number: u32, total: u32) -> Option<Self> {
         if number >= total {
             return None;
         }
 
-        if let Some(total) = NonZeroU64::new(total) {
+        if let Some(total) = NonZeroU32::new(total) {
             Some(Self { number, total })
         } else {
             panic!("unreachable: total is at least 1")
@@ -151,12 +151,12 @@ impl ShardId {
     }
 
     /// Identifying number of the shard, 0-indexed.
-    pub const fn number(self) -> u64 {
+    pub const fn number(self) -> u32 {
         self.number
     }
 
     /// Total number of shards, 1-indexed.
-    pub const fn total(self) -> u64 {
+    pub const fn total(self) -> u32 {
         self.total.get()
     }
 }
@@ -167,22 +167,22 @@ impl ShardId {
 impl Display for ShardId {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.debug_list()
-            .entries(Into::<[u64; 2]>::into(*self))
+            .entries(Into::<[u32; 2]>::into(*self))
             .finish()
     }
 }
 
-impl TryFrom<[u64; 2]> for ShardId {
+impl TryFrom<[u32; 2]> for ShardId {
     type Error = ShardIdParseError;
 
-    fn try_from([number, total]: [u64; 2]) -> Result<Self, Self::Error> {
+    fn try_from([number, total]: [u32; 2]) -> Result<Self, Self::Error> {
         Self::new_checked(number, total).ok_or(ShardIdParseError {
             kind: ShardIdParseErrorType::NumberGreaterOrEqualTotal { number, total },
         })
     }
 }
 
-impl From<ShardId> for [u64; 2] {
+impl From<ShardId> for [u32; 2] {
     fn from(id: ShardId) -> Self {
         [id.number(), id.total()]
     }
@@ -235,8 +235,8 @@ mod tests {
             &value,
             &[
                 Token::Tuple { len: 2 },
-                Token::U64(0),
-                Token::U64(1),
+                Token::U32(0),
+                Token::U32(1),
                 Token::TupleEnd,
             ],
         )

--- a/twilight-model/src/gateway/payload/incoming/ready.rs
+++ b/twilight-model/src/gateway/payload/incoming/ready.rs
@@ -118,8 +118,8 @@ mod tests {
                 Token::Str("shard"),
                 Token::Some,
                 Token::Tuple { len: 2 },
-                Token::U64(4),
-                Token::U64(7),
+                Token::U32(4),
+                Token::U32(7),
                 Token::TupleEnd,
                 Token::Str("user"),
                 Token::Struct {

--- a/twilight-model/src/gateway/session_start_limit.rs
+++ b/twilight-model/src/gateway/session_start_limit.rs
@@ -4,14 +4,18 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct SessionStartLimit {
     /// Maximum number of session that may be started concurrently.
-    pub max_concurrency: u64,
+    pub max_concurrency: u8,
     /// Number of remaining sessions for a given time period.
-    pub remaining: u64,
-    /// When the remaining sessions resets back to the total.
+    ///
+    /// Max 1999.
+    pub remaining: u16,
+    /// Milliseconds until `remaining` resets back to `total`.
     pub reset_after: u64,
     /// Total number of sessions that can be started within the given time
     /// period.
-    pub total: u64,
+    ///
+    /// Max 2000.
+    pub total: u16,
 }
 
 #[cfg(test)]
@@ -36,13 +40,13 @@ mod tests {
                     len: 4,
                 },
                 Token::Str("max_concurrency"),
-                Token::U64(16),
+                Token::U8(16),
                 Token::Str("remaining"),
-                Token::U64(998),
+                Token::U16(998),
                 Token::Str("reset_after"),
                 Token::U64(84_686_789),
                 Token::Str("total"),
-                Token::U64(1_000),
+                Token::U16(1_000),
                 Token::StructEnd,
             ],
         );

--- a/twilight-model/src/gateway/session_start_limit.rs
+++ b/twilight-model/src/gateway/session_start_limit.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
 
 /// Current gateway session utilization status.
-/// 
+///
 /// Most bots have a `max_concurrency` of 1 and a `total` of 1000, but this is
 /// increased for those with large bot sharding (in more than 150,000 guilds).
 /// See [Discord Docs/Sharding for Large Bots].
-/// 
+///
 /// [Discord Docs/Sharding for Large Bots]: https://discord.com/developers/docs/topics/gateway#sharding-for-large-bots
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct SessionStartLimit {

--- a/twilight-model/src/gateway/session_start_limit.rs
+++ b/twilight-model/src/gateway/session_start_limit.rs
@@ -1,13 +1,19 @@
 use serde::{Deserialize, Serialize};
 
 /// Current gateway session utilization status.
+/// 
+/// Most bots have a `max_concurrency` of 1 and a `total` of 1000, but this is
+/// increased for those with large bot sharding (in more than 150,000 guilds).
+/// See [Discord Docs/Sharding for Large Bots].
+/// 
+/// [Discord Docs/Sharding for Large Bots]: https://discord.com/developers/docs/topics/gateway#sharding-for-large-bots
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct SessionStartLimit {
     /// Maximum number of session that may be started concurrently.
     pub max_concurrency: u8,
     /// Number of remaining sessions for a given time period.
     ///
-    /// Max 1999.
+    /// Max 2000.
     pub remaining: u16,
     /// Milliseconds until `remaining` resets back to `total`.
     pub reset_after: u64,


### PR DESCRIPTION
Saves a bit of space, for example, no one is running more than 2^32 shards (in fact the largest bot runs about 10 times under 2^16).

This also happens to fix a bug in the `LargeBotQueue` implementation.

This is a prelude to the `vilgotf/feat/gateway-queue/rewrite` branch (which is essentially ready) where I've done a (mosltly documentation) rework of the gateway-queue crate.
