### PR TITLE
feat(cache_in_memory)!: In-memory cache with generic types

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ bot's token. You must also depend on `tokio`, `twilight-cache-inmemory`,
 
 ```rust,no_run
 use std::{env, error::Error, sync::Arc};
-use twilight_cache_inmemory::{InMemoryCache, ResourceType};
+use twilight_cache_inmemory::{DefaultInMemoryCache, ResourceType};
 use twilight_gateway::{Event, EventTypeFlags, Intents, Shard, ShardId, StreamExt as _};
 use twilight_http::Client as HttpClient;
 
@@ -142,7 +142,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Since we only care about new messages, make the cache only
     // cache new messages.
-    let cache = InMemoryCache::builder()
+    let cache = DefaultInMemoryCache::builder()
         .resource_types(ResourceType::MESSAGE)
         .build();
 

--- a/book/src/chapter_1_crates/section_4_cache_inmemory.md
+++ b/book/src/chapter_1_crates/section_4_cache_inmemory.md
@@ -12,14 +12,14 @@ Process new messages that come over a shard into the cache:
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 use std::env;
-use twilight_cache_inmemory::InMemoryCache;
+use twilight_cache_inmemory::DefaultInMemoryCache;
 use twilight_gateway::{EventTypeFlags, Intents, Shard, ShardId, StreamExt as _};
 
 let token = env::var("DISCORD_TOKEN")?;
 
 let mut shard = Shard::new(ShardId::ONE, token, Intents::GUILD_MESSAGES);
 
-let cache = InMemoryCache::new();
+let cache = DefaultInMemoryCache::new();
 
 while let Some(item) = shard.next_event(EventTypeFlags::all()).await {
     let Ok(event) = item else {

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -47,9 +47,8 @@ in from a channel:
 
 ```rust,no_run
 use std::{env, error::Error, sync::Arc};
-use twilight_cache_inmemory::{InMemoryCache, ResourceType};
+use twilight_cache_inmemory::{DefaultInMemoryCache, ResourceType};
 use twilight_gateway::{Event, EventTypeFlags, Intents, Shard, ShardId, StreamExt as _};
-
 use twilight_http::Client as HttpClient;
 
 #[tokio::main]
@@ -68,7 +67,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let http = Arc::new(HttpClient::new(token));
 
     // Since we only care about messages, make the cache only process messages.
-    let cache = InMemoryCache::builder()
+    let cache = DefaultInMemoryCache::builder()
         .resource_types(ResourceType::MESSAGE)
         .build();
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,11 +21,16 @@ serde_json = { version = "1" }
 tokio = { default-features = false, features = ["macros", "signal", "rt-multi-thread"], version = "1.0" }
 tracing = "0.1"
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log"], version = "0.3" }
+twilight-cache-inmemory = { path = "../twilight-cache-inmemory", features = ["permission-calculator"] }
 twilight-gateway = { path = "../twilight-gateway" }
 twilight-http = { path = "../twilight-http" }
 twilight-lavalink = { path = "../twilight-lavalink" }
 twilight-model = { path = "../twilight-model" }
 twilight-standby = { path = "../twilight-standby" }
+
+[[example]]
+name = "cache-optimization"
+path = "cache-optimization/main.rs"
 
 [[example]]
 name = "gateway-queue-http"

--- a/examples/cache-optimization/main.rs
+++ b/examples/cache-optimization/main.rs
@@ -1,0 +1,70 @@
+//! This example demonstrates the usage of [`InMemoryCache`] with custom cached
+//! types. The actual fields stored here are kept to a minimum for the sake of
+//! simplicity, in reality you may want to store a lot more information.
+
+use std::env;
+use twilight_gateway::{Event, EventTypeFlags, Intents, Shard, ShardId, StreamExt as _};
+use twilight_http::Client;
+
+mod models;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let event_types = EventTypeFlags::MESSAGE_CREATE
+        | EventTypeFlags::GUILD_CREATE
+        | EventTypeFlags::GUILD_UPDATE
+        | EventTypeFlags::GUILD_DELETE
+        | EventTypeFlags::MEMBER_ADD
+        | EventTypeFlags::MEMBER_REMOVE;
+
+    let mut shard = Shard::new(
+        ShardId::ONE,
+        env::var("DISCORD_TOKEN")?,
+        Intents::GUILDS
+            | Intents::GUILD_MEMBERS
+            | Intents::GUILD_MESSAGES
+            | Intents::MESSAGE_CONTENT,
+    );
+
+    let client = Client::new(env::var("DISCORD_TOKEN")?);
+
+    let cache = models::CustomInMemoryCache::new();
+
+    while let Some(item) = shard.next_event(event_types).await {
+        let Ok(event) = item else {
+            tracing::warn!(source = ?item.unwrap_err(), "error receiving event");
+
+            continue;
+        };
+
+        cache.update(&event);
+
+        if let Event::MessageCreate(msg) = event {
+            if !msg.content.starts_with("!guild-info") {
+                continue;
+            }
+
+            let Some(guild_id) = msg.guild_id else {
+                continue;
+            };
+
+            let Some(guild) = cache.guild(guild_id) else {
+                continue;
+            };
+
+            let text = format!(
+                "The owner of this server is <@{}>. The guild currently has {} members.",
+                guild.owner_id,
+                guild
+                    .member_count
+                    .map_or(String::from("N/A"), |c| c.to_string()),
+            );
+
+            client.create_message(msg.channel_id).content(&text).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/examples/cache-optimization/models/channel.rs
+++ b/examples/cache-optimization/models/channel.rs
@@ -1,0 +1,63 @@
+use twilight_cache_inmemory::CacheableChannel;
+use twilight_model::{
+    channel::{permission_overwrite::PermissionOverwrite, Channel, ChannelType},
+    id::{
+        marker::{ChannelMarker, GuildMarker},
+        Id,
+    },
+    util::Timestamp,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedChannel {
+    pub id: Id<ChannelMarker>,
+    pub guild_id: Option<Id<GuildMarker>>,
+    pub kind: ChannelType,
+    pub parent_id: Option<Id<ChannelMarker>>,
+}
+
+impl From<Channel> for MinimalCachedChannel {
+    fn from(channel: Channel) -> Self {
+        Self {
+            id: channel.id,
+            guild_id: channel.guild_id,
+            kind: channel.kind,
+            parent_id: channel.parent_id,
+        }
+    }
+}
+
+impl PartialEq<Channel> for MinimalCachedChannel {
+    fn eq(&self, other: &Channel) -> bool {
+        self.id == other.id
+            && self.guild_id == other.guild_id
+            && self.kind == other.kind
+            && self.parent_id == other.parent_id
+    }
+}
+
+impl CacheableChannel for MinimalCachedChannel {
+    fn guild_id(&self) -> Option<Id<GuildMarker>> {
+        self.guild_id
+    }
+
+    fn id(&self) -> Id<ChannelMarker> {
+        self.id
+    }
+
+    fn kind(&self) -> ChannelType {
+        self.kind
+    }
+
+    fn parent_id(&self) -> Option<Id<ChannelMarker>> {
+        self.parent_id
+    }
+
+    fn permission_overwrites(&self) -> Option<&[PermissionOverwrite]> {
+        None
+    }
+
+    fn set_last_pin_timestamp(&mut self, _timestamp: Option<Timestamp>) {
+        // We don't store this information, so this is a no-op
+    }
+}

--- a/examples/cache-optimization/models/current_user.rs
+++ b/examples/cache-optimization/models/current_user.rs
@@ -1,0 +1,28 @@
+use twilight_cache_inmemory::CacheableCurrentUser;
+use twilight_model::{
+    id::{marker::UserMarker, Id},
+    user::CurrentUser,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedCurrentUser {
+    pub id: Id<UserMarker>,
+}
+
+impl From<CurrentUser> for MinimalCachedCurrentUser {
+    fn from(value: CurrentUser) -> Self {
+        Self { id: value.id }
+    }
+}
+
+impl PartialEq<CurrentUser> for MinimalCachedCurrentUser {
+    fn eq(&self, other: &CurrentUser) -> bool {
+        self.id == other.id
+    }
+}
+
+impl CacheableCurrentUser for MinimalCachedCurrentUser {
+    fn id(&self) -> Id<UserMarker> {
+        self.id
+    }
+}

--- a/examples/cache-optimization/models/emoji.rs
+++ b/examples/cache-optimization/models/emoji.rs
@@ -1,0 +1,24 @@
+use twilight_cache_inmemory::CacheableEmoji;
+use twilight_model::{
+    guild::Emoji,
+    id::{marker::EmojiMarker, Id},
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedEmoji {
+    pub id: Id<EmojiMarker>,
+}
+
+impl From<Emoji> for MinimalCachedEmoji {
+    fn from(value: Emoji) -> Self {
+        Self { id: value.id }
+    }
+}
+
+impl PartialEq<Emoji> for MinimalCachedEmoji {
+    fn eq(&self, other: &Emoji) -> bool {
+        self.id == other.id
+    }
+}
+
+impl CacheableEmoji for MinimalCachedEmoji {}

--- a/examples/cache-optimization/models/guild.rs
+++ b/examples/cache-optimization/models/guild.rs
@@ -1,0 +1,66 @@
+use twilight_cache_inmemory::CacheableGuild;
+use twilight_model::{
+    gateway::payload::incoming::GuildUpdate,
+    guild::Guild,
+    id::{
+        marker::{GuildMarker, UserMarker},
+        Id,
+    },
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedGuild {
+    pub id: Id<GuildMarker>,
+    pub owner_id: Id<UserMarker>,
+    pub member_count: Option<u64>,
+}
+
+impl From<Guild> for MinimalCachedGuild {
+    fn from(guild: Guild) -> Self {
+        Self {
+            id: guild.id,
+            owner_id: guild.owner_id,
+            member_count: guild.member_count,
+        }
+    }
+}
+
+impl PartialEq<Guild> for MinimalCachedGuild {
+    fn eq(&self, other: &Guild) -> bool {
+        self.id == other.id
+            && self.owner_id == other.owner_id
+            && self.member_count == other.member_count
+    }
+}
+
+impl CacheableGuild for MinimalCachedGuild {
+    fn id(&self) -> Id<GuildMarker> {
+        self.id
+    }
+
+    fn owner_id(&self) -> Id<UserMarker> {
+        self.owner_id
+    }
+
+    fn set_unavailable(&mut self, _unavailable: bool) {
+        // We don't store this information, so this is a no-op
+    }
+
+    fn update_with_guild_update(&mut self, guild_update: &GuildUpdate) {
+        self.id = guild_update.id;
+        self.owner_id = guild_update.owner_id;
+        self.member_count = guild_update.member_count;
+    }
+
+    fn increase_member_count(&mut self, amount: u64) {
+        if let Some(count) = self.member_count.as_mut() {
+            *count += amount;
+        }
+    }
+
+    fn decrease_member_count(&mut self, amount: u64) {
+        if let Some(count) = self.member_count.as_mut() {
+            *count -= amount;
+        }
+    }
+}

--- a/examples/cache-optimization/models/guild_integration.rs
+++ b/examples/cache-optimization/models/guild_integration.rs
@@ -1,0 +1,24 @@
+use twilight_cache_inmemory::CacheableGuildIntegration;
+use twilight_model::{
+    guild::GuildIntegration,
+    id::{marker::IntegrationMarker, Id},
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedGuildIntegration {
+    pub id: Id<IntegrationMarker>,
+}
+
+impl From<GuildIntegration> for MinimalCachedGuildIntegration {
+    fn from(integration: GuildIntegration) -> Self {
+        Self { id: integration.id }
+    }
+}
+
+impl PartialEq<GuildIntegration> for MinimalCachedGuildIntegration {
+    fn eq(&self, other: &GuildIntegration) -> bool {
+        self.id == other.id
+    }
+}
+
+impl CacheableGuildIntegration for MinimalCachedGuildIntegration {}

--- a/examples/cache-optimization/models/member.rs
+++ b/examples/cache-optimization/models/member.rs
@@ -1,4 +1,4 @@
-use twilight_cache_inmemory::{model::ComputedInteractionMemberFields, CacheableMember};
+use twilight_cache_inmemory::{model::ComputedInteractionMember, CacheableMember};
 use twilight_model::{
     application::interaction::InteractionMember,
     gateway::payload::incoming::MemberUpdate,
@@ -37,23 +37,11 @@ impl From<(Id<UserMarker>, PartialMember)> for MinimalCachedMember {
     }
 }
 
-impl
-    From<(
-        Id<UserMarker>,
-        InteractionMember,
-        ComputedInteractionMemberFields,
-    )> for MinimalCachedMember
-{
-    fn from(
-        (user_id, member, _): (
-            Id<UserMarker>,
-            InteractionMember,
-            ComputedInteractionMemberFields,
-        ),
-    ) -> Self {
+impl From<ComputedInteractionMember> for MinimalCachedMember {
+    fn from(member: ComputedInteractionMember) -> Self {
         Self {
-            user_id,
-            roles: member.roles,
+            user_id: member.user_id,
+            roles: member.interaction_member.roles,
             avatar: member.avatar,
         }
     }
@@ -70,7 +58,7 @@ impl PartialEq<PartialMember> for MinimalCachedMember {
         other
             .user
             .as_ref()
-            .map_or(true, |user| user.id == self.user_id)
+            .map_or(false, |user| user.id == self.user_id)
             && self.roles == other.roles
             && self.avatar == other.avatar
     }

--- a/examples/cache-optimization/models/member.rs
+++ b/examples/cache-optimization/models/member.rs
@@ -1,0 +1,111 @@
+use twilight_cache_inmemory::{model::ComputedInteractionMemberFields, CacheableMember};
+use twilight_model::{
+    application::interaction::InteractionMember,
+    gateway::payload::incoming::MemberUpdate,
+    guild::{Member, PartialMember},
+    id::{
+        marker::{RoleMarker, UserMarker},
+        Id,
+    },
+    util::{ImageHash, Timestamp},
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedMember {
+    pub user_id: Id<UserMarker>,
+    pub roles: Vec<Id<RoleMarker>>,
+    pub avatar: Option<ImageHash>,
+}
+
+impl From<Member> for MinimalCachedMember {
+    fn from(member: Member) -> Self {
+        Self {
+            user_id: member.user.id,
+            roles: member.roles,
+            avatar: member.avatar,
+        }
+    }
+}
+
+impl From<(Id<UserMarker>, PartialMember)> for MinimalCachedMember {
+    fn from((user_id, member): (Id<UserMarker>, PartialMember)) -> Self {
+        Self {
+            user_id,
+            roles: member.roles,
+            avatar: member.avatar,
+        }
+    }
+}
+
+impl
+    From<(
+        Id<UserMarker>,
+        InteractionMember,
+        ComputedInteractionMemberFields,
+    )> for MinimalCachedMember
+{
+    fn from(
+        (user_id, member, _): (
+            Id<UserMarker>,
+            InteractionMember,
+            ComputedInteractionMemberFields,
+        ),
+    ) -> Self {
+        Self {
+            user_id,
+            roles: member.roles,
+            avatar: member.avatar,
+        }
+    }
+}
+
+impl PartialEq<Member> for MinimalCachedMember {
+    fn eq(&self, other: &Member) -> bool {
+        self.user_id == other.user.id && self.roles == other.roles && self.avatar == other.avatar
+    }
+}
+
+impl PartialEq<PartialMember> for MinimalCachedMember {
+    fn eq(&self, other: &PartialMember) -> bool {
+        other
+            .user
+            .as_ref()
+            .map_or(true, |user| user.id == self.user_id)
+            && self.roles == other.roles
+            && self.avatar == other.avatar
+    }
+}
+
+impl PartialEq<InteractionMember> for MinimalCachedMember {
+    fn eq(&self, other: &InteractionMember) -> bool {
+        self.roles == other.roles && self.avatar == other.avatar
+    }
+}
+
+impl CacheableMember for MinimalCachedMember {
+    fn avatar(&self) -> Option<ImageHash> {
+        self.avatar
+    }
+
+    fn communication_disabled_until(&self) -> Option<Timestamp> {
+        None
+    }
+
+    fn deaf(&self) -> Option<bool> {
+        None
+    }
+
+    fn mute(&self) -> Option<bool> {
+        None
+    }
+
+    fn roles(&self) -> &[Id<RoleMarker>] {
+        &self.roles
+    }
+
+    fn update_with_member_update(&mut self, member_update: &MemberUpdate) {
+        self.user_id = member_update.user.id;
+        self.roles = member_update.roles.clone();
+        self.avatar = member_update.avatar;
+    }
+}

--- a/examples/cache-optimization/models/message.rs
+++ b/examples/cache-optimization/models/message.rs
@@ -8,17 +8,21 @@ use twilight_model::{
 #[derive(Clone, Debug, PartialEq)]
 pub struct MinimalCachedMessage {
     pub id: Id<MessageMarker>,
+    pub content: String,
 }
 
 impl From<Message> for MinimalCachedMessage {
     fn from(message: Message) -> Self {
-        Self { id: message.id }
+        Self {
+            id: message.id,
+            content: message.content,
+        }
     }
 }
 
 impl PartialEq<Message> for MinimalCachedMessage {
     fn eq(&self, other: &Message) -> bool {
-        self.id == other.id
+        self.id == other.id && self.content == other.content
     }
 }
 
@@ -48,6 +52,8 @@ impl CacheableMessage for MinimalCachedMessage {
     }
 
     fn update_with_message_update(&mut self, message_update: &MessageUpdate) {
-        self.id = message_update.id;
+        if let Some(content) = &message_update.content {
+            self.content = content.clone();
+        }
     }
 }

--- a/examples/cache-optimization/models/message.rs
+++ b/examples/cache-optimization/models/message.rs
@@ -1,0 +1,53 @@
+use twilight_cache_inmemory::CacheableMessage;
+use twilight_model::{
+    channel::{message::Reaction, Message},
+    gateway::payload::incoming::MessageUpdate,
+    id::{marker::MessageMarker, Id},
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedMessage {
+    pub id: Id<MessageMarker>,
+}
+
+impl From<Message> for MinimalCachedMessage {
+    fn from(message: Message) -> Self {
+        Self { id: message.id }
+    }
+}
+
+impl PartialEq<Message> for MinimalCachedMessage {
+    fn eq(&self, other: &Message) -> bool {
+        self.id == other.id
+    }
+}
+
+impl CacheableMessage for MinimalCachedMessage {
+    fn add_reaction(&mut self, _reaction: Reaction) {
+        // No-op
+    }
+
+    fn clear_reactions(&mut self) {
+        // No-op
+    }
+
+    fn reactions(&self) -> &[Reaction] {
+        &[]
+    }
+
+    fn reactions_mut(&mut self) -> &mut [Reaction] {
+        &mut []
+    }
+
+    fn remove_reaction(&mut self, _idx: usize) {
+        // No-op
+    }
+
+    fn retain_reactions(&mut self, _f: impl FnMut(&Reaction) -> bool) {
+        // No-op
+    }
+
+    fn update_with_message_update(&mut self, message_update: &MessageUpdate) {
+        self.id = message_update.id;
+    }
+}

--- a/examples/cache-optimization/models/mod.rs
+++ b/examples/cache-optimization/models/mod.rs
@@ -17,9 +17,10 @@ pub mod sticker;
 pub mod user;
 pub mod voice_state;
 
-struct CustomInMemoryCache;
+#[derive(Clone, Debug)]
+pub struct CustomCacheModels;
 
-impl CacheableModels for CustomInMemoryCache {
+impl CacheableModels for CustomCacheModels {
     type Channel = channel::MinimalCachedChannel;
     type CurrentUser = current_user::MinimalCachedCurrentUser;
     type Emoji = emoji::MinimalCachedEmoji;
@@ -36,4 +37,4 @@ impl CacheableModels for CustomInMemoryCache {
 }
 
 /// Type alias for a cache that uses our custom cache types.
-pub type CustomInMemoryCache = InMemoryCache<CustomInMemoryCache>;
+pub type CustomInMemoryCache = InMemoryCache<CustomCacheModels>;

--- a/examples/cache-optimization/models/mod.rs
+++ b/examples/cache-optimization/models/mod.rs
@@ -1,5 +1,6 @@
 //! Type definitions and trait implementations for a custom in-memory cache
 //! that stores very little data about its entities.
+use twilight_cache_inmemory::CacheableModels;
 use twilight_cache_inmemory::InMemoryCache;
 
 pub mod channel;
@@ -16,19 +17,23 @@ pub mod sticker;
 pub mod user;
 pub mod voice_state;
 
+struct CustomInMemoryCache;
+
+impl CacheableModels for CustomInMemoryCache {
+    type Channel = channel::MinimalCachedChannel;
+    type CurrentUser = current_user::MinimalCachedCurrentUser;
+    type Emoji = emoji::MinimalCachedEmoji;
+    type Guild = guild::MinimalCachedGuild;
+    type GuildIntegration = guild_integration::MinimalCachedGuildIntegration;
+    type Member = member::MinimalCachedMember;
+    type Message = message::MinimalCachedMessage;
+    type Presence = presence::MinimalCachedPresence;
+    type Role = role::MinimalCachedRole;
+    type StageInstance = stage_instance::MinimalCachedStageInstance;
+    type Sticker = sticker::MinimalCachedSticker;
+    type User = user::MinimalCachedUser;
+    type VoiceState = voice_state::MinimalCachedVoiceState;
+}
+
 /// Type alias for a cache that uses our custom cache types.
-pub type CustomInMemoryCache = InMemoryCache<
-    channel::MinimalCachedChannel,
-    current_user::MinimalCachedCurrentUser,
-    emoji::MinimalCachedEmoji,
-    guild::MinimalCachedGuild,
-    guild_integration::MinimalCachedGuildIntegration,
-    member::MinimalCachedMember,
-    message::MinimalCachedMessage,
-    presence::MinimalCachedPresence,
-    role::MinimalCachedRole,
-    stage_instance::MinimalCachedStageInstance,
-    sticker::MinimalCachedSticker,
-    user::MinimalCachedUser,
-    voice_state::MinimalCachedVoiceState,
->;
+pub type CustomInMemoryCache = InMemoryCache<CustomInMemoryCache>;

--- a/examples/cache-optimization/models/mod.rs
+++ b/examples/cache-optimization/models/mod.rs
@@ -1,0 +1,34 @@
+//! Type definitions and trait implementations for a custom in-memory cache
+//! that stores very little data about its entities.
+use twilight_cache_inmemory::InMemoryCache;
+
+pub mod channel;
+pub mod current_user;
+pub mod emoji;
+pub mod guild;
+pub mod guild_integration;
+pub mod member;
+pub mod message;
+pub mod presence;
+pub mod role;
+pub mod stage_instance;
+pub mod sticker;
+pub mod user;
+pub mod voice_state;
+
+/// Type alias for a cache that uses our custom cache types.
+pub type CustomInMemoryCache = InMemoryCache<
+    channel::MinimalCachedChannel,
+    current_user::MinimalCachedCurrentUser,
+    emoji::MinimalCachedEmoji,
+    guild::MinimalCachedGuild,
+    guild_integration::MinimalCachedGuildIntegration,
+    member::MinimalCachedMember,
+    message::MinimalCachedMessage,
+    presence::MinimalCachedPresence,
+    role::MinimalCachedRole,
+    stage_instance::MinimalCachedStageInstance,
+    sticker::MinimalCachedSticker,
+    user::MinimalCachedUser,
+    voice_state::MinimalCachedVoiceState,
+>;

--- a/examples/cache-optimization/models/presence.rs
+++ b/examples/cache-optimization/models/presence.rs
@@ -1,0 +1,31 @@
+use twilight_cache_inmemory::CacheablePresence;
+use twilight_model::{
+    gateway::presence::Presence,
+    id::{
+        marker::{GuildMarker, UserMarker},
+        Id,
+    },
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedPresence {
+    pub guild_id: Id<GuildMarker>,
+    pub user_id: Id<UserMarker>,
+}
+
+impl From<Presence> for MinimalCachedPresence {
+    fn from(presence: Presence) -> Self {
+        Self {
+            guild_id: presence.guild_id,
+            user_id: presence.user.id(),
+        }
+    }
+}
+
+impl PartialEq<Presence> for MinimalCachedPresence {
+    fn eq(&self, other: &Presence) -> bool {
+        self.guild_id == other.guild_id && self.user_id == other.user.id()
+    }
+}
+
+impl CacheablePresence for MinimalCachedPresence {}

--- a/examples/cache-optimization/models/role.rs
+++ b/examples/cache-optimization/models/role.rs
@@ -1,0 +1,44 @@
+use twilight_cache_inmemory::CacheableRole;
+use twilight_model::{
+    guild::{Permissions, Role},
+    id::{marker::RoleMarker, Id},
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedRole {
+    pub id: Id<RoleMarker>,
+    pub permissions: Permissions,
+    pub position: i64,
+}
+
+impl From<Role> for MinimalCachedRole {
+    fn from(role: Role) -> Self {
+        Self {
+            id: role.id,
+            permissions: role.permissions,
+            position: role.position,
+        }
+    }
+}
+
+impl PartialEq<Role> for MinimalCachedRole {
+    fn eq(&self, other: &Role) -> bool {
+        self.id == other.id
+            && self.permissions == other.permissions
+            && self.position == other.position
+    }
+}
+
+impl CacheableRole for MinimalCachedRole {
+    fn id(&self) -> Id<RoleMarker> {
+        self.id
+    }
+
+    fn permissions(&self) -> Permissions {
+        self.permissions
+    }
+
+    fn position(&self) -> i64 {
+        self.position
+    }
+}

--- a/examples/cache-optimization/models/stage_instance.rs
+++ b/examples/cache-optimization/models/stage_instance.rs
@@ -1,0 +1,24 @@
+use twilight_cache_inmemory::CacheableStageInstance;
+use twilight_model::{
+    channel::StageInstance,
+    id::{marker::StageMarker, Id},
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedStageInstance {
+    pub id: Id<StageMarker>,
+}
+
+impl From<StageInstance> for MinimalCachedStageInstance {
+    fn from(stage: StageInstance) -> Self {
+        Self { id: stage.id }
+    }
+}
+
+impl PartialEq<StageInstance> for MinimalCachedStageInstance {
+    fn eq(&self, other: &StageInstance) -> bool {
+        self.id == other.id
+    }
+}
+
+impl CacheableStageInstance for MinimalCachedStageInstance {}

--- a/examples/cache-optimization/models/sticker.rs
+++ b/examples/cache-optimization/models/sticker.rs
@@ -1,0 +1,28 @@
+use twilight_cache_inmemory::CacheableSticker;
+use twilight_model::{
+    channel::message::Sticker,
+    id::{marker::StickerMarker, Id},
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedSticker {
+    pub id: Id<StickerMarker>,
+}
+
+impl From<Sticker> for MinimalCachedSticker {
+    fn from(sticker: Sticker) -> Self {
+        Self { id: sticker.id }
+    }
+}
+
+impl PartialEq<Sticker> for MinimalCachedSticker {
+    fn eq(&self, other: &Sticker) -> bool {
+        self.id == other.id
+    }
+}
+
+impl CacheableSticker for MinimalCachedSticker {
+    fn id(&self) -> Id<StickerMarker> {
+        self.id
+    }
+}

--- a/examples/cache-optimization/models/user.rs
+++ b/examples/cache-optimization/models/user.rs
@@ -1,0 +1,24 @@
+use twilight_cache_inmemory::CacheableUser;
+use twilight_model::{
+    id::{marker::UserMarker, Id},
+    user::User,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedUser {
+    pub id: Id<UserMarker>,
+}
+
+impl From<User> for MinimalCachedUser {
+    fn from(user: User) -> Self {
+        Self { id: user.id }
+    }
+}
+
+impl PartialEq<User> for MinimalCachedUser {
+    fn eq(&self, other: &User) -> bool {
+        self.id == other.id
+    }
+}
+
+impl CacheableUser for MinimalCachedUser {}

--- a/examples/cache-optimization/models/voice_state.rs
+++ b/examples/cache-optimization/models/voice_state.rs
@@ -1,0 +1,33 @@
+use twilight_cache_inmemory::CacheableVoiceState;
+use twilight_model::{
+    id::{
+        marker::{ChannelMarker, GuildMarker},
+        Id,
+    },
+    voice::VoiceState,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MinimalCachedVoiceState {
+    pub channel_id: Id<ChannelMarker>,
+}
+
+impl From<(Id<ChannelMarker>, Id<GuildMarker>, VoiceState)> for MinimalCachedVoiceState {
+    fn from((channel_id, _, _): (Id<ChannelMarker>, Id<GuildMarker>, VoiceState)) -> Self {
+        Self { channel_id }
+    }
+}
+
+impl PartialEq<VoiceState> for MinimalCachedVoiceState {
+    fn eq(&self, other: &VoiceState) -> bool {
+        other
+            .channel_id
+            .map_or(false, |channel_id| channel_id == self.channel_id)
+    }
+}
+
+impl CacheableVoiceState for MinimalCachedVoiceState {
+    fn channel_id(&self) -> Id<ChannelMarker> {
+        self.channel_id
+    }
+}

--- a/twilight-cache-inmemory/README.md
+++ b/twilight-cache-inmemory/README.md
@@ -34,7 +34,7 @@ Update a cache with events that come in through the gateway:
 
 ```rust,no_run
 use std::{env, error::Error};
-use twilight_cache_inmemory::InMemoryCache;
+use twilight_cache_inmemory::DefaultInMemoryCache;
 use twilight_gateway::{EventTypeFlags, Intents, Shard, ShardId, StreamExt as _};
 
 #[tokio::main]
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut shard = Shard::new(ShardId::ONE, token, Intents::GUILD_MESSAGES);
 
     // Create a cache, caching up to 10 messages per channel:
-    let cache = InMemoryCache::builder().message_cache_size(10).build();
+    let cache = DefaultInMemoryCache::builder().message_cache_size(10).build();
 
     while let Some(item) = shard.next_event(EventTypeFlags::all()).await {
         let Ok(event) = item else {

--- a/twilight-cache-inmemory/src/builder.rs
+++ b/twilight-cache-inmemory/src/builder.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use crate::CacheableModels;
+use crate::{CacheableModels, DefaultCacheModels};
 
 use super::{
     config::{Config, ResourceType},
@@ -12,7 +12,10 @@ use super::{
 #[allow(clippy::type_complexity)]
 #[must_use = "has no effect if not built"]
 #[derive(Debug)]
-pub struct InMemoryCacheBuilder<CacheModels: CacheableModels>(Config, PhantomData<CacheModels>);
+pub struct InMemoryCacheBuilder<CacheModels: CacheableModels = DefaultCacheModels>(
+    Config,
+    PhantomData<CacheModels>,
+);
 
 impl<CacheModels: CacheableModels> InMemoryCacheBuilder<CacheModels> {
     /// Creates a builder to configure and construct an [`InMemoryCache`].

--- a/twilight-cache-inmemory/src/builder.rs
+++ b/twilight-cache-inmemory/src/builder.rs
@@ -1,17 +1,7 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use twilight_model::{
-    channel::{Channel, StageInstance},
-    guild::{GuildIntegration, Role},
-    user::{CurrentUser, User},
-};
-
-use crate::{
-    model, CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-    CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence, CacheableRole,
-    CacheableStageInstance, CacheableSticker, CacheableUser, CacheableVoiceState,
-};
+use crate::CacheableModels;
 
 use super::{
     config::{Config, ResourceType},
@@ -22,70 +12,9 @@ use super::{
 #[allow(clippy::type_complexity)]
 #[must_use = "has no effect if not built"]
 #[derive(Debug)]
-pub struct InMemoryCacheBuilder<
-    CachedChannel: CacheableChannel = Channel,
-    CachedCurrentUser: CacheableCurrentUser = CurrentUser,
-    CachedEmoji: CacheableEmoji = model::CachedEmoji,
-    CachedGuild: CacheableGuild = model::CachedGuild,
-    CachedGuildIntegration: CacheableGuildIntegration = GuildIntegration,
-    CachedMember: CacheableMember = model::CachedMember,
-    CachedMessage: CacheableMessage = model::CachedMessage,
-    CachedPresence: CacheablePresence = model::CachedPresence,
-    CachedRole: CacheableRole = Role,
-    CachedStageInstance: CacheableStageInstance = StageInstance,
-    CachedSticker: CacheableSticker = model::CachedSticker,
-    CachedUser: CacheableUser = User,
-    CachedVoiceState: CacheableVoiceState = model::CachedVoiceState,
->(
-    Config,
-    PhantomData<(
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    )>,
-);
+pub struct InMemoryCacheBuilder<CacheModels: CacheableModels>(Config, PhantomData<CacheModels>);
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    InMemoryCacheBuilder<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >
-{
+impl<CacheModels: CacheableModels> InMemoryCacheBuilder<CacheModels> {
     /// Creates a builder to configure and construct an [`InMemoryCache`].
     pub const fn new() -> Self {
         Self(Config::new(), PhantomData)
@@ -93,23 +22,7 @@ impl<
 
     /// Consume the builder, returning a configured cache.
     #[allow(clippy::type_complexity)]
-    pub fn build(
-        self,
-    ) -> InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > {
+    pub fn build(self) -> InMemoryCache<CacheModels> {
         InMemoryCache::new_with_config(self.0)
     }
 
@@ -132,37 +45,7 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    > Default
-    for InMemoryCacheBuilder<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >
-{
+impl<CacheModels: CacheableModels> Default for InMemoryCacheBuilder<CacheModels> {
     fn default() -> Self {
         Self(Config::default(), PhantomData)
     }

--- a/twilight-cache-inmemory/src/builder.rs
+++ b/twilight-cache-inmemory/src/builder.rs
@@ -1,21 +1,115 @@
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use twilight_model::{
+    channel::{Channel, StageInstance},
+    guild::{GuildIntegration, Role},
+    user::{CurrentUser, User},
+};
+
+use crate::{
+    model, CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+    CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence, CacheableRole,
+    CacheableStageInstance, CacheableSticker, CacheableUser, CacheableVoiceState,
+};
+
 use super::{
     config::{Config, ResourceType},
     InMemoryCache,
 };
 
 /// Builder to configure and construct an [`InMemoryCache`].
-#[derive(Debug, Default)]
+#[allow(clippy::type_complexity)]
 #[must_use = "has no effect if not built"]
-pub struct InMemoryCacheBuilder(Config);
+#[derive(Debug)]
+pub struct InMemoryCacheBuilder<
+    CachedChannel: CacheableChannel = Channel,
+    CachedCurrentUser: CacheableCurrentUser = CurrentUser,
+    CachedEmoji: CacheableEmoji = model::CachedEmoji,
+    CachedGuild: CacheableGuild = model::CachedGuild,
+    CachedGuildIntegration: CacheableGuildIntegration = GuildIntegration,
+    CachedMember: CacheableMember = model::CachedMember,
+    CachedMessage: CacheableMessage = model::CachedMessage,
+    CachedPresence: CacheablePresence = model::CachedPresence,
+    CachedRole: CacheableRole = Role,
+    CachedStageInstance: CacheableStageInstance = StageInstance,
+    CachedSticker: CacheableSticker = model::CachedSticker,
+    CachedUser: CacheableUser = User,
+    CachedVoiceState: CacheableVoiceState = model::CachedVoiceState,
+>(
+    Config,
+    PhantomData<(
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    )>,
+);
 
-impl InMemoryCacheBuilder {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCacheBuilder<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     /// Creates a builder to configure and construct an [`InMemoryCache`].
     pub const fn new() -> Self {
-        Self(Config::new())
+        Self(Config::new(), PhantomData)
     }
 
     /// Consume the builder, returning a configured cache.
-    pub fn build(self) -> InMemoryCache {
+    #[allow(clippy::type_complexity)]
+    pub fn build(
+        self,
+    ) -> InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > {
         InMemoryCache::new_with_config(self.0)
     }
 
@@ -35,6 +129,42 @@ impl InMemoryCacheBuilder {
         self.0.message_cache_size = message_cache_size;
 
         self
+    }
+}
+
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    > Default
+    for InMemoryCacheBuilder<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
+    fn default() -> Self {
+        Self(Config::default(), PhantomData)
     }
 }
 

--- a/twilight-cache-inmemory/src/event/channel.rs
+++ b/twilight-cache-inmemory/src/event/channel.rs
@@ -1,11 +1,49 @@
-use crate::{config::ResourceType, InMemoryCache, UpdateCache};
+use crate::{
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
+    InMemoryCache, ResourceType, UpdateCache,
+};
 use twilight_model::{
     channel::Channel,
     gateway::payload::incoming::{ChannelCreate, ChannelDelete, ChannelPinsUpdate, ChannelUpdate},
     id::{marker::ChannelMarker, Id},
 };
 
-impl InMemoryCache {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     pub(crate) fn cache_channels(&self, channels: impl IntoIterator<Item = Channel>) {
         for channel in channels {
             self.cache_channel(channel);
@@ -20,7 +58,8 @@ impl InMemoryCache {
                 .insert(channel.id);
         }
 
-        self.channels.insert(channel.id, channel);
+        self.channels
+            .insert(channel.id, CachedChannel::from(channel));
     }
 
     /// Delete a guild channel from the cache.
@@ -29,7 +68,7 @@ impl InMemoryCache {
     /// of channels will be deleted.
     pub(crate) fn delete_channel(&self, channel_id: Id<ChannelMarker>) {
         if let Some((_, channel)) = self.channels.remove(&channel_id) {
-            if let Some(guild_id) = channel.guild_id {
+            if let Some(guild_id) = channel.guild_id() {
                 let maybe_channels = self.guild_channels.get_mut(&guild_id);
 
                 if let Some(mut channels) = maybe_channels {
@@ -40,8 +79,55 @@ impl InMemoryCache {
     }
 }
 
-impl UpdateCache for ChannelCreate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for ChannelCreate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
@@ -50,8 +136,55 @@ impl UpdateCache for ChannelCreate {
     }
 }
 
-impl UpdateCache for ChannelDelete {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for ChannelDelete
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
@@ -60,20 +193,114 @@ impl UpdateCache for ChannelDelete {
     }
 }
 
-impl UpdateCache for ChannelPinsUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for ChannelPinsUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
 
         if let Some(mut channel) = cache.channels.get_mut(&self.channel_id) {
-            channel.last_pin_timestamp = self.last_pin_timestamp;
+            channel.set_last_pin_timestamp(self.last_pin_timestamp);
         }
     }
 }
 
-impl UpdateCache for ChannelUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for ChannelUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
@@ -84,7 +311,7 @@ impl UpdateCache for ChannelUpdate {
 
 #[cfg(test)]
 mod tests {
-    use crate::{test, InMemoryCache};
+    use crate::{test, DefaultInMemoryCache};
     use twilight_model::gateway::{
         event::Event,
         payload::incoming::{ChannelDelete, ChannelUpdate},
@@ -92,7 +319,7 @@ mod tests {
 
     #[test]
     fn channel_delete_guild() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         let (guild_id, channel_id, channel) = test::guild_channel_text();
 
         cache.cache_channel(channel.clone());
@@ -110,7 +337,7 @@ mod tests {
 
     #[test]
     fn channel_update_guild() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         let (guild_id, channel_id, channel) = test::guild_channel_text();
 
         cache.update(&ChannelUpdate(channel));

--- a/twilight-cache-inmemory/src/event/channel.rs
+++ b/twilight-cache-inmemory/src/event/channel.rs
@@ -1,49 +1,11 @@
-use crate::{
-    traits::{
-        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
-        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
-        CacheableVoiceState,
-    },
-    InMemoryCache, ResourceType, UpdateCache,
-};
+use crate::{traits::CacheableChannel, CacheableModels, InMemoryCache, ResourceType, UpdateCache};
 use twilight_model::{
     channel::Channel,
     gateway::payload::incoming::{ChannelCreate, ChannelDelete, ChannelPinsUpdate, ChannelUpdate},
     id::{marker::ChannelMarker, Id},
 };
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >
-{
+impl<CacheModels: CacheableModels> InMemoryCache<CacheModels> {
     pub(crate) fn cache_channels(&self, channels: impl IntoIterator<Item = Channel>) {
         for channel in channels {
             self.cache_channel(channel);
@@ -59,7 +21,7 @@ impl<
         }
 
         self.channels
-            .insert(channel.id, CachedChannel::from(channel));
+            .insert(channel.id, CacheModels::Channel::from(channel));
     }
 
     /// Delete a guild channel from the cache.
@@ -79,55 +41,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for ChannelCreate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ChannelCreate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
@@ -136,55 +51,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for ChannelDelete
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ChannelDelete {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
@@ -193,55 +61,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for ChannelPinsUpdate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ChannelPinsUpdate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
@@ -252,55 +73,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for ChannelUpdate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ChannelUpdate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/emoji.rs
+++ b/twilight-cache-inmemory/src/event/emoji.rs
@@ -1,9 +1,4 @@
-use crate::{
-    config::ResourceType, CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-    CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence, CacheableRole,
-    CacheableStageInstance, CacheableSticker, CacheableUser, CacheableVoiceState, GuildResource,
-    InMemoryCache, UpdateCache,
-};
+use crate::{config::ResourceType, CacheableModels, GuildResource, InMemoryCache, UpdateCache};
 use std::borrow::Cow;
 use twilight_model::{
     gateway::payload::incoming::GuildEmojisUpdate,
@@ -11,37 +6,7 @@ use twilight_model::{
     id::{marker::GuildMarker, Id},
 };
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >
-{
+impl<CacheModels: CacheableModels> InMemoryCache<CacheModels> {
     pub(crate) fn cache_emojis(&self, guild_id: Id<GuildMarker>, emojis: Vec<Emoji>) {
         if let Some(mut guild_emojis) = self.guild_emojis.get_mut(&guild_id) {
             let incoming: Vec<_> = emojis.iter().map(|e| e.id).collect();
@@ -78,7 +43,7 @@ impl<
         }
 
         let emoji_id = emoji.id;
-        let cached = CachedEmoji::from(emoji);
+        let cached = CacheModels::Emoji::from(emoji);
 
         self.emojis.insert(
             emoji_id,
@@ -95,55 +60,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for GuildEmojisUpdate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for GuildEmojisUpdate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::EMOJI) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/emoji.rs
+++ b/twilight-cache-inmemory/src/event/emoji.rs
@@ -1,4 +1,9 @@
-use crate::{config::ResourceType, model::CachedEmoji, GuildResource, InMemoryCache, UpdateCache};
+use crate::{
+    config::ResourceType, CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+    CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence, CacheableRole,
+    CacheableStageInstance, CacheableSticker, CacheableUser, CacheableVoiceState, GuildResource,
+    InMemoryCache, UpdateCache,
+};
 use std::borrow::Cow;
 use twilight_model::{
     gateway::payload::incoming::GuildEmojisUpdate,
@@ -6,7 +11,37 @@ use twilight_model::{
     id::{marker::GuildMarker, Id},
 };
 
-impl InMemoryCache {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     pub(crate) fn cache_emojis(&self, guild_id: Id<GuildMarker>, emojis: Vec<Emoji>) {
         if let Some(mut guild_emojis) = self.guild_emojis.get_mut(&guild_id) {
             let incoming: Vec<_> = emojis.iter().map(|e| e.id).collect();
@@ -43,7 +78,7 @@ impl InMemoryCache {
         }
 
         let emoji_id = emoji.id;
-        let cached = CachedEmoji::from_model(emoji);
+        let cached = CachedEmoji::from(emoji);
 
         self.emojis.insert(
             emoji_id,
@@ -60,8 +95,55 @@ impl InMemoryCache {
     }
 }
 
-impl UpdateCache for GuildEmojisUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for GuildEmojisUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::EMOJI) {
             return;
         }
@@ -72,7 +154,7 @@ impl UpdateCache for GuildEmojisUpdate {
 
 #[cfg(test)]
 mod tests {
-    use crate::{test, InMemoryCache};
+    use crate::{test, DefaultInMemoryCache};
     use twilight_model::{
         gateway::payload::incoming::GuildEmojisUpdate,
         id::{marker::EmojiMarker, Id},
@@ -91,7 +173,7 @@ mod tests {
             }
         }
 
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
 
         // Single inserts
         {
@@ -147,7 +229,7 @@ mod tests {
 
     #[test]
     fn emoji_removal() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
 
         let guild_id = Id::new(1);
 

--- a/twilight-cache-inmemory/src/event/guild.rs
+++ b/twilight-cache-inmemory/src/event/guild.rs
@@ -1,9 +1,4 @@
-use crate::{
-    config::ResourceType, CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-    CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence, CacheableRole,
-    CacheableStageInstance, CacheableSticker, CacheableUser, CacheableVoiceState, InMemoryCache,
-    UpdateCache,
-};
+use crate::{config::ResourceType, CacheableGuild, CacheableModels, InMemoryCache, UpdateCache};
 use dashmap::DashMap;
 use std::{collections::HashSet, hash::Hash, mem};
 use twilight_model::{
@@ -12,37 +7,7 @@ use twilight_model::{
     id::{marker::GuildMarker, Id},
 };
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >
-{
+impl<CacheModels: CacheableModels> InMemoryCache<CacheModels> {
     #[allow(clippy::too_many_lines)]
     fn cache_guild(&self, mut guild: Guild) {
         // The map and set creation needs to occur first, so caching states and
@@ -101,7 +66,7 @@ impl<
         }
 
         if self.wants(ResourceType::GUILD) {
-            let guild = CachedGuild::from(guild);
+            let guild = CacheModels::Guild::from(guild);
             self.unavailable_guilds.remove(&guild.id());
             self.guilds.insert(guild.id(), guild);
         }
@@ -169,161 +134,20 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for GuildCreate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for GuildCreate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         cache.cache_guild(self.0.clone());
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for GuildDelete
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for GuildDelete {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         cache.delete_guild(self.id, false);
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for GuildUpdate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for GuildUpdate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::GUILD) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/guild.rs
+++ b/twilight-cache-inmemory/src/event/guild.rs
@@ -1,85 +1,64 @@
 use crate::{
-    config::ResourceType,
-    model::{CachedGuild, CachedPresence},
-    InMemoryCache, UpdateCache,
+    config::ResourceType, CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+    CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence, CacheableRole,
+    CacheableStageInstance, CacheableSticker, CacheableUser, CacheableVoiceState, InMemoryCache,
+    UpdateCache,
 };
 use dashmap::DashMap;
-use std::{collections::HashSet, hash::Hash};
+use std::{collections::HashSet, hash::Hash, mem};
 use twilight_model::{
     gateway::payload::incoming::{GuildCreate, GuildDelete, GuildUpdate},
     guild::Guild,
     id::{marker::GuildMarker, Id},
 };
 
-impl InMemoryCache {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     #[allow(clippy::too_many_lines)]
-    fn cache_guild(&self, guild: Guild) {
-        let Guild {
-            afk_channel_id,
-            afk_timeout,
-            application_id,
-            approximate_member_count: _,
-            approximate_presence_count: _,
-            banner,
-            channels,
-            default_message_notifications,
-            description,
-            discovery_splash,
-            emojis,
-            explicit_content_filter,
-            features,
-            icon,
-            id,
-            joined_at,
-            large,
-            max_members,
-            max_presences,
-            max_video_channel_users,
-            member_count,
-            members,
-            mfa_level,
-            name,
-            nsfw_level,
-            owner_id,
-            owner,
-            permissions,
-            preferred_locale,
-            premium_progress_bar_enabled,
-            premium_subscription_count,
-            premium_tier,
-            presences,
-            public_updates_channel_id,
-            roles,
-            rules_channel_id,
-            safety_alerts_channel_id,
-            splash,
-            stage_instances,
-            stickers,
-            system_channel_flags,
-            system_channel_id,
-            threads,
-            unavailable,
-            vanity_url_code,
-            verification_level,
-            voice_states,
-            widget_channel_id,
-            widget_enabled,
-        } = guild;
-
+    fn cache_guild(&self, mut guild: Guild) {
         // The map and set creation needs to occur first, so caching states and
         // objects always has a place to put them.
         if self.wants(ResourceType::CHANNEL) {
-            self.guild_channels.insert(id, HashSet::new());
+            self.guild_channels.insert(guild.id, HashSet::new());
 
-            let mut channels = channels;
-            let mut threads = threads;
+            let mut channels = mem::take(&mut guild.channels);
+            let mut threads = mem::take(&mut guild.threads);
 
             for channel in &mut channels {
-                channel.guild_id = Some(id);
+                channel.guild_id = Some(guild.id);
             }
 
             for channel in &mut threads {
-                channel.guild_id = Some(id);
+                channel.guild_id = Some(guild.id);
             }
 
             self.cache_channels(channels);
@@ -87,82 +66,42 @@ impl InMemoryCache {
         }
 
         if self.wants(ResourceType::EMOJI) {
-            self.guild_emojis.insert(id, HashSet::new());
-            self.cache_emojis(id, emojis);
+            self.guild_emojis.insert(guild.id, HashSet::new());
+            self.cache_emojis(guild.id, mem::take(&mut guild.emojis));
         }
 
         if self.wants(ResourceType::MEMBER) {
-            self.guild_members.insert(id, HashSet::new());
-            self.cache_members(id, members);
+            self.guild_members.insert(guild.id, HashSet::new());
+            self.cache_members(guild.id, mem::take(&mut guild.members));
         }
 
         if self.wants(ResourceType::PRESENCE) {
-            self.guild_presences.insert(id, HashSet::new());
-            self.cache_presences(id, presences.into_iter().map(CachedPresence::from));
+            self.guild_presences.insert(guild.id, HashSet::new());
+            self.cache_presences(guild.id, mem::take(&mut guild.presences));
         }
 
         if self.wants(ResourceType::ROLE) {
-            self.guild_roles.insert(id, HashSet::new());
-            self.cache_roles(id, roles);
+            self.guild_roles.insert(guild.id, HashSet::new());
+            self.cache_roles(guild.id, mem::take(&mut guild.roles));
         }
 
         if self.wants(ResourceType::STICKER) {
-            self.guild_stage_instances.insert(id, HashSet::new());
-            self.cache_stickers(id, stickers);
+            self.guild_stage_instances.insert(guild.id, HashSet::new());
+            self.cache_stickers(guild.id, mem::take(&mut guild.stickers));
         }
 
         if self.wants(ResourceType::VOICE_STATE) {
-            self.voice_state_guilds.insert(id, HashSet::new());
-            self.cache_voice_states(voice_states);
+            self.voice_state_guilds.insert(guild.id, HashSet::new());
+            self.cache_voice_states(mem::take(&mut guild.voice_states));
         }
 
         if self.wants(ResourceType::STAGE_INSTANCE) {
-            self.guild_stage_instances.insert(id, HashSet::new());
-            self.cache_stage_instances(id, stage_instances);
+            self.guild_stage_instances.insert(guild.id, HashSet::new());
+            self.cache_stage_instances(guild.id, mem::take(&mut guild.stage_instances));
         }
 
         if self.wants(ResourceType::GUILD) {
-            let guild = CachedGuild {
-                afk_channel_id,
-                afk_timeout,
-                application_id,
-                banner,
-                default_message_notifications,
-                description,
-                discovery_splash,
-                explicit_content_filter,
-                features,
-                icon,
-                id,
-                joined_at,
-                large,
-                max_members,
-                max_presences,
-                max_video_channel_users,
-                member_count,
-                mfa_level,
-                name,
-                nsfw_level,
-                owner_id,
-                owner,
-                permissions,
-                preferred_locale,
-                premium_progress_bar_enabled,
-                premium_subscription_count,
-                premium_tier,
-                public_updates_channel_id,
-                rules_channel_id,
-                safety_alerts_channel_id,
-                splash,
-                system_channel_id,
-                system_channel_flags,
-                unavailable,
-                vanity_url_code,
-                verification_level,
-                widget_channel_id,
-                widget_enabled,
-            };
-
+            let guild = CachedGuild::from(guild);
             self.unavailable_guilds.remove(&guild.id());
             self.guilds.insert(guild.id(), guild);
         }
@@ -184,7 +123,7 @@ impl InMemoryCache {
         if self.wants(ResourceType::GUILD) {
             if unavailable {
                 if let Some(mut guild) = self.guilds.get_mut(&id) {
-                    guild.unavailable = true;
+                    guild.set_unavailable(true);
                 }
             } else {
                 self.guilds.remove(&id);
@@ -230,58 +169,174 @@ impl InMemoryCache {
     }
 }
 
-impl UpdateCache for GuildCreate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for GuildCreate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         cache.cache_guild(self.0.clone());
     }
 }
 
-impl UpdateCache for GuildDelete {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for GuildDelete
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         cache.delete_guild(self.id, false);
     }
 }
 
-impl UpdateCache for GuildUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for GuildUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::GUILD) {
             return;
         }
 
         if let Some(mut guild) = cache.guilds.get_mut(&self.0.id) {
-            guild.afk_channel_id = self.afk_channel_id;
-            guild.afk_timeout = self.afk_timeout;
-            guild.banner = self.banner;
-            guild.default_message_notifications = self.default_message_notifications;
-            guild.description = self.description.clone();
-            guild.features = self.features.clone();
-            guild.icon = self.icon;
-            guild.max_members = self.max_members;
-            guild.max_presences = Some(self.max_presences.unwrap_or(25000));
-            guild.mfa_level = self.mfa_level;
-            guild.name = self.name.clone();
-            guild.nsfw_level = self.nsfw_level;
-            guild.owner = self.owner;
-            guild.owner_id = self.owner_id;
-            guild.permissions = self.permissions;
-            guild.preferred_locale = self.preferred_locale.clone();
-            guild.premium_tier = self.premium_tier;
-            guild
-                .premium_subscription_count
-                .replace(self.premium_subscription_count.unwrap_or_default());
-            guild.splash = self.splash;
-            guild.system_channel_id = self.system_channel_id;
-            guild.verification_level = self.verification_level;
-            guild.vanity_url_code = self.vanity_url_code.clone();
-            guild.widget_channel_id = self.widget_channel_id;
-            guild.widget_enabled = self.widget_enabled;
+            guild.update_with_guild_update(self);
         };
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{test, InMemoryCache};
+    use crate::{test, DefaultInMemoryCache};
     use std::str::FromStr;
     use twilight_model::{
         channel::{
@@ -449,7 +504,7 @@ mod tests {
             widget_enabled: None,
         };
 
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         cache.cache_guild(guild);
 
         let channel = cache.channel(Id::new(111)).unwrap();
@@ -468,7 +523,7 @@ mod tests {
 
     #[test]
     fn guild_update() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         let guild = test::guild(Id::new(1), None);
 
         cache.update(&GuildCreate(guild.clone()));
@@ -522,7 +577,7 @@ mod tests {
     fn guild_member_count() {
         let user_id = Id::new(2);
         let guild_id = Id::new(1);
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         let user = test::user(user_id);
         let member = test::member(user_id);
         let guild = test::guild(guild_id, Some(1));
@@ -541,7 +596,7 @@ mod tests {
     fn guild_members_size_after_unavailable() {
         let user_id = Id::new(2);
         let guild_id = Id::new(1);
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         let member = test::member(user_id);
         let mut guild = test::guild(guild_id, Some(1));
         guild.members.push(member);

--- a/twilight-cache-inmemory/src/event/integration.rs
+++ b/twilight-cache-inmemory/src/event/integration.rs
@@ -1,4 +1,13 @@
-use crate::{config::ResourceType, InMemoryCache, UpdateCache};
+use crate::{
+    config::ResourceType,
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
+    InMemoryCache, UpdateCache,
+};
 use twilight_model::{
     gateway::payload::incoming::{IntegrationCreate, IntegrationDelete, IntegrationUpdate},
     guild::GuildIntegration,
@@ -8,7 +17,37 @@ use twilight_model::{
     },
 };
 
-impl InMemoryCache {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     fn cache_integration(&self, guild_id: Id<GuildMarker>, integration: GuildIntegration) {
         self.guild_integrations
             .entry(guild_id)
@@ -19,7 +58,7 @@ impl InMemoryCache {
             &self.integrations,
             guild_id,
             (guild_id, integration.id),
-            integration,
+            CachedGuildIntegration::from(integration),
         );
     }
 
@@ -36,8 +75,55 @@ impl InMemoryCache {
     }
 }
 
-impl UpdateCache for IntegrationCreate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for IntegrationCreate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::INTEGRATION) {
             return;
         }
@@ -47,14 +133,61 @@ impl UpdateCache for IntegrationCreate {
                 &cache.integrations,
                 guild_id,
                 (guild_id, self.id),
-                self.0.clone(),
+                CachedGuildIntegration::from(self.0.clone()),
             );
         }
     }
 }
 
-impl UpdateCache for IntegrationDelete {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for IntegrationDelete
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::INTEGRATION) {
             return;
         }
@@ -63,8 +196,55 @@ impl UpdateCache for IntegrationDelete {
     }
 }
 
-impl UpdateCache for IntegrationUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for IntegrationUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::INTEGRATION) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/integration.rs
+++ b/twilight-cache-inmemory/src/event/integration.rs
@@ -1,13 +1,4 @@
-use crate::{
-    config::ResourceType,
-    traits::{
-        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
-        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
-        CacheableVoiceState,
-    },
-    InMemoryCache, UpdateCache,
-};
+use crate::{config::ResourceType, CacheableModels, InMemoryCache, UpdateCache};
 use twilight_model::{
     gateway::payload::incoming::{IntegrationCreate, IntegrationDelete, IntegrationUpdate},
     guild::GuildIntegration,
@@ -17,37 +8,7 @@ use twilight_model::{
     },
 };
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >
-{
+impl<CacheModels: CacheableModels> InMemoryCache<CacheModels> {
     fn cache_integration(&self, guild_id: Id<GuildMarker>, integration: GuildIntegration) {
         self.guild_integrations
             .entry(guild_id)
@@ -58,7 +19,7 @@ impl<
             &self.integrations,
             guild_id,
             (guild_id, integration.id),
-            CachedGuildIntegration::from(integration),
+            CacheModels::GuildIntegration::from(integration),
         );
     }
 
@@ -75,55 +36,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for IntegrationCreate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for IntegrationCreate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::INTEGRATION) {
             return;
         }
@@ -133,61 +47,14 @@ impl<
                 &cache.integrations,
                 guild_id,
                 (guild_id, self.id),
-                CachedGuildIntegration::from(self.0.clone()),
+                CacheModels::GuildIntegration::from(self.0.clone()),
             );
         }
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for IntegrationDelete
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for IntegrationDelete {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::INTEGRATION) {
             return;
         }
@@ -196,55 +63,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for IntegrationUpdate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for IntegrationUpdate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::INTEGRATION) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/interaction.rs
+++ b/twilight-cache-inmemory/src/event/interaction.rs
@@ -1,67 +1,11 @@
-use crate::{
-    config::ResourceType,
-    traits::{
-        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
-        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
-        CacheableVoiceState,
-    },
-    InMemoryCache, UpdateCache,
-};
+use crate::{config::ResourceType, CacheableModels, InMemoryCache, UpdateCache};
 use std::borrow::Cow;
 use twilight_model::{
     application::interaction::InteractionData, gateway::payload::incoming::InteractionCreate,
 };
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for InteractionCreate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for InteractionCreate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         // Cache interaction member
         if cache.wants(ResourceType::MEMBER) {
             if let (Some(member), Some(guild_id)) = (&self.member, self.guild_id) {

--- a/twilight-cache-inmemory/src/event/interaction.rs
+++ b/twilight-cache-inmemory/src/event/interaction.rs
@@ -1,11 +1,67 @@
-use crate::{config::ResourceType, InMemoryCache, UpdateCache};
+use crate::{
+    config::ResourceType,
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
+    InMemoryCache, UpdateCache,
+};
 use std::borrow::Cow;
 use twilight_model::{
     application::interaction::InteractionData, gateway::payload::incoming::InteractionCreate,
 };
 
-impl UpdateCache for InteractionCreate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for InteractionCreate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         // Cache interaction member
         if cache.wants(ResourceType::MEMBER) {
             if let (Some(member), Some(guild_id)) = (&self.member, self.guild_id) {
@@ -59,7 +115,7 @@ impl UpdateCache for InteractionCreate {
 
 #[cfg(test)]
 mod tests {
-    use crate::InMemoryCache;
+    use crate::DefaultInMemoryCache;
     use std::collections::HashMap;
     use twilight_model::{
         application::{
@@ -92,7 +148,7 @@ mod tests {
         let avatar3 = ImageHash::parse(b"5e23c298295ad37936cfe24ad314774f")?;
         let flags = MemberFlags::BYPASSES_VERIFICATION | MemberFlags::DID_REJOIN;
 
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
 
         cache.update(&InteractionCreate(Interaction {
             app_permissions: Some(Permissions::SEND_MESSAGES),

--- a/twilight-cache-inmemory/src/event/member.rs
+++ b/twilight-cache-inmemory/src/event/member.rs
@@ -3,13 +3,8 @@ use std::borrow::Cow;
 use crate::{
     config::ResourceType,
     model::member::ComputedInteractionMember,
-    traits::{
-        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
-        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
-        CacheableVoiceState,
-    },
-    InMemoryCache, UpdateCache,
+    traits::{CacheableGuild, CacheableMember},
+    CacheableModels, InMemoryCache, UpdateCache,
 };
 use twilight_model::{
     application::interaction::InteractionMember,
@@ -21,37 +16,7 @@ use twilight_model::{
     },
 };
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >
-{
+impl<CacheModels: CacheableModels> InMemoryCache<CacheModels> {
     pub(crate) fn cache_members(
         &self,
         guild_id: Id<GuildMarker>,
@@ -73,7 +38,7 @@ impl<
         }
 
         self.cache_user(Cow::Borrowed(&member.user), Some(guild_id));
-        let cached = CachedMember::from(member);
+        let cached = CacheModels::Member::from(member);
         self.members.insert(id, cached);
         self.guild_members
             .entry(guild_id)
@@ -100,7 +65,7 @@ impl<
             .or_default()
             .insert(user_id);
 
-        let cached = CachedMember::from((user_id, member.clone()));
+        let cached = CacheModels::Member::from((user_id, member.clone()));
         self.members.insert(id, cached);
     }
 
@@ -123,7 +88,7 @@ impl<
             .or_default()
             .insert(user_id);
 
-        let cached = CachedMember::from(ComputedInteractionMember {
+        let cached = CacheModels::Member::from(ComputedInteractionMember {
             avatar,
             deaf,
             interaction_member: member.clone(),
@@ -135,55 +100,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for MemberAdd
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for MemberAdd {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if cache.wants(ResourceType::GUILD) {
             if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
                 guild.increase_member_count(1);
@@ -198,55 +116,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for MemberChunk
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for MemberChunk {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::MEMBER) {
             return;
         }
@@ -259,55 +130,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for MemberRemove
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for MemberRemove {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if cache.wants(ResourceType::GUILD) {
             if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
                 guild.decrease_member_count(1);
@@ -340,55 +164,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for MemberUpdate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for MemberUpdate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::MEMBER) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/member.rs
+++ b/twilight-cache-inmemory/src/event/member.rs
@@ -1,9 +1,16 @@
+use std::borrow::Cow;
+
 use crate::{
     config::ResourceType,
-    model::{member::ComputedInteractionMemberFields, CachedMember},
+    model::member::ComputedInteractionMemberFields,
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
     InMemoryCache, UpdateCache,
 };
-use std::borrow::Cow;
 use twilight_model::{
     application::interaction::InteractionMember,
     gateway::payload::incoming::{MemberAdd, MemberChunk, MemberRemove, MemberUpdate},
@@ -14,7 +21,37 @@ use twilight_model::{
     },
 };
 
-impl InMemoryCache {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     pub(crate) fn cache_members(
         &self,
         guild_id: Id<GuildMarker>,
@@ -36,7 +73,7 @@ impl InMemoryCache {
         }
 
         self.cache_user(Cow::Borrowed(&member.user), Some(guild_id));
-        let cached = CachedMember::from_model(member);
+        let cached = CachedMember::from(member);
         self.members.insert(id, cached);
         self.guild_members
             .entry(guild_id)
@@ -63,7 +100,7 @@ impl InMemoryCache {
             .or_default()
             .insert(user_id);
 
-        let cached = CachedMember::from_partial_member(user_id, member.clone());
+        let cached = CachedMember::from((user_id, member.clone()));
         self.members.insert(id, cached);
     }
 
@@ -86,21 +123,68 @@ impl InMemoryCache {
             .or_default()
             .insert(user_id);
 
-        let cached = CachedMember::from_interaction_member(
+        let cached = CachedMember::from((
             user_id,
             member.clone(),
             ComputedInteractionMemberFields { avatar, deaf, mute },
-        );
+        ));
 
         self.members.insert(id, cached);
     }
 }
 
-impl UpdateCache for MemberAdd {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for MemberAdd
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if cache.wants(ResourceType::GUILD) {
             if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
-                guild.member_count = guild.member_count.map(|count| count + 1);
+                guild.increase_member_count(1);
             }
         }
 
@@ -112,8 +196,55 @@ impl UpdateCache for MemberAdd {
     }
 }
 
-impl UpdateCache for MemberChunk {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for MemberChunk
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::MEMBER) {
             return;
         }
@@ -126,11 +257,58 @@ impl UpdateCache for MemberChunk {
     }
 }
 
-impl UpdateCache for MemberRemove {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for MemberRemove
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if cache.wants(ResourceType::GUILD) {
             if let Some(mut guild) = cache.guilds.get_mut(&self.guild_id) {
-                guild.member_count = guild.member_count.map(|count| count - 1);
+                guild.decrease_member_count(1);
             }
         }
 
@@ -160,38 +338,76 @@ impl UpdateCache for MemberRemove {
     }
 }
 
-impl UpdateCache for MemberUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for MemberUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::MEMBER) {
             return;
         }
 
         let key = (self.guild_id, self.user.id);
 
-        let Some(mut member) = cache.members.get_mut(&key) else {
-            return;
-        };
-
-        member.avatar = self.avatar;
-        member.deaf = self.deaf.or_else(|| member.deaf());
-        member.mute = self.mute.or_else(|| member.mute());
-        member.nick = self.nick.clone();
-        member.roles = self.roles.clone();
-        member.joined_at = self.joined_at;
-        member.pending = self.pending;
-        member.communication_disabled_until = self.communication_disabled_until;
+        if let Some(mut member) = cache.members.get_mut(&key) {
+            member.update_with_member_update(self);
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{test, InMemoryCache};
+    use crate::{test, DefaultInMemoryCache};
     use std::borrow::Cow;
     use twilight_model::{gateway::payload::incoming::MemberRemove, id::Id};
 
     #[test]
     fn cache_guild_member() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
 
         // Single inserts
         {
@@ -249,7 +465,7 @@ mod tests {
     #[test]
     fn cache_user_guild_state() {
         let user_id = Id::new(2);
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         cache.cache_user(Cow::Owned(test::user(user_id)), Some(Id::new(1)));
 
         // Test the guild's ID is the only one in the user's set of guilds.

--- a/twilight-cache-inmemory/src/event/member.rs
+++ b/twilight-cache-inmemory/src/event/member.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use crate::{
     config::ResourceType,
-    model::member::ComputedInteractionMemberFields,
+    model::member::ComputedInteractionMember,
     traits::{
         CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
         CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
@@ -123,11 +123,13 @@ impl<
             .or_default()
             .insert(user_id);
 
-        let cached = CachedMember::from((
+        let cached = CachedMember::from(ComputedInteractionMember {
+            avatar,
+            deaf,
+            interaction_member: member.clone(),
+            mute,
             user_id,
-            member.clone(),
-            ComputedInteractionMemberFields { avatar, deaf, mute },
-        ));
+        });
 
         self.members.insert(id, cached);
     }

--- a/twilight-cache-inmemory/src/event/message.rs
+++ b/twilight-cache-inmemory/src/event/message.rs
@@ -1,11 +1,67 @@
-use crate::{config::ResourceType, model::CachedMessage, InMemoryCache, UpdateCache};
+use crate::{
+    config::ResourceType,
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
+    InMemoryCache, UpdateCache,
+};
 use std::borrow::Cow;
 use twilight_model::gateway::payload::incoming::{
     MessageCreate, MessageDelete, MessageDeleteBulk, MessageUpdate,
 };
 
-impl UpdateCache for MessageCreate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for MessageCreate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if cache.wants(ResourceType::USER) {
             cache.cache_user(Cow::Borrowed(&self.author), self.guild_id);
         }
@@ -41,8 +97,55 @@ impl UpdateCache for MessageCreate {
     }
 }
 
-impl UpdateCache for MessageDelete {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for MessageDelete
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::MESSAGE) {
             return;
         }
@@ -57,8 +160,55 @@ impl UpdateCache for MessageDelete {
     }
 }
 
-impl UpdateCache for MessageDeleteBulk {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for MessageDeleteBulk
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::MESSAGE) {
             return;
         }
@@ -78,59 +228,68 @@ impl UpdateCache for MessageDeleteBulk {
     }
 }
 
-impl UpdateCache for MessageUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for MessageUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::MESSAGE) {
             return;
         }
 
         if let Some(mut message) = cache.messages.get_mut(&self.id) {
-            if let Some(attachments) = &self.attachments {
-                message.attachments = attachments.clone();
-            }
-
-            if let Some(content) = &self.content {
-                message.content = content.clone();
-            }
-
-            if let Some(edited_timestamp) = self.edited_timestamp {
-                message.edited_timestamp.replace(edited_timestamp);
-            }
-
-            if let Some(embeds) = &self.embeds {
-                message.embeds = embeds.clone();
-            }
-
-            if let Some(mention_everyone) = self.mention_everyone {
-                message.mention_everyone = mention_everyone;
-            }
-
-            if let Some(mention_roles) = &self.mention_roles {
-                message.mention_roles = mention_roles.clone();
-            }
-
-            if let Some(mentions) = &self.mentions {
-                message.mentions = mentions.iter().map(|x| x.id).collect::<Vec<_>>();
-            }
-
-            if let Some(pinned) = self.pinned {
-                message.pinned = pinned;
-            }
-
-            if let Some(timestamp) = self.timestamp {
-                message.timestamp = timestamp;
-            }
-
-            if let Some(tts) = self.tts {
-                message.tts = tts;
-            }
+            message.update_with_message_update(self);
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{InMemoryCache, ResourceType};
+    use crate::{DefaultInMemoryCache, ResourceType};
     use twilight_model::{
         channel::message::{Message, MessageFlags, MessageType},
         gateway::payload::incoming::MessageCreate,
@@ -143,7 +302,7 @@ mod tests {
     #[test]
     fn message_create() -> Result<(), ImageHashParseError> {
         let joined_at = Some(Timestamp::from_secs(1_632_072_645).expect("non zero"));
-        let cache = InMemoryCache::builder()
+        let cache = DefaultInMemoryCache::builder()
             .resource_types(ResourceType::MESSAGE | ResourceType::MEMBER | ResourceType::USER)
             .message_cache_size(2)
             .build();

--- a/twilight-cache-inmemory/src/event/message.rs
+++ b/twilight-cache-inmemory/src/event/message.rs
@@ -1,67 +1,11 @@
-use crate::{
-    config::ResourceType,
-    traits::{
-        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
-        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
-        CacheableVoiceState,
-    },
-    InMemoryCache, UpdateCache,
-};
+use crate::{config::ResourceType, CacheableMessage, CacheableModels, InMemoryCache, UpdateCache};
 use std::borrow::Cow;
 use twilight_model::gateway::payload::incoming::{
     MessageCreate, MessageDelete, MessageDeleteBulk, MessageUpdate,
 };
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for MessageCreate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for MessageCreate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if cache.wants(ResourceType::USER) {
             cache.cache_user(Cow::Borrowed(&self.author), self.guild_id);
         }
@@ -93,59 +37,12 @@ impl<
         channel_messages.push_front(self.0.id);
         cache
             .messages
-            .insert(self.0.id, CachedMessage::from(self.0.clone()));
+            .insert(self.0.id, CacheModels::Message::from(self.0.clone()));
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for MessageDelete
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for MessageDelete {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::MESSAGE) {
             return;
         }
@@ -160,55 +57,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for MessageDeleteBulk
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for MessageDeleteBulk {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::MESSAGE) {
             return;
         }
@@ -228,55 +78,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for MessageUpdate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for MessageUpdate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::MESSAGE) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/mod.rs
+++ b/twilight-cache-inmemory/src/event/mod.rs
@@ -13,20 +13,60 @@ pub mod sticker;
 pub mod thread;
 pub mod voice_state;
 
-use crate::{config::ResourceType, InMemoryCache, UpdateCache};
 use std::{borrow::Cow, collections::HashSet};
+
+use crate::{
+    config::ResourceType,
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
+    InMemoryCache, UpdateCache,
+};
 use twilight_model::{
     gateway::payload::incoming::{Ready, UnavailableGuild, UserUpdate},
     id::{marker::GuildMarker, Id},
     user::{CurrentUser, User},
 };
 
-impl InMemoryCache {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     fn cache_current_user(&self, current_user: CurrentUser) {
         self.current_user
             .lock()
             .expect("current user poisoned")
-            .replace(current_user);
+            .replace(CachedCurrentUser::from(current_user));
     }
 
     pub(crate) fn cache_user(&self, user: Cow<'_, User>, guild_id: Option<Id<GuildMarker>>) {
@@ -46,7 +86,7 @@ impl InMemoryCache {
         let user = user.into_owned();
         let user_id = user.id;
 
-        self.users.insert(user_id, user);
+        self.users.insert(user_id, CachedUser::from(user));
 
         if let Some(guild_id) = guild_id {
             let mut guild_id_set = HashSet::new();
@@ -61,8 +101,55 @@ impl InMemoryCache {
     }
 }
 
-impl UpdateCache for Ready {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for Ready
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if cache.wants(ResourceType::USER_CURRENT) {
             cache.cache_current_user(self.user.clone());
         }
@@ -75,16 +162,110 @@ impl UpdateCache for Ready {
     }
 }
 
-impl UpdateCache for UnavailableGuild {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for UnavailableGuild
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if cache.wants(ResourceType::GUILD) {
             cache.unavailable_guild(self.id);
         }
     }
 }
 
-impl UpdateCache for UserUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for UserUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::USER_CURRENT) {
             return;
         }
@@ -95,14 +276,14 @@ impl UpdateCache for UserUpdate {
 
 #[cfg(test)]
 mod tests {
-    use crate::{test, InMemoryCache};
+    use crate::{test, DefaultInMemoryCache};
 
     /// Test retrieval of the current user, notably that it doesn't simply
     /// panic or do anything funny. This is the only synchronous mutex that we
     /// might have trouble with across await points if we're not careful.
     #[test]
     fn current_user_retrieval() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         assert!(cache.current_user().is_none());
         cache.cache_current_user(test::current_user(1));
         assert!(cache.current_user().is_some());

--- a/twilight-cache-inmemory/src/event/presence.rs
+++ b/twilight-cache-inmemory/src/event/presence.rs
@@ -1,46 +1,132 @@
-use crate::{config::ResourceType, model::CachedPresence, InMemoryCache, UpdateCache};
+use crate::{
+    config::ResourceType,
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
+    InMemoryCache, UpdateCache,
+};
 use twilight_model::{
-    gateway::payload::incoming::PresenceUpdate,
+    gateway::{payload::incoming::PresenceUpdate, presence::Presence},
     id::{marker::GuildMarker, Id},
 };
 
-impl InMemoryCache {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     pub(crate) fn cache_presences(
         &self,
         guild_id: Id<GuildMarker>,
-        presences: impl IntoIterator<Item = CachedPresence>,
+        presences: impl IntoIterator<Item = Presence>,
     ) {
         for presence in presences {
             self.cache_presence(guild_id, presence);
         }
     }
 
-    fn cache_presence(&self, guild_id: Id<GuildMarker>, presence: CachedPresence) {
+    fn cache_presence(&self, guild_id: Id<GuildMarker>, presence: Presence) {
         self.guild_presences
             .entry(guild_id)
             .or_default()
-            .insert(presence.user_id);
+            .insert(presence.user.id());
 
-        self.presences
-            .insert((guild_id, presence.user_id()), presence);
+        self.presences.insert(
+            (guild_id, presence.user.id()),
+            CachedPresence::from(presence),
+        );
     }
 }
 
-impl UpdateCache for PresenceUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for PresenceUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::PRESENCE) {
             return;
         }
 
-        let presence = CachedPresence::from_model(self.0.clone());
-
-        cache.cache_presence(self.guild_id, presence);
+        cache.cache_presence(self.guild_id, self.0.clone());
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{test, InMemoryCache};
+    use crate::{test, DefaultInMemoryCache};
     use twilight_model::{
         gateway::{
             event::Event,
@@ -52,7 +138,7 @@ mod tests {
 
     #[test]
     fn presence_update() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
 
         let guild_id = Id::new(1);
         let user_id = Id::new(1);

--- a/twilight-cache-inmemory/src/event/presence.rs
+++ b/twilight-cache-inmemory/src/event/presence.rs
@@ -1,49 +1,10 @@
-use crate::{
-    config::ResourceType,
-    traits::{
-        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
-        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
-        CacheableVoiceState,
-    },
-    InMemoryCache, UpdateCache,
-};
+use crate::{config::ResourceType, CacheableModels, InMemoryCache, UpdateCache};
 use twilight_model::{
     gateway::{payload::incoming::PresenceUpdate, presence::Presence},
     id::{marker::GuildMarker, Id},
 };
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >
-{
+impl<CacheModels: CacheableModels> InMemoryCache<CacheModels> {
     pub(crate) fn cache_presences(
         &self,
         guild_id: Id<GuildMarker>,
@@ -62,60 +23,13 @@ impl<
 
         self.presences.insert(
             (guild_id, presence.user.id()),
-            CachedPresence::from(presence),
+            CacheModels::Presence::from(presence),
         );
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for PresenceUpdate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for PresenceUpdate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::PRESENCE) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/reaction.rs
+++ b/twilight-cache-inmemory/src/event/reaction.rs
@@ -1,12 +1,7 @@
 use crate::{
     config::ResourceType,
-    traits::{
-        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
-        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
-        CacheableVoiceState,
-    },
-    InMemoryCache, UpdateCache,
+    traits::{CacheableCurrentUser, CacheableMessage},
+    CacheableModels, InMemoryCache, UpdateCache,
 };
 use twilight_model::{
     channel::message::{Reaction, ReactionCountDetails, ReactionType},
@@ -15,55 +10,8 @@ use twilight_model::{
     },
 };
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for ReactionAdd
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ReactionAdd {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::REACTION) {
             return;
         }
@@ -109,55 +57,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for ReactionRemove
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ReactionRemove {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::REACTION) {
             return;
         }
@@ -188,55 +89,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for ReactionRemoveAll
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ReactionRemoveAll {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::REACTION) {
             return;
         }
@@ -249,55 +103,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for ReactionRemoveEmoji
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ReactionRemoveEmoji {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::REACTION) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/role.rs
+++ b/twilight-cache-inmemory/src/event/role.rs
@@ -1,13 +1,4 @@
-use crate::{
-    config::ResourceType,
-    traits::{
-        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
-        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
-        CacheableVoiceState,
-    },
-    InMemoryCache, UpdateCache,
-};
+use crate::{config::ResourceType, CacheableModels, InMemoryCache, UpdateCache};
 use twilight_model::{
     gateway::payload::incoming::{RoleCreate, RoleDelete, RoleUpdate},
     guild::Role,
@@ -17,37 +8,7 @@ use twilight_model::{
     },
 };
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >
-{
+impl<CacheModels: CacheableModels> InMemoryCache<CacheModels> {
     pub(crate) fn cache_roles(
         &self,
         guild_id: Id<GuildMarker>,
@@ -66,7 +27,12 @@ impl<
             .insert(role.id);
 
         // Insert the role into the all roles map
-        crate::upsert_guild_item(&self.roles, guild_id, role.id, CachedRole::from(role));
+        crate::upsert_guild_item(
+            &self.roles,
+            guild_id,
+            role.id,
+            CacheModels::Role::from(role),
+        );
     }
 
     fn delete_role(&self, role_id: Id<RoleMarker>) {
@@ -78,55 +44,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for RoleCreate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for RoleCreate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::ROLE) {
             return;
         }
@@ -135,55 +54,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for RoleDelete
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for RoleDelete {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::ROLE) {
             return;
         }
@@ -192,55 +64,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for RoleUpdate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for RoleUpdate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::ROLE) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/role.rs
+++ b/twilight-cache-inmemory/src/event/role.rs
@@ -1,4 +1,13 @@
-use crate::{config::ResourceType, InMemoryCache, UpdateCache};
+use crate::{
+    config::ResourceType,
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
+    InMemoryCache, UpdateCache,
+};
 use twilight_model::{
     gateway::payload::incoming::{RoleCreate, RoleDelete, RoleUpdate},
     guild::Role,
@@ -8,7 +17,37 @@ use twilight_model::{
     },
 };
 
-impl InMemoryCache {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     pub(crate) fn cache_roles(
         &self,
         guild_id: Id<GuildMarker>,
@@ -27,7 +66,7 @@ impl InMemoryCache {
             .insert(role.id);
 
         // Insert the role into the all roles map
-        crate::upsert_guild_item(&self.roles, guild_id, role.id, role);
+        crate::upsert_guild_item(&self.roles, guild_id, role.id, CachedRole::from(role));
     }
 
     fn delete_role(&self, role_id: Id<RoleMarker>) {
@@ -39,8 +78,55 @@ impl InMemoryCache {
     }
 }
 
-impl UpdateCache for RoleCreate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for RoleCreate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::ROLE) {
             return;
         }
@@ -49,8 +135,55 @@ impl UpdateCache for RoleCreate {
     }
 }
 
-impl UpdateCache for RoleDelete {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for RoleDelete
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::ROLE) {
             return;
         }
@@ -59,8 +192,55 @@ impl UpdateCache for RoleDelete {
     }
 }
 
-impl UpdateCache for RoleUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for RoleUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::ROLE) {
             return;
         }
@@ -71,12 +251,12 @@ impl UpdateCache for RoleUpdate {
 
 #[cfg(test)]
 mod tests {
-    use crate::{test, InMemoryCache};
+    use crate::{test, DefaultInMemoryCache};
     use twilight_model::{gateway::payload::incoming::RoleCreate, id::Id};
 
     #[test]
     fn insert_role_on_event() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
 
         cache.update(&RoleCreate {
             guild_id: Id::new(1),
@@ -93,7 +273,7 @@ mod tests {
 
     #[test]
     fn cache_role() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
 
         // Single inserts
         {

--- a/twilight-cache-inmemory/src/event/stage_instance.rs
+++ b/twilight-cache-inmemory/src/event/stage_instance.rs
@@ -1,13 +1,4 @@
-use crate::{
-    config::ResourceType,
-    traits::{
-        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
-        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
-        CacheableVoiceState,
-    },
-    InMemoryCache, UpdateCache,
-};
+use crate::{config::ResourceType, CacheableModels, InMemoryCache, UpdateCache};
 use twilight_model::{
     channel::StageInstance,
     gateway::payload::incoming::{StageInstanceCreate, StageInstanceDelete, StageInstanceUpdate},
@@ -17,37 +8,7 @@ use twilight_model::{
     },
 };
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >
-{
+impl<CacheModels: CacheableModels> InMemoryCache<CacheModels> {
     pub(crate) fn cache_stage_instances(
         &self,
         guild_id: Id<GuildMarker>,
@@ -68,7 +29,7 @@ impl<
             &self.stage_instances,
             guild_id,
             stage_instance.id,
-            CachedStageInstance::from(stage_instance),
+            CacheModels::StageInstance::from(stage_instance),
         );
     }
 
@@ -83,55 +44,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for StageInstanceCreate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for StageInstanceCreate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::STAGE_INSTANCE) {
             return;
         }
@@ -140,55 +54,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for StageInstanceDelete
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for StageInstanceDelete {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::STAGE_INSTANCE) {
             return;
         }
@@ -197,55 +64,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for StageInstanceUpdate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for StageInstanceUpdate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::STAGE_INSTANCE) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/stage_instance.rs
+++ b/twilight-cache-inmemory/src/event/stage_instance.rs
@@ -1,4 +1,13 @@
-use crate::{config::ResourceType, InMemoryCache, UpdateCache};
+use crate::{
+    config::ResourceType,
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
+    InMemoryCache, UpdateCache,
+};
 use twilight_model::{
     channel::StageInstance,
     gateway::payload::incoming::{StageInstanceCreate, StageInstanceDelete, StageInstanceUpdate},
@@ -8,7 +17,37 @@ use twilight_model::{
     },
 };
 
-impl InMemoryCache {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     pub(crate) fn cache_stage_instances(
         &self,
         guild_id: Id<GuildMarker>,
@@ -29,7 +68,7 @@ impl InMemoryCache {
             &self.stage_instances,
             guild_id,
             stage_instance.id,
-            stage_instance,
+            CachedStageInstance::from(stage_instance),
         );
     }
 
@@ -44,8 +83,55 @@ impl InMemoryCache {
     }
 }
 
-impl UpdateCache for StageInstanceCreate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for StageInstanceCreate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::STAGE_INSTANCE) {
             return;
         }
@@ -54,8 +140,55 @@ impl UpdateCache for StageInstanceCreate {
     }
 }
 
-impl UpdateCache for StageInstanceDelete {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for StageInstanceDelete
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::STAGE_INSTANCE) {
             return;
         }
@@ -64,8 +197,55 @@ impl UpdateCache for StageInstanceDelete {
     }
 }
 
-impl UpdateCache for StageInstanceUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for StageInstanceUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::STAGE_INSTANCE) {
             return;
         }
@@ -76,7 +256,7 @@ impl UpdateCache for StageInstanceUpdate {
 
 #[cfg(test)]
 mod tests {
-    use crate::InMemoryCache;
+    use crate::DefaultInMemoryCache;
     use twilight_model::{
         channel::{stage_instance::PrivacyLevel, StageInstance},
         gateway::payload::incoming::{
@@ -87,7 +267,7 @@ mod tests {
 
     #[test]
     fn stage_channels() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
 
         let stage_instance = StageInstance {
             channel_id: Id::new(1),

--- a/twilight-cache-inmemory/src/event/sticker.rs
+++ b/twilight-cache-inmemory/src/event/sticker.rs
@@ -81,7 +81,7 @@ impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for GuildStickersUpd
 
 #[cfg(test)]
 mod tests {
-    use crate::{test, InMemoryCache, DefaultCacheModels};
+    use crate::{test, DefaultCacheModels, InMemoryCache};
     use twilight_model::id::{
         marker::{GuildMarker, StickerMarker},
         Id,

--- a/twilight-cache-inmemory/src/event/sticker.rs
+++ b/twilight-cache-inmemory/src/event/sticker.rs
@@ -1,14 +1,52 @@
-use crate::{
-    config::ResourceType, model::CachedSticker, GuildResource, InMemoryCache, UpdateCache,
-};
 use std::{borrow::Cow, collections::HashSet};
+
+use crate::{
+    config::ResourceType,
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
+    GuildResource, InMemoryCache, UpdateCache,
+};
 use twilight_model::{
-    channel::message::sticker::Sticker,
+    channel::message::Sticker,
     gateway::payload::incoming::GuildStickersUpdate,
     id::{marker::GuildMarker, Id},
 };
 
-impl InMemoryCache {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     pub(crate) fn cache_stickers(&self, guild_id: Id<GuildMarker>, stickers: Vec<Sticker>) {
         if let Some(mut guild_stickers) = self.guild_stickers.get_mut(&guild_id) {
             let incoming_sticker_ids = stickers
@@ -50,10 +88,10 @@ impl InMemoryCache {
         }
 
         let sticker_id = sticker.id;
-        let cached = CachedSticker::from_model(sticker);
+        let cached = CachedSticker::from(sticker);
 
         self.stickers.insert(
-            cached.id,
+            cached.id(),
             GuildResource {
                 guild_id,
                 value: cached,
@@ -67,8 +105,55 @@ impl InMemoryCache {
     }
 }
 
-impl UpdateCache for GuildStickersUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for GuildStickersUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::STICKER) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/thread.rs
+++ b/twilight-cache-inmemory/src/event/thread.rs
@@ -1,66 +1,10 @@
-use crate::{
-    config::ResourceType,
-    traits::{
-        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
-        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
-        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
-        CacheableVoiceState,
-    },
-    InMemoryCache, UpdateCache,
-};
+use crate::{config::ResourceType, CacheableModels, InMemoryCache, UpdateCache};
 use twilight_model::gateway::payload::incoming::{
     ThreadCreate, ThreadDelete, ThreadListSync, ThreadUpdate,
 };
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for ThreadCreate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ThreadCreate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
@@ -69,55 +13,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for ThreadDelete
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ThreadDelete {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
@@ -126,55 +23,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for ThreadListSync
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ThreadListSync {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
@@ -183,55 +33,8 @@ impl<
     }
 }
 
-impl<
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    UpdateCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > for ThreadUpdate
-{
-    fn update(
-        &self,
-        cache: &InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) {
+impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ThreadUpdate {
+    fn update(&self, cache: &InMemoryCache<CacheModels>) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/thread.rs
+++ b/twilight-cache-inmemory/src/event/thread.rs
@@ -1,10 +1,66 @@
-use crate::{config::ResourceType, InMemoryCache, UpdateCache};
+use crate::{
+    config::ResourceType,
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
+    InMemoryCache, UpdateCache,
+};
 use twilight_model::gateway::payload::incoming::{
     ThreadCreate, ThreadDelete, ThreadListSync, ThreadUpdate,
 };
 
-impl UpdateCache for ThreadCreate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for ThreadCreate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
@@ -13,8 +69,55 @@ impl UpdateCache for ThreadCreate {
     }
 }
 
-impl UpdateCache for ThreadDelete {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for ThreadDelete
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
@@ -23,8 +126,55 @@ impl UpdateCache for ThreadDelete {
     }
 }
 
-impl UpdateCache for ThreadListSync {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for ThreadListSync
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }
@@ -33,8 +183,55 @@ impl UpdateCache for ThreadListSync {
     }
 }
 
-impl UpdateCache for ThreadUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for ThreadUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::CHANNEL) {
             return;
         }

--- a/twilight-cache-inmemory/src/event/voice_state.rs
+++ b/twilight-cache-inmemory/src/event/voice_state.rs
@@ -1,7 +1,47 @@
-use crate::{config::ResourceType, model::CachedVoiceState, InMemoryCache, UpdateCache};
-use twilight_model::{gateway::payload::incoming::VoiceStateUpdate, voice::VoiceState};
+use crate::{
+    config::ResourceType,
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
+    InMemoryCache, UpdateCache,
+};
+use twilight_model::gateway::payload::incoming::VoiceStateUpdate;
+use twilight_model::voice::VoiceState;
 
-impl InMemoryCache {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     pub(crate) fn cache_voice_states(&self, voice_states: impl IntoIterator<Item = VoiceState>) {
         for voice_state in voice_states {
             self.cache_voice_state(voice_state);
@@ -34,8 +74,7 @@ impl InMemoryCache {
         }
 
         if let Some(channel_id) = voice_state.channel_id {
-            let cached_voice_state =
-                CachedVoiceState::from_model(channel_id, guild_id, voice_state);
+            let cached_voice_state = CachedVoiceState::from((channel_id, guild_id, voice_state));
 
             self.voice_states
                 .insert((guild_id, user_id), cached_voice_state);
@@ -72,8 +111,55 @@ impl InMemoryCache {
     }
 }
 
-impl UpdateCache for VoiceStateUpdate {
-    fn update(&self, cache: &InMemoryCache) {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for VoiceStateUpdate
+{
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         if !cache.wants(ResourceType::VOICE_STATE) {
             return;
         }
@@ -88,7 +174,7 @@ impl UpdateCache for VoiceStateUpdate {
 
 #[cfg(test)]
 mod tests {
-    use crate::{model::CachedVoiceState, test, InMemoryCache, ResourceType};
+    use crate::{model::CachedVoiceState, test, DefaultInMemoryCache, ResourceType};
     use std::str::FromStr;
     use twilight_model::{
         gateway::payload::incoming::VoiceStateUpdate,
@@ -104,7 +190,7 @@ mod tests {
 
     #[test]
     fn voice_state_inserts_and_removes() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
 
         // Note: Channel ids are `<guildid><idx>` where idx is the index of the channel id
         // This is done to prevent channel id collisions between guilds
@@ -241,7 +327,7 @@ mod tests {
 
     #[test]
     fn voice_states() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         cache.cache_voice_state(test::voice_state(Id::new(1), Some(Id::new(2)), Id::new(3)));
         cache.cache_voice_state(test::voice_state(Id::new(1), Some(Id::new(2)), Id::new(4)));
 
@@ -254,7 +340,7 @@ mod tests {
 
     #[test]
     fn voice_states_with_no_cached_guilds() {
-        let cache = InMemoryCache::builder()
+        let cache = DefaultInMemoryCache::builder()
             .resource_types(ResourceType::VOICE_STATE)
             .build();
 
@@ -281,7 +367,7 @@ mod tests {
     fn voice_states_members() -> Result<(), ImageHashParseError> {
         let joined_at = Some(Timestamp::from_secs(1_632_072_645).expect("non zero"));
 
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
 
         let avatar = ImageHash::parse(b"169280485ba78d541a9090e7ea35a14e")?;
         let flags = MemberFlags::BYPASSES_VERIFICATION | MemberFlags::DID_REJOIN;
@@ -357,11 +443,11 @@ mod tests {
         const GUILD_ID: Id<GuildMarker> = Id::new(1);
         const USER_ID: Id<UserMarker> = Id::new(3);
 
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         let voice_state = test::voice_state(GUILD_ID, Some(CHANNEL_ID), USER_ID);
         cache.update(&VoiceStateUpdate(voice_state.clone()));
 
-        let cached = CachedVoiceState::from_model(CHANNEL_ID, GUILD_ID, voice_state);
+        let cached = CachedVoiceState::from((CHANNEL_ID, GUILD_ID, voice_state));
         let in_cache = cache.voice_state(USER_ID, GUILD_ID).unwrap();
         assert_eq!(in_cache.value(), &cached);
     }

--- a/twilight-cache-inmemory/src/iter.rs
+++ b/twilight-cache-inmemory/src/iter.rs
@@ -152,6 +152,7 @@ impl<'a, CacheModels: CacheableModels> InMemoryCacheIter<'a, CacheModels> {
     }
 
     /// Create an iterator over the integrations in the cache.
+    #[allow(clippy::type_complexity)]
     pub fn integrations(
         &self,
     ) -> ResourceIter<

--- a/twilight-cache-inmemory/src/iter.rs
+++ b/twilight-cache-inmemory/src/iter.rs
@@ -13,11 +13,13 @@
 //! dereferences to the value.
 
 use crate::{
-    model::{
-        CachedEmoji, CachedGuild, CachedMember, CachedMessage, CachedPresence, CachedSticker,
-        CachedVoiceState,
+    model,
+    traits::{
+        CacheableChannel, CacheableGuild, CacheableMember, CacheableMessage, CacheableRole,
+        CacheableVoiceState,
     },
-    GuildResource, InMemoryCache,
+    CacheableCurrentUser, CacheableEmoji, CacheableGuildIntegration, CacheablePresence,
+    CacheableStageInstance, CacheableSticker, CacheableUser, GuildResource, InMemoryCache,
 };
 use dashmap::{iter::Iter, mapref::multiple::RefMulti};
 use std::{hash::Hash, ops::Deref};
@@ -31,7 +33,7 @@ use twilight_model::{
         },
         Id,
     },
-    user::User,
+    user::{CurrentUser, User},
 };
 
 /// Reference to a resource value being iterated over in the cache.
@@ -85,9 +87,9 @@ impl<K: Eq + Hash, V> Deref for IterReference<'_, K, V> {
 /// Count the number of users in the cache whose username begins with "twi":
 ///
 /// ```no_run
-/// use twilight_cache_inmemory::InMemoryCache;
+/// use twilight_cache_inmemory::DefaultInMemoryCache;
 ///
-/// let cache = InMemoryCache::new();
+/// let cache = DefaultInMemoryCache::new();
 ///
 /// // later in the application...
 /// let count = cache
@@ -109,10 +111,10 @@ impl<K: Eq + Hash, V> Deref for IterReference<'_, K, V> {
 /// like:
 ///
 /// ```no_run
-/// use twilight_cache_inmemory::InMemoryCache;
+/// use twilight_cache_inmemory::DefaultInMemoryCache;
 /// use twilight_model::id::Id;
 ///
-/// let cache = InMemoryCache::new();
+/// let cache = DefaultInMemoryCache::new();
 ///
 /// // later in the application...
 /// let guild_id = Id::new(1);
@@ -130,22 +132,120 @@ impl<K: Eq + Hash, V> Deref for IterReference<'_, K, V> {
 ///     }
 /// }
 /// ```
+#[allow(clippy::type_complexity)]
 #[derive(Debug)]
-pub struct InMemoryCacheIter<'a>(&'a InMemoryCache);
+pub struct InMemoryCacheIter<
+    'a,
+    CachedChannel: CacheableChannel = Channel,
+    CachedCurrentUser: CacheableCurrentUser = CurrentUser,
+    CachedEmoji: CacheableEmoji = model::CachedEmoji,
+    CachedGuild: CacheableGuild = model::CachedGuild,
+    CachedGuildIntegration: CacheableGuildIntegration = GuildIntegration,
+    CachedMember: CacheableMember = model::CachedMember,
+    CachedMessage: CacheableMessage = model::CachedMessage,
+    CachedPresence: CacheablePresence = model::CachedPresence,
+    CachedRole: CacheableRole = Role,
+    CachedStageInstance: CacheableStageInstance = StageInstance,
+    CachedSticker: CacheableSticker = model::CachedSticker,
+    CachedUser: CacheableUser = User,
+    CachedVoiceState: CacheableVoiceState = model::CachedVoiceState,
+>(
+    &'a InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >,
+);
 
-impl<'a> InMemoryCacheIter<'a> {
+impl<
+        'a,
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCacheIter<
+        'a,
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     /// Create a new interface to create iterators over various resource types.
-    pub(super) const fn new(cache: &'a InMemoryCache) -> Self {
+    #[allow(clippy::type_complexity)]
+    pub(super) const fn new(
+        cache: &'a InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) -> Self {
         Self(cache)
     }
 
     /// Immutable reference to the underlying cache.
-    pub const fn cache_ref(&'a self) -> &'a InMemoryCache {
+    #[allow(clippy::type_complexity)]
+    pub const fn cache_ref(
+        &'a self,
+    ) -> &'a InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > {
         self.0
     }
 
     /// Create an iterator over the channels in the cache.
-    pub fn channels(&self) -> ResourceIter<'a, Id<ChannelMarker>, Channel> {
+    pub fn channels(&self) -> ResourceIter<'a, Id<ChannelMarker>, CachedChannel> {
         ResourceIter::new(self.0.channels.iter())
     }
 
@@ -162,8 +262,11 @@ impl<'a> InMemoryCacheIter<'a> {
     /// Create an iterator over the integrations in the cache.
     pub fn integrations(
         &self,
-    ) -> ResourceIter<'a, (Id<GuildMarker>, Id<IntegrationMarker>), GuildResource<GuildIntegration>>
-    {
+    ) -> ResourceIter<
+        'a,
+        (Id<GuildMarker>, Id<IntegrationMarker>),
+        GuildResource<CachedGuildIntegration>,
+    > {
         ResourceIter::new(self.0.integrations.iter())
     }
 
@@ -183,14 +286,14 @@ impl<'a> InMemoryCacheIter<'a> {
     }
 
     /// Create an iterator over the roles in the cache.
-    pub fn roles(&self) -> ResourceIter<'a, Id<RoleMarker>, GuildResource<Role>> {
+    pub fn roles(&self) -> ResourceIter<'a, Id<RoleMarker>, GuildResource<CachedRole>> {
         ResourceIter::new(self.0.roles.iter())
     }
 
     /// Create an iterator over the stage instances in the cache.
     pub fn stage_instances(
         &self,
-    ) -> ResourceIter<'a, Id<StageMarker>, GuildResource<StageInstance>> {
+    ) -> ResourceIter<'a, Id<StageMarker>, GuildResource<CachedStageInstance>> {
         ResourceIter::new(self.0.stage_instances.iter())
     }
 
@@ -200,7 +303,7 @@ impl<'a> InMemoryCacheIter<'a> {
     }
 
     /// Create an iterator over the users in the cache.
-    pub fn users(&self) -> ResourceIter<'a, Id<UserMarker>, User> {
+    pub fn users(&self) -> ResourceIter<'a, Id<UserMarker>, CachedUser> {
         ResourceIter::new(self.0.users.iter())
     }
 
@@ -221,9 +324,9 @@ impl<'a> InMemoryCacheIter<'a> {
 /// Count how many users across all guilds are pending:
 ///
 /// ```no_run
-/// use twilight_cache_inmemory::InMemoryCache;
+/// use twilight_cache_inmemory::DefaultInMemoryCache;
 ///
-/// let cache = InMemoryCache::new();
+/// let cache = DefaultInMemoryCache::new();
 ///
 /// // later in the application...
 /// let count = cache
@@ -256,7 +359,7 @@ impl<'a, K: Eq + Hash, V> Iterator for ResourceIter<'a, K, V> {
 #[cfg(test)]
 mod tests {
     use super::{InMemoryCacheIter, IterReference, ResourceIter};
-    use crate::{test, InMemoryCache};
+    use crate::{test, DefaultInMemoryCache};
     use static_assertions::assert_impl_all;
     use std::{borrow::Cow, fmt::Debug};
     use twilight_model::{
@@ -276,7 +379,7 @@ mod tests {
             (Id::new(3), Some(guild_id)),
             (Id::new(4), None),
         ];
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
 
         for (user_id, maybe_guild_id) in users {
             cache.cache_user(Cow::Owned(test::user(*user_id)), *maybe_guild_id);

--- a/twilight-cache-inmemory/src/iter.rs
+++ b/twilight-cache-inmemory/src/iter.rs
@@ -12,28 +12,15 @@
 //! underlying key and value. It also implements [`std::ops::Deref`] and
 //! dereferences to the value.
 
-use crate::{
-    model,
-    traits::{
-        CacheableChannel, CacheableGuild, CacheableMember, CacheableMessage, CacheableRole,
-        CacheableVoiceState,
-    },
-    CacheableCurrentUser, CacheableEmoji, CacheableGuildIntegration, CacheablePresence,
-    CacheableStageInstance, CacheableSticker, CacheableUser, GuildResource, InMemoryCache,
-};
+use crate::{CacheableModels, GuildResource, InMemoryCache};
 use dashmap::{iter::Iter, mapref::multiple::RefMulti};
 use std::{hash::Hash, ops::Deref};
-use twilight_model::{
-    channel::{Channel, StageInstance},
-    guild::{GuildIntegration, Role},
-    id::{
-        marker::{
-            ChannelMarker, EmojiMarker, GuildMarker, IntegrationMarker, MessageMarker, RoleMarker,
-            StageMarker, StickerMarker, UserMarker,
-        },
-        Id,
+use twilight_model::id::{
+    marker::{
+        ChannelMarker, EmojiMarker, GuildMarker, IntegrationMarker, MessageMarker, RoleMarker,
+        StageMarker, StickerMarker, UserMarker,
     },
-    user::{CurrentUser, User},
+    Id,
 };
 
 /// Reference to a resource value being iterated over in the cache.
@@ -134,128 +121,33 @@ impl<K: Eq + Hash, V> Deref for IterReference<'_, K, V> {
 /// ```
 #[allow(clippy::type_complexity)]
 #[derive(Debug)]
-pub struct InMemoryCacheIter<
-    'a,
-    CachedChannel: CacheableChannel = Channel,
-    CachedCurrentUser: CacheableCurrentUser = CurrentUser,
-    CachedEmoji: CacheableEmoji = model::CachedEmoji,
-    CachedGuild: CacheableGuild = model::CachedGuild,
-    CachedGuildIntegration: CacheableGuildIntegration = GuildIntegration,
-    CachedMember: CacheableMember = model::CachedMember,
-    CachedMessage: CacheableMessage = model::CachedMessage,
-    CachedPresence: CacheablePresence = model::CachedPresence,
-    CachedRole: CacheableRole = Role,
-    CachedStageInstance: CacheableStageInstance = StageInstance,
-    CachedSticker: CacheableSticker = model::CachedSticker,
-    CachedUser: CacheableUser = User,
-    CachedVoiceState: CacheableVoiceState = model::CachedVoiceState,
->(
-    &'a InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >,
-);
+pub struct InMemoryCacheIter<'a, CacheModels: CacheableModels>(&'a InMemoryCache<CacheModels>);
 
-impl<
-        'a,
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    InMemoryCacheIter<
-        'a,
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >
-{
+impl<'a, CacheModels: CacheableModels> InMemoryCacheIter<'a, CacheModels> {
     /// Create a new interface to create iterators over various resource types.
     #[allow(clippy::type_complexity)]
-    pub(super) const fn new(
-        cache: &'a InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) -> Self {
+    pub(super) const fn new(cache: &'a InMemoryCache<CacheModels>) -> Self {
         Self(cache)
     }
 
     /// Immutable reference to the underlying cache.
     #[allow(clippy::type_complexity)]
-    pub const fn cache_ref(
-        &'a self,
-    ) -> &'a InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > {
+    pub const fn cache_ref(&'a self) -> &'a InMemoryCache<CacheModels> {
         self.0
     }
 
     /// Create an iterator over the channels in the cache.
-    pub fn channels(&self) -> ResourceIter<'a, Id<ChannelMarker>, CachedChannel> {
+    pub fn channels(&self) -> ResourceIter<'a, Id<ChannelMarker>, CacheModels::Channel> {
         ResourceIter::new(self.0.channels.iter())
     }
 
     /// Create an iterator over the emojis in the cache.
-    pub fn emojis(&self) -> ResourceIter<'a, Id<EmojiMarker>, GuildResource<CachedEmoji>> {
+    pub fn emojis(&self) -> ResourceIter<'a, Id<EmojiMarker>, GuildResource<CacheModels::Emoji>> {
         ResourceIter::new(self.0.emojis.iter())
     }
 
     /// Create an iterator over the guilds in the cache.
-    pub fn guilds(&self) -> ResourceIter<'a, Id<GuildMarker>, CachedGuild> {
+    pub fn guilds(&self) -> ResourceIter<'a, Id<GuildMarker>, CacheModels::Guild> {
         ResourceIter::new(self.0.guilds.iter())
     }
 
@@ -265,52 +157,58 @@ impl<
     ) -> ResourceIter<
         'a,
         (Id<GuildMarker>, Id<IntegrationMarker>),
-        GuildResource<CachedGuildIntegration>,
+        GuildResource<CacheModels::GuildIntegration>,
     > {
         ResourceIter::new(self.0.integrations.iter())
     }
 
     /// Create an iterator over the members across all guilds in the cache.
-    pub fn members(&self) -> ResourceIter<'a, (Id<GuildMarker>, Id<UserMarker>), CachedMember> {
+    pub fn members(
+        &self,
+    ) -> ResourceIter<'a, (Id<GuildMarker>, Id<UserMarker>), CacheModels::Member> {
         ResourceIter::new(self.0.members.iter())
     }
 
     /// Create an iterator over the messages in the cache.
-    pub fn messages(&self) -> ResourceIter<'a, Id<MessageMarker>, CachedMessage> {
+    pub fn messages(&self) -> ResourceIter<'a, Id<MessageMarker>, CacheModels::Message> {
         ResourceIter::new(self.0.messages.iter())
     }
 
     /// Create an iterator over the presences in the cache.
-    pub fn presences(&self) -> ResourceIter<'a, (Id<GuildMarker>, Id<UserMarker>), CachedPresence> {
+    pub fn presences(
+        &self,
+    ) -> ResourceIter<'a, (Id<GuildMarker>, Id<UserMarker>), CacheModels::Presence> {
         ResourceIter::new(self.0.presences.iter())
     }
 
     /// Create an iterator over the roles in the cache.
-    pub fn roles(&self) -> ResourceIter<'a, Id<RoleMarker>, GuildResource<CachedRole>> {
+    pub fn roles(&self) -> ResourceIter<'a, Id<RoleMarker>, GuildResource<CacheModels::Role>> {
         ResourceIter::new(self.0.roles.iter())
     }
 
     /// Create an iterator over the stage instances in the cache.
     pub fn stage_instances(
         &self,
-    ) -> ResourceIter<'a, Id<StageMarker>, GuildResource<CachedStageInstance>> {
+    ) -> ResourceIter<'a, Id<StageMarker>, GuildResource<CacheModels::StageInstance>> {
         ResourceIter::new(self.0.stage_instances.iter())
     }
 
     /// Create an iterator over the stickers in the cache.
-    pub fn stickers(&self) -> ResourceIter<'a, Id<StickerMarker>, GuildResource<CachedSticker>> {
+    pub fn stickers(
+        &self,
+    ) -> ResourceIter<'a, Id<StickerMarker>, GuildResource<CacheModels::Sticker>> {
         ResourceIter::new(self.0.stickers.iter())
     }
 
     /// Create an iterator over the users in the cache.
-    pub fn users(&self) -> ResourceIter<'a, Id<UserMarker>, CachedUser> {
+    pub fn users(&self) -> ResourceIter<'a, Id<UserMarker>, CacheModels::User> {
         ResourceIter::new(self.0.users.iter())
     }
 
     /// Create an iterator over the voice states in the cache.
     pub fn voice_states(
         &self,
-    ) -> ResourceIter<'a, (Id<GuildMarker>, Id<UserMarker>), CachedVoiceState> {
+    ) -> ResourceIter<'a, (Id<GuildMarker>, Id<UserMarker>), CacheModels::VoiceState> {
         ResourceIter::new(self.0.voice_states.iter())
     }
 }
@@ -359,7 +257,7 @@ impl<'a, K: Eq + Hash, V> Iterator for ResourceIter<'a, K, V> {
 #[cfg(test)]
 mod tests {
     use super::{InMemoryCacheIter, IterReference, ResourceIter};
-    use crate::{test, DefaultInMemoryCache};
+    use crate::{test, DefaultCacheModels, DefaultInMemoryCache};
     use static_assertions::assert_impl_all;
     use std::{borrow::Cow, fmt::Debug};
     use twilight_model::{
@@ -367,7 +265,7 @@ mod tests {
         user::User,
     };
 
-    assert_impl_all!(InMemoryCacheIter<'_>: Debug, Send, Sync);
+    assert_impl_all!(InMemoryCacheIter<'_, DefaultCacheModels>: Debug, Send, Sync);
     assert_impl_all!(IterReference<'_, Id<UserMarker>, User>: Send, Sync);
     assert_impl_all!(ResourceIter<'_, Id<UserMarker>, User>: Iterator, Send, Sync);
 

--- a/twilight-cache-inmemory/src/lib.rs
+++ b/twilight-cache-inmemory/src/lib.rs
@@ -189,7 +189,7 @@ fn upsert_guild_item<K: Eq + Hash, V: PartialEq>(
 // When adding a field here, be sure to add it to `InMemoryCache::clear` if
 // necessary.
 #[derive(Debug)]
-pub struct InMemoryCache<CacheModels: CacheableModels> {
+pub struct InMemoryCache<CacheModels: CacheableModels = DefaultCacheModels> {
     config: Config,
     channels: DashMap<Id<ChannelMarker>, CacheModels::Channel>,
     channel_messages: DashMap<Id<ChannelMarker>, VecDeque<Id<MessageMarker>>>,
@@ -228,7 +228,7 @@ pub struct InMemoryCache<CacheModels: CacheableModels> {
 }
 
 #[allow(missing_docs)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DefaultCacheModels;
 
 impl CacheableModels for DefaultCacheModels {

--- a/twilight-cache-inmemory/src/lib.rs
+++ b/twilight-cache-inmemory/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod iter;
 pub mod model;
+pub mod traits;
 
 #[cfg(feature = "permission-calculator")]
 pub mod permission;
@@ -30,18 +31,18 @@ pub use self::{
     builder::InMemoryCacheBuilder,
     config::{Config, ResourceType},
     stats::InMemoryCacheStats,
+    traits::{
+        CacheableChannel, CacheableCurrentUser, CacheableEmoji, CacheableGuild,
+        CacheableGuildIntegration, CacheableMember, CacheableMessage, CacheablePresence,
+        CacheableRole, CacheableStageInstance, CacheableSticker, CacheableUser,
+        CacheableVoiceState,
+    },
 };
 
 #[cfg(feature = "permission-calculator")]
 pub use self::permission::InMemoryCachePermissions;
 
-use self::{
-    iter::InMemoryCacheIter,
-    model::{
-        CachedEmoji, CachedGuild, CachedMember, CachedMessage, CachedPresence, CachedSticker,
-        CachedVoiceState,
-    },
-};
+use self::iter::InMemoryCacheIter;
 use dashmap::{
     mapref::{entry::Entry, one::Ref},
     DashMap, DashSet,
@@ -187,13 +188,27 @@ fn upsert_guild_item<K: Eq + Hash, V: PartialEq>(
 /// [`Intents`]: ::twilight_model::gateway::Intents
 // When adding a field here, be sure to add it to `InMemoryCache::clear` if
 // necessary.
-#[derive(Debug, Default)]
-pub struct InMemoryCache {
+#[derive(Debug)]
+pub struct InMemoryCache<
+    CachedChannel: CacheableChannel = Channel,
+    CachedCurrentUser: CacheableCurrentUser = CurrentUser,
+    CachedEmoji: CacheableEmoji = model::CachedEmoji,
+    CachedGuild: CacheableGuild = model::CachedGuild,
+    CachedGuildIntegration: CacheableGuildIntegration = GuildIntegration,
+    CachedMember: CacheableMember = model::CachedMember,
+    CachedMessage: CacheableMessage = model::CachedMessage,
+    CachedPresence: CacheablePresence = model::CachedPresence,
+    CachedRole: CacheableRole = Role,
+    CachedStageInstance: CacheableStageInstance = StageInstance,
+    CachedSticker: CacheableSticker = model::CachedSticker,
+    CachedUser: CacheableUser = User,
+    CachedVoiceState: CacheableVoiceState = model::CachedVoiceState,
+> {
     config: Config,
-    channels: DashMap<Id<ChannelMarker>, Channel>,
+    channels: DashMap<Id<ChannelMarker>, CachedChannel>,
     channel_messages: DashMap<Id<ChannelMarker>, VecDeque<Id<MessageMarker>>>,
     // So long as the lock isn't held across await or panic points this is fine.
-    current_user: Mutex<Option<CurrentUser>>,
+    current_user: Mutex<Option<CachedCurrentUser>>,
     emojis: DashMap<Id<EmojiMarker>, GuildResource<CachedEmoji>>,
     guilds: DashMap<Id<GuildMarker>, CachedGuild>,
     guild_channels: DashMap<Id<GuildMarker>, HashSet<Id<ChannelMarker>>>,
@@ -205,15 +220,15 @@ pub struct InMemoryCache {
     guild_stage_instances: DashMap<Id<GuildMarker>, HashSet<Id<StageMarker>>>,
     guild_stickers: DashMap<Id<GuildMarker>, HashSet<Id<StickerMarker>>>,
     integrations:
-        DashMap<(Id<GuildMarker>, Id<IntegrationMarker>), GuildResource<GuildIntegration>>,
+        DashMap<(Id<GuildMarker>, Id<IntegrationMarker>), GuildResource<CachedGuildIntegration>>,
     members: DashMap<(Id<GuildMarker>, Id<UserMarker>), CachedMember>,
     messages: DashMap<Id<MessageMarker>, CachedMessage>,
     presences: DashMap<(Id<GuildMarker>, Id<UserMarker>), CachedPresence>,
-    roles: DashMap<Id<RoleMarker>, GuildResource<Role>>,
-    stage_instances: DashMap<Id<StageMarker>, GuildResource<StageInstance>>,
+    roles: DashMap<Id<RoleMarker>, GuildResource<CachedRole>>,
+    stage_instances: DashMap<Id<StageMarker>, GuildResource<CachedStageInstance>>,
     stickers: DashMap<Id<StickerMarker>, GuildResource<CachedSticker>>,
     unavailable_guilds: DashSet<Id<GuildMarker>>,
-    users: DashMap<Id<UserMarker>, User>,
+    users: DashMap<Id<UserMarker>, CachedUser>,
     user_guilds: DashMap<Id<UserMarker>, HashSet<Id<GuildMarker>>>,
     /// Mapping of channels and the users currently connected.
     #[allow(clippy::type_complexity)]
@@ -224,8 +239,56 @@ pub struct InMemoryCache {
     voice_states: DashMap<(Id<GuildMarker>, Id<UserMarker>), CachedVoiceState>,
 }
 
-/// Implemented methods and types for the cache.
-impl InMemoryCache {
+/// The default implementation of [`InMemoryCache`].
+/// This is a type alias to the trait type defaults to allow the compiler
+/// to properly infer the generics.
+pub type DefaultInMemoryCache = InMemoryCache<
+    Channel,
+    CurrentUser,
+    model::CachedEmoji,
+    model::CachedGuild,
+    GuildIntegration,
+    model::CachedMember,
+    model::CachedMessage,
+    model::CachedPresence,
+    Role,
+    StageInstance,
+    model::CachedSticker,
+    User,
+    model::CachedVoiceState,
+>;
+
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
     /// Creates a new, empty cache.
     ///
     /// # Examples
@@ -234,16 +297,33 @@ impl InMemoryCache {
     /// the message cache to 50 messages per channel:
     ///
     /// ```
-    /// use twilight_cache_inmemory::InMemoryCache;
+    /// use twilight_cache_inmemory::DefaultInMemoryCache;
     ///
-    /// let cache = InMemoryCache::builder().message_cache_size(50).build();
+    /// let cache = DefaultInMemoryCache::builder()
+    ///     .message_cache_size(50)
+    ///     .build();
     /// ```
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Create a new builder to configure and construct an in-memory cache.
-    pub const fn builder() -> InMemoryCacheBuilder {
+    #[allow(clippy::type_complexity)]
+    pub const fn builder() -> InMemoryCacheBuilder<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > {
         InMemoryCacheBuilder::new()
     }
 
@@ -297,17 +377,34 @@ impl InMemoryCache {
     /// Iterate over every guild in the cache and print their IDs and names:
     ///
     /// ```no_run
-    /// use twilight_cache_inmemory::InMemoryCache;
+    /// use twilight_cache_inmemory::DefaultInMemoryCache;
     ///
-    /// let cache = InMemoryCache::new();
+    /// let cache = DefaultInMemoryCache::new();
     ///
     /// // later in the application...
     /// for guild in cache.iter().guilds() {
     ///     println!("{}: {}", guild.id(), guild.name());
     /// }
     /// ```
-    #[allow(clippy::iter_not_returning_iterator)]
-    pub const fn iter(&self) -> InMemoryCacheIter<'_> {
+    #[allow(clippy::iter_not_returning_iterator, clippy::type_complexity)]
+    pub const fn iter(
+        &self,
+    ) -> InMemoryCacheIter<
+        '_,
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > {
         InMemoryCacheIter::new(self)
     }
 
@@ -318,15 +415,33 @@ impl InMemoryCache {
     /// Print the number of guilds in a cache:
     ///
     /// ```
-    /// use twilight_cache_inmemory::InMemoryCache;
+    /// use twilight_cache_inmemory::DefaultInMemoryCache;
     ///
-    /// let cache = InMemoryCache::new();
+    /// let cache = DefaultInMemoryCache::new();
     ///
     /// // later on...
     /// let guilds = cache.stats().guilds();
     /// println!("guild count: {guilds}");
     /// ```
-    pub const fn stats(&self) -> InMemoryCacheStats<'_> {
+    #[allow(clippy::type_complexity)]
+    pub const fn stats(
+        &self,
+    ) -> InMemoryCacheStats<
+        '_,
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > {
         InMemoryCacheStats::new(self)
     }
 
@@ -343,12 +458,12 @@ impl InMemoryCache {
     ///
     /// ```no_run
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use twilight_cache_inmemory::{InMemoryCache, ResourceType};
+    /// use twilight_cache_inmemory::{DefaultInMemoryCache, ResourceType};
     /// use twilight_model::id::Id;
     ///
     /// let resource_types = ResourceType::CHANNEL | ResourceType::MEMBER | ResourceType::ROLE;
     ///
-    /// let cache = InMemoryCache::builder()
+    /// let cache = DefaultInMemoryCache::builder()
     ///     .resource_types(resource_types)
     ///     .build();
     ///
@@ -360,18 +475,53 @@ impl InMemoryCache {
     /// # Ok(()) }
     /// ```
     #[cfg(feature = "permission-calculator")]
-    pub const fn permissions(&self) -> InMemoryCachePermissions<'_> {
+    #[allow(clippy::type_complexity)]
+    pub const fn permissions(
+        &self,
+    ) -> InMemoryCachePermissions<
+        '_,
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > {
         InMemoryCachePermissions::new(self)
     }
 
     /// Update the cache with an event from the gateway.
-    pub fn update(&self, value: &impl UpdateCache) {
+    pub fn update(
+        &self,
+        value: &impl UpdateCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         value.update(self);
     }
 
     /// Gets the current user.
     #[allow(clippy::missing_panics_doc)]
-    pub fn current_user(&self) -> Option<CurrentUser> {
+    pub fn current_user(&self) -> Option<CachedCurrentUser> {
         self.current_user
             .lock()
             .expect("current user poisoned")
@@ -382,7 +532,7 @@ impl InMemoryCache {
     pub fn channel(
         &self,
         channel_id: Id<ChannelMarker>,
-    ) -> Option<Reference<'_, Id<ChannelMarker>, Channel>> {
+    ) -> Option<Reference<'_, Id<ChannelMarker>, CachedChannel>> {
         self.channels.get(&channel_id).map(Reference::new)
     }
 
@@ -557,7 +707,11 @@ impl InMemoryCache {
         guild_id: Id<GuildMarker>,
         integration_id: Id<IntegrationMarker>,
     ) -> Option<
-        Reference<'_, (Id<GuildMarker>, Id<IntegrationMarker>), GuildResource<GuildIntegration>>,
+        Reference<
+            '_,
+            (Id<GuildMarker>, Id<IntegrationMarker>),
+            GuildResource<CachedGuildIntegration>,
+        >,
     > {
         self.integrations
             .get(&(guild_id, integration_id))
@@ -614,7 +768,7 @@ impl InMemoryCache {
     pub fn role(
         &self,
         role_id: Id<RoleMarker>,
-    ) -> Option<Reference<'_, Id<RoleMarker>, GuildResource<Role>>> {
+    ) -> Option<Reference<'_, Id<RoleMarker>, GuildResource<CachedRole>>> {
         self.roles.get(&role_id).map(Reference::new)
     }
 
@@ -626,7 +780,7 @@ impl InMemoryCache {
     pub fn stage_instance(
         &self,
         stage_id: Id<StageMarker>,
-    ) -> Option<Reference<'_, Id<StageMarker>, GuildResource<StageInstance>>> {
+    ) -> Option<Reference<'_, Id<StageMarker>, GuildResource<CachedStageInstance>>> {
         self.stage_instances.get(&stage_id).map(Reference::new)
     }
 
@@ -650,7 +804,10 @@ impl InMemoryCache {
     /// This requires the [`GUILD_MEMBERS`] intent.
     ///
     /// [`GUILD_MEMBERS`]: ::twilight_model::gateway::Intents::GUILD_MEMBERS
-    pub fn user(&self, user_id: Id<UserMarker>) -> Option<Reference<'_, Id<UserMarker>, User>> {
+    pub fn user(
+        &self,
+        user_id: Id<UserMarker>,
+    ) -> Option<Reference<'_, Id<UserMarker>, CachedUser>> {
         self.users.get(&user_id).map(Reference::new)
     }
 
@@ -681,7 +838,7 @@ impl InMemoryCache {
     pub fn voice_channel_states(
         &self,
         channel_id: Id<ChannelMarker>,
-    ) -> Option<VoiceChannelStates<'_>> {
+    ) -> Option<VoiceChannelStates<'_, CachedVoiceState>> {
         let user_ids = self.voice_state_channels.get(&channel_id)?;
 
         Some(VoiceChannelStates {
@@ -723,15 +880,16 @@ impl InMemoryCache {
 
         let mut highest_role: Option<(i64, Id<RoleMarker>)> = None;
 
-        for role_id in &member.roles {
+        for role_id in member.roles() {
             if let Some(role) = self.role(*role_id) {
                 if let Some((position, id)) = highest_role {
-                    if role.position < position || (role.position == position && role.id > id) {
+                    if role.position() < position || (role.position() == position && role.id() > id)
+                    {
                         continue;
                     }
                 }
 
-                highest_role = Some((role.position, role.id));
+                highest_role = Some((role.position(), role.id()));
             }
         }
 
@@ -741,7 +899,7 @@ impl InMemoryCache {
     fn new_with_config(config: Config) -> Self {
         Self {
             config,
-            ..InMemoryCache::default()
+            ..Self::default()
         }
     }
 
@@ -749,6 +907,72 @@ impl InMemoryCache {
     /// processed.
     const fn wants(&self, resource_type: ResourceType) -> bool {
         self.config.resource_types().contains(resource_type)
+    }
+}
+
+// This needs to be implemented manually because the compiler apparently
+// can't derive Default for a struct with generics.
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    > Default
+    for InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
+    fn default() -> Self {
+        Self {
+            config: Config::default(),
+            channels: DashMap::new(),
+            channel_messages: DashMap::new(),
+            current_user: Mutex::new(None),
+            emojis: DashMap::new(),
+            guilds: DashMap::new(),
+            guild_channels: DashMap::new(),
+            guild_emojis: DashMap::new(),
+            guild_integrations: DashMap::new(),
+            guild_members: DashMap::new(),
+            guild_presences: DashMap::new(),
+            guild_roles: DashMap::new(),
+            guild_stage_instances: DashMap::new(),
+            guild_stickers: DashMap::new(),
+            integrations: DashMap::new(),
+            members: DashMap::new(),
+            messages: DashMap::new(),
+            presences: DashMap::new(),
+            roles: DashMap::new(),
+            stage_instances: DashMap::new(),
+            stickers: DashMap::new(),
+            unavailable_guilds: DashSet::new(),
+            users: DashMap::new(),
+            user_guilds: DashMap::new(),
+            voice_state_channels: DashMap::new(),
+            voice_state_guilds: DashMap::new(),
+            voice_states: DashMap::new(),
+        }
     }
 }
 
@@ -815,22 +1039,55 @@ mod private {
 /// Implemented for dispatch events.
 ///
 /// This trait is sealed and cannot be implemented.
-pub trait UpdateCache: private::Sealed {
+pub trait UpdateCache<
+    CachedChannel: CacheableChannel,
+    CachedCurrentUser: CacheableCurrentUser,
+    CachedEmoji: CacheableEmoji,
+    CachedGuild: CacheableGuild,
+    CachedGuildIntegration: CacheableGuildIntegration,
+    CachedMember: CacheableMember,
+    CachedMessage: CacheableMessage,
+    CachedPresence: CacheablePresence,
+    CachedRole: CacheableRole,
+    CachedStageInstance: CacheableStageInstance,
+    CachedSticker: CacheableSticker,
+    CachedUser: CacheableUser,
+    CachedVoiceState: CacheableVoiceState,
+>: private::Sealed
+{
     /// Updates the cache based on data contained within an event.
     // Allow this for presentation purposes in documentation.
-    #[allow(unused_variables)]
-    fn update(&self, cache: &InMemoryCache) {}
+    #[allow(unused_variables, clippy::type_complexity)]
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
+    }
 }
 
 /// Iterator over a voice channel's list of voice states.
-pub struct VoiceChannelStates<'a> {
+pub struct VoiceChannelStates<'a, CachedVoiceState> {
     index: usize,
     #[allow(clippy::type_complexity)]
     user_ids: Ref<'a, Id<ChannelMarker>, HashSet<(Id<GuildMarker>, Id<UserMarker>)>>,
     voice_states: &'a DashMap<(Id<GuildMarker>, Id<UserMarker>), CachedVoiceState>,
 }
 
-impl<'a> Iterator for VoiceChannelStates<'a> {
+impl<'a, CachedVoiceState> Iterator for VoiceChannelStates<'a, CachedVoiceState> {
     type Item = Reference<'a, (Id<GuildMarker>, Id<UserMarker>), CachedVoiceState>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -846,51 +1103,98 @@ impl<'a> Iterator for VoiceChannelStates<'a> {
     }
 }
 
-impl UpdateCache for Event {
+impl<
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    UpdateCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > for Event
+{
     // clippy: using `.deref()` is cleaner
-    #[allow(clippy::cognitive_complexity, clippy::explicit_deref_methods)]
-    fn update(&self, c: &InMemoryCache) {
+    #[allow(clippy::explicit_deref_methods)]
+    fn update(
+        &self,
+        cache: &InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) {
         match self {
-            Event::ChannelCreate(v) => c.update(v.deref()),
-            Event::ChannelDelete(v) => c.update(v.deref()),
-            Event::ChannelPinsUpdate(v) => c.update(v),
-            Event::ChannelUpdate(v) => c.update(v.deref()),
-            Event::GuildCreate(v) => c.update(v.deref()),
-            Event::GuildDelete(v) => c.update(v),
-            Event::GuildEmojisUpdate(v) => c.update(v),
-            Event::GuildStickersUpdate(v) => c.update(v),
-            Event::GuildUpdate(v) => c.update(v.deref()),
-            Event::IntegrationCreate(v) => c.update(v.deref()),
-            Event::IntegrationDelete(v) => c.update(v),
-            Event::IntegrationUpdate(v) => c.update(v.deref()),
-            Event::InteractionCreate(v) => c.update(v.deref()),
-            Event::MemberAdd(v) => c.update(v.deref()),
-            Event::MemberRemove(v) => c.update(v),
-            Event::MemberUpdate(v) => c.update(v.deref()),
-            Event::MemberChunk(v) => c.update(v),
-            Event::MessageCreate(v) => c.update(v.deref()),
-            Event::MessageDelete(v) => c.update(v),
-            Event::MessageDeleteBulk(v) => c.update(v),
-            Event::MessageUpdate(v) => c.update(v.deref()),
-            Event::PresenceUpdate(v) => c.update(v.deref()),
-            Event::ReactionAdd(v) => c.update(v.deref()),
-            Event::ReactionRemove(v) => c.update(v.deref()),
-            Event::ReactionRemoveAll(v) => c.update(v),
-            Event::ReactionRemoveEmoji(v) => c.update(v),
-            Event::Ready(v) => c.update(v.deref()),
-            Event::RoleCreate(v) => c.update(v),
-            Event::RoleDelete(v) => c.update(v),
-            Event::RoleUpdate(v) => c.update(v),
-            Event::StageInstanceCreate(v) => c.update(v),
-            Event::StageInstanceDelete(v) => c.update(v),
-            Event::StageInstanceUpdate(v) => c.update(v),
-            Event::ThreadCreate(v) => c.update(v.deref()),
-            Event::ThreadUpdate(v) => c.update(v.deref()),
-            Event::ThreadDelete(v) => c.update(v),
-            Event::ThreadListSync(v) => c.update(v),
-            Event::UnavailableGuild(v) => c.update(v),
-            Event::UserUpdate(v) => c.update(v),
-            Event::VoiceStateUpdate(v) => c.update(v.deref()),
+            Event::ChannelCreate(v) => cache.update(v.deref()),
+            Event::ChannelDelete(v) => cache.update(v.deref()),
+            Event::ChannelPinsUpdate(v) => cache.update(v),
+            Event::ChannelUpdate(v) => cache.update(v.deref()),
+            Event::GuildCreate(v) => cache.update(v.deref()),
+            Event::GuildDelete(v) => cache.update(v),
+            Event::GuildEmojisUpdate(v) => cache.update(v),
+            Event::GuildStickersUpdate(v) => cache.update(v),
+            Event::GuildUpdate(v) => cache.update(v.deref()),
+            Event::IntegrationCreate(v) => cache.update(v.deref()),
+            Event::IntegrationDelete(v) => cache.update(v),
+            Event::IntegrationUpdate(v) => cache.update(v.deref()),
+            Event::InteractionCreate(v) => cache.update(v.deref()),
+            Event::MemberAdd(v) => cache.update(v.deref()),
+            Event::MemberRemove(v) => cache.update(v),
+            Event::MemberUpdate(v) => cache.update(v.deref()),
+            Event::MemberChunk(v) => cache.update(v),
+            Event::MessageCreate(v) => cache.update(v.deref()),
+            Event::MessageDelete(v) => cache.update(v),
+            Event::MessageDeleteBulk(v) => cache.update(v),
+            Event::MessageUpdate(v) => cache.update(v.deref()),
+            Event::PresenceUpdate(v) => cache.update(v.deref()),
+            Event::ReactionAdd(v) => cache.update(v.deref()),
+            Event::ReactionRemove(v) => cache.update(v.deref()),
+            Event::ReactionRemoveAll(v) => cache.update(v),
+            Event::ReactionRemoveEmoji(v) => cache.update(v),
+            Event::Ready(v) => cache.update(v.deref()),
+            Event::RoleCreate(v) => cache.update(v),
+            Event::RoleDelete(v) => cache.update(v),
+            Event::RoleUpdate(v) => cache.update(v),
+            Event::StageInstanceCreate(v) => cache.update(v),
+            Event::StageInstanceDelete(v) => cache.update(v),
+            Event::StageInstanceUpdate(v) => cache.update(v),
+            Event::ThreadCreate(v) => cache.update(v.deref()),
+            Event::ThreadUpdate(v) => cache.update(v.deref()),
+            Event::ThreadDelete(v) => cache.update(v),
+            Event::ThreadListSync(v) => cache.update(v),
+            Event::UnavailableGuild(v) => cache.update(v),
+            Event::UserUpdate(v) => cache.update(v),
+            Event::VoiceStateUpdate(v) => cache.update(v.deref()),
             // Ignored events.
             Event::AutoModerationActionExecution(_)
             | Event::AutoModerationRuleCreate(_)
@@ -926,7 +1230,7 @@ impl UpdateCache for Event {
 
 #[cfg(test)]
 mod tests {
-    use crate::{test, InMemoryCache};
+    use crate::{test, DefaultInMemoryCache};
     use twilight_model::{
         gateway::payload::incoming::RoleDelete,
         guild::{Member, MemberFlags, Permissions, Role, RoleFlags},
@@ -936,7 +1240,7 @@ mod tests {
 
     #[test]
     fn syntax_update() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         cache.update(&RoleDelete {
             guild_id: Id::new(1),
             role_id: Id::new(1),
@@ -945,7 +1249,7 @@ mod tests {
 
     #[test]
     fn clear() {
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         cache.cache_emoji(Id::new(1), test::emoji(Id::new(3), None));
         cache.cache_member(Id::new(2), test::member(Id::new(2)));
         cache.clear();
@@ -956,7 +1260,7 @@ mod tests {
     #[test]
     fn highest_role() {
         let joined_at = Some(Timestamp::from_secs(1_632_072_645).expect("non zero"));
-        let cache = InMemoryCache::new();
+        let cache = DefaultInMemoryCache::new();
         let guild_id = Id::new(1);
         let user = test::user(Id::new(1));
         let flags = MemberFlags::BYPASSES_VERIFICATION | MemberFlags::DID_REJOIN;

--- a/twilight-cache-inmemory/src/lib.rs
+++ b/twilight-cache-inmemory/src/lib.rs
@@ -188,6 +188,7 @@ fn upsert_guild_item<K: Eq + Hash, V: PartialEq>(
 /// [`Intents`]: ::twilight_model::gateway::Intents
 // When adding a field here, be sure to add it to `InMemoryCache::clear` if
 // necessary.
+#[allow(clippy::type_complexity)]
 #[derive(Debug)]
 pub struct InMemoryCache<CacheModels: CacheableModels = DefaultCacheModels> {
     config: Config,

--- a/twilight-cache-inmemory/src/model/emoji.rs
+++ b/twilight-cache-inmemory/src/model/emoji.rs
@@ -1,3 +1,4 @@
+use crate::CacheableEmoji;
 use serde::Serialize;
 use twilight_model::{
     guild::Emoji,
@@ -65,9 +66,10 @@ impl CachedEmoji {
     pub const fn user_id(&self) -> Option<Id<UserMarker>> {
         self.user_id
     }
+}
 
-    /// Construct a cached emoji from its [`twilight_model`] form.
-    pub(crate) fn from_model(emoji: Emoji) -> Self {
+impl From<Emoji> for CachedEmoji {
+    fn from(emoji: Emoji) -> Self {
         let Emoji {
             animated,
             available,
@@ -79,7 +81,7 @@ impl CachedEmoji {
             user,
         } = emoji;
 
-        CachedEmoji {
+        Self {
             animated,
             available,
             id,
@@ -104,6 +106,8 @@ impl PartialEq<Emoji> for CachedEmoji {
             && self.available == other.available
     }
 }
+
+impl CacheableEmoji for CachedEmoji {}
 
 #[cfg(test)]
 mod tests {

--- a/twilight-cache-inmemory/src/model/guild.rs
+++ b/twilight-cache-inmemory/src/model/guild.rs
@@ -2,9 +2,10 @@ use std::slice::Iter;
 
 use serde::Serialize;
 use twilight_model::{
+    gateway::payload::incoming::GuildUpdate,
     guild::{
-        AfkTimeout, DefaultMessageNotificationLevel, ExplicitContentFilter, GuildFeature, MfaLevel,
-        NSFWLevel, Permissions, PremiumTier, SystemChannelFlags, VerificationLevel,
+        AfkTimeout, DefaultMessageNotificationLevel, ExplicitContentFilter, Guild, GuildFeature,
+        MfaLevel, NSFWLevel, Permissions, PremiumTier, SystemChannelFlags, VerificationLevel,
     },
     id::{
         marker::{ApplicationMarker, ChannelMarker, GuildMarker, UserMarker},
@@ -12,6 +13,8 @@ use twilight_model::{
     },
     util::{ImageHash, Timestamp},
 };
+
+use crate::CacheableGuild;
 
 /// Represents a cached [`Guild`].
 ///
@@ -272,6 +275,188 @@ impl CachedGuild {
     /// Whether the widget is enabled.
     pub const fn widget_enabled(&self) -> Option<bool> {
         self.widget_enabled
+    }
+}
+
+impl From<Guild> for CachedGuild {
+    fn from(guild: Guild) -> Self {
+        let Guild {
+            afk_channel_id,
+            afk_timeout,
+            application_id,
+            approximate_member_count: _,
+            approximate_presence_count: _,
+            banner,
+            default_message_notifications,
+            description,
+            discovery_splash,
+            explicit_content_filter,
+            features,
+            icon,
+            id,
+            joined_at,
+            large,
+            max_members,
+            max_presences,
+            max_video_channel_users,
+            member_count,
+            mfa_level,
+            name,
+            nsfw_level,
+            owner_id,
+            owner,
+            permissions,
+            preferred_locale,
+            premium_progress_bar_enabled,
+            premium_subscription_count,
+            premium_tier,
+            public_updates_channel_id,
+            rules_channel_id,
+            safety_alerts_channel_id,
+            splash,
+            system_channel_flags,
+            system_channel_id,
+            unavailable,
+            vanity_url_code,
+            verification_level,
+            widget_channel_id,
+            widget_enabled,
+            ..
+        } = guild;
+
+        Self {
+            afk_channel_id,
+            afk_timeout,
+            application_id,
+            banner,
+            default_message_notifications,
+            description,
+            discovery_splash,
+            explicit_content_filter,
+            features,
+            icon,
+            id,
+            joined_at,
+            large,
+            max_members,
+            max_presences,
+            max_video_channel_users,
+            member_count,
+            mfa_level,
+            name,
+            nsfw_level,
+            owner_id,
+            owner,
+            permissions,
+            preferred_locale,
+            premium_progress_bar_enabled,
+            premium_subscription_count,
+            premium_tier,
+            public_updates_channel_id,
+            rules_channel_id,
+            safety_alerts_channel_id,
+            splash,
+            system_channel_id,
+            system_channel_flags,
+            unavailable,
+            vanity_url_code,
+            verification_level,
+            widget_channel_id,
+            widget_enabled,
+        }
+    }
+}
+
+impl PartialEq<Guild> for CachedGuild {
+    fn eq(&self, other: &Guild) -> bool {
+        self.afk_channel_id == other.afk_channel_id
+            && self.afk_timeout == other.afk_timeout
+            && self.application_id == other.application_id
+            && self.banner == other.banner
+            && self.default_message_notifications == other.default_message_notifications
+            && self.description == other.description
+            && self.discovery_splash == other.discovery_splash
+            && self.explicit_content_filter == other.explicit_content_filter
+            && self.features == other.features
+            && self.icon == other.icon
+            && self.joined_at == other.joined_at
+            && self.large == other.large
+            && self.max_members == other.max_members
+            && self.max_presences == other.max_presences
+            && self.max_video_channel_users == other.max_video_channel_users
+            && self.member_count == other.member_count
+            && self.mfa_level == other.mfa_level
+            && self.name == other.name
+            && self.nsfw_level == other.nsfw_level
+            && self.owner_id == other.owner_id
+            && self.owner == other.owner
+            && self.permissions == other.permissions
+            && self.preferred_locale == other.preferred_locale
+            && self.premium_progress_bar_enabled == other.premium_progress_bar_enabled
+            && self.premium_subscription_count == other.premium_subscription_count
+            && self.premium_tier == other.premium_tier
+            && self.public_updates_channel_id == other.public_updates_channel_id
+            && self.rules_channel_id == other.rules_channel_id
+            && self.safety_alerts_channel_id == other.safety_alerts_channel_id
+            && self.splash == other.splash
+            && self.system_channel_id == other.system_channel_id
+            && self.system_channel_flags == other.system_channel_flags
+            && self.unavailable == other.unavailable
+            && self.vanity_url_code == other.vanity_url_code
+            && self.verification_level == other.verification_level
+            && self.widget_channel_id == other.widget_channel_id
+            && self.widget_enabled == other.widget_enabled
+    }
+}
+
+impl CacheableGuild for CachedGuild {
+    fn id(&self) -> Id<GuildMarker> {
+        self.id
+    }
+
+    #[cfg(feature = "permission-calculator")]
+    fn owner_id(&self) -> Id<UserMarker> {
+        self.owner_id
+    }
+
+    fn set_unavailable(&mut self, unavailable: bool) {
+        self.unavailable = unavailable;
+    }
+
+    fn update_with_guild_update(&mut self, guild_update: &GuildUpdate) {
+        self.afk_channel_id = guild_update.afk_channel_id;
+        self.afk_timeout = guild_update.afk_timeout;
+        self.banner = guild_update.banner;
+        self.default_message_notifications = guild_update.default_message_notifications;
+        self.description = guild_update.description.clone();
+        self.features = guild_update.features.clone();
+        self.icon = guild_update.icon;
+        self.max_members = guild_update.max_members;
+        self.max_presences = Some(guild_update.max_presences.unwrap_or(25000));
+        self.mfa_level = guild_update.mfa_level;
+        self.name = guild_update.name.clone();
+        self.nsfw_level = guild_update.nsfw_level;
+        self.owner = guild_update.owner;
+        self.owner_id = guild_update.owner_id;
+        self.permissions = guild_update.permissions;
+        self.preferred_locale = guild_update.preferred_locale.clone();
+        self.premium_tier = guild_update.premium_tier;
+        self.premium_subscription_count
+            .replace(guild_update.premium_subscription_count.unwrap_or_default());
+        self.splash = guild_update.splash;
+        self.system_channel_id = guild_update.system_channel_id;
+        self.verification_level = guild_update.verification_level;
+        self.vanity_url_code = guild_update.vanity_url_code.clone();
+        self.widget_channel_id = guild_update.widget_channel_id;
+        self.widget_enabled = guild_update.widget_enabled;
+    }
+
+    fn increase_member_count(&mut self, amount: u64) {
+        self.member_count = self.member_count.map(|count| count + amount);
+    }
+
+    fn decrease_member_count(&mut self, amount: u64) {
+        self.member_count = self.member_count.map(|count| count - amount);
     }
 }
 

--- a/twilight-cache-inmemory/src/model/member.rs
+++ b/twilight-cache-inmemory/src/model/member.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use twilight_model::{
     application::interaction::InteractionMember,
+    gateway::payload::incoming::MemberUpdate,
     guild::{Member, MemberFlags, PartialMember},
     id::{
         marker::{RoleMarker, UserMarker},
@@ -9,12 +10,32 @@ use twilight_model::{
     util::{ImageHash, Timestamp},
 };
 
-/// Computed fields required to complete a full cached member via
-/// [`CachedMember::from_interaction_member`] that are not otherwise present.
-pub(crate) struct ComputedInteractionMemberFields {
-    pub avatar: Option<ImageHash>,
-    pub deaf: Option<bool>,
-    pub mute: Option<bool>,
+use crate::CacheableMember;
+
+/// Computed fields required to complete a full cached member by implementing
+/// [`CacheableMember`] that are not otherwise present.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ComputedInteractionMemberFields {
+    pub(crate) avatar: Option<ImageHash>,
+    pub(crate) deaf: Option<bool>,
+    pub(crate) mute: Option<bool>,
+}
+
+impl ComputedInteractionMemberFields {
+    /// Member's guild avatar.
+    pub const fn avatar(&self) -> Option<ImageHash> {
+        self.avatar
+    }
+
+    /// Whether the member is deafened in a voice channel.
+    pub const fn deaf(&self) -> Option<bool> {
+        self.deaf
+    }
+
+    /// Whether the member is muted in a voice channel.
+    pub const fn mute(&self) -> Option<bool> {
+        self.mute
+    }
 }
 
 /// Represents a cached [`Member`].
@@ -100,10 +121,10 @@ impl CachedMember {
     pub const fn user_id(&self) -> Id<UserMarker> {
         self.user_id
     }
+}
 
-    /// Construct a cached member from its [`twilight_model`] form.
-    #[allow(clippy::missing_const_for_fn)]
-    pub(crate) fn from_model(member: Member) -> Self {
+impl From<Member> for CachedMember {
+    fn from(member: Member) -> Self {
         let Member {
             avatar,
             communication_disabled_until,
@@ -132,14 +153,21 @@ impl CachedMember {
             user_id: user.id,
         }
     }
+}
 
-    // clippy: the member field's destructor needs to drop
-    // clippy: the contents of `fields` is consumed
-    #[allow(clippy::missing_const_for_fn, clippy::needless_pass_by_value)]
-    pub(crate) fn from_interaction_member(
-        user_id: Id<UserMarker>,
-        member: InteractionMember,
-        fields: ComputedInteractionMemberFields,
+impl
+    From<(
+        Id<UserMarker>,
+        InteractionMember,
+        ComputedInteractionMemberFields,
+    )> for CachedMember
+{
+    fn from(
+        (user_id, member, fields): (
+            Id<UserMarker>,
+            InteractionMember,
+            ComputedInteractionMemberFields,
+        ),
     ) -> Self {
         let InteractionMember {
             avatar: _,
@@ -168,8 +196,10 @@ impl CachedMember {
             user_id,
         }
     }
+}
 
-    pub(crate) fn from_partial_member(user_id: Id<UserMarker>, member: PartialMember) -> Self {
+impl From<(Id<UserMarker>, PartialMember)> for CachedMember {
+    fn from((user_id, member): (Id<UserMarker>, PartialMember)) -> Self {
         let PartialMember {
             avatar,
             communication_disabled_until,
@@ -233,6 +263,40 @@ impl PartialEq<InteractionMember> for CachedMember {
             && self.nick == other.nick
             && self.premium_since == other.premium_since
             && self.roles == other.roles
+    }
+}
+
+impl CacheableMember for CachedMember {
+    fn roles(&self) -> &[Id<RoleMarker>] {
+        &self.roles
+    }
+
+    #[cfg(feature = "permission-calculator")]
+    fn communication_disabled_until(&self) -> Option<Timestamp> {
+        self.communication_disabled_until
+    }
+
+    fn avatar(&self) -> Option<ImageHash> {
+        self.avatar
+    }
+
+    fn deaf(&self) -> Option<bool> {
+        self.deaf
+    }
+
+    fn mute(&self) -> Option<bool> {
+        self.mute
+    }
+
+    fn update_with_member_update(&mut self, member_update: &MemberUpdate) {
+        self.avatar = member_update.avatar;
+        self.deaf = member_update.deaf.or_else(|| self.deaf());
+        self.mute = member_update.mute.or_else(|| self.mute());
+        self.nick = member_update.nick.clone();
+        self.roles = member_update.roles.clone();
+        self.joined_at = member_update.joined_at;
+        self.pending = member_update.pending;
+        self.communication_disabled_until = member_update.communication_disabled_until;
     }
 }
 

--- a/twilight-cache-inmemory/src/model/mod.rs
+++ b/twilight-cache-inmemory/src/model/mod.rs
@@ -10,6 +10,11 @@ mod sticker;
 mod voice_state;
 
 pub use self::{
-    emoji::CachedEmoji, guild::CachedGuild, member::CachedMember, message::CachedMessage,
-    presence::CachedPresence, sticker::CachedSticker, voice_state::CachedVoiceState,
+    emoji::CachedEmoji,
+    guild::CachedGuild,
+    member::{CachedMember, ComputedInteractionMemberFields},
+    message::CachedMessage,
+    presence::CachedPresence,
+    sticker::CachedSticker,
+    voice_state::CachedVoiceState,
 };

--- a/twilight-cache-inmemory/src/model/mod.rs
+++ b/twilight-cache-inmemory/src/model/mod.rs
@@ -12,7 +12,7 @@ mod voice_state;
 pub use self::{
     emoji::CachedEmoji,
     guild::CachedGuild,
-    member::{CachedMember, ComputedInteractionMemberFields},
+    member::{CachedMember, ComputedInteractionMember},
     message::CachedMessage,
     presence::CachedPresence,
     sticker::CachedSticker,

--- a/twilight-cache-inmemory/src/model/presence.rs
+++ b/twilight-cache-inmemory/src/model/presence.rs
@@ -7,6 +7,8 @@ use twilight_model::{
     },
 };
 
+use crate::CacheablePresence;
+
 /// Represents a cached [`Presence`].
 ///
 /// [`Presence`]: twilight_model::gateway::presence::Presence
@@ -44,10 +46,10 @@ impl CachedPresence {
     pub const fn user_id(&self) -> Id<UserMarker> {
         self.user_id
     }
+}
 
-    /// Construct a cached presence from its [`twilight_model`] form.
-    #[allow(clippy::missing_const_for_fn)]
-    pub(crate) fn from_model(presence: Presence) -> Self {
+impl From<Presence> for CachedPresence {
+    fn from(presence: Presence) -> Self {
         let Presence {
             activities,
             client_status,
@@ -76,11 +78,7 @@ impl PartialEq<Presence> for CachedPresence {
     }
 }
 
-impl From<Presence> for CachedPresence {
-    fn from(presence: Presence) -> Self {
-        Self::from_model(presence)
-    }
-}
+impl CacheablePresence for CachedPresence {}
 
 #[cfg(test)]
 mod tests {

--- a/twilight-cache-inmemory/src/model/sticker.rs
+++ b/twilight-cache-inmemory/src/model/sticker.rs
@@ -10,6 +10,8 @@ use twilight_model::{
     },
 };
 
+use crate::CacheableSticker;
+
 /// Representation of a cached [`Sticker`].
 ///
 /// [`Sticker`]: twilight_model::channel::message::sticker::Sticker
@@ -94,9 +96,10 @@ impl CachedSticker {
     pub const fn user_id(&self) -> Option<Id<UserMarker>> {
         self.user_id
     }
+}
 
-    /// Construct a cached sticker from its [`twilight_model`] form.
-    pub(crate) fn from_model(sticker: Sticker) -> Self {
+impl From<Sticker> for CachedSticker {
+    fn from(sticker: Sticker) -> Self {
         let Sticker {
             available,
             description,
@@ -140,6 +143,12 @@ impl PartialEq<Sticker> for CachedSticker {
             && self.sort_value == other.sort_value
             && self.tags == other.tags
             && self.user_id == other.user.as_ref().map(|user| user.id)
+    }
+}
+
+impl CacheableSticker for CachedSticker {
+    fn id(&self) -> Id<StickerMarker> {
+        self.id
     }
 }
 

--- a/twilight-cache-inmemory/src/model/voice_state.rs
+++ b/twilight-cache-inmemory/src/model/voice_state.rs
@@ -8,6 +8,8 @@ use twilight_model::{
     voice::VoiceState,
 };
 
+use crate::CacheableVoiceState;
+
 /// Represents a cached [`VoiceState`].
 ///
 /// [`VoiceState`]: twilight_model::voice::VoiceState
@@ -88,13 +90,11 @@ impl CachedVoiceState {
     pub const fn user_id(&self) -> Id<UserMarker> {
         self.user_id
     }
+}
 
-    /// Construct a cached voice state from its [`twilight_model`] form.
-    #[allow(clippy::missing_const_for_fn)]
-    pub(crate) fn from_model(
-        channel_id: Id<ChannelMarker>,
-        guild_id: Id<GuildMarker>,
-        voice_state: VoiceState,
+impl From<(Id<ChannelMarker>, Id<GuildMarker>, VoiceState)> for CachedVoiceState {
+    fn from(
+        (channel_id, guild_id, voice_state): (Id<ChannelMarker>, Id<GuildMarker>, VoiceState),
     ) -> Self {
         // Reasons for dropping fields:
         //
@@ -151,6 +151,12 @@ impl PartialEq<VoiceState> for CachedVoiceState {
     }
 }
 
+impl CacheableVoiceState for CachedVoiceState {
+    fn channel_id(&self) -> Id<ChannelMarker> {
+        self.channel_id
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::CachedVoiceState;
@@ -196,7 +202,7 @@ mod tests {
     #[test]
     fn eq() {
         let voice_state = test::voice_state(GUILD_ID, Some(CHANNEL_ID), USER_ID);
-        let cached = CachedVoiceState::from_model(CHANNEL_ID, GUILD_ID, voice_state.clone());
+        let cached = CachedVoiceState::from((CHANNEL_ID, GUILD_ID, voice_state.clone()));
 
         assert_eq!(cached, voice_state);
     }
@@ -204,7 +210,7 @@ mod tests {
     #[test]
     fn getters() {
         let voice_state = test::voice_state(GUILD_ID, Some(CHANNEL_ID), USER_ID);
-        let cached = CachedVoiceState::from_model(CHANNEL_ID, GUILD_ID, voice_state.clone());
+        let cached = CachedVoiceState::from((CHANNEL_ID, GUILD_ID, voice_state.clone()));
 
         assert_eq!(Some(cached.channel_id()), voice_state.channel_id);
         assert_eq!(cached.deaf(), voice_state.deaf);

--- a/twilight-cache-inmemory/src/stats.rs
+++ b/twilight-cache-inmemory/src/stats.rs
@@ -3,7 +3,7 @@ use twilight_model::id::{
     Id,
 };
 
-use crate::CacheableModels;
+use crate::{CacheableModels, DefaultCacheModels};
 
 use super::InMemoryCache;
 
@@ -31,7 +31,9 @@ use super::InMemoryCache;
 /// [`users`]: Self::users
 #[allow(clippy::type_complexity)]
 #[derive(Clone, Debug)]
-pub struct InMemoryCacheStats<'a, CacheModels: CacheableModels>(&'a InMemoryCache<CacheModels>);
+pub struct InMemoryCacheStats<'a, CacheModels: CacheableModels = DefaultCacheModels>(
+    &'a InMemoryCache<CacheModels>,
+);
 
 impl<'a, CacheModels: CacheableModels> InMemoryCacheStats<'a, CacheModels> {
     #[allow(clippy::type_complexity)]

--- a/twilight-cache-inmemory/src/stats.rs
+++ b/twilight-cache-inmemory/src/stats.rs
@@ -1,6 +1,21 @@
-use twilight_model::id::{
-    marker::{ChannelMarker, GuildMarker},
-    Id,
+use twilight_model::{
+    channel::{Channel, StageInstance},
+    guild::{GuildIntegration, Role},
+    id::{
+        marker::{ChannelMarker, GuildMarker},
+        Id,
+    },
+    user::{CurrentUser, User},
+};
+
+use crate::{
+    model,
+    traits::{
+        CacheableChannel, CacheableGuild, CacheableMember, CacheableMessage, CacheableRole,
+        CacheableVoiceState,
+    },
+    CacheableCurrentUser, CacheableEmoji, CacheableGuildIntegration, CacheablePresence,
+    CacheableStageInstance, CacheableSticker, CacheableUser,
 };
 
 use super::InMemoryCache;
@@ -17,9 +32,9 @@ use super::InMemoryCache;
 /// Retrieve the number of users stored in the cache:
 ///
 /// ```no_run
-/// use twilight_cache_inmemory::InMemoryCache;
+/// use twilight_cache_inmemory::DefaultInMemoryCache;
 ///
-/// let cache = InMemoryCache::new();
+/// let cache = DefaultInMemoryCache::new();
 ///
 /// // later on...
 /// println!("user count: {}", cache.stats().users());
@@ -27,22 +42,137 @@ use super::InMemoryCache;
 ///
 /// [`channel_messages`]: Self::channel_messages
 /// [`users`]: Self::users
+#[allow(clippy::type_complexity)]
 #[derive(Clone, Debug)]
-pub struct InMemoryCacheStats<'a>(&'a InMemoryCache);
+pub struct InMemoryCacheStats<
+    'a,
+    CachedChannel: CacheableChannel = Channel,
+    CachedCurrentUser: CacheableCurrentUser = CurrentUser,
+    CachedEmoji: CacheableEmoji = model::CachedEmoji,
+    CachedGuild: CacheableGuild = model::CachedGuild,
+    CachedGuildIntegration: CacheableGuildIntegration = GuildIntegration,
+    CachedMember: CacheableMember = model::CachedMember,
+    CachedMessage: CacheableMessage = model::CachedMessage,
+    CachedPresence: CacheablePresence = model::CachedPresence,
+    CachedRole: CacheableRole = Role,
+    CachedStageInstance: CacheableStageInstance = StageInstance,
+    CachedSticker: CacheableSticker = model::CachedSticker,
+    CachedUser: CacheableUser = User,
+    CachedVoiceState: CacheableVoiceState = model::CachedVoiceState,
+>(
+    &'a InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >,
+);
 
-impl<'a> InMemoryCacheStats<'a> {
-    pub(super) const fn new(cache: &'a InMemoryCache) -> Self {
+impl<
+        'a,
+        CachedChannel: CacheableChannel,
+        CachedCurrentUser: CacheableCurrentUser,
+        CachedEmoji: CacheableEmoji,
+        CachedGuild: CacheableGuild,
+        CachedGuildIntegration: CacheableGuildIntegration,
+        CachedMember: CacheableMember,
+        CachedMessage: CacheableMessage,
+        CachedPresence: CacheablePresence,
+        CachedRole: CacheableRole,
+        CachedStageInstance: CacheableStageInstance,
+        CachedSticker: CacheableSticker,
+        CachedUser: CacheableUser,
+        CachedVoiceState: CacheableVoiceState,
+    >
+    InMemoryCacheStats<
+        'a,
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    >
+{
+    #[allow(clippy::type_complexity)]
+    pub(super) const fn new(
+        cache: &'a InMemoryCache<
+            CachedChannel,
+            CachedCurrentUser,
+            CachedEmoji,
+            CachedGuild,
+            CachedGuildIntegration,
+            CachedMember,
+            CachedMessage,
+            CachedPresence,
+            CachedRole,
+            CachedStageInstance,
+            CachedSticker,
+            CachedUser,
+            CachedVoiceState,
+        >,
+    ) -> Self {
         Self(cache)
     }
 
     /// Return an immutable reference to the underlying cache.
-    pub const fn cache_ref(&'a self) -> &'a InMemoryCache {
+    #[allow(clippy::type_complexity)]
+    pub const fn cache_ref(
+        &'a self,
+    ) -> &'a InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > {
         self.0
     }
 
     /// Consume the statistics interface, returning the underlying cache
     /// reference.
-    pub const fn into_cache(self) -> &'a InMemoryCache {
+    #[allow(clippy::type_complexity)]
+    pub const fn into_cache(
+        self,
+    ) -> &'a InMemoryCache<
+        CachedChannel,
+        CachedCurrentUser,
+        CachedEmoji,
+        CachedGuild,
+        CachedGuildIntegration,
+        CachedMember,
+        CachedMessage,
+        CachedPresence,
+        CachedRole,
+        CachedStageInstance,
+        CachedSticker,
+        CachedUser,
+        CachedVoiceState,
+    > {
         self.0
     }
 

--- a/twilight-cache-inmemory/src/stats.rs
+++ b/twilight-cache-inmemory/src/stats.rs
@@ -1,22 +1,9 @@
-use twilight_model::{
-    channel::{Channel, StageInstance},
-    guild::{GuildIntegration, Role},
-    id::{
-        marker::{ChannelMarker, GuildMarker},
-        Id,
-    },
-    user::{CurrentUser, User},
+use twilight_model::id::{
+    marker::{ChannelMarker, GuildMarker},
+    Id,
 };
 
-use crate::{
-    model,
-    traits::{
-        CacheableChannel, CacheableGuild, CacheableMember, CacheableMessage, CacheableRole,
-        CacheableVoiceState,
-    },
-    CacheableCurrentUser, CacheableEmoji, CacheableGuildIntegration, CacheablePresence,
-    CacheableStageInstance, CacheableSticker, CacheableUser,
-};
+use crate::CacheableModels;
 
 use super::InMemoryCache;
 
@@ -44,135 +31,24 @@ use super::InMemoryCache;
 /// [`users`]: Self::users
 #[allow(clippy::type_complexity)]
 #[derive(Clone, Debug)]
-pub struct InMemoryCacheStats<
-    'a,
-    CachedChannel: CacheableChannel = Channel,
-    CachedCurrentUser: CacheableCurrentUser = CurrentUser,
-    CachedEmoji: CacheableEmoji = model::CachedEmoji,
-    CachedGuild: CacheableGuild = model::CachedGuild,
-    CachedGuildIntegration: CacheableGuildIntegration = GuildIntegration,
-    CachedMember: CacheableMember = model::CachedMember,
-    CachedMessage: CacheableMessage = model::CachedMessage,
-    CachedPresence: CacheablePresence = model::CachedPresence,
-    CachedRole: CacheableRole = Role,
-    CachedStageInstance: CacheableStageInstance = StageInstance,
-    CachedSticker: CacheableSticker = model::CachedSticker,
-    CachedUser: CacheableUser = User,
-    CachedVoiceState: CacheableVoiceState = model::CachedVoiceState,
->(
-    &'a InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >,
-);
+pub struct InMemoryCacheStats<'a, CacheModels: CacheableModels>(&'a InMemoryCache<CacheModels>);
 
-impl<
-        'a,
-        CachedChannel: CacheableChannel,
-        CachedCurrentUser: CacheableCurrentUser,
-        CachedEmoji: CacheableEmoji,
-        CachedGuild: CacheableGuild,
-        CachedGuildIntegration: CacheableGuildIntegration,
-        CachedMember: CacheableMember,
-        CachedMessage: CacheableMessage,
-        CachedPresence: CacheablePresence,
-        CachedRole: CacheableRole,
-        CachedStageInstance: CacheableStageInstance,
-        CachedSticker: CacheableSticker,
-        CachedUser: CacheableUser,
-        CachedVoiceState: CacheableVoiceState,
-    >
-    InMemoryCacheStats<
-        'a,
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    >
-{
+impl<'a, CacheModels: CacheableModels> InMemoryCacheStats<'a, CacheModels> {
     #[allow(clippy::type_complexity)]
-    pub(super) const fn new(
-        cache: &'a InMemoryCache<
-            CachedChannel,
-            CachedCurrentUser,
-            CachedEmoji,
-            CachedGuild,
-            CachedGuildIntegration,
-            CachedMember,
-            CachedMessage,
-            CachedPresence,
-            CachedRole,
-            CachedStageInstance,
-            CachedSticker,
-            CachedUser,
-            CachedVoiceState,
-        >,
-    ) -> Self {
+    pub(super) const fn new(cache: &'a InMemoryCache<CacheModels>) -> Self {
         Self(cache)
     }
 
     /// Return an immutable reference to the underlying cache.
     #[allow(clippy::type_complexity)]
-    pub const fn cache_ref(
-        &'a self,
-    ) -> &'a InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > {
+    pub const fn cache_ref(&'a self) -> &'a InMemoryCache<CacheModels> {
         self.0
     }
 
     /// Consume the statistics interface, returning the underlying cache
     /// reference.
     #[allow(clippy::type_complexity)]
-    pub const fn into_cache(
-        self,
-    ) -> &'a InMemoryCache<
-        CachedChannel,
-        CachedCurrentUser,
-        CachedEmoji,
-        CachedGuild,
-        CachedGuildIntegration,
-        CachedMember,
-        CachedMessage,
-        CachedPresence,
-        CachedRole,
-        CachedStageInstance,
-        CachedSticker,
-        CachedUser,
-        CachedVoiceState,
-    > {
+    pub const fn into_cache(self) -> &'a InMemoryCache<CacheModels> {
         self.0
     }
 

--- a/twilight-cache-inmemory/src/test.rs
+++ b/twilight-cache-inmemory/src/test.rs
@@ -1,4 +1,4 @@
-use crate::InMemoryCache;
+use crate::DefaultInMemoryCache;
 use twilight_model::{
     channel::{
         message::{
@@ -25,14 +25,14 @@ use twilight_model::{
     voice::VoiceState,
 };
 
-pub fn cache() -> InMemoryCache {
-    InMemoryCache::new()
+pub fn cache() -> DefaultInMemoryCache {
+    DefaultInMemoryCache::new()
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn cache_with_message_and_reactions() -> InMemoryCache {
+pub fn cache_with_message_and_reactions() -> DefaultInMemoryCache {
     let joined_at = Some(Timestamp::from_secs(1_632_072_645).expect("non zero"));
-    let cache = InMemoryCache::new();
+    let cache = DefaultInMemoryCache::new();
     let avatar = ImageHash::parse(b"6961d9f1fdb5880bf4a3ec6348d3bbcf").unwrap();
     let flags = MemberFlags::BYPASSES_VERIFICATION | MemberFlags::DID_REJOIN;
 

--- a/twilight-cache-inmemory/src/traits.rs
+++ b/twilight-cache-inmemory/src/traits.rs
@@ -46,6 +46,23 @@ use twilight_model::{
 #[cfg(feature = "permission-calculator")]
 use twilight_model::{channel::permission_overwrite::PermissionOverwrite, guild::Permissions};
 
+#[allow(missing_docs)]
+pub trait CacheableModels: Debug {
+    type Member: CacheableMember;
+    type Role: CacheableRole;
+    type Channel: CacheableChannel;
+    type Guild: CacheableGuild;
+    type VoiceState: CacheableVoiceState;
+    type Message: CacheableMessage;
+    type CurrentUser: CacheableCurrentUser;
+    type Sticker: CacheableSticker;
+    type Emoji: CacheableEmoji;
+    type GuildIntegration: CacheableGuildIntegration;
+    type Presence: CacheablePresence;
+    type StageInstance: CacheableStageInstance;
+    type User: CacheableUser;
+}
+
 /// Trait for a generic cached representation of a [`Member`].
 pub trait CacheableMember:
     From<Member>

--- a/twilight-cache-inmemory/src/traits.rs
+++ b/twilight-cache-inmemory/src/traits.rs
@@ -1,0 +1,276 @@
+//! Traits for implementing a [`InMemoryCache`] with custom structs.
+//!
+//! By default, the cache uses widely compatible default types that contain almost all
+//! fields that are present in the Discord API. Fields that are never used by the user
+//! will result in excess memory usage that will especially matter to big bots with a
+//! lot of cached data.
+//!
+//! The traits in this module allow creating custom cached representations of Discord
+//! API models compatible with the [`InMemoryCache`]. They may be mixed with the default
+//! types provided by twilight, which also implement these traits.
+//!
+//! However, as Discord extends its API models with new fields or changes the types,
+//! the trait definitions may change in minor crate releases to allow twilight to keep
+//! up with upstream API changes. Since not all fields are required for caching logic,
+//! this is not very likely to happen on a regular basis, but should be considered when
+//! deciding to opt for writing custom types.
+//!
+//! Many traits require getters for certain types, which means they are used for caching
+//! logic. However, users generally won't have to store all the fields. It is possible
+//! to return `None` or empty arrays on most of the methods if the data that is accessed
+//! is not stored in the custom implementation.
+//!
+//! [`InMemoryCache`]: crate::InMemoryCache
+
+use crate::model::member::ComputedInteractionMemberFields;
+use std::fmt::Debug;
+use twilight_model::{
+    application::interaction::InteractionMember,
+    channel::{
+        message::{Reaction, Sticker},
+        Channel, ChannelType, Message, StageInstance,
+    },
+    gateway::{
+        payload::incoming::{GuildUpdate, MemberUpdate, MessageUpdate},
+        presence::Presence,
+    },
+    guild::{Emoji, Guild, GuildIntegration, Member, PartialMember, Role},
+    id::{
+        marker::{ChannelMarker, GuildMarker, RoleMarker, StickerMarker, UserMarker},
+        Id,
+    },
+    user::{CurrentUser, User},
+    util::{ImageHash, Timestamp},
+    voice::VoiceState,
+};
+#[cfg(feature = "permission-calculator")]
+use twilight_model::{channel::permission_overwrite::PermissionOverwrite, guild::Permissions};
+
+/// Trait for a generic cached representation of a [`Member`].
+pub trait CacheableMember:
+    From<Member>
+    + From<(
+        Id<UserMarker>,
+        InteractionMember,
+        ComputedInteractionMemberFields,
+    )> + From<(Id<UserMarker>, PartialMember)>
+    + PartialEq<Member>
+    + PartialEq<PartialMember>
+    + PartialEq<InteractionMember>
+    + PartialEq<Self>
+    + Clone
+    + Debug
+{
+    /// Roles of this member.
+    fn roles(&self) -> &[Id<RoleMarker>];
+
+    /// Timestamp until which this member's communication is disabled.
+    #[cfg(feature = "permission-calculator")]
+    fn communication_disabled_until(&self) -> Option<Timestamp>;
+
+    /// Avatar of this member.
+    fn avatar(&self) -> Option<ImageHash>;
+
+    /// Whether this member is deafened.
+    fn deaf(&self) -> Option<bool>;
+
+    /// Whether this member is muted.
+    fn mute(&self) -> Option<bool>;
+
+    /// Update the cached data with a [`MemberUpdate`] event.
+    fn update_with_member_update(&mut self, member_update: &MemberUpdate);
+}
+
+/// Trait for a generic cached representation of a [`Role`].
+pub trait CacheableRole: From<Role> + PartialEq<Role> + PartialEq<Self> + Clone + Debug {
+    /// Role's position in the guild roles.
+    fn position(&self) -> i64;
+
+    /// ID of the role.
+    fn id(&self) -> Id<RoleMarker>;
+
+    /// Permissions granted to members with the role.
+    #[cfg(feature = "permission-calculator")]
+    fn permissions(&self) -> Permissions;
+}
+
+impl CacheableRole for Role {
+    fn position(&self) -> i64 {
+        self.position
+    }
+
+    fn id(&self) -> Id<RoleMarker> {
+        self.id
+    }
+
+    #[cfg(feature = "permission-calculator")]
+    fn permissions(&self) -> Permissions {
+        self.permissions
+    }
+}
+
+/// Trait for a generic cached representation of a [`Channel`].
+pub trait CacheableChannel:
+    From<Channel> + PartialEq<Channel> + PartialEq<Self> + Clone + Debug
+{
+    /// ID of the guild this channel belongs to.
+    fn guild_id(&self) -> Option<Id<GuildMarker>>;
+
+    /// Type of the channel.
+    fn kind(&self) -> ChannelType;
+
+    /// ID of the parent channel if this is a thread.
+    #[cfg(feature = "permission-calculator")]
+    fn parent_id(&self) -> Option<Id<ChannelMarker>>;
+
+    /// ID of the channel.
+    fn id(&self) -> Id<ChannelMarker>;
+
+    /// Permission overwrites for the channel.
+    #[cfg(feature = "permission-calculator")]
+    fn permission_overwrites(&self) -> Option<&[PermissionOverwrite]>;
+
+    /// Set the last pin timestamp to a new timestamp.
+    fn set_last_pin_timestamp(&mut self, timestamp: Option<Timestamp>);
+}
+
+impl CacheableChannel for Channel {
+    fn guild_id(&self) -> Option<Id<GuildMarker>> {
+        self.guild_id
+    }
+
+    fn kind(&self) -> ChannelType {
+        self.kind
+    }
+
+    #[cfg(feature = "permission-calculator")]
+    fn parent_id(&self) -> Option<Id<ChannelMarker>> {
+        self.parent_id
+    }
+
+    fn id(&self) -> Id<ChannelMarker> {
+        self.id
+    }
+
+    #[cfg(feature = "permission-calculator")]
+    fn permission_overwrites(&self) -> Option<&[PermissionOverwrite]> {
+        self.permission_overwrites.as_deref()
+    }
+
+    fn set_last_pin_timestamp(&mut self, timestamp: Option<Timestamp>) {
+        self.last_pin_timestamp = timestamp;
+    }
+}
+
+/// Trait for a generic cached representation of a [`Guild`].
+pub trait CacheableGuild: From<Guild> + PartialEq<Guild> + PartialEq<Self> + Clone + Debug {
+    /// ID of the guild.
+    fn id(&self) -> Id<GuildMarker>;
+
+    /// ID of the guild's owner.
+    #[cfg(feature = "permission-calculator")]
+    fn owner_id(&self) -> Id<UserMarker>;
+
+    /// Set the guild's unavailable flag.
+    fn set_unavailable(&mut self, unavailable: bool);
+
+    /// Update the cached data with a [`GuildUpdate`] event. Fields containing other
+    /// cached structures such as channels are cleared prior.
+    fn update_with_guild_update(&mut self, guild_update: &GuildUpdate);
+
+    /// Increase the guild member count.
+    fn increase_member_count(&mut self, amount: u64);
+
+    /// Decrease the guild member count.
+    fn decrease_member_count(&mut self, amount: u64);
+}
+
+/// Trait for a generic cached representation of a [`VoiceState`].
+pub trait CacheableVoiceState:
+    From<(Id<ChannelMarker>, Id<GuildMarker>, VoiceState)>
+    + PartialEq<VoiceState>
+    + PartialEq<Self>
+    + Clone
+    + Debug
+{
+    /// ID of the channel this voice state belongs to.
+    fn channel_id(&self) -> Id<ChannelMarker>;
+}
+
+/// Trait for a generic cached representation of a [`Message`].
+pub trait CacheableMessage:
+    From<Message> + PartialEq<Message> + PartialEq<Self> + Clone + Debug
+{
+    /// Update the cached data with a [`MessageUpdate`] event.
+    fn update_with_message_update(&mut self, message_update: &MessageUpdate);
+
+    /// Reactions added to this message.
+    fn reactions(&self) -> &[Reaction];
+
+    /// Mutable getter for reactions added to this message.
+    fn reactions_mut(&mut self) -> &mut [Reaction];
+
+    /// Retain all reactions to this message matching a predicate, removing non-matching ones.
+    fn retain_reactions(&mut self, f: impl FnMut(&Reaction) -> bool);
+
+    /// Clear all reactions to this message.
+    fn clear_reactions(&mut self);
+
+    /// Add a reaction to this message.
+    fn add_reaction(&mut self, reaction: Reaction);
+
+    /// Remove a reaction from this message.
+    fn remove_reaction(&mut self, idx: usize);
+}
+
+/// Trait for a generic cached representation of a [`CurrentUser`].
+pub trait CacheableCurrentUser:
+    From<CurrentUser> + PartialEq<CurrentUser> + PartialEq<Self> + Clone + Debug
+{
+    /// ID of the user.
+    fn id(&self) -> Id<UserMarker>;
+}
+
+impl CacheableCurrentUser for CurrentUser {
+    fn id(&self) -> Id<UserMarker> {
+        self.id
+    }
+}
+
+/// Trait for a generic cached representation of a [`Sticker`].
+pub trait CacheableSticker:
+    From<Sticker> + PartialEq<Sticker> + PartialEq<Self> + Clone + Debug
+{
+    /// ID of the sticker.
+    fn id(&self) -> Id<StickerMarker>;
+}
+
+/// Trait for a generic cached representation of a [`Emoji`].
+pub trait CacheableEmoji: From<Emoji> + PartialEq<Emoji> + PartialEq<Self> + Clone + Debug {}
+
+/// Trait for a generic cached representation of a [`GuildIntegration`].
+pub trait CacheableGuildIntegration:
+    From<GuildIntegration> + PartialEq<GuildIntegration> + PartialEq<Self> + Clone + Debug
+{
+}
+
+impl CacheableGuildIntegration for GuildIntegration {}
+
+/// Trait for a generic cached representation of a [`Presence`].
+pub trait CacheablePresence:
+    From<Presence> + PartialEq<Presence> + PartialEq<Self> + Clone + Debug
+{
+}
+
+/// Trait for a generic cached representation of a [`StageInstance`].
+pub trait CacheableStageInstance:
+    From<StageInstance> + PartialEq<StageInstance> + PartialEq<Self> + Clone + Debug
+{
+}
+
+impl CacheableStageInstance for StageInstance {}
+
+/// Trait for a generic cached representation of a [`User`].
+pub trait CacheableUser: From<User> + PartialEq<User> + PartialEq<Self> + Clone + Debug {}
+
+impl CacheableUser for User {}

--- a/twilight-cache-inmemory/src/traits.rs
+++ b/twilight-cache-inmemory/src/traits.rs
@@ -22,7 +22,7 @@
 //!
 //! [`InMemoryCache`]: crate::InMemoryCache
 
-use crate::model::member::ComputedInteractionMemberFields;
+use crate::model::member::ComputedInteractionMember;
 use std::fmt::Debug;
 use twilight_model::{
     application::interaction::InteractionMember,
@@ -49,11 +49,8 @@ use twilight_model::{channel::permission_overwrite::PermissionOverwrite, guild::
 /// Trait for a generic cached representation of a [`Member`].
 pub trait CacheableMember:
     From<Member>
-    + From<(
-        Id<UserMarker>,
-        InteractionMember,
-        ComputedInteractionMemberFields,
-    )> + From<(Id<UserMarker>, PartialMember)>
+    + From<ComputedInteractionMember>
+    + From<(Id<UserMarker>, PartialMember)>
     + PartialEq<Member>
     + PartialEq<PartialMember>
     + PartialEq<InteractionMember>

--- a/twilight-cache-inmemory/src/traits.rs
+++ b/twilight-cache-inmemory/src/traits.rs
@@ -46,20 +46,33 @@ use twilight_model::{
 #[cfg(feature = "permission-calculator")]
 use twilight_model::{channel::permission_overwrite::PermissionOverwrite, guild::Permissions};
 
-#[allow(missing_docs)]
-pub trait CacheableModels: Debug {
+/// Super-trait for the generic cached representations of Discord API models.
+pub trait CacheableModels: Clone + Debug {
+    /// The cached [`Member`] model representation.
     type Member: CacheableMember;
+    /// The cached [`Role`] model representation.
     type Role: CacheableRole;
+    /// The cached [`Channel`] model representation.
     type Channel: CacheableChannel;
+    /// The cached [`Guild`] model representation.
     type Guild: CacheableGuild;
+    /// The cached [`VoiceState`] model representation.
     type VoiceState: CacheableVoiceState;
+    /// The cached [`Message`] model representation.
     type Message: CacheableMessage;
+    /// The cached [`CurrentUser`] model representation.
     type CurrentUser: CacheableCurrentUser;
+    /// The cached [`Sticker`] model representation.
     type Sticker: CacheableSticker;
+    /// The cached [`Emoji`] model representation.
     type Emoji: CacheableEmoji;
+    /// The cached [`GuildIntegration`] model representation.
     type GuildIntegration: CacheableGuildIntegration;
+    /// The cached [`Presence`] model representation.
     type Presence: CacheablePresence;
+    /// The cached [`StageInstance`] model representation.
     type StageInstance: CacheableStageInstance;
+    /// The cached [`User`] model representation.
     type User: CacheableUser;
 }
 


### PR DESCRIPTION
Adds support for using custom structs for cached representation of Discord API data via generics on InMemoryCache and a set of traits for cached data that is required for caching functionality.

I remember this was discussed a long time ago but AFAIK there never was an RFC for it. I went ahead to try and see if it could be implemented at all, this is a proof of concept.

Feedback welcome!

Some notes:
- The compiler can't infer the default types for the generics yet (even though it should), so `DefaultInMemoryCache` is necessary
- This could be made less breaking by naming the new `DefaultInMemoryCache` to `InMemoryCache`  and renaming the latter, but I think this is the better name long-term and this change is so huge, it should go to `next` either way
- Migration is still very straightforward (just replace `InMemoryCache` imports with `DefaultInMemoryCache`)
- Functionality is very much untouched, all I did was moving field access to the traits and `from_model` methods were replaced with `From` implementations
- It is very uncommon for traits to have conditional methods (in this case some getters are only required with the `permission-calculator` feature enabled), but in this case users *will* explicitly enable it and this is very low-level anyways. If the permission calculator is not needed, the methods definitely shouldn't need to be provided, because the fields don't have to be stored at all
- This could potentially reduce memory usage drastically when structs are optimized properly by implementors, which should definitely outweigh the relatively annoying amount of generics. Plus, the generics are pretty much set in stone until Discord adds entirely new models, which will require a lot of changes in twilight already
- "But users should just write their own cache at this point" - Disagree. I think that 99% of the usecases will be removing a couple of fields to save up to several megabytes or even gigabytes of memory at scale and the caching logic itself is universal. Copy pasting twilight only creates a higher burden of maintainance for library users and this way the actual logic remains in our control, allowing for bugfixes to be distributed quickly