### PR TITLE
feat(model): add feature-gated rkyv implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ include = ["src/**/*.rs", "README.md"]
 license = "ISC"
 repository = "https://github.com/twilight-rs/twilight.git"
 rust-version = "1.64"
+
+# awaiting release of https://github.com/rkyv/rkyv/pull/358
+[patch.crates-io]
+rkyv = { git = "https://github.com/rkyv/rkyv" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,3 @@ include = ["src/**/*.rs", "README.md"]
 license = "ISC"
 repository = "https://github.com/twilight-rs/twilight.git"
 rust-version = "1.64"
-
-# awaiting merge of https://github.com/rkyv/rkyv/pull/358
-[patch.crates-io]
-rkyv = { git = "https://github.com/MaxOhn/rkyv", branch = "disambiguate-macro" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ include = ["src/**/*.rs", "README.md"]
 license = "ISC"
 repository = "https://github.com/twilight-rs/twilight.git"
 rust-version = "1.64"
+
+# awaiting merge of https://github.com/rkyv/rkyv/pull/358
+[patch.crates-io]
+rkyv = { git = "https://github.com/MaxOhn/rkyv", branch = "disambiguate-macro" }

--- a/twilight-model/Cargo.toml
+++ b/twilight-model/Cargo.toml
@@ -20,6 +20,9 @@ serde_repr = { default-features = false, version = "0.1.5" }
 time = { default-features = false, features = ["parsing", "std"], version = "0.3" }
 tracing = { default-features = false, version = "0.1.16" }
 
+# Optional dependencies.
+rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7" }
+
 [dev-dependencies]
 criterion = { default-features = false, version = "0.4" }
 serde_json = { default-features = false, features = ["std"], version = "1" }

--- a/twilight-model/src/application/command/command_type.rs
+++ b/twilight-model/src/application/command/command_type.rs
@@ -4,6 +4,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum CommandType {
     /// Slash command.
     ///

--- a/twilight-model/src/application/command/mod.rs
+++ b/twilight-model/src/application/command/mod.rs
@@ -38,8 +38,13 @@ use std::collections::HashMap;
 ///
 /// [Discord Docs/Application Command Object]: https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Command {
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub application_id: Option<Id<ApplicationMarker>>,
     /// Default permissions required for a member to run the command.
     ///
@@ -68,8 +73,10 @@ pub struct Command {
     pub description_localizations: Option<HashMap<String, String>>,
     /// Guild ID of the command, if not global.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub id: Option<Id<CommandMarker>>,
     #[serde(rename = "type")]
     pub kind: CommandType,

--- a/twilight-model/src/application/command/option.rs
+++ b/twilight-model/src/application/command/option.rs
@@ -17,6 +17,11 @@ use std::{cmp::Eq, collections::HashMap};
 /// [`Command`]: super::Command
 /// [Discord Docs/Localization]: https://discord.com/developers/docs/interactions/application-commands#localization
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
+)]
 pub struct CommandOption {
     /// Whether the command supports autocomplete.
     ///
@@ -39,6 +44,7 @@ pub struct CommandOption {
     ///
     /// [`Channel`]: CommandOptionType::Channel
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::Map<rkyv::with::CopyOptimize>))]
     pub channel_types: Option<Vec<ChannelType>>,
     /// List of predetermined choices users can select from.
     ///
@@ -137,6 +143,7 @@ pub struct CommandOption {
     /// [`SubCommand`]: CommandOptionType::SubCommand
     /// [`SubCommandGroup`]: CommandOptionType::SubCommandGroup
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", omit_bounds)]
     pub options: Option<Vec<CommandOption>>,
     /// Whether the option is required.
     ///
@@ -153,6 +160,10 @@ pub struct CommandOption {
 
 /// A predetermined choice users can select.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct CommandOptionChoice {
     /// Name of the choice. Must be 100 characters or less.
     pub name: String,
@@ -177,6 +188,10 @@ pub struct CommandOptionChoice {
 /// [`CommandOption`]'s [`CommandOptionType`].
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum CommandOptionChoiceValue {
     /// String choice. Must be 100 characters or less.
     String(String),
@@ -192,6 +207,11 @@ pub enum CommandOptionChoiceValue {
 /// [`CommandOption`]'s [`CommandOptionType`].
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum CommandOptionValue {
     /// Integer type.
     Integer(i64),
@@ -203,6 +223,11 @@ pub enum CommandOptionValue {
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum CommandOptionType {
     SubCommand = 1,
     SubCommandGroup = 2,

--- a/twilight-model/src/application/command/permissions.rs
+++ b/twilight-model/src/application/command/permissions.rs
@@ -12,6 +12,10 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 /// List of [`CommandPermission`]s for a command in a guild.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildCommandPermissions {
     /// ID of the application the command belongs to.
     pub application_id: Id<ApplicationMarker>,
@@ -27,6 +31,11 @@ pub struct GuildCommandPermissions {
 
 /// Member, channel or role explicit permission to use a command.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct CommandPermission {
     /// Affected resource.
     pub id: CommandPermissionType,
@@ -36,6 +45,11 @@ pub struct CommandPermission {
 
 /// Resources commands can allow or disallow from executing them.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum CommandPermissionType {
     /// Affected channel.
     ///

--- a/twilight-model/src/application/interaction/application_command/mod.rs
+++ b/twilight-model/src/application/interaction/application_command/mod.rs
@@ -28,9 +28,14 @@ use serde::{Deserialize, Serialize};
 /// [`ApplicationCommandAutocomplete`]: crate::application::interaction::InteractionType::ApplicationCommandAutocomplete
 /// [Discord Docs/Application Command Data Structure]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-application-command-data-structure
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct CommandData {
     /// ID of the guild the command is registered to.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     /// ID of the command.
     pub id: Id<CommandMarker>,
@@ -47,5 +52,6 @@ pub struct CommandData {
     pub resolved: Option<CommandInteractionDataResolved>,
     /// If this is a user or message command, the ID of the targeted user/message.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub target_id: Option<Id<GenericMarker>>,
 }

--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -18,6 +18,10 @@ use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 ///
 /// [Discord Docs/Application Command Object]: https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-interaction-data-option-structure
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct CommandDataOption {
     /// Name of the option.
     pub name: String,
@@ -326,6 +330,11 @@ impl<'de> Deserialize<'de> for CommandDataOption {
 
 /// Combined value and value type for a [`CommandDataOption`].
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
+)]
 pub enum CommandOptionValue {
     /// Attachment option.
     Attachment(Id<AttachmentMarker>),
@@ -356,9 +365,9 @@ pub enum CommandOptionValue {
     /// String option.
     String(String),
     /// Subcommand option.
-    SubCommand(Vec<CommandDataOption>),
+    SubCommand(#[cfg_attr(feature = "rkyv", omit_bounds)] Vec<CommandDataOption>),
     /// Subcommand group option.
-    SubCommandGroup(Vec<CommandDataOption>),
+    SubCommandGroup(#[cfg_attr(feature = "rkyv", omit_bounds)] Vec<CommandDataOption>),
     /// User option.
     User(Id<UserMarker>),
 }

--- a/twilight-model/src/application/interaction/application_command/resolved.rs
+++ b/twilight-model/src/application/interaction/application_command/resolved.rs
@@ -18,6 +18,10 @@ use std::collections::hash_map::HashMap;
 /// [`ApplicationCommand`]: crate::application::interaction::InteractionType::ApplicationCommand
 /// [Discord Docs/Resolved Data Structure]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct CommandInteractionDataResolved {
     /// Map of resolved attachments.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -45,6 +49,10 @@ pub struct CommandInteractionDataResolved {
 ///
 /// [`Interaction`]: crate::application::interaction::Interaction
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct InteractionChannel {
     /// ID of the channel.
     pub id: Id<ChannelMarker>,
@@ -57,6 +65,7 @@ pub struct InteractionChannel {
     pub name: String,
     /// ID of the channel the thread was created in.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub parent_id: Option<Id<ChannelMarker>>,
     /// Computed permissions, including overwrites, for the invoking user in the channel.
     pub permissions: Permissions,
@@ -69,6 +78,10 @@ pub struct InteractionChannel {
 ///
 /// [`Interaction`]: crate::application::interaction::Interaction
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct InteractionMember {
     /// Member's guild avatar.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -92,6 +105,7 @@ pub struct InteractionMember {
     pub premium_since: Option<Timestamp>,
     /// Member roles.
     #[serde(default)]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub roles: Vec<Id<RoleMarker>>,
 }
 

--- a/twilight-model/src/application/interaction/interaction_type.rs
+++ b/twilight-model/src/application/interaction/interaction_type.rs
@@ -9,6 +9,11 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum InteractionType {
     /// Interaction involves a ping (webhook-based interactions).
     ///

--- a/twilight-model/src/application/interaction/message_component.rs
+++ b/twilight-model/src/application/interaction/message_component.rs
@@ -12,6 +12,10 @@ use serde::{Deserialize, Serialize};
 /// [`MessageComponent`]: crate::application::interaction::InteractionType::MessageComponent
 /// [Discord Docs/Message Component Data Structure]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-message-component-data-structure
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MessageComponentInteractionData {
     /// User defined identifier for the component.
     ///

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -38,6 +38,10 @@ use std::fmt::{Formatter, Result as FmtResult};
 ///
 /// [Discord Docs/Interaction Object]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-structure
 #[derive(Clone, Debug, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Interaction {
     /// App's permissions in the channel the interaction was sent from.
     ///
@@ -52,6 +56,7 @@ pub struct Interaction {
     ///
     /// [`Ping`]: InteractionType::Ping
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub channel_id: Option<Id<ChannelMarker>>,
     /// Data from the interaction.
     ///
@@ -67,6 +72,7 @@ pub struct Interaction {
     pub data: Option<InteractionData>,
     /// ID of the guild the interaction was invoked in.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     /// Guild’s preferred locale.
     ///
@@ -394,6 +400,10 @@ impl<'de> Visitor<'de> for InteractionVisitor {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(untagged)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum InteractionData {
     /// Data received for the [`ApplicationCommand`] and [`ApplicationCommandAutocomplete`]
     /// interaction types.

--- a/twilight-model/src/application/interaction/modal.rs
+++ b/twilight-model/src/application/interaction/modal.rs
@@ -13,6 +13,10 @@ use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 /// [`ModalSubmit`]: crate::application::interaction::InteractionType::ModalSubmit
 /// [Discord Docs/Modal Submit Data Structure]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ModalInteractionData {
     /// List of user inputs.
     pub components: Vec<ModalInteractionDataActionRow>,
@@ -31,6 +35,10 @@ pub struct ModalInteractionData {
 /// [`ActionRow`]: crate::application::interaction::modal::ModalInteractionDataActionRow
 /// [Discord Docs/Modal Submit Data Structure]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ModalInteractionDataActionRow {
     /// List of components.
     pub components: Vec<ModalInteractionDataComponent>,
@@ -53,6 +61,10 @@ impl Serialize for ModalInteractionDataActionRow {
 ///
 /// [Discord Docs/Message Components]: https://discord.com/developers/docs/interactions/message-components
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ModalInteractionDataComponent {
     /// User defined identifier for the component.
     ///

--- a/twilight-model/src/channel/attachment.rs
+++ b/twilight-model/src/channel/attachment.rs
@@ -5,6 +5,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Attachment {
     /// Attachment's [media type].
     ///

--- a/twilight-model/src/channel/channel_mention.rs
+++ b/twilight-model/src/channel/channel_mention.rs
@@ -8,6 +8,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ChannelMention {
     pub guild_id: Id<GuildMarker>,
     pub id: Id<ChannelMarker>,

--- a/twilight-model/src/channel/channel_type.rs
+++ b/twilight-model/src/channel/channel_type.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum ChannelType {
     GuildText,
     Private,

--- a/twilight-model/src/channel/flags.rs
+++ b/twilight-model/src/channel/flags.rs
@@ -5,6 +5,11 @@ use serde::{
 };
 
 bitflags! {
+    #[cfg_attr(
+        feature = "rkyv",
+        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+        archive(as = "Self")
+    )]
     pub struct ChannelFlags: u64 {
         /// Channel is pinned in a forum.
         const PINNED = 1 << 1;

--- a/twilight-model/src/channel/followed_channel.rs
+++ b/twilight-model/src/channel/followed_channel.rs
@@ -11,6 +11,11 @@ use serde::{Deserialize, Serialize};
 /// and the [`Id<WebhookMarker>`] that was created in the
 /// target channel.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct FollowedChannel {
     pub channel_id: Id<ChannelMarker>,
     pub webhook_id: Id<WebhookMarker>,

--- a/twilight-model/src/channel/forum.rs
+++ b/twilight-model/src/channel/forum.rs
@@ -8,10 +8,15 @@ use serde::{Deserialize, Serialize};
 ///
 /// Exactly one of `emoji_id` and `emoji_name` must be set.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct DefaultReaction {
     /// ID of custom guild emoji.
     ///
     /// Conflicts with `emoji_name`.
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub emoji_id: Option<Id<EmojiMarker>>,
     /// Unicode emoji character.
     ///
@@ -26,6 +31,11 @@ pub struct DefaultReaction {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum ForumLayout {
     /// Display posts as a collection of tiles.
     GalleryView,
@@ -77,6 +87,11 @@ impl From<ForumLayout> for u8 {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum ForumSortOrder {
     /// Sort forum posts by creation time (from most recent to oldest).
     CreationDate,
@@ -123,6 +138,10 @@ impl From<ForumSortOrder> for u8 {
 /// [`Channel`]: super::Channel
 /// [`GuildForum`]: super::ChannelType::GuildForum
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ForumTag {
     /// ID of custom guild emoji.
     ///
@@ -131,6 +150,7 @@ pub struct ForumTag {
     ///
     /// Conflicts with `emoji_name`.
     #[serde(with = "crate::visitor::zeroable_id")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub emoji_id: Option<Id<EmojiMarker>>,
     /// Unicode emoji character.
     ///

--- a/twilight-model/src/channel/message/activity.rs
+++ b/twilight-model/src/channel/message/activity.rs
@@ -2,6 +2,10 @@ use serde::{Deserialize, Serialize};
 
 /// Activity associated with a message.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MessageActivity {
     /// [`MessageActivityType`]
     #[serde(rename = "type")]
@@ -15,6 +19,11 @@ pub struct MessageActivity {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum MessageActivityType {
     /// Join the the party.
     Join,

--- a/twilight-model/src/channel/message/allowed_mentions.rs
+++ b/twilight-model/src/channel/message/allowed_mentions.rs
@@ -20,6 +20,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [Discord Docs/Message Formatting]: https://discord.com/developers/docs/reference#message-formatting
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AllowedMentions {
     /// List of allowed mention types.
     ///
@@ -29,6 +33,7 @@ pub struct AllowedMentions {
     /// [`roles`]: Self::roles
     /// [`users`]: Self::users
     #[serde(default)]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub parse: Vec<MentionType>,
     /// For replies, whether to mention the message author.
     ///
@@ -37,9 +42,11 @@ pub struct AllowedMentions {
     pub replied_user: bool,
     /// List of roles to mention.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub roles: Vec<Id<RoleMarker>>,
     /// List of users to mention.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub users: Vec<Id<UserMarker>>,
 }
 
@@ -47,6 +54,11 @@ pub struct AllowedMentions {
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum MentionType {
     /// `@everyone` and `@here` mentions.
     Everyone,

--- a/twilight-model/src/channel/message/application.rs
+++ b/twilight-model/src/channel/message/application.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Application`]: crate::oauth::Application
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MessageApplication {
     /// Default rich presence invite cover image.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/channel/message/component/action_row.rs
+++ b/twilight-model/src/channel/message/component/action_row.rs
@@ -2,8 +2,14 @@ use super::Component;
 
 /// Non-interactive [`Component`] container of other (non action row) components.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
+)]
 pub struct ActionRow {
     /// List of components in the action row.
+    #[cfg_attr(feature = "rkyv", omit_bounds)]
     pub components: Vec<Component>,
 }
 

--- a/twilight-model/src/channel/message/component/button.rs
+++ b/twilight-model/src/channel/message/component/button.rs
@@ -5,6 +5,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Component`]: super::Component
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Button {
     /// User defined identifier for the button.
     ///
@@ -34,6 +38,11 @@ pub struct Button {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum ButtonStyle {
     /// Button indicates a primary action.
     ///

--- a/twilight-model/src/channel/message/component/kind.rs
+++ b/twilight-model/src/channel/message/component/kind.rs
@@ -7,6 +7,11 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum ComponentType {
     /// Component is an [`ActionRow`].
     ///

--- a/twilight-model/src/channel/message/component/mod.rs
+++ b/twilight-model/src/channel/message/component/mod.rs
@@ -108,6 +108,10 @@ use std::fmt::{Formatter, Result as FmtResult};
 /// });
 /// ```
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum Component {
     /// Top level, non-interactive container of other (non action row) components.
     ActionRow(ActionRow),

--- a/twilight-model/src/channel/message/component/select_menu.rs
+++ b/twilight-model/src/channel/message/component/select_menu.rs
@@ -5,6 +5,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Component`]: super::Component
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct SelectMenu {
     /// Developer defined identifier.
     pub custom_id: String,
@@ -24,6 +28,10 @@ pub struct SelectMenu {
 
 /// Dropdown options that are part of [`SelectMenu`].
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct SelectMenuOption {
     /// Whether the option will be selected by default.
     #[serde(default)]

--- a/twilight-model/src/channel/message/component/text_input.rs
+++ b/twilight-model/src/channel/message/component/text_input.rs
@@ -4,6 +4,10 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 ///
 /// [`Component`]: super::Component
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct TextInput {
     /// User defined identifier for the input text.
     pub custom_id: String,
@@ -31,6 +35,11 @@ pub struct TextInput {
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum TextInputStyle {
     /// Intended for short single-line text.
     Short = 1,

--- a/twilight-model/src/channel/message/embed/author.rs
+++ b/twilight-model/src/channel/message/embed/author.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct EmbedAuthor {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_url: Option<String>,

--- a/twilight-model/src/channel/message/embed/field.rs
+++ b/twilight-model/src/channel/message/embed/field.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct EmbedField {
     #[serde(default)]
     pub inline: bool,

--- a/twilight-model/src/channel/message/embed/footer.rs
+++ b/twilight-model/src/channel/message/embed/footer.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct EmbedFooter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_url: Option<String>,

--- a/twilight-model/src/channel/message/embed/image.rs
+++ b/twilight-model/src/channel/message/embed/image.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct EmbedImage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u64>,

--- a/twilight-model/src/channel/message/embed/mod.rs
+++ b/twilight-model/src/channel/message/embed/mod.rs
@@ -18,6 +18,10 @@ use crate::util::Timestamp;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Embed {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<EmbedAuthor>,

--- a/twilight-model/src/channel/message/embed/provider.rs
+++ b/twilight-model/src/channel/message/embed/provider.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct EmbedProvider {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/twilight-model/src/channel/message/embed/thumbnail.rs
+++ b/twilight-model/src/channel/message/embed/thumbnail.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct EmbedThumbnail {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u64>,

--- a/twilight-model/src/channel/message/embed/video.rs
+++ b/twilight-model/src/channel/message/embed/video.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct EmbedVideo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u64>,

--- a/twilight-model/src/channel/message/flags.rs
+++ b/twilight-model/src/channel/message/flags.rs
@@ -5,6 +5,11 @@ use serde::{
 };
 
 bitflags! {
+    #[cfg_attr(
+        feature = "rkyv",
+        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+        archive(as = "Self")
+    )]
     /// Flags to signal state and modify the look of a message.
     pub struct MessageFlags: u64 {
         /// Has been published to subscribed channels via Channel Following.

--- a/twilight-model/src/channel/message/interaction.rs
+++ b/twilight-model/src/channel/message/interaction.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 
 /// Associated interaction metadata.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MessageInteraction {
     /// ID of the interaction.
     pub id: Id<InteractionMarker>,

--- a/twilight-model/src/channel/message/kind.rs
+++ b/twilight-model/src/channel/message/kind.rs
@@ -11,6 +11,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum MessageType {
     /// Regular message.
     Regular,

--- a/twilight-model/src/channel/message/mention.rs
+++ b/twilight-model/src/channel/message/mention.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 
 /// Mention of a user in a message.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Mention {
     /// Hash of the user's avatar, if any.
     pub avatar: Option<ImageHash>,

--- a/twilight-model/src/channel/message/mod.rs
+++ b/twilight-model/src/channel/message/mod.rs
@@ -49,6 +49,11 @@ use serde::{Deserialize, Serialize};
 
 /// Text message sent in a [`Channel`].
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(bound(serialize = "__S: rkyv::ser::Serializer"))
+)]
 pub struct Message {
     /// Present with Rich Presence-related chat embeds.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -62,6 +67,7 @@ pub struct Message {
     ///
     /// [`Interaction`]: crate::application::interaction::Interaction
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub application_id: Option<Id<ApplicationMarker>>,
     /// List of attachments.
     ///
@@ -129,6 +135,7 @@ pub struct Message {
     ///
     /// [`Guild`]: crate::guild::Guild
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     /// Id of the message.
     pub id: Id<MessageMarker>,
@@ -154,6 +161,7 @@ pub struct Message {
     /// [`Role`]s mentioned in the message.
     ///
     /// [`Role`]: crate::guild::Role
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub mention_roles: Vec<Id<RoleMarker>>,
     /// Users mentioned in the message.
     pub mentions: Vec<Mention>,
@@ -169,6 +177,7 @@ pub struct Message {
     ///
     /// [`reference`]: Self::reference
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::Niche), omit_bounds)]
     pub referenced_message: Option<Box<Message>>,
     /// Information about the role subscription purchase or renewal that
     /// prompted this message.
@@ -190,6 +199,7 @@ pub struct Message {
     pub tts: bool,
     /// ID of the webhook that generated the message.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub webhook_id: Option<Id<WebhookMarker>>,
 }
 

--- a/twilight-model/src/channel/message/reaction.rs
+++ b/twilight-model/src/channel/message/reaction.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 
 /// Reaction below a message.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Reaction {
     /// Amount of reactions this emoji has.
     pub count: u64,
@@ -15,6 +19,10 @@ pub struct Reaction {
 /// Type of [`Reaction`].
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum ReactionType {
     /// Custom [`Emoji`].
     ///

--- a/twilight-model/src/channel/message/reference.rs
+++ b/twilight-model/src/channel/message/reference.rs
@@ -6,18 +6,25 @@ use serde::{Deserialize, Serialize};
 
 /// Message reference struct.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MessageReference {
     /// Originating message's channel ID.
     ///
     /// Note: optional when creating a reply, but always present when receiving
     /// an event or response containing this model.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub channel_id: Option<Id<ChannelMarker>>,
     /// Originating message's guild ID.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     /// Originating message's ID.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub message_id: Option<Id<MessageMarker>>,
     /// Whether to error if the referenced message doesn't exist instead of
     /// sending a normal message.

--- a/twilight-model/src/channel/message/role_subscription_data.rs
+++ b/twilight-model/src/channel/message/role_subscription_data.rs
@@ -5,6 +5,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Message`]: super::Message
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct RoleSubscriptionData {
     /// Whether this notification is for a renewal rather than a new purchase.
     pub is_renewal: bool,

--- a/twilight-model/src/channel/message/sticker/format_type.rs
+++ b/twilight-model/src/channel/message/sticker/format_type.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum StickerFormatType {
     /// Sticker format is a PNG.
     Png,

--- a/twilight-model/src/channel/message/sticker/kind.rs
+++ b/twilight-model/src/channel/message/sticker/kind.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum StickerType {
     /// Official sticker in a pack.
     ///

--- a/twilight-model/src/channel/message/sticker/message.rs
+++ b/twilight-model/src/channel/message/sticker/message.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Sticker`]: super::Sticker
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MessageSticker {
     /// Format type.
     pub format_type: StickerFormatType,

--- a/twilight-model/src/channel/message/sticker/mod.rs
+++ b/twilight-model/src/channel/message/sticker/mod.rs
@@ -25,6 +25,10 @@ use serde::{Deserialize, Serialize};
 
 /// Message sticker.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Sticker {
     /// Whether the sticker is available.
     #[serde(default, skip_serializing_if = "is_false")]
@@ -35,6 +39,7 @@ pub struct Sticker {
     pub format_type: StickerFormatType,
     /// ID of the guild that owns the sticker.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     /// Unique ID of the sticker.
     pub id: Id<StickerMarker>,
@@ -45,6 +50,7 @@ pub struct Sticker {
     pub name: String,
     /// Unique ID of the pack the sticker is in.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub pack_id: Option<Id<StickerPackMarker>>,
     /// Sticker's sort order within a pack.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/channel/message/sticker/pack.rs
+++ b/twilight-model/src/channel/message/sticker/pack.rs
@@ -9,10 +9,16 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Standard`]: super::StickerType::Standard
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct StickerPack {
     /// ID of the sticker pack's banner image.
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub banner_asset_id: Option<Id<StickerBannerAssetMarker>>,
     /// ID of the sticker that is shown as the pack's icon.
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub cover_sticker_id: Option<Id<StickerMarker>>,
     /// Description of the sticker pack.
     pub description: String,

--- a/twilight-model/src/channel/mod.rs
+++ b/twilight-model/src/channel/mod.rs
@@ -54,11 +54,17 @@ use serde::{Deserialize, Serialize};
 ///
 /// [Discord Docs/Channel]: https://discord.com/developers/docs/resources/channel
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Channel {
     /// ID of the application that created the channel.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub application_id: Option<Id<ApplicationMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::Map<rkyv::with::CopyOptimize>))]
     pub applied_tags: Option<Vec<Id<TagMarker>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub available_tags: Option<Vec<ForumTag>>,
@@ -87,6 +93,7 @@ pub struct Channel {
     pub flags: Option<ChannelFlags>,
     /// ID of the guild the channel is in.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     /// Hash of the channel's icon.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -107,6 +114,7 @@ pub struct Channel {
     /// For forum channels, this is the ID of the last created thread in the
     /// forum.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub last_message_id: Option<Id<GenericMarker>>,
     /// ID of the last message pinned in the channel.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -143,6 +151,7 @@ pub struct Channel {
     pub nsfw: Option<bool>,
     /// ID of the creator of the channel.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub owner_id: Option<Id<UserMarker>>,
     /// ID of the parent channel.
     ///
@@ -150,6 +159,7 @@ pub struct Channel {
     ///
     /// For threads this is the ID of the channel the thread was created in.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub parent_id: Option<Id<ChannelMarker>>,
     /// Explicit permission overwrites for members and roles.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/channel/permission_overwrite.rs
+++ b/twilight-model/src/channel/permission_overwrite.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 
 /// Permission overwrite data for a role or member.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct PermissionOverwrite {
     pub allow: Permissions,
     pub deny: Permissions,
@@ -19,6 +24,11 @@ pub struct PermissionOverwrite {
 #[derive(Clone, Copy, Debug, Serialize, Eq, Hash, PartialEq, Deserialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8", rename_all = "snake_case")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum PermissionOverwriteType {
     /// Permission overwrite targets an individual member.
     Member,

--- a/twilight-model/src/channel/stage_instance/mod.rs
+++ b/twilight-model/src/channel/stage_instance/mod.rs
@@ -9,12 +9,17 @@ use crate::id::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct StageInstance {
     pub channel_id: Id<ChannelMarker>,
     pub guild_id: Id<GuildMarker>,
     /// The id of the [`GuildScheduledEvent`].
     ///
     /// [`GuildScheduledEvent`]: crate::guild::scheduled_event::GuildScheduledEvent
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_scheduled_event_id: Option<Id<ScheduledEventMarker>>,
     pub id: Id<StageMarker>,
     pub privacy_level: PrivacyLevel,

--- a/twilight-model/src/channel/stage_instance/privacy_level.rs
+++ b/twilight-model/src/channel/stage_instance/privacy_level.rs
@@ -3,6 +3,11 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum PrivacyLevel {
     GuildOnly = 2,
 }

--- a/twilight-model/src/channel/thread/auto_archive_duration.rs
+++ b/twilight-model/src/channel/thread/auto_archive_duration.rs
@@ -6,6 +6,11 @@ use serde::{
 use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum AutoArchiveDuration {
     Hour,
     Day,

--- a/twilight-model/src/channel/thread/listing.rs
+++ b/twilight-model/src/channel/thread/listing.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 
 /// Response body returned in thread listing methods.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ThreadsListing {
     /// Whether there are potentially more threads that could be returned.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/channel/thread/member.rs
+++ b/twilight-model/src/channel/thread/member.rs
@@ -10,10 +10,15 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ThreadMember {
     // Values currently unknown and undocumented.
     pub flags: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub id: Option<Id<ChannelMarker>>,
     pub join_timestamp: Timestamp,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -21,6 +26,7 @@ pub struct ThreadMember {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub presence: Option<Presence>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub user_id: Option<Id<UserMarker>>,
 }
 

--- a/twilight-model/src/channel/thread/metadata.rs
+++ b/twilight-model/src/channel/thread/metadata.rs
@@ -5,6 +5,10 @@ use serde::{Deserialize, Serialize};
 /// The thread metadata object contains a number of thread-specific channel fields
 /// that are not needed by other channel types.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ThreadMetadata {
     pub archived: bool,
     /// Duration without messages before the thread automatically archives.

--- a/twilight-model/src/channel/video_quality_mode.rs
+++ b/twilight-model/src/channel/video_quality_mode.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum VideoQualityMode {
     /// Discord chooses the quality for optimal performance.
     Auto,

--- a/twilight-model/src/channel/webhook/channel.rs
+++ b/twilight-model/src/channel/webhook/channel.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 
 /// Partial channel object that a webhook is following.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct WebhookChannel {
     pub id: Id<ChannelMarker>,
     pub name: String,

--- a/twilight-model/src/channel/webhook/guild.rs
+++ b/twilight-model/src/channel/webhook/guild.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 
 /// Partial guild object that a webhook is following.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct WebhookGuild {
     pub icon: Option<ImageHash>,
     pub id: Id<GuildMarker>,

--- a/twilight-model/src/channel/webhook/kind.rs
+++ b/twilight-model/src/channel/webhook/kind.rs
@@ -2,6 +2,11 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum WebhookType {
     Incoming,
     ChannelFollower,

--- a/twilight-model/src/channel/webhook/mod.rs
+++ b/twilight-model/src/channel/webhook/mod.rs
@@ -15,12 +15,18 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Webhook {
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub application_id: Option<Id<ApplicationMarker>>,
     pub avatar: Option<ImageHash>,
     pub channel_id: Id<ChannelMarker>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     pub id: Id<WebhookMarker>,
     #[serde(default = "WebhookType::default", rename = "type")]

--- a/twilight-model/src/gateway/close_code.rs
+++ b/twilight-model/src/gateway/close_code.rs
@@ -12,6 +12,11 @@ use std::{
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u16)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum CloseCode {
     /// An unknown error occurred.
     UnknownError = 4000,

--- a/twilight-model/src/gateway/connection_info/bot_connection_info.rs
+++ b/twilight-model/src/gateway/connection_info/bot_connection_info.rs
@@ -4,6 +4,10 @@ use serde::{Deserialize, Serialize};
 /// Gateway information containing the recommended shard count and session
 /// availability.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct BotConnectionInfo {
     /// Current session availability and session connection concurrency limits.
     pub session_start_limit: SessionStartLimit,

--- a/twilight-model/src/gateway/connection_info/mod.rs
+++ b/twilight-model/src/gateway/connection_info/mod.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 
 /// Gateway information containing the URL to connect to.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ConnectionInfo {
     /// URL to the gateway.
     pub url: String,

--- a/twilight-model/src/gateway/event/dispatch.rs
+++ b/twilight-model/src/gateway/event/dispatch.rs
@@ -13,6 +13,10 @@ use serde::{
 // implementation.
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum DispatchEvent {
     AutoModerationActionExecution(AutoModerationActionExecution),
     AutoModerationRuleCreate(Box<AutoModerationRuleCreate>),

--- a/twilight-model/src/gateway/event/gateway.rs
+++ b/twilight-model/src/gateway/event/gateway.rs
@@ -19,6 +19,10 @@ use std::{
 /// An event from the gateway, which can either be a dispatch event with
 /// stateful updates or a heartbeat, hello, etc. that a shard needs to operate.
 #[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum GatewayEvent {
     Dispatch(u64, DispatchEvent),
     Heartbeat(u64),

--- a/twilight-model/src/gateway/event/kind.rs
+++ b/twilight-model/src/gateway/event/kind.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 /// The type of an event.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum EventType {
     AutoModerationActionExecution,
     AutoModerationRuleCreate,

--- a/twilight-model/src/gateway/event/mod.rs
+++ b/twilight-model/src/gateway/event/mod.rs
@@ -23,6 +23,10 @@ use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 ///
 /// [gateway close event]: Self::GatewayClose
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum Event {
     /// Message was blocked by AutoMod according to a rule.
     AutoModerationActionExecution(AutoModerationActionExecution),

--- a/twilight-model/src/gateway/frame.rs
+++ b/twilight-model/src/gateway/frame.rs
@@ -17,10 +17,15 @@ use std::borrow::Cow;
 /// [causing a session resume]: CloseFrame::RESUME
 /// [full session disconnect]: CloseFrame::NORMAL
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct CloseFrame<'a> {
     /// Reason for the close.
     pub code: u16,
     /// Textual representation of the reason the connection is being closed.
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::AsOwned))]
     pub reason: Cow<'a, str>,
 }
 

--- a/twilight-model/src/gateway/id.rs
+++ b/twilight-model/src/gateway/id.rs
@@ -93,6 +93,11 @@ pub enum ShardIdParseErrorType {
 /// [Discord Docs/Sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(try_from = "[u64; 2]", into = "[u64; 2]")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct ShardId {
     /// Number of the shard, 0-indexed.
     number: u64,

--- a/twilight-model/src/gateway/intents.rs
+++ b/twilight-model/src/gateway/intents.rs
@@ -13,6 +13,11 @@ bitflags! {
     /// [Discord Docs/Gateway Intents].
     ///
     /// [Discord Docs/Gateway Intents]: https://discord.com/developers/docs/topics/gateway#gateway-intents
+    #[cfg_attr(
+        feature = "rkyv",
+        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+        archive(as = "Self")
+    )]
     pub struct Intents: u64 {
         /// Guilds intent.
         ///

--- a/twilight-model/src/gateway/opcode.rs
+++ b/twilight-model/src/gateway/opcode.rs
@@ -4,6 +4,11 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum OpCode {
     /// [`DispatchEvent`] and sequence number.
     ///

--- a/twilight-model/src/gateway/payload/incoming/auto_moderation_action_execution.rs
+++ b/twilight-model/src/gateway/payload/incoming/auto_moderation_action_execution.rs
@@ -14,6 +14,10 @@ use serde::{Deserialize, Serialize};
 /// [`Permissions::MANAGE_GUILD`]: crate::guild::Permissions::MANAGE_GUILD
 #[allow(clippy::doc_markdown)]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AutoModerationActionExecution {
     /// Action which was executed.
     pub action: AutoModerationAction,
@@ -25,9 +29,11 @@ pub struct AutoModerationActionExecution {
     ///
     /// [`SendAlertMessage`]: crate::guild::auto_moderation::AutoModerationActionType::SendAlertMessage
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub alert_system_message_id: Option<Id<MessageMarker>>,
     /// ID of the channel in which user content was posted.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub channel_id: Option<Id<ChannelMarker>>,
     /// User generated text content.
     ///
@@ -50,6 +56,7 @@ pub struct AutoModerationActionExecution {
     /// Will not exist if message was blocked by AutoMod or content was not part
     /// of any message.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub message_id: Option<Id<MessageMarker>>,
     /// ID of the rule which action belongs to.
     pub rule_id: Id<AutoModerationRuleMarker>,

--- a/twilight-model/src/gateway/payload/incoming/auto_moderation_rule_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/auto_moderation_rule_create.rs
@@ -8,6 +8,10 @@ use std::ops::{Deref, DerefMut};
 ///
 /// [`Permissions::MANAGE_GUILD`]: crate::guild::Permissions::MANAGE_GUILD
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AutoModerationRuleCreate(pub AutoModerationRule);
 
 impl Deref for AutoModerationRuleCreate {

--- a/twilight-model/src/gateway/payload/incoming/auto_moderation_rule_delete.rs
+++ b/twilight-model/src/gateway/payload/incoming/auto_moderation_rule_delete.rs
@@ -8,6 +8,10 @@ use std::ops::{Deref, DerefMut};
 ///
 /// [`Permissions::MANAGE_GUILD`]: crate::guild::Permissions::MANAGE_GUILD
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AutoModerationRuleDelete(pub AutoModerationRule);
 
 impl Deref for AutoModerationRuleDelete {

--- a/twilight-model/src/gateway/payload/incoming/auto_moderation_rule_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/auto_moderation_rule_update.rs
@@ -8,6 +8,10 @@ use std::ops::{Deref, DerefMut};
 ///
 /// [`Permissions::MANAGE_GUILD`]: crate::guild::Permissions::MANAGE_GUILD
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AutoModerationRuleUpdate(pub AutoModerationRule);
 
 impl Deref for AutoModerationRuleUpdate {

--- a/twilight-model/src/gateway/payload/incoming/ban_add.rs
+++ b/twilight-model/src/gateway/payload/incoming/ban_add.rs
@@ -5,6 +5,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct BanAdd {
     pub guild_id: Id<GuildMarker>,
     pub user: User,

--- a/twilight-model/src/gateway/payload/incoming/ban_remove.rs
+++ b/twilight-model/src/gateway/payload/incoming/ban_remove.rs
@@ -5,6 +5,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct BanRemove {
     pub guild_id: Id<GuildMarker>,
     pub user: User,

--- a/twilight-model/src/gateway/payload/incoming/channel_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/channel_create.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ChannelCreate(pub Channel);
 
 impl Deref for ChannelCreate {

--- a/twilight-model/src/gateway/payload/incoming/channel_delete.rs
+++ b/twilight-model/src/gateway/payload/incoming/channel_delete.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ChannelDelete(pub Channel);
 
 impl Deref for ChannelDelete {

--- a/twilight-model/src/gateway/payload/incoming/channel_pins_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/channel_pins_update.rs
@@ -8,9 +8,14 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ChannelPinsUpdate {
     pub channel_id: Id<ChannelMarker>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     pub last_pin_timestamp: Option<Timestamp>,
 }

--- a/twilight-model/src/gateway/payload/incoming/channel_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/channel_update.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ChannelUpdate(pub Channel);
 
 impl Deref for ChannelUpdate {

--- a/twilight-model/src/gateway/payload/incoming/command_permissions_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/command_permissions_update.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct CommandPermissionsUpdate(pub GuildCommandPermissions);
 
 impl Deref for CommandPermissionsUpdate {

--- a/twilight-model/src/gateway/payload/incoming/guild_audit_log_entry_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_audit_log_entry_create.rs
@@ -13,6 +13,10 @@ use std::ops::{Deref, DerefMut};
 /// [`Event`]:crate::gateway::event::Event
 /// [`VIEW_AUDIT_LOG`]: crate::guild::Permissions::VIEW_AUDIT_LOG
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildAuditLogEntryCreate(pub AuditLogEntry);
 
 impl Deref for GuildAuditLogEntryCreate {

--- a/twilight-model/src/gateway/payload/incoming/guild_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_create.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildCreate(pub Guild);
 
 impl Deref for GuildCreate {

--- a/twilight-model/src/gateway/payload/incoming/guild_delete.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_delete.rs
@@ -2,6 +2,11 @@ use crate::id::{marker::GuildMarker, Id};
 use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct GuildDelete {
     pub id: Id<GuildMarker>,
     // If `unavailable` is `None` the user was removed from the guild.

--- a/twilight-model/src/gateway/payload/incoming/guild_emojis_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_emojis_update.rs
@@ -5,6 +5,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildEmojisUpdate {
     pub emojis: Vec<Emoji>,
     pub guild_id: Id<GuildMarker>,

--- a/twilight-model/src/gateway/payload/incoming/guild_integrations_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_integrations_update.rs
@@ -2,6 +2,11 @@ use crate::id::{marker::GuildMarker, Id};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct GuildIntegrationsUpdate {
     pub guild_id: Id<GuildMarker>,
 }

--- a/twilight-model/src/gateway/payload/incoming/guild_scheduled_event_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_scheduled_event_create.rs
@@ -6,6 +6,10 @@ use std::ops::{Deref, DerefMut};
 ///
 /// [`GuildScheduledEvent`]: crate::guild::scheduled_event::GuildScheduledEvent
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildScheduledEventCreate(pub GuildScheduledEvent);
 
 impl Deref for GuildScheduledEventCreate {

--- a/twilight-model/src/gateway/payload/incoming/guild_scheduled_event_delete.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_scheduled_event_delete.rs
@@ -6,6 +6,10 @@ use std::ops::{Deref, DerefMut};
 ///
 /// [`GuildScheduledEvent`]: crate::guild::scheduled_event::GuildScheduledEvent
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildScheduledEventDelete(pub GuildScheduledEvent);
 
 impl Deref for GuildScheduledEventDelete {

--- a/twilight-model/src/gateway/payload/incoming/guild_scheduled_event_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_scheduled_event_update.rs
@@ -6,6 +6,10 @@ use std::ops::{Deref, DerefMut};
 ///
 /// [`GuildScheduledEvent`]: crate::guild::scheduled_event::GuildScheduledEvent
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildScheduledEventUpdate(pub GuildScheduledEvent);
 
 impl Deref for GuildScheduledEventUpdate {

--- a/twilight-model/src/gateway/payload/incoming/guild_scheduled_event_user_add.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_scheduled_event_user_add.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 
 /// Sent when a user has subscribed to a guild scheduled event.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct GuildScheduledEventUserAdd {
     /// Guild ID of the scheduled event.
     pub guild_id: Id<GuildMarker>,

--- a/twilight-model/src/gateway/payload/incoming/guild_scheduled_event_user_remove.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_scheduled_event_user_remove.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 
 /// Sent when a user has unsubscribed from a guild scheduled event.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct GuildScheduledEventUserRemove {
     /// Guild ID of the scheduled event.
     pub guild_id: Id<GuildMarker>,

--- a/twilight-model/src/gateway/payload/incoming/guild_stickers_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_stickers_update.rs
@@ -5,6 +5,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildStickersUpdate {
     pub guild_id: Id<GuildMarker>,
     pub stickers: Vec<Sticker>,

--- a/twilight-model/src/gateway/payload/incoming/guild_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_update.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildUpdate(pub PartialGuild);
 
 impl Deref for GuildUpdate {

--- a/twilight-model/src/gateway/payload/incoming/hello.rs
+++ b/twilight-model/src/gateway/payload/incoming/hello.rs
@@ -1,6 +1,11 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct Hello {
     pub heartbeat_interval: u64,
 }

--- a/twilight-model/src/gateway/payload/incoming/integration_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/integration_create.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct IntegrationCreate(pub GuildIntegration);
 
 impl Deref for IntegrationCreate {

--- a/twilight-model/src/gateway/payload/incoming/integration_delete.rs
+++ b/twilight-model/src/gateway/payload/incoming/integration_delete.rs
@@ -5,9 +5,14 @@ use crate::id::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct IntegrationDelete {
     /// ID of the Bot/OAuth2 application for this integration.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub application_id: Option<Id<ApplicationMarker>>,
     /// ID of the guild.
     pub guild_id: Id<GuildMarker>,

--- a/twilight-model/src/gateway/payload/incoming/integration_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/integration_update.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct IntegrationUpdate(pub GuildIntegration);
 
 impl Deref for IntegrationUpdate {

--- a/twilight-model/src/gateway/payload/incoming/interaction_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/interaction_create.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct InteractionCreate(pub Interaction);
 
 impl Deref for InteractionCreate {

--- a/twilight-model/src/gateway/payload/incoming/invite_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/invite_create.rs
@@ -15,6 +15,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Invite`]: crate::guild::invite::Invite
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct InviteCreate {
     /// ID of the channel invited users will first see.
     pub channel_id: Id<ChannelMarker>,
@@ -53,6 +57,10 @@ pub struct InviteCreate {
 /// Information about the user whose stream to display for a voice channel
 /// stream invite.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct PartialUser {
     /// Hash of the user's avatar.
     pub avatar: Option<ImageHash>,

--- a/twilight-model/src/gateway/payload/incoming/invite_delete.rs
+++ b/twilight-model/src/gateway/payload/incoming/invite_delete.rs
@@ -5,6 +5,10 @@ use crate::id::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct InviteDelete {
     pub channel_id: Id<ChannelMarker>,
     pub code: String,

--- a/twilight-model/src/gateway/payload/incoming/member_add.rs
+++ b/twilight-model/src/gateway/payload/incoming/member_add.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MemberAdd {
     pub guild_id: Id<GuildMarker>,
     #[serde(flatten)]

--- a/twilight-model/src/gateway/payload/incoming/member_chunk.rs
+++ b/twilight-model/src/gateway/payload/incoming/member_chunk.rs
@@ -13,6 +13,10 @@ use serde::{
 use std::fmt::{Formatter, Result as FmtResult};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MemberChunk {
     pub chunk_count: u32,
     pub chunk_index: u32,
@@ -20,6 +24,7 @@ pub struct MemberChunk {
     pub members: Vec<Member>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nonce: Option<String>,
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub not_found: Vec<Id<UserMarker>>,
     #[serde(default)]
     pub presences: Vec<Presence>,

--- a/twilight-model/src/gateway/payload/incoming/member_remove.rs
+++ b/twilight-model/src/gateway/payload/incoming/member_remove.rs
@@ -5,6 +5,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MemberRemove {
     pub guild_id: Id<GuildMarker>,
     pub user: User,

--- a/twilight-model/src/gateway/payload/incoming/member_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/member_update.rs
@@ -9,6 +9,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MemberUpdate {
     /// Member's guild avatar.
     pub avatar: Option<ImageHash>,
@@ -30,6 +34,7 @@ pub struct MemberUpdate {
     #[serde(default)]
     pub pending: bool,
     pub premium_since: Option<Timestamp>,
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub roles: Vec<Id<RoleMarker>>,
     pub user: User,
 }

--- a/twilight-model/src/gateway/payload/incoming/message_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/message_create.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MessageCreate(pub Message);
 
 impl Deref for MessageCreate {

--- a/twilight-model/src/gateway/payload/incoming/message_delete.rs
+++ b/twilight-model/src/gateway/payload/incoming/message_delete.rs
@@ -5,9 +5,14 @@ use crate::id::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MessageDelete {
     pub channel_id: Id<ChannelMarker>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     pub id: Id<MessageMarker>,
 }

--- a/twilight-model/src/gateway/payload/incoming/message_delete_bulk.rs
+++ b/twilight-model/src/gateway/payload/incoming/message_delete_bulk.rs
@@ -5,9 +5,15 @@ use crate::id::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MessageDeleteBulk {
     pub channel_id: Id<ChannelMarker>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub ids: Vec<Id<MessageMarker>>,
 }

--- a/twilight-model/src/gateway/payload/incoming/message_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/message_update.rs
@@ -13,6 +13,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MessageUpdate {
     /// List of attachments.
     ///
@@ -43,6 +47,7 @@ pub struct MessageUpdate {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embeds: Option<Vec<Embed>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     pub id: Id<MessageMarker>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
@@ -50,6 +55,7 @@ pub struct MessageUpdate {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mention_everyone: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::Map<rkyv::with::CopyOptimize>))]
     pub mention_roles: Option<Vec<Id<RoleMarker>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mentions: Option<Vec<Mention>>,

--- a/twilight-model/src/gateway/payload/incoming/presence_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/presence_update.rs
@@ -14,6 +14,10 @@ use std::ops::{Deref, DerefMut};
 /// [`Intents::GUILD_PRESENCES`]: crate::gateway::Intents
 /// [Discord Docs/Presence Update]: https://discord.com/developers/docs/topics/gateway#presence-update
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct PresenceUpdate(pub Presence);
 
 impl Deref for PresenceUpdate {

--- a/twilight-model/src/gateway/payload/incoming/reaction_add.rs
+++ b/twilight-model/src/gateway/payload/incoming/reaction_add.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ReactionAdd(pub GatewayReaction);
 
 impl Deref for ReactionAdd {

--- a/twilight-model/src/gateway/payload/incoming/reaction_remove.rs
+++ b/twilight-model/src/gateway/payload/incoming/reaction_remove.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ReactionRemove(pub GatewayReaction);
 
 impl Deref for ReactionRemove {

--- a/twilight-model/src/gateway/payload/incoming/reaction_remove_all.rs
+++ b/twilight-model/src/gateway/payload/incoming/reaction_remove_all.rs
@@ -5,9 +5,14 @@ use crate::id::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ReactionRemoveAll {
     pub channel_id: Id<ChannelMarker>,
     pub message_id: Id<MessageMarker>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
 }

--- a/twilight-model/src/gateway/payload/incoming/reaction_remove_emoji.rs
+++ b/twilight-model/src/gateway/payload/incoming/reaction_remove_emoji.rs
@@ -8,6 +8,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ReactionRemoveEmoji {
     pub channel_id: Id<ChannelMarker>,
     pub emoji: ReactionType,

--- a/twilight-model/src/gateway/payload/incoming/ready.rs
+++ b/twilight-model/src/gateway/payload/incoming/ready.rs
@@ -4,8 +4,13 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Ready {
     pub application: PartialApplication,
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub guilds: Vec<UnavailableGuild>,
     pub resume_gateway_url: String,
     pub session_id: String,

--- a/twilight-model/src/gateway/payload/incoming/role_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/role_create.rs
@@ -5,6 +5,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct RoleCreate {
     pub guild_id: Id<GuildMarker>,
     pub role: Role,

--- a/twilight-model/src/gateway/payload/incoming/role_delete.rs
+++ b/twilight-model/src/gateway/payload/incoming/role_delete.rs
@@ -5,6 +5,11 @@ use crate::id::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct RoleDelete {
     pub guild_id: Id<GuildMarker>,
     pub role_id: Id<RoleMarker>,

--- a/twilight-model/src/gateway/payload/incoming/role_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/role_update.rs
@@ -5,6 +5,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct RoleUpdate {
     pub guild_id: Id<GuildMarker>,
     pub role: Role,

--- a/twilight-model/src/gateway/payload/incoming/stage_instance_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/stage_instance_create.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct StageInstanceCreate(pub StageInstance);
 
 impl Deref for StageInstanceCreate {

--- a/twilight-model/src/gateway/payload/incoming/stage_instance_delete.rs
+++ b/twilight-model/src/gateway/payload/incoming/stage_instance_delete.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct StageInstanceDelete(pub StageInstance);
 
 impl Deref for StageInstanceDelete {

--- a/twilight-model/src/gateway/payload/incoming/stage_instance_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/stage_instance_update.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct StageInstanceUpdate(pub StageInstance);
 
 impl Deref for StageInstanceUpdate {

--- a/twilight-model/src/gateway/payload/incoming/thread_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/thread_create.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ThreadCreate(pub Channel);
 
 impl Deref for ThreadCreate {

--- a/twilight-model/src/gateway/payload/incoming/thread_delete.rs
+++ b/twilight-model/src/gateway/payload/incoming/thread_delete.rs
@@ -8,6 +8,11 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct ThreadDelete {
     pub guild_id: Id<GuildMarker>,
     pub id: Id<ChannelMarker>,

--- a/twilight-model/src/gateway/payload/incoming/thread_list_sync.rs
+++ b/twilight-model/src/gateway/payload/incoming/thread_list_sync.rs
@@ -8,8 +8,13 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ThreadListSync {
     #[serde(default)]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub channel_ids: Vec<Id<ChannelMarker>>,
     pub guild_id: Id<GuildMarker>,
     pub members: Vec<ThreadMember>,

--- a/twilight-model/src/gateway/payload/incoming/thread_member_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/thread_member_update.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ThreadMemberUpdate(pub ThreadMember);
 
 impl Deref for ThreadMemberUpdate {

--- a/twilight-model/src/gateway/payload/incoming/thread_members_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/thread_members_update.rs
@@ -12,6 +12,10 @@ use serde::{
 use std::fmt::{Formatter, Result as FmtResult};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ThreadMembersUpdate {
     /// List of thread members.
     ///
@@ -27,6 +31,7 @@ pub struct ThreadMembersUpdate {
     /// This is an approximation and may not be accurate.
     pub member_count: i32,
     #[serde(default)]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub removed_member_ids: Vec<Id<UserMarker>>,
 }
 

--- a/twilight-model/src/gateway/payload/incoming/thread_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/thread_update.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ThreadUpdate(pub Channel);
 
 impl Deref for ThreadUpdate {

--- a/twilight-model/src/gateway/payload/incoming/typing_start.rs
+++ b/twilight-model/src/gateway/payload/incoming/typing_start.rs
@@ -8,9 +8,14 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct TypingStart {
     pub channel_id: Id<ChannelMarker>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub member: Option<Member>,

--- a/twilight-model/src/gateway/payload/incoming/unavailable_guild.rs
+++ b/twilight-model/src/gateway/payload/incoming/unavailable_guild.rs
@@ -2,6 +2,11 @@ use crate::id::{marker::GuildMarker, Id};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct UnavailableGuild {
     pub id: Id<GuildMarker>,
 }

--- a/twilight-model/src/gateway/payload/incoming/user_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/user_update.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct UserUpdate(pub CurrentUser);
 
 impl Deref for UserUpdate {

--- a/twilight-model/src/gateway/payload/incoming/voice_server_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/voice_server_update.rs
@@ -2,6 +2,10 @@ use crate::id::{marker::GuildMarker, Id};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct VoiceServerUpdate {
     /// Discord voice server endpoint.
     pub endpoint: Option<String>,

--- a/twilight-model/src/gateway/payload/incoming/voice_state_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/voice_state_update.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct VoiceStateUpdate(pub VoiceState);
 
 impl Deref for VoiceStateUpdate {

--- a/twilight-model/src/gateway/payload/incoming/webhooks_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/webhooks_update.rs
@@ -5,6 +5,11 @@ use crate::id::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct WebhooksUpdate {
     pub channel_id: Id<ChannelMarker>,
     pub guild_id: Id<GuildMarker>,

--- a/twilight-model/src/gateway/presence/activity.rs
+++ b/twilight-model/src/gateway/presence/activity.rs
@@ -8,8 +8,13 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Activity {
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub application_id: Option<Id<ApplicationMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub assets: Option<ActivityAssets>,

--- a/twilight-model/src/gateway/presence/activity_assets.rs
+++ b/twilight-model/src/gateway/presence/activity_assets.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ActivityAssets {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub large_image: Option<String>,

--- a/twilight-model/src/gateway/presence/activity_button.rs
+++ b/twilight-model/src/gateway/presence/activity_button.rs
@@ -50,6 +50,10 @@ use std::fmt::{Formatter, Result as FmtResult};
 /// # Ok(()) }
 /// ```
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum ActivityButton {
     /// Activity button is a link.
     Link(ActivityButtonLink),
@@ -201,6 +205,10 @@ impl Serialize for ActivityButton {
 
 /// Button used in an activity with a URL.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ActivityButtonLink {
     /// Text shown on the button.
     pub label: String,
@@ -228,6 +236,10 @@ pub struct ActivityButtonLink {
 /// ```
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(transparent)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ActivityButtonText {
     /// Text shown on the button.
     pub label: String,

--- a/twilight-model/src/gateway/presence/activity_emoji.rs
+++ b/twilight-model/src/gateway/presence/activity_emoji.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ActivityEmoji {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub animated: Option<bool>,

--- a/twilight-model/src/gateway/presence/activity_flags.rs
+++ b/twilight-model/src/gateway/presence/activity_flags.rs
@@ -5,6 +5,11 @@ use serde::{
 };
 
 bitflags! {
+    #[cfg_attr(
+        feature = "rkyv",
+        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+        archive(as = "Self")
+    )]
     pub struct ActivityFlags: u64 {
         const INSTANCE = 1;
         const JOIN = 1 << 1;

--- a/twilight-model/src/gateway/presence/activity_party.rs
+++ b/twilight-model/src/gateway/presence/activity_party.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
 pub struct ActivityParty {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/gateway/presence/activity_party.rs
+++ b/twilight-model/src/gateway/presence/activity_party.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+)]
 pub struct ActivityParty {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,

--- a/twilight-model/src/gateway/presence/activity_secrets.rs
+++ b/twilight-model/src/gateway/presence/activity_secrets.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ActivitySecrets {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub join: Option<String>,

--- a/twilight-model/src/gateway/presence/activity_timestamps.rs
+++ b/twilight-model/src/gateway/presence/activity_timestamps.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ActivityTimestamps {
     /// Unix time of when the activity started, in milliseconds.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/gateway/presence/activity_type.rs
+++ b/twilight-model/src/gateway/presence/activity_type.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum ActivityType {
     Playing,
     Streaming,

--- a/twilight-model/src/gateway/presence/client_status.rs
+++ b/twilight-model/src/gateway/presence/client_status.rs
@@ -2,6 +2,10 @@ use crate::gateway::presence::Status;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct ClientStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub desktop: Option<Status>,

--- a/twilight-model/src/gateway/presence/minimal_activity.rs
+++ b/twilight-model/src/gateway/presence/minimal_activity.rs
@@ -1,6 +1,10 @@
 use super::{Activity, ActivityType};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct MinimalActivity {
     pub kind: ActivityType,
     pub name: String,

--- a/twilight-model/src/gateway/presence/mod.rs
+++ b/twilight-model/src/gateway/presence/mod.rs
@@ -36,6 +36,10 @@ use serde::{
 use std::fmt::{Formatter, Result as FmtResult};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Presence {
     #[serde(default)]
     pub activities: Vec<Activity>,
@@ -47,6 +51,10 @@ pub struct Presence {
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum UserOrId {
     User(User),
     UserId { id: Id<UserMarker> },

--- a/twilight-model/src/gateway/presence/status.rs
+++ b/twilight-model/src/gateway/presence/status.rs
@@ -1,6 +1,11 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum Status {
     #[serde(rename = "dnd")]
     DoNotDisturb,

--- a/twilight-model/src/gateway/reaction.rs
+++ b/twilight-model/src/gateway/reaction.rs
@@ -9,9 +9,14 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GatewayReaction {
     pub channel_id: Id<ChannelMarker>,
     pub emoji: ReactionType,
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     pub member: Option<Member>,
     pub message_id: Id<MessageMarker>,

--- a/twilight-model/src/gateway/session_start_limit.rs
+++ b/twilight-model/src/gateway/session_start_limit.rs
@@ -2,6 +2,11 @@ use serde::{Deserialize, Serialize};
 
 /// Current gateway session utilization status.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct SessionStartLimit {
     /// Maximum number of session that may be started concurrently.
     pub max_concurrency: u64,

--- a/twilight-model/src/guild/afk_timeout.rs
+++ b/twilight-model/src/guild/afk_timeout.rs
@@ -16,6 +16,10 @@ use std::time::Duration;
 /// [`Guild::afk_timeout`]: super::Guild::afk_timeout
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AfkTimeout(u16);
 
 impl AfkTimeout {

--- a/twilight-model/src/guild/audit_log/change.rs
+++ b/twilight-model/src/guild/audit_log/change.rs
@@ -28,6 +28,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [role]: super::super::Role
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AffectedRole {
     /// ID of the role.
     pub id: Id<RoleMarker>,
@@ -38,6 +42,10 @@ pub struct AffectedRole {
 /// Value of a change which may be one of multiple types.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum AuditLogChangeTypeValue {
     /// Value is an unsigned integer.
     Unsigned(u64),
@@ -51,14 +59,20 @@ pub enum AuditLogChangeTypeValue {
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case", tag = "key")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum AuditLogChange {
     /// AFK channel ID was changed.
     AfkChannelId {
         /// New ID of the AFK channel.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         new: Option<Id<ChannelMarker>>,
         /// Old ID of the AFK channel.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         old: Option<Id<ChannelMarker>>,
     },
     /// Timeout to cause a user to be moved to an AFK voice channel.
@@ -83,8 +97,10 @@ pub enum AuditLogChange {
     ApplicationId {
         /// Application's ID.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         new: Option<Id<ApplicationMarker>>,
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         old: Option<Id<ApplicationMarker>>,
     },
     /// Thread is now archived/unarchived.
@@ -154,9 +170,11 @@ pub enum AuditLogChange {
     ChannelId {
         /// New invite's channel.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         new: Option<Id<ChannelMarker>>,
         /// Old invite's channel.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         old: Option<Id<ChannelMarker>>,
     },
     /// Code of an invite.
@@ -307,9 +325,11 @@ pub enum AuditLogChange {
     GuildId {
         /// New guild that a sticker is in.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         new: Option<Id<GuildMarker>>,
         /// Old guild that a sticker is in.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         old: Option<Id<GuildMarker>>,
     },
     /// Whether a role is hoisted.
@@ -334,8 +354,10 @@ pub enum AuditLogChange {
     Id {
         /// New entity's ID.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         new: Option<Id<GenericMarker>>,
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         old: Option<Id<GenericMarker>>,
     },
     /// Hash of a guild scheduled event cover.
@@ -360,8 +382,10 @@ pub enum AuditLogChange {
     InviterId {
         /// User ID.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         new: Option<Id<UserMarker>>,
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         old: Option<Id<UserMarker>>,
     },
     /// Location for a scheduled event changed.
@@ -467,9 +491,11 @@ pub enum AuditLogChange {
     OwnerId {
         /// New owner's ID.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         new: Option<Id<UserMarker>>,
         /// Old owner's ID.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         old: Option<Id<UserMarker>>,
     },
     /// Permission overwrites on a channel changed.
@@ -529,9 +555,11 @@ pub enum AuditLogChange {
     PublicUpdatesChannelId {
         /// New public updates channel ID.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         new: Option<Id<ChannelMarker>>,
         /// Old public updates channel ID.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         old: Option<Id<ChannelMarker>>,
     },
     /// Ratelimit per user in a textual channel.
@@ -576,9 +604,11 @@ pub enum AuditLogChange {
     RulesChannelId {
         /// New rules channel.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         new: Option<Id<ChannelMarker>>,
         /// Old rules channel.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         old: Option<Id<ChannelMarker>>,
     },
     /// Hash of a guild's splash.
@@ -603,9 +633,11 @@ pub enum AuditLogChange {
     SystemChannelId {
         /// New system channel ID.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         new: Option<Id<ChannelMarker>>,
         /// Old system channel ID.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         old: Option<Id<ChannelMarker>>,
     },
     /// Related emoji of a sticker.
@@ -696,9 +728,11 @@ pub enum AuditLogChange {
     WidgetChannelId {
         /// New channel ID.
         #[serde(rename = "new_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         new: Option<Id<ChannelMarker>>,
         /// Old channel ID.
         #[serde(rename = "old_value", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
         old: Option<Id<ChannelMarker>>,
     },
     /// Whether a widget is enabled.

--- a/twilight-model/src/guild/audit_log/change_key.rs
+++ b/twilight-model/src/guild/audit_log/change_key.rs
@@ -10,6 +10,11 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum AuditLogChangeKey {
     /// AFK voice channel for a guild.
     AfkChannelId,

--- a/twilight-model/src/guild/audit_log/entry.rs
+++ b/twilight-model/src/guild/audit_log/entry.rs
@@ -9,6 +9,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`AuditLog`]: super::AuditLog
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AuditLogEntry {
     /// Type of event to cause the entry.
     pub action_type: AuditLogEventType,
@@ -22,6 +26,7 @@ pub struct AuditLogEntry {
     ///
     /// [`GuildAuditLogEntryCreate`]: crate::gateway::payload::incoming::GuildAuditLogEntryCreate
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     /// ID of the entire entry.
     pub id: Id<AuditLogEntryMarker>,
@@ -33,10 +38,12 @@ pub struct AuditLogEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
     /// ID of the target entity.
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub target_id: Option<Id<GenericMarker>>,
     /// ID of the [user] that performed the action.
     ///
     /// [user]: crate::user::User
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub user_id: Option<Id<UserMarker>>,
 }
 

--- a/twilight-model/src/guild/audit_log/event_type.rs
+++ b/twilight-model/src/guild/audit_log/event_type.rs
@@ -5,6 +5,11 @@ use serde::{Deserialize, Serialize};
 /// [`AuditLogEntry`]: super::AuditLogEntry
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(from = "u16", into = "u16")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum AuditLogEventType {
     /// [Guild] was updated.
     ///

--- a/twilight-model/src/guild/audit_log/integration.rs
+++ b/twilight-model/src/guild/audit_log/integration.rs
@@ -11,6 +11,10 @@ use serde::{Deserialize, Serialize};
 /// [audit log]: super::AuditLog
 /// [guild integration]: super::super::GuildIntegration
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AuditLogGuildIntegration {
     /// Account of the integration.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -26,6 +30,7 @@ pub struct AuditLogGuildIntegration {
     pub expire_grace_period: Option<u64>,
     /// ID of the integration.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub id: Option<Id<IntegrationMarker>>,
     /// Type of integration.
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
@@ -35,6 +40,7 @@ pub struct AuditLogGuildIntegration {
     pub name: Option<String>,
     /// ID that the integration uses for subscribers.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub role_id: Option<Id<IntegrationMarker>>,
     /// When the integration was last synced.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/guild/audit_log/mod.rs
+++ b/twilight-model/src/guild/audit_log/mod.rs
@@ -36,6 +36,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [1]: https://discord.com/developers/docs/resources/audit-log#audit-log-object
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AuditLog {
     /// List of referenced application commands.
     pub application_commands: Vec<Command>,

--- a/twilight-model/src/guild/audit_log/optional_entry_info.rs
+++ b/twilight-model/src/guild/audit_log/optional_entry_info.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`AuditLogEventType`]: super::AuditLogEventType
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AuditLogOptionalEntryInfo {
     /// Name of the Auto Moderation rule that was triggered.
     ///
@@ -61,6 +65,7 @@ pub struct AuditLogOptionalEntryInfo {
     /// [`AuditLogEventType::StageInstanceDelete`]: super::AuditLogEventType::StageInstanceDelete
     /// [`AuditLogEventType::StageInstanceUpdate`]: super::AuditLogEventType::StageInstanceUpdate
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub channel_id: Option<Id<ChannelMarker>>,
     /// Number of entities that were targeted.
     ///
@@ -98,6 +103,7 @@ pub struct AuditLogOptionalEntryInfo {
     /// [`AuditLogEventType::ChannelOverwriteCreate`]: super::AuditLogEventType::ChannelOverwriteCreate
     /// [`AuditLogEventType::ChannelOverwriteDelete`]: super::AuditLogEventType::ChannelOverwriteDelete
     /// [`AuditLogEventType::ChannelOverwriteUpdate`]: super::AuditLogEventType::ChannelOverwriteUpdate
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub id: Option<Id<GenericMarker>>,
     /// Type of overwritten entity.
     ///
@@ -131,6 +137,7 @@ pub struct AuditLogOptionalEntryInfo {
     /// [`AuditLogEventType::MessagePin`]: super::AuditLogEventType::MessagePin
     /// [`AuditLogEventType::MessageUnpin`]: super::AuditLogEventType::MessageUnpin
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub message_id: Option<Id<MessageMarker>>,
     /// Name of a role.
     ///

--- a/twilight-model/src/guild/auto_moderation/action.rs
+++ b/twilight-model/src/guild/auto_moderation/action.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 
 /// An action which will execute whenever a rule is triggered.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AutoModerationAction {
     /// Type of action.
     #[serde(rename = "type")]
@@ -16,9 +20,14 @@ pub struct AutoModerationAction {
 /// Additional metadata needed during execution for a specific
 /// [`AutoModerationActionType`].
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AutoModerationActionMetadata {
     /// Channel to which user content should be logged.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub channel_id: Option<Id<ChannelMarker>>,
     /// Additional explanation that will be shown to members whenever their message is blocked.
     ///
@@ -35,6 +44,11 @@ pub struct AutoModerationActionMetadata {
 /// Type of [`AutoModerationAction`].
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum AutoModerationActionType {
     /// Blocks the content of a message according to the rule.
     BlockMessage,

--- a/twilight-model/src/guild/auto_moderation/event_type.rs
+++ b/twilight-model/src/guild/auto_moderation/event_type.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 /// Indicates in what event context a rule should be checked.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum AutoModerationEventType {
     /// When a member sends or edits a message in a guild.
     MessageSend,

--- a/twilight-model/src/guild/auto_moderation/mod.rs
+++ b/twilight-model/src/guild/auto_moderation/mod.rs
@@ -32,6 +32,10 @@ use serde::{Deserialize, Serialize};
 
 /// Configured auto moderation rule.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AutoModerationRule {
     /// Actions which will execute when the rule is triggered.
     pub actions: Vec<AutoModerationAction>,
@@ -44,10 +48,12 @@ pub struct AutoModerationRule {
     /// Channels that should not be affected by the rule.
     ///
     /// Maximum of 50.
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub exempt_channels: Vec<Id<ChannelMarker>>,
     /// Roles that should not be affected by the rule.
     ///
     /// Maximum of 20.
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub exempt_roles: Vec<Id<RoleMarker>>,
     /// ID of the guild the rule belongs to.
     pub guild_id: Id<GuildMarker>,

--- a/twilight-model/src/guild/auto_moderation/preset_type.rs
+++ b/twilight-model/src/guild/auto_moderation/preset_type.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 /// Internally pre-defined wordsets which will be searched for in content.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum AutoModerationKeywordPresetType {
     /// Words that may be considered forms of swearing or cursing.
     Profanity,

--- a/twilight-model/src/guild/auto_moderation/trigger_metadata.rs
+++ b/twilight-model/src/guild/auto_moderation/trigger_metadata.rs
@@ -7,6 +7,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`AutoModerationRule::trigger_type`]: super::AutoModerationRule::trigger_type
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct AutoModerationTriggerMetadata {
     /// Substrings that will be exempt from triggering the preset type.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -22,6 +26,7 @@ pub struct AutoModerationTriggerMetadata {
     ///
     /// [Discord Docs/Keyword Matching Strategies]: https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::Map<rkyv::with::CopyOptimize>))]
     pub presets: Option<Vec<AutoModerationKeywordPresetType>>,
 }
 

--- a/twilight-model/src/guild/auto_moderation/trigger_type.rs
+++ b/twilight-model/src/guild/auto_moderation/trigger_type.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 /// Characterizes the type of content which can trigger the rule.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum AutoModerationTriggerType {
     /// Check if content contains words from a user defined list of keywords.
     ///

--- a/twilight-model/src/guild/ban.rs
+++ b/twilight-model/src/guild/ban.rs
@@ -2,6 +2,10 @@ use crate::user::User;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Ban {
     pub reason: Option<String>,
     pub user: User,

--- a/twilight-model/src/guild/default_message_notification_level.rs
+++ b/twilight-model/src/guild/default_message_notification_level.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum DefaultMessageNotificationLevel {
     All,
     Mentions,

--- a/twilight-model/src/guild/emoji.rs
+++ b/twilight-model/src/guild/emoji.rs
@@ -9,6 +9,10 @@ use serde::{Deserialize, Serialize};
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Emoji {
     #[serde(default)]
     pub animated: bool,
@@ -24,6 +28,7 @@ pub struct Emoji {
     #[serde(default)]
     pub require_colons: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub roles: Vec<Id<RoleMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,

--- a/twilight-model/src/guild/explicit_content_filter.rs
+++ b/twilight-model/src/guild/explicit_content_filter.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum ExplicitContentFilter {
     None,
     MembersWithoutRole,

--- a/twilight-model/src/guild/feature.rs
+++ b/twilight-model/src/guild/feature.rs
@@ -11,6 +11,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "String", into = "Cow<'static, str>")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum GuildFeature {
     /// Has access to set an animated guild banner image.
     AnimatedBanner,

--- a/twilight-model/src/guild/info.rs
+++ b/twilight-model/src/guild/info.rs
@@ -6,6 +6,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildInfo {
     pub icon: Option<ImageHash>,
     pub id: Id<GuildMarker>,

--- a/twilight-model/src/guild/integration.rs
+++ b/twilight-model/src/guild/integration.rs
@@ -12,6 +12,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildIntegration {
     pub account: IntegrationAccount,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -27,6 +31,7 @@ pub struct GuildIntegration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expire_grace_period: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     pub id: Id<IntegrationMarker>,
     #[serde(rename = "type")]
@@ -35,6 +40,7 @@ pub struct GuildIntegration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub revoked: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub role_id: Option<Id<RoleMarker>>,
     /// An array of [OAuth2 scopes] which the application has been authorized for.
     ///

--- a/twilight-model/src/guild/integration_account.rs
+++ b/twilight-model/src/guild/integration_account.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct IntegrationAccount {
     pub id: String,
     pub name: String,

--- a/twilight-model/src/guild/integration_application.rs
+++ b/twilight-model/src/guild/integration_application.rs
@@ -7,6 +7,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct IntegrationApplication {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bot: Option<User>,

--- a/twilight-model/src/guild/integration_expire_behavior.rs
+++ b/twilight-model/src/guild/integration_expire_behavior.rs
@@ -4,6 +4,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum IntegrationExpireBehavior {
     /// Remove the role when the integration expires.
     RemoveRole,

--- a/twilight-model/src/guild/integration_type.rs
+++ b/twilight-model/src/guild/integration_type.rs
@@ -11,6 +11,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "String", into = "Cow<'static, str>")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub enum GuildIntegrationType {
     /// Integration is a Discord application.
     Discord,

--- a/twilight-model/src/guild/invite/channel.rs
+++ b/twilight-model/src/guild/invite/channel.rs
@@ -5,6 +5,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct InviteChannel {
     /// ID of the channel.
     pub id: Id<ChannelMarker>,

--- a/twilight-model/src/guild/invite/guild.rs
+++ b/twilight-model/src/guild/invite/guild.rs
@@ -7,6 +7,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct InviteGuild {
     /// Hash of the banner image.
     pub banner: Option<ImageHash>,

--- a/twilight-model/src/guild/invite/mod.rs
+++ b/twilight-model/src/guild/invite/mod.rs
@@ -14,6 +14,10 @@ use crate::{user::User, util::Timestamp};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Invite {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub approximate_member_count: Option<u64>,

--- a/twilight-model/src/guild/invite/target_type.rs
+++ b/twilight-model/src/guild/invite/target_type.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum TargetType {
     Stream,
     EmbeddedApplication,

--- a/twilight-model/src/guild/invite/welcome_screen.rs
+++ b/twilight-model/src/guild/invite/welcome_screen.rs
@@ -5,6 +5,10 @@ use crate::id::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct WelcomeScreen {
     /// Guild description.
     pub description: Option<String>,
@@ -13,12 +17,17 @@ pub struct WelcomeScreen {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct WelcomeScreenChannel {
     /// ID of the channel.
     pub channel_id: Id<ChannelMarker>,
     /// Description of the channel.
     pub description: String,
     /// ID of the emoji if the emoji is custom.
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub emoji_id: Option<Id<EmojiMarker>>,
     /// Emoji's name if it is custom, or the unicode character.
     pub emoji_name: Option<String>,

--- a/twilight-model/src/guild/member.rs
+++ b/twilight-model/src/guild/member.rs
@@ -13,6 +13,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Guild`]: super::Guild
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Member {
     /// Member's guild avatar.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -32,6 +36,7 @@ pub struct Member {
     pub pending: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub premium_since: Option<Timestamp>,
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub roles: Vec<Id<RoleMarker>>,
     pub user: User,
 }

--- a/twilight-model/src/guild/member_flags.rs
+++ b/twilight-model/src/guild/member_flags.rs
@@ -8,6 +8,11 @@ bitflags! {
     ///
     /// [`Member`]: crate::guild::Member
     /// [Discord's documentation]: https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags
+    #[cfg_attr(
+        feature = "rkyv",
+        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+        archive(as = "Self")
+    )]
     pub struct MemberFlags: u64 {
         /// Member has left and rejoined the guild.
         const DID_REJOIN = 1 << 0;

--- a/twilight-model/src/guild/mfa_level.rs
+++ b/twilight-model/src/guild/mfa_level.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum MfaLevel {
     None,
     Elevated,

--- a/twilight-model/src/guild/mod.rs
+++ b/twilight-model/src/guild/mod.rs
@@ -75,9 +75,15 @@ use serde::{
 use std::fmt::{Formatter, Result as FmtResult};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+)]
 pub struct Guild {
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub afk_channel_id: Option<Id<ChannelMarker>>,
     pub afk_timeout: AfkTimeout,
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub application_id: Option<Id<ApplicationMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub approximate_member_count: Option<u64>,
@@ -127,8 +133,10 @@ pub struct Guild {
     pub presences: Vec<Presence>,
     /// ID of the where moderators of Community guilds receive notices from
     /// Discord.
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub public_updates_channel_id: Option<Id<ChannelMarker>>,
     pub roles: Vec<Role>,
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub rules_channel_id: Option<Id<ChannelMarker>>,
     pub splash: Option<ImageHash>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -136,6 +144,7 @@ pub struct Guild {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub stickers: Vec<Sticker>,
     pub system_channel_flags: SystemChannelFlags,
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub system_channel_id: Option<Id<ChannelMarker>>,
     #[serde(default)]
     pub threads: Vec<Channel>,
@@ -146,6 +155,7 @@ pub struct Guild {
     #[serde(default)]
     pub voice_states: Vec<VoiceState>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub widget_channel_id: Option<Id<ChannelMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub widget_enabled: Option<bool>,

--- a/twilight-model/src/guild/mod.rs
+++ b/twilight-model/src/guild/mod.rs
@@ -77,7 +77,7 @@ use std::fmt::{Formatter, Result as FmtResult};
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
 pub struct Guild {
     #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]

--- a/twilight-model/src/guild/nsfw_level.rs
+++ b/twilight-model/src/guild/nsfw_level.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum NSFWLevel {
     Default,
     Explicit,

--- a/twilight-model/src/guild/partial_guild.rs
+++ b/twilight-model/src/guild/partial_guild.rs
@@ -12,9 +12,15 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct PartialGuild {
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub afk_channel_id: Option<Id<ChannelMarker>>,
     pub afk_timeout: AfkTimeout,
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub application_id: Option<Id<ApplicationMarker>>,
     pub banner: Option<ImageHash>,
     pub default_message_notifications: DefaultMessageNotificationLevel,
@@ -47,15 +53,19 @@ pub struct PartialGuild {
     pub premium_tier: PremiumTier,
     /// ID of the where moderators of Community guilds receive notices from
     /// Discord.
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub public_updates_channel_id: Option<Id<ChannelMarker>>,
     pub roles: Vec<Role>,
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub rules_channel_id: Option<Id<ChannelMarker>>,
     pub splash: Option<ImageHash>,
     pub system_channel_flags: SystemChannelFlags,
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub system_channel_id: Option<Id<ChannelMarker>>,
     pub verification_level: VerificationLevel,
     pub vanity_url_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub widget_channel_id: Option<Id<ChannelMarker>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub widget_enabled: Option<bool>,

--- a/twilight-model/src/guild/partial_member.rs
+++ b/twilight-model/src/guild/partial_member.rs
@@ -9,6 +9,10 @@ use serde::{Deserialize, Serialize};
 use super::MemberFlags;
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct PartialMember {
     /// Member's guild avatar.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -28,6 +32,7 @@ pub struct PartialMember {
     pub permissions: Option<Permissions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub premium_since: Option<Timestamp>,
+    #[cfg_attr(feature = "rkyv", with(rkyv::with::CopyOptimize))]
     pub roles: Vec<Id<RoleMarker>>,
     pub user: Option<User>,
 }

--- a/twilight-model/src/guild/permissions.rs
+++ b/twilight-model/src/guild/permissions.rs
@@ -6,6 +6,11 @@ use serde::{
 use std::fmt::{Formatter, Result as FmtResult};
 
 bitflags! {
+    #[cfg_attr(
+        feature = "rkyv",
+        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+        archive(as = "Self")
+    )]
     pub struct Permissions: u64 {
         const CREATE_INVITE = 1;
         const KICK_MEMBERS = 1 << 1;

--- a/twilight-model/src/guild/premium_tier.rs
+++ b/twilight-model/src/guild/premium_tier.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum PremiumTier {
     None,
     Tier1,

--- a/twilight-model/src/guild/preview.rs
+++ b/twilight-model/src/guild/preview.rs
@@ -7,6 +7,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildPreview {
     pub approximate_member_count: u64,
     pub approximate_presence_count: u64,

--- a/twilight-model/src/guild/prune.rs
+++ b/twilight-model/src/guild/prune.rs
@@ -1,6 +1,11 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct GuildPrune {
     pub pruned: u64,
 }

--- a/twilight-model/src/guild/role.rs
+++ b/twilight-model/src/guild/role.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 use std::cmp::{Ord, Ordering, PartialOrd};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Role {
     pub color: u32,
     pub hoist: bool,

--- a/twilight-model/src/guild/role_tags.rs
+++ b/twilight-model/src/guild/role_tags.rs
@@ -11,6 +11,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`Role`]: super::Role
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct RoleTags {
     /// Whether this role is available for purchase.
     #[serde(
@@ -21,6 +25,7 @@ pub struct RoleTags {
     pub available_for_purchase: bool,
     /// ID of the bot the role belongs to.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub bot_id: Option<Id<UserMarker>>,
     /// Whether this role is a guild's linked role.
     #[serde(
@@ -31,9 +36,11 @@ pub struct RoleTags {
     pub guild_connections: bool,
     /// ID of the integration the role belongs to.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub integration_id: Option<Id<IntegrationMarker>>,
     /// ID of the role's subscription SKU and listing.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub subscription_listing_id: Option<Id<RoleSubscriptionSkuMarker>>,
     /// Whether this is the guild's premium subscriber role.
     #[serde(

--- a/twilight-model/src/guild/scheduled_event/mod.rs
+++ b/twilight-model/src/guild/scheduled_event/mod.rs
@@ -25,12 +25,17 @@ use serde::{Deserialize, Serialize};
 /// [`creator`]: Self::creator
 /// [`creator_id`]: Self::creator_id
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildScheduledEvent {
     /// ID of the stage or voice channel if there is one.
     ///
     /// Present on events of [`EntityType::StageInstance`] and
     /// [`EntityType::Voice`].
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub channel_id: Option<Id<ChannelMarker>>,
     /// User object of the event's creator.
     ///
@@ -41,12 +46,14 @@ pub struct GuildScheduledEvent {
     ///
     /// Only present on events created after October 25th, 2021.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub creator_id: Option<Id<UserMarker>>,
     /// Description of the event.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// ID of the event's entity.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub entity_id: Option<Id<ScheduledEventEntityMarker>>,
     /// Metadata of an entity, if it exists.
     ///
@@ -83,6 +90,10 @@ pub struct GuildScheduledEvent {
 
 /// Metadata associated with an event.
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct EntityMetadata {
     /// Physical location of an event with type [`EntityType::External`].
     pub location: Option<String>,
@@ -92,6 +103,11 @@ pub struct EntityMetadata {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum EntityType {
     /// Event takes place in a stage instance.
     StageInstance,
@@ -129,6 +145,11 @@ impl From<EntityType> for u8 {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum PrivacyLevel {
     /// Event is only accessible to guild members.
     GuildOnly,
@@ -158,6 +179,11 @@ impl From<PrivacyLevel> for u8 {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum Status {
     /// Event is scheduled.
     ///

--- a/twilight-model/src/guild/scheduled_event/user.rs
+++ b/twilight-model/src/guild/scheduled_event/user.rs
@@ -7,6 +7,10 @@ use serde::{Deserialize, Serialize};
 
 /// Container for user and member data returned by Discord.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildScheduledEventUser {
     /// ID of the scheduled event.
     pub guild_scheduled_event_id: Id<ScheduledEventMarker>,

--- a/twilight-model/src/guild/system_channel_flags.rs
+++ b/twilight-model/src/guild/system_channel_flags.rs
@@ -5,6 +5,11 @@ use serde::{
 };
 
 bitflags! {
+    #[cfg_attr(
+        feature = "rkyv",
+        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+        archive(as = "Self")
+    )]
     pub struct SystemChannelFlags: u64 {
         /// Suppress member join notifications.
         const SUPPRESS_JOIN_NOTIFICATIONS = 1;

--- a/twilight-model/src/guild/template/guild.rs
+++ b/twilight-model/src/guild/template/guild.rs
@@ -11,7 +11,12 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct TemplateGuild {
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub afk_channel_id: Option<Id<ChannelMarker>>,
     pub afk_timeout: AfkTimeout,
     pub channels: Vec<Channel>,
@@ -23,6 +28,7 @@ pub struct TemplateGuild {
     pub preferred_locale: String,
     pub roles: Vec<TemplateRole>,
     pub system_channel_flags: SystemChannelFlags,
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub system_channel_id: Option<Id<ChannelMarker>>,
     pub verification_level: VerificationLevel,
 }

--- a/twilight-model/src/guild/template/mod.rs
+++ b/twilight-model/src/guild/template/mod.rs
@@ -15,6 +15,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Template {
     pub code: String,
     pub created_at: Timestamp,

--- a/twilight-model/src/guild/template/role.rs
+++ b/twilight-model/src/guild/template/role.rs
@@ -5,6 +5,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct TemplateRole {
     pub color: u32,
     pub hoist: bool,

--- a/twilight-model/src/guild/unavailable_guild.rs
+++ b/twilight-model/src/guild/unavailable_guild.rs
@@ -2,6 +2,11 @@ use crate::id::{marker::GuildMarker, Id};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct UnavailableGuild {
     pub id: Id<GuildMarker>,
     pub unavailable: bool,

--- a/twilight-model/src/guild/vanity_url.rs
+++ b/twilight-model/src/guild/vanity_url.rs
@@ -2,6 +2,10 @@ use serde::{Deserialize, Serialize};
 
 /// Information about a guild's vanity URL setting.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct VanityUrl {
     /// Code of the vanity URL.
     ///

--- a/twilight-model/src/guild/verification_level.rs
+++ b/twilight-model/src/guild/verification_level.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum VerificationLevel {
     None,
     Low,

--- a/twilight-model/src/guild/widget/mod.rs
+++ b/twilight-model/src/guild/widget/mod.rs
@@ -14,6 +14,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildWidget {
     pub channels: Vec<GuildWidgetChannel>,
     pub id: Id<GuildMarker>,
@@ -24,6 +28,10 @@ pub struct GuildWidget {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildWidgetChannel {
     pub id: Id<ChannelMarker>,
     pub name: String,
@@ -31,6 +39,10 @@ pub struct GuildWidgetChannel {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct GuildWidgetMember {
     pub avatar: Option<ImageHash>,
     pub avatar_url: Option<String>,

--- a/twilight-model/src/guild/widget/settings.rs
+++ b/twilight-model/src/guild/widget/settings.rs
@@ -2,6 +2,11 @@ use crate::id::{marker::ChannelMarker, Id};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct GuildWidgetSettings {
     pub channel_id: Id<ChannelMarker>,
     pub enabled: bool,

--- a/twilight-model/src/id/anonymizable.rs
+++ b/twilight-model/src/id/anonymizable.rs
@@ -4,6 +4,12 @@ use super::Id;
 use std::hash::{Hash, Hasher};
 
 #[derive(Debug)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self"),
+    archive(bound(archive = "Id<T>: rkyv::Archive<Archived = Id<T>>"))
+)]
 pub enum AnonymizableId<T> {
     Anonymized,
     Id(Id<T>),

--- a/twilight-model/src/id/mod.rs
+++ b/twilight-model/src/id/mod.rs
@@ -45,6 +45,12 @@ pub mod marker;
 
 mod anonymizable;
 
+#[cfg(feature = "rkyv")]
+mod niche;
+
+#[cfg(feature = "rkyv")]
+pub use niche::IdNiche;
+
 pub use anonymizable::AnonymizableId;
 
 use serde::{
@@ -76,6 +82,14 @@ use std::{
 /// [marker documentation]: marker
 /// [user]: marker::UserMarker
 #[repr(transparent)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self"),
+    archive(bound(
+        archive = "PhantomData<fn(T) -> T>: rkyv::Archive<Archived = PhantomData<fn(T) -> T>>"
+    ))
+)]
 pub struct Id<T> {
     phantom: PhantomData<fn(T) -> T>,
     value: NonZeroU64,

--- a/twilight-model/src/id/niche.rs
+++ b/twilight-model/src/id/niche.rs
@@ -14,8 +14,8 @@ type ArchivedOptionId = ArchivedOptionNonZeroU64;
 ///
 /// ```
 /// use core::mem::size_of;
-/// use twilight_model::id::{Id, IdNiche, marker::UserMarker};
 /// use rkyv::{Archive, Archived};
+/// use twilight_model::id::{Id, IdNiche, marker::UserMarker};
 ///
 /// #[derive(Archive)]
 /// struct BasicExample {
@@ -25,7 +25,7 @@ type ArchivedOptionId = ArchivedOptionNonZeroU64;
 /// #[derive(Archive)]
 /// struct NichedExample {
 ///     #[with(IdNiche)]
-///     id_opt: Option<Id<UserMarker>>
+///     id_opt: Option<Id<UserMarker>>,
 /// }
 ///
 /// assert!(size_of::<Archived<BasicExample>>() > size_of::<Archived<NichedExample>>);

--- a/twilight-model/src/id/niche.rs
+++ b/twilight-model/src/id/niche.rs
@@ -1,0 +1,63 @@
+use rkyv::{
+    niche::option_nonzero::ArchivedOptionNonZeroU64,
+    with::{ArchiveWith, DeserializeWith, SerializeWith},
+    Fallible,
+};
+
+use super::Id;
+
+type ArchivedOptionId = ArchivedOptionNonZeroU64;
+
+/// An rkyv wrapper that niches `Option<Id<T>>` into an optimized layout.
+///
+/// # Example
+///
+/// ```
+/// use core::mem::size_of;
+/// use twilight_model::id::{Id, IdNiche, marker::UserMarker};
+/// use rkyv::{Archive, Archived};
+///
+/// #[derive(Archive)]
+/// struct BasicExample {
+///     id_opt: Option<Id<UserMarker>>,
+/// }
+///
+/// #[derive(Archive)]
+/// struct NichedExample {
+///     #[with(IdNiche)]
+///     id_opt: Option<Id<UserMarker>>
+/// }
+///
+/// assert!(size_of::<Archived<BasicExample>>() > size_of::<Archived<NichedExample>>);
+/// ```
+pub struct IdNiche;
+
+impl<T> ArchiveWith<Option<Id<T>>> for IdNiche {
+    type Archived = ArchivedOptionId;
+    type Resolver = ();
+
+    #[inline]
+    #[allow(unsafe_code)]
+    unsafe fn resolve_with(
+        field: &Option<Id<T>>,
+        _: usize,
+        _: Self::Resolver,
+        out: *mut Self::Archived,
+    ) {
+        ArchivedOptionId::resolve_from_option(field.map(Id::into_nonzero), out);
+    }
+}
+
+impl<S: Fallible + ?Sized, T> SerializeWith<Option<Id<T>>, S> for IdNiche {
+    #[inline]
+    fn serialize_with(_: &Option<Id<T>>, _: &mut S) -> Result<Self::Resolver, S::Error> {
+        Ok(())
+    }
+}
+
+impl<D: Fallible + ?Sized, T> DeserializeWith<ArchivedOptionId, Option<Id<T>>, D> for IdNiche {
+    #[inline]
+    fn deserialize_with(field: &ArchivedOptionId, _: &mut D) -> Result<Option<Id<T>>, D::Error> {
+        Ok(field.as_ref().map(|&id| Id::from_nonzero(id)))
+    }
+}

--- a/twilight-model/src/oauth/application.rs
+++ b/twilight-model/src/oauth/application.rs
@@ -10,6 +10,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Application {
     pub bot_public: bool,
     pub bot_require_code_grant: bool,
@@ -20,6 +24,7 @@ pub struct Application {
     pub custom_install_url: Option<String>,
     /// Description of the application.
     pub description: String,
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     /// Public flags of the application.
     pub flags: Option<ApplicationFlags>,
@@ -33,6 +38,7 @@ pub struct Application {
     /// Name of the application.
     pub name: String,
     pub owner: Option<User>,
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub primary_sku_id: Option<Id<OauthSkuMarker>>,
     /// URL of the application's privacy policy.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/oauth/application_flags.rs
+++ b/twilight-model/src/oauth/application_flags.rs
@@ -5,6 +5,11 @@ use serde::{
 };
 
 bitflags! {
+    #[cfg_attr(
+        feature = "rkyv",
+        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+        archive(as = "Self")
+    )]
     pub struct ApplicationFlags: u64 {
         /// Intent required for bots in 100 guilds or more to receive
         /// [`PresenceUpdate`] events.

--- a/twilight-model/src/oauth/current_authorization_information.rs
+++ b/twilight-model/src/oauth/current_authorization_information.rs
@@ -12,6 +12,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [1]: https://discord.com/developers/docs/topics/oauth2#get-current-authorization-information
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct CurrentAuthorizationInformation {
     /// Current application.
     pub application: Application,

--- a/twilight-model/src/oauth/install_params.rs
+++ b/twilight-model/src/oauth/install_params.rs
@@ -7,6 +7,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [Discord Docs/Install Params Object]: https://discord.com/developers/docs/resources/application#install-params-object
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct InstallParams {
     /// Permissions to request for the bot role.
     pub permissions: Permissions,

--- a/twilight-model/src/oauth/partial_application.rs
+++ b/twilight-model/src/oauth/partial_application.rs
@@ -3,6 +3,11 @@ use crate::id::{marker::ApplicationMarker, Id};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct PartialApplication {
     pub flags: ApplicationFlags,
     pub id: Id<ApplicationMarker>,

--- a/twilight-model/src/oauth/team/member.rs
+++ b/twilight-model/src/oauth/team/member.rs
@@ -6,6 +6,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct TeamMember {
     pub membership_state: TeamMembershipState,
     pub permissions: Vec<String>,

--- a/twilight-model/src/oauth/team/membership_state.rs
+++ b/twilight-model/src/oauth/team/membership_state.rs
@@ -3,6 +3,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum TeamMembershipState {
     Invited,
     Accepted,

--- a/twilight-model/src/oauth/team/mod.rs
+++ b/twilight-model/src/oauth/team/mod.rs
@@ -13,6 +13,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct Team {
     pub icon: Option<ImageHash>,
     pub id: Id<OauthTeamMarker>,

--- a/twilight-model/src/user/current_user.rs
+++ b/twilight-model/src/user/current_user.rs
@@ -6,6 +6,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct CurrentUser {
     /// Accent color of the user's banner.
     ///

--- a/twilight-model/src/user/current_user_guild.rs
+++ b/twilight-model/src/user/current_user_guild.rs
@@ -12,6 +12,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// [Discord Docs/Get Current User Guilds]: https://discord.com/developers/docs/resources/user#get-current-user-guilds-example-partial-guild
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct CurrentUserGuild {
     /// Unique ID.
     pub id: Id<GuildMarker>,

--- a/twilight-model/src/user/flags.rs
+++ b/twilight-model/src/user/flags.rs
@@ -5,6 +5,11 @@ use serde::{
 };
 
 bitflags! {
+    #[cfg_attr(
+        feature = "rkyv",
+        derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+        archive(as = "Self")
+    )]
     pub struct UserFlags: u64 {
         /// Discord Employee.
         const STAFF = 1;

--- a/twilight-model/src/user/mod.rs
+++ b/twilight-model/src/user/mod.rs
@@ -119,6 +119,10 @@ impl Display for DiscriminatorDisplay {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct User {
     /// Accent color of the user's banner.
     ///

--- a/twilight-model/src/user/premium_type.rs
+++ b/twilight-model/src/user/premium_type.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[non_exhaustive]
 #[serde(from = "u8", into = "u8")]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum PremiumType {
     /// User doesn't have premium.
     None,

--- a/twilight-model/src/user/profile.rs
+++ b/twilight-model/src/user/profile.rs
@@ -6,6 +6,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct UserProfile {
     /// Accent color of the user's banner.
     ///

--- a/twilight-model/src/util/image_hash.rs
+++ b/twilight-model/src/util/image_hash.rs
@@ -117,6 +117,11 @@ pub enum ImageHashParseErrorType {
 ///
 /// Parsing methods only support hashes provided by Discord's APIs.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub struct ImageHash {
     /// Whether the image is animated.
     ///

--- a/twilight-model/src/voice/close_code.rs
+++ b/twilight-model/src/voice/close_code.rs
@@ -4,6 +4,11 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u16)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum CloseCode {
     /// An invalid opcode was sent.
     UnknownOpcode = 4001,

--- a/twilight-model/src/voice/opcode.rs
+++ b/twilight-model/src/voice/opcode.rs
@@ -4,6 +4,11 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 #[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[non_exhaustive]
 #[repr(u8)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    archive(as = "Self")
+)]
 pub enum OpCode {
     /// Start a voice websocket connection.
     Identify = 0,

--- a/twilight-model/src/voice/voice_region.rs
+++ b/twilight-model/src/voice/voice_region.rs
@@ -2,6 +2,10 @@ use serde::{Deserialize, Serialize};
 
 /// Geographically based collection of voice servers.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct VoiceRegion {
     /// Whether this is a custom voice region, used for e.g. events.
     pub custom: bool,

--- a/twilight-model/src/voice/voice_state.rs
+++ b/twilight-model/src/voice/voice_state.rs
@@ -11,15 +11,21 @@ use serde::{Deserialize, Serialize};
 /// User's voice connection status.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 pub struct VoiceState {
     /// Channel this user is connected to.
     ///
     /// [`None`] corresponds to being disconnected.
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub channel_id: Option<Id<ChannelMarker>>,
     /// Whether this user is server deafened.
     pub deaf: bool,
     /// Guild this voice state is for.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "rkyv", with(crate::id::IdNiche))]
     pub guild_id: Option<Id<GuildMarker>>,
     /// Member this voice state is for.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This implements [rkyv](https://github.com/rkyv/rkyv)'s `Archive`, `Deserialize`, and `Serialize` traits for most types if the `rkyv` feature is enabled.

Tasks:
- [x] Implement traits for types
- [x] Await https://github.com/rkyv/rkyv/pull/358 to remove the dependency patch
- [ ] Publicly expose archived types and resolvers
- [ ] Provide validation support for safe checked deserialization

If this goes through, considering rkyv will be additional overhead for future type changes.
Although, fortunately, the only manual implementation was written for `Timestamp`; for all other types the derive macros were sufficient.
Another downside is that the trait implementations bring one - most of the time even two - new types for every type they're implemented on (`Archived{TypeName}` and `{TypeName}Resolver`). This could lead to larger binaries and longer compile times. Since this is behind a feature flag and only enabled if people actually need rkyv though, I don't think this should be an issue.

The advantage would be that users have access to highly performant (de)serialization which can be especially useful for caching purposes.
It might even be an option to store data in the in-memory cache in serialized form to reduce its size and instead of dealing with references into the dashmaps, one could provide methods that take an `FnOnce` and execute it on archived types such as
```rs
impl InMemoryCache {
    pub fn user<F, O>(&self, user_id: Id<UserMarker>, f: F) -> Option<O>
    where
        F: FnOnce(&Archived<User>) -> O,
    {
        self.users
            .get(&user_id)
            .map(|bytes| unsafe { rkyv::archived_root::<User>(bytes) })
            .map(f)    
    }
}
```
This just serves as an example, I can't say how much (if any) performance / memory improvement this would bring for now, maybe its more of a project for a third-party crate.

One could argue "Why stop at rkyv, traits for [prost](https://github.com/tokio-rs/prost), [abomonation](https://github.com/TimelyDataflow/abomonation), [flatbuffers](https://github.com/google/flatbuffers), and all other ones should be supported too!"
which is a valid point and remains for you to decide. I just think that rkyv comes with a great amount of utility and its performance scores amazingly in [benchmarks](https://github.com/djkoloski/rust_serialization_benchmark).

If you're fine adding this, I'll look into completing the remaining task.