### PR TITLE
feat(model): Add new `USE_SOUNDBOARD`, `MANAGE_GUILD_EXPRESSIONS` and `VIEW_CREATOR_MONETIZATION_ANALYTICS` permissions

### DIFF
--- a/twilight-model/src/guild/permissions.rs
+++ b/twilight-model/src/guild/permissions.rs
@@ -39,6 +39,8 @@ bitflags! {
         const MANAGE_NICKNAMES = 1 << 27;
         const MANAGE_ROLES = 1 << 28;
         const MANAGE_WEBHOOKS = 1 << 29;
+        #[deprecated(since = "0.15.2", note = "use `MANAGE_GUILD_EXPRESSIONS` instead")]
+        const MANAGE_EMOJIS_AND_STICKERS = 1 << 30;
         /// Allows management and editing of emojis, stickers, and soundboard sounds.
         const MANAGE_GUILD_EXPRESSIONS = 1 << 30;
         const USE_SLASH_COMMANDS = 1 << 31;

--- a/twilight-model/src/guild/permissions.rs
+++ b/twilight-model/src/guild/permissions.rs
@@ -70,7 +70,7 @@ bitflags! {
         const MODERATE_MEMBERS = 1 << 40;
         /// Allows for viewing role subscription insights.
         const VIEW_CREATOR_MONETIZATION_ANALYTICS = 1 << 41;
-        /// Allows for using the soundboard in a voice channel
+        /// Allows for using soundboard in a voice channel
         const USE_SOUNDBOARD = 1 << 42;
     }
 }

--- a/twilight-model/src/guild/permissions.rs
+++ b/twilight-model/src/guild/permissions.rs
@@ -39,7 +39,8 @@ bitflags! {
         const MANAGE_NICKNAMES = 1 << 27;
         const MANAGE_ROLES = 1 << 28;
         const MANAGE_WEBHOOKS = 1 << 29;
-        const MANAGE_EMOJIS_AND_STICKERS = 1 << 30;
+        /// Allows management and editing of emojis, stickers, and soundboard sounds.
+        const MANAGE_GUILD_EXPRESSIONS = 1 << 30;
         const USE_SLASH_COMMANDS = 1 << 31;
         const REQUEST_TO_SPEAK = 1 << 32;
         /// Allows for creating, editing, and deleting scheduled events.
@@ -65,6 +66,10 @@ bitflags! {
         ///
         /// [Guild Timeouts]: https://support.discord.com/hc/en-us/articles/4413305239191-Time-Out-FAQ
         const MODERATE_MEMBERS = 1 << 40;
+        /// Allows for viewing role subscription insights.
+        const VIEW_CREATOR_MONETIZATION_ANALYTICS = 1 << 41;
+        /// Allows for using the soundboard in a voice channel
+        const USE_SOUNDBOARD = 1 << 42;
     }
 }
 
@@ -176,7 +181,7 @@ mod tests {
     const_assert_eq!(Permissions::MANAGE_NICKNAMES.bits(), 1 << 27);
     const_assert_eq!(Permissions::MANAGE_ROLES.bits(), 1 << 28);
     const_assert_eq!(Permissions::MANAGE_WEBHOOKS.bits(), 1 << 29);
-    const_assert_eq!(Permissions::MANAGE_EMOJIS_AND_STICKERS.bits(), 1 << 30);
+    const_assert_eq!(Permissions::MANAGE_GUILD_EXPRESSIONS.bits(), 1 << 30);
     const_assert_eq!(Permissions::USE_SLASH_COMMANDS.bits(), 1 << 31);
     const_assert_eq!(Permissions::REQUEST_TO_SPEAK.bits(), 1 << 32);
     const_assert_eq!(Permissions::MANAGE_EVENTS.bits(), 1 << 33);
@@ -187,6 +192,11 @@ mod tests {
     const_assert_eq!(Permissions::SEND_MESSAGES_IN_THREADS.bits(), 1 << 38);
     const_assert_eq!(Permissions::USE_EMBEDDED_ACTIVITIES.bits(), 1 << 39);
     const_assert_eq!(Permissions::MODERATE_MEMBERS.bits(), 1 << 40);
+    const_assert_eq!(
+        Permissions::VIEW_CREATOR_MONETIZATION_ANALYTICS.bits(),
+        1 << 41
+    );
+    const_assert_eq!(Permissions::USE_SOUNDBOARD.bits(), 1 << 42);
 
     #[test]
     fn serde() {

--- a/twilight-util/src/permission_calculator/mod.rs
+++ b/twilight-util/src/permission_calculator/mod.rs
@@ -220,7 +220,7 @@ impl<'a> PermissionCalculator<'a> {
     /// permissions.
     ///
     /// **Note** that this method will not return guild-level permissions such
-    /// as [Manage Emojis and Stickers]; if you need the guild-level permissions
+    /// as [Manage Guild Expressions]; if you need the guild-level permissions
     /// use [`root`].
     ///
     /// # Conditional exclusions
@@ -310,7 +310,7 @@ impl<'a> PermissionCalculator<'a> {
     /// - [Ban Members]
     /// - [Change Nickname]
     /// - [Kick Members]
-    /// - [Manage Emojis and Stickers]
+    /// - [Manage Guild Expressions]
     /// - [Manage Guild]
     /// - [Manage Nicknames]
     /// - [View Audit Log]
@@ -333,7 +333,7 @@ impl<'a> PermissionCalculator<'a> {
     /// [Deafen Members]: twilight_model::guild::Permissions::DEAFEN_MEMBERS
     /// [Embed Links]: twilight_model::guild::Permissions::EMBED_LINKS
     /// [Kick Members]: twilight_model::guild::Permissions::KICK_MEMBERS
-    /// [Manage Emojis and Stickers]: twilight_model::guild::Permissions::MANAGE_EMOJIS_AND_STICKERS
+    /// [Manage Guild Expressions]: twilight_model::guild::Permissions::MANAGE_GUILD_EXPRESSIONS
     /// [Manage Guild]: twilight_model::guild::Permissions::MANAGE_GUILD
     /// [Manage Messages]: twilight_model::guild::Permissions::MANAGE_MESSAGES
     /// [Manage Nicknames]: twilight_model::guild::Permissions::MANAGE_NICKNAMES

--- a/twilight-util/src/permission_calculator/preset.rs
+++ b/twilight-util/src/permission_calculator/preset.rs
@@ -19,7 +19,7 @@ pub const PERMISSIONS_ROOT_ONLY: Permissions = Permissions::from_bits_truncate(
         | Permissions::BAN_MEMBERS.bits()
         | Permissions::CHANGE_NICKNAME.bits()
         | Permissions::KICK_MEMBERS.bits()
-        | Permissions::MANAGE_EMOJIS_AND_STICKERS.bits()
+        | Permissions::MANAGE_GUILD_EXPRESSIONS.bits()
         | Permissions::MANAGE_GUILD.bits()
         | Permissions::MANAGE_NICKNAMES.bits()
         | Permissions::VIEW_AUDIT_LOG.bits()


### PR DESCRIPTION
Adds:
- `USE_SOUNDBOARD` for the upcoming soundboard feature
- `MANAGE_GUILD_EXPRESSIONS`, renamed from `MANAGE_EMOJIS_AND_STICKERS` to now include editing soundboard sounds.
- `VIEW_CREATOR_MONETIZATION_ANALYTICS` for permissions on viewing subscription insights.

Ref:
- https://github.com/discord/discord-api-docs/pull/6017