### PR TITLE
docs(model): fix event integration variant docs

### DIFF
--- a/twilight-model/src/gateway/event/mod.rs
+++ b/twilight-model/src/gateway/event/mod.rs
@@ -89,9 +89,9 @@ pub enum Event {
     GuildUpdate(Box<GuildUpdate>),
     /// A guild integration was created.
     IntegrationCreate(Box<IntegrationCreate>),
-    /// A guild integration was updated.
-    IntegrationDelete(IntegrationDelete),
     /// A guild integration was deleted.
+    IntegrationDelete(IntegrationDelete),
+    /// A guild integration was updated.
     IntegrationUpdate(Box<IntegrationUpdate>),
     /// An interaction was invoked by a user.
     InteractionCreate(Box<InteractionCreate>),


### PR DESCRIPTION
Fix the documentation for `IntegrationDelete` and `IntegrationUpdate`, which said "A guild integration was updated" and "A guild integration was deleted", respectively, which is the inverse of what they actually are.

Closes issue #2167.