### PR TITLE
fix(http): update current member nullable nick

### DIFF
--- a/twilight-http/src/request/guild/update_current_member.rs
+++ b/twilight-http/src/request/guild/update_current_member.rs
@@ -1,7 +1,7 @@
 use crate::{
     client::Client,
     error::Error,
-    request::{self, AuditLogReason, Request, TryIntoRequest},
+    request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
     response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
@@ -15,7 +15,7 @@ use twilight_validate::request::{
 #[derive(Serialize)]
 struct UpdateCurrentMemberFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    nick: Option<&'a str>,
+    nick: Option<Nullable<&'a str>>,
 }
 
 /// Update the user's member in a guild.
@@ -54,7 +54,7 @@ impl<'a> UpdateCurrentMember<'a> {
             validate_nickname(nick)?;
         }
 
-        self.fields.nick = nick;
+        self.fields.nick = Some(Nullable(nick));
 
         Ok(self)
     }


### PR DESCRIPTION
Field is documented as being both nullable and optional.

First reported in our Discord server's support forum <https://discord.com/channels/745809834183753828/1092061820610695258>
