### PR TITLE
feat(gateway): support overriding Config's intents & token

### DIFF
--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -255,7 +255,7 @@ impl ConfigBuilder {
     ///
     /// When reusing an existing config to share its TLS context, this allows
     /// for overriding shards' intents.
-    pub fn intents(mut self, intents: Intents) -> Self {
+    pub const fn intents(mut self, intents: Intents) -> Self {
         self.inner.intents = intents;
 
         self

--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -251,6 +251,16 @@ impl ConfigBuilder {
         self
     }
 
+    /// Override the intents to use when identifying with the gateway.
+    ///
+    /// When reusing an existing config to share its TLS context, this allows
+    /// for overriding shards' intents.
+    pub fn intents(mut self, intents: Intents) -> Self {
+        self.inner.intents = intents;
+
+        self
+    }
+
     /// Set the maximum number of members in a guild to load the member list.
     ///
     /// Default value is `50`. The minimum value is `50` and the maximum is
@@ -382,6 +392,20 @@ impl ConfigBuilder {
     #[allow(clippy::missing_const_for_fn)]
     pub fn session(mut self, session: Session) -> Self {
         self.inner.session = Some(session);
+
+        self
+    }
+
+    /// Override the token to use when identifying with the gateway.
+    ///
+    /// When reusing an existing config to share its TLS context, this allows
+    /// for overriding shards' intents.
+    pub fn token(mut self, mut token: String) -> Self {
+        if !token.starts_with("Bot ") {
+            token.insert_str(0, "Bot ");
+        }
+
+        self.inner.token = Token::new(token.into_boxed_str());
 
         self
     }


### PR DESCRIPTION
Reusing the TLS context can result in dramatically reduced memory usage when running multiple shards, unfortunately it requires cloning an existing `Config` (which can be quite awkward). This PR allows reusing the TLS context when running a different set of intents per shard and/or running multple set of shards (multiple bots).

In the future, it would be nice to figure out an API where the TLS context can be shared not only inside twilight-gateway but also with twilight-http and third-party users' TLS clients.