### PR TITLE
docs(standby): timeout example

### DIFF
--- a/twilight-standby/README.md
+++ b/twilight-standby/README.md
@@ -34,6 +34,12 @@ The difference is that if you use the futures variant in a loop then you may
 miss some events while processing a received event. By using a stream, you
 won't miss any events.
 
+## Timeouts
+
+Timeouts on futures isn't directly provided by Standby. Futures can be timed out
+with support from crates such as [`tokio::time::timeout`]. An example of this is
+detailed on the [`Standby`] type.
+
 ## Examples
 
 ### At a glance
@@ -132,6 +138,7 @@ async fn react(msg: Message, standby: Arc<Standby>) -> anyhow::Result<()> {
 
 For more examples, check out each of the methods on [`Standby`].
 
+[`tokio::time::timeout`]: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html
 [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
 [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -91,6 +91,27 @@ impl<T: Debug> Debug for Bystander<T> {
 ///
 /// To use a Standby instance in multiple tasks, consider wrapping it in an
 /// [`std::sync::Arc`] or [`std::rc::Rc`].
+///
+/// # Examples
+///
+/// ## Timeouts
+///
+/// Futures can be timed out by passing the future returned by Standby to
+/// functions such as [`tokio::time::timeout`]:
+///
+/// ```rust,no_run
+/// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::time::Duration;
+/// use twilight_model::gateway::event::{Event, EventType};
+/// use twilight_standby::Standby;
+///
+/// let standby = Standby::new();
+/// let future = standby.wait_for_event(|event: &Event| event.kind() == EventType::Ready);
+/// let event = tokio::time::timeout(Duration::from_secs(1), future).await?;
+/// # Ok(()) }
+/// ```
+///
+/// [`tokio::time::timeout`]: https://docs.rs/tokio/latest/tokio/time/fn.timeout.html
 #[derive(Debug, Default)]
 pub struct Standby {
     /// List of component bystanders where the ID of the message is known


### PR DESCRIPTION
Document how to use timeouts with Standby futures by using functions such as `tokio::time::timeout`.

Documentation added after a support thread was received in our Discord server:
<https://discord.com/channels/745809834183753828/1083498439964368966>