### PR TITLE
perf(gateway): speed up spurious ratelimiter poll

### DIFF
--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = { default-features = false, features = ["std"], version = "0.3" }
 rand = { default-features = false, features = ["std", "std_rng"], version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
-tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.8" }
+tokio = { default-features = false, features = ["macros", "net", "rt", "sync", "time"], version = "1.8" }
 tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.18" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-gateway-queue = { default-features = false, path = "../twilight-gateway-queue", version = "0.15.1" }
@@ -46,7 +46,7 @@ anyhow = { default-features = false, features = ["std"], version = "1" }
 futures = { default-features = false, version = "0.3" }
 serde_test = { default-features = false, version = "1.0.136" }
 static_assertions = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["macros", "rt-multi-thread", "test-util"], version = "1.12" }
+tokio = { default-features = false, features = ["rt-multi-thread", "test-util"], version = "1.12" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log"], version = "0.3" }
 
 [features]

--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = { default-features = false, features = ["std"], version = "0.3" }
 rand = { default-features = false, features = ["std", "std_rng"], version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
-tokio = { default-features = false, features = ["macros", "net", "rt", "sync", "time"], version = "1.8" }
+tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.8" }
 tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.18" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-gateway-queue = { default-features = false, path = "../twilight-gateway-queue", version = "0.15.1" }
@@ -46,7 +46,7 @@ anyhow = { default-features = false, features = ["std"], version = "1" }
 futures = { default-features = false, version = "0.3" }
 serde_test = { default-features = false, version = "1.0.136" }
 static_assertions = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["rt-multi-thread", "test-util"], version = "1.12" }
+tokio = { default-features = false, features = ["macros", "rt-multi-thread", "test-util"], version = "1.12" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log"], version = "0.3" }
 
 [features]

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -43,11 +43,7 @@ impl CommandRatelimiter {
         let mut delay = Box::pin(sleep(Duration::ZERO));
 
         // Hack to register the timer.
-        tokio::select! {
-            biased;
-            _ = &mut delay => {}
-            _ = async {} => {}
-        }
+        (&mut delay).await;
 
         Self {
             delay,

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -1062,7 +1062,7 @@ impl Shard {
                 tracing::debug!(?heartbeat_interval, ?jitter, "received hello");
 
                 if self.config().ratelimit_messages() {
-                    self.ratelimiter = Some(CommandRatelimiter::new(heartbeat_interval));
+                    self.ratelimiter = Some(CommandRatelimiter::new(heartbeat_interval).await);
                 }
 
                 let mut interval = time::interval_at(Instant::now() + jitter, heartbeat_interval);


### PR DESCRIPTION
In #2143, the ratelimiter's performance was increased due to removing the call to `Instant::now` when the instant queue is not full. This PR goes one step further and removes it for *all* spurious calls, where spurious equates to calling `poll_available` when the timer has not fired.
