### PR TITLE
fix(http): use reason in update guild sticker

### DIFF
--- a/twilight-http/src/request/guild/sticker/update_guild_sticker.rs
+++ b/twilight-http/src/request/guild/sticker/update_guild_sticker.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{AuditLogReason, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Request, TryIntoRequest},
     response::{Response, ResponseFuture},
     routing::Route,
 };
@@ -159,11 +159,15 @@ impl IntoFuture for UpdateGuildSticker<'_> {
 
 impl TryIntoRequest for UpdateGuildSticker<'_> {
     fn try_into_request(self) -> Result<Request, Error> {
-        let request = Request::builder(&Route::UpdateGuildSticker {
+        let mut request = Request::builder(&Route::UpdateGuildSticker {
             guild_id: self.guild_id.get(),
             sticker_id: self.sticker_id.get(),
         })
         .json(&self.fields)?;
+
+        if let Some(reason) = self.reason {
+            request = request.headers(request::audit_header(reason)?);
+        }
 
         Ok(request.build())
     }


### PR DESCRIPTION
The `UpdateGuildSticker` request supports specifying a reason, but doesn't actually use it. This makes it use it when building the request.

Found in #2171.