### PR TITLE
fix(model): Don't deserialize option values as `Id`'s if option type is `String`

### DIFF
--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -720,4 +720,29 @@ mod tests {
             ],
         );
     }
+
+    #[test]
+    fn leading_zeroes_string_option_value() {
+        let value = CommandDataOption {
+            name: "opt".to_string(),
+            value: CommandOptionValue::String("0001".to_owned()),
+        };
+
+        serde_test::assert_de_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "CommandDataOption",
+                    len: 3,
+                },
+                Token::Str("name"),
+                Token::Str("opt"),
+                Token::Str("type"),
+                Token::U8(CommandOptionType::String as u8),
+                Token::Str("value"),
+                Token::String("0001"),
+                Token::StructEnd,
+            ],
+        );
+    }
 }

--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -202,18 +202,15 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         CommandOptionType::Attachment => {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
-                            match &val {
-                                ValueEnvelope::String(id) => {
-                                    CommandOptionValue::Attachment(id.parse().map_err(|_e| {
-                                        DeError::invalid_type(val.as_unexpected(), &"attachment id")
-                                    })?)
-                                }
-                                _ => {
-                                    return Err(DeError::invalid_type(
-                                        val.as_unexpected(),
-                                        &"attachment id",
-                                    ))
-                                }
+                            if let ValueEnvelope::String(id) = &val {
+                                CommandOptionValue::Attachment(id.parse().map_err(|_e| {
+                                    DeError::invalid_type(val.as_unexpected(), &"attachment id")
+                                })?)
+                            } else {
+                                return Err(DeError::invalid_type(
+                                    val.as_unexpected(),
+                                    &"attachment id",
+                                ));
                             }
                         }
                         CommandOptionType::Boolean => {
@@ -228,18 +225,15 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         CommandOptionType::Channel => {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
-                            match &val {
-                                ValueEnvelope::String(id) => {
-                                    CommandOptionValue::Channel(id.parse().map_err(|_e| {
-                                        DeError::invalid_type(val.as_unexpected(), &"channel id")
-                                    })?)
-                                }
-                                _ => {
-                                    return Err(DeError::invalid_type(
-                                        val.as_unexpected(),
-                                        &"channel id",
-                                    ))
-                                }
+                            if let ValueEnvelope::String(id) = &val {
+                                CommandOptionValue::Channel(id.parse().map_err(|_e| {
+                                    DeError::invalid_type(val.as_unexpected(), &"channel id")
+                                })?)
+                            } else {
+                                return Err(DeError::invalid_type(
+                                    val.as_unexpected(),
+                                    &"channel id",
+                                ));
                             }
                         }
                         CommandOptionType::Integer => {
@@ -254,21 +248,15 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         CommandOptionType::Mentionable => {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
-                            match &val {
-                                ValueEnvelope::String(id) => {
-                                    CommandOptionValue::Mentionable(id.parse().map_err(|_e| {
-                                        DeError::invalid_type(
-                                            val.as_unexpected(),
-                                            &"mentionable id",
-                                        )
-                                    })?)
-                                }
-                                _ => {
-                                    return Err(DeError::invalid_type(
-                                        val.as_unexpected(),
-                                        &"mentionable id",
-                                    ))
-                                }
+                            if let ValueEnvelope::String(id) = &val {
+                                CommandOptionValue::Mentionable(id.parse().map_err(|_e| {
+                                    DeError::invalid_type(val.as_unexpected(), &"mentionable id")
+                                })?)
+                            } else {
+                                return Err(DeError::invalid_type(
+                                    val.as_unexpected(),
+                                    &"mentionable id",
+                                ));
                             }
                         }
                         CommandOptionType::Number => {
@@ -296,18 +284,12 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         CommandOptionType::Role => {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
-                            match &val {
-                                ValueEnvelope::String(id) => {
-                                    CommandOptionValue::Role(id.parse().map_err(|_e| {
-                                        DeError::invalid_type(val.as_unexpected(), &"role id")
-                                    })?)
-                                }
-                                _ => {
-                                    return Err(DeError::invalid_type(
-                                        val.as_unexpected(),
-                                        &"role id",
-                                    ))
-                                }
+                            if let ValueEnvelope::String(id) = &val {
+                                CommandOptionValue::Role(id.parse().map_err(|_e| {
+                                    DeError::invalid_type(val.as_unexpected(), &"role id")
+                                })?)
+                            } else {
+                                return Err(DeError::invalid_type(val.as_unexpected(), &"role id"));
                             }
                         }
                         CommandOptionType::String => {
@@ -326,18 +308,12 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                         CommandOptionType::User => {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
-                            match &val {
-                                ValueEnvelope::String(id) => {
-                                    CommandOptionValue::User(id.parse().map_err(|_e| {
-                                        DeError::invalid_type(val.as_unexpected(), &"user id")
-                                    })?)
-                                }
-                                _ => {
-                                    return Err(DeError::invalid_type(
-                                        val.as_unexpected(),
-                                        &"user id",
-                                    ))
-                                }
+                            if let ValueEnvelope::String(id) = &val {
+                                CommandOptionValue::User(id.parse().map_err(|_e| {
+                                    DeError::invalid_type(val.as_unexpected(), &"user id")
+                                })?)
+                            } else {
+                                return Err(DeError::invalid_type(val.as_unexpected(), &"user id"));
                             }
                         }
                     }

--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -206,6 +206,11 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
+                                ValueEnvelope::String(id) => {
+                                    CommandOptionValue::Attachment(id.parse().map_err(|_e| {
+                                        DeError::invalid_type(val.as_unexpected(), &"attachment id")
+                                    })?)
+                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::Attachment(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
@@ -228,6 +233,11 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
+                                ValueEnvelope::String(id) => {
+                                    CommandOptionValue::Channel(id.parse().map_err(|_e| {
+                                        DeError::invalid_type(val.as_unexpected(), &"channel id")
+                                    })?)
+                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::Channel(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
@@ -250,6 +260,14 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
+                                ValueEnvelope::String(id) => {
+                                    CommandOptionValue::Mentionable(id.parse().map_err(|_e| {
+                                        DeError::invalid_type(
+                                            val.as_unexpected(),
+                                            &"mentionable id",
+                                        )
+                                    })?)
+                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::Mentionable(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
@@ -285,6 +303,11 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
+                                ValueEnvelope::String(id) => {
+                                    CommandOptionValue::Role(id.parse().map_err(|_e| {
+                                        DeError::invalid_type(val.as_unexpected(), &"role id")
+                                    })?)
+                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::Role(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
@@ -311,6 +334,11 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
+                                ValueEnvelope::String(id) => {
+                                    CommandOptionValue::User(id.parse().map_err(|_e| {
+                                        DeError::invalid_type(val.as_unexpected(), &"user id")
+                                    })?)
+                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::User(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(

--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -206,11 +206,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
-                                ValueEnvelope::String(id) => {
-                                    CommandOptionValue::Attachment(id.parse().map_err(|_e| {
-                                        DeError::invalid_type(val.as_unexpected(), &"attachment id")
-                                    })?)
-                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::Attachment(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
@@ -233,11 +228,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
-                                ValueEnvelope::String(id) => {
-                                    CommandOptionValue::Channel(id.parse().map_err(|_e| {
-                                        DeError::invalid_type(val.as_unexpected(), &"channel id")
-                                    })?)
-                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::Channel(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
@@ -260,14 +250,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
-                                ValueEnvelope::String(id) => {
-                                    CommandOptionValue::Mentionable(id.parse().map_err(|_e| {
-                                        DeError::invalid_type(
-                                            val.as_unexpected(),
-                                            &"mentionable id",
-                                        )
-                                    })?)
-                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::Mentionable(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
@@ -303,11 +285,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
-                                ValueEnvelope::String(id) => {
-                                    CommandOptionValue::Role(id.parse().map_err(|_e| {
-                                        DeError::invalid_type(val.as_unexpected(), &"role id")
-                                    })?)
-                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::Role(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
@@ -334,11 +311,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
-                                ValueEnvelope::String(id) => {
-                                    CommandOptionValue::User(id.parse().map_err(|_e| {
-                                        DeError::invalid_type(val.as_unexpected(), &"user id")
-                                    })?)
-                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::User(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(

--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -177,8 +177,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             // string, then we deserialize it as a string. Otherwise,
                             // we deserialize it using the default ValueEnvelope behavior.
                             if let Some(CommandOptionType::String) = kind_opt {
-                                value_opt =
-                                    Some(ValueEnvelope::String(map.next_value::<String>()?));
+                                value_opt = Some(ValueEnvelope::String(map.next_value()?));
                             } else {
                                 value_opt = Some(map.next_value()?);
                             }

--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -10,10 +10,7 @@ use serde::{
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::{
-    fmt::{Debug, Display, Formatter, Result as FmtResult},
-    str::FromStr,
-};
+use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
 /// Data received when a user fills in a command option.
 ///
@@ -209,11 +206,11 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
-                                ValueEnvelope::String(id) => CommandOptionValue::Attachment(
-                                    Id::from_str(id.as_str()).map_err(|_e| {
+                                ValueEnvelope::String(id) => {
+                                    CommandOptionValue::Attachment(id.parse().map_err(|_e| {
                                         DeError::invalid_type(val.as_unexpected(), &"attachment id")
-                                    })?,
-                                ),
+                                    })?)
+                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::Attachment(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
@@ -236,11 +233,11 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
-                                ValueEnvelope::String(id) => CommandOptionValue::Channel(
-                                    Id::from_str(id.as_str()).map_err(|_e| {
+                                ValueEnvelope::String(id) => {
+                                    CommandOptionValue::Channel(id.parse().map_err(|_e| {
                                         DeError::invalid_type(val.as_unexpected(), &"channel id")
-                                    })?,
-                                ),
+                                    })?)
+                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::Channel(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
@@ -263,14 +260,14 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             match &val {
-                                ValueEnvelope::String(id) => CommandOptionValue::Mentionable(
-                                    Id::from_str(id.as_str()).map_err(|_e| {
+                                ValueEnvelope::String(id) => {
+                                    CommandOptionValue::Mentionable(id.parse().map_err(|_e| {
                                         DeError::invalid_type(
                                             val.as_unexpected(),
                                             &"mentionable id",
                                         )
-                                    })?,
-                                ),
+                                    })?)
+                                }
                                 ValueEnvelope::Id(id) => CommandOptionValue::Mentionable(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
@@ -307,9 +304,9 @@ impl<'de> Deserialize<'de> for CommandDataOption {
 
                             match &val {
                                 ValueEnvelope::String(id) => {
-                                    CommandOptionValue::Role(Id::from_str(id.as_str()).map_err(
-                                        |_e| DeError::invalid_type(val.as_unexpected(), &"role id"),
-                                    )?)
+                                    CommandOptionValue::Role(id.parse().map_err(|_e| {
+                                        DeError::invalid_type(val.as_unexpected(), &"role id")
+                                    })?)
                                 }
                                 ValueEnvelope::Id(id) => CommandOptionValue::Role(id.cast()),
                                 _ => {
@@ -338,9 +335,9 @@ impl<'de> Deserialize<'de> for CommandDataOption {
 
                             match &val {
                                 ValueEnvelope::String(id) => {
-                                    CommandOptionValue::User(Id::from_str(id.as_str()).map_err(
-                                        |_e| DeError::invalid_type(val.as_unexpected(), &"user id"),
-                                    )?)
+                                    CommandOptionValue::User(id.parse().map_err(|_e| {
+                                        DeError::invalid_type(val.as_unexpected(), &"user id")
+                                    })?)
                                 }
                                 ValueEnvelope::Id(id) => CommandOptionValue::User(id.cast()),
                                 _ => {

--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -172,17 +172,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                                 return Err(DeError::duplicate_field("value"));
                             }
 
-                            // This is an edge case to handle string options.
-                            // Because Id's take precedence over strings, we
-                            // need to check if the option type is a string
-                            // prior to deserializing the value. If it is a
-                            // string, then we deserialize it as a string. Otherwise,
-                            // we deserialize it using the default ValueEnvelope behavior.
-                            if let Some(CommandOptionType::String) = kind_opt {
-                                value_opt = Some(ValueEnvelope::String(map.next_value()?));
-                            } else {
-                                value_opt = Some(map.next_value()?);
-                            }
+                            value_opt = Some(map.next_value()?);
                         }
                         Fields::Options => {
                             if !options.is_empty() {

--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -87,10 +87,10 @@ impl<'de> Deserialize<'de> for CommandDataOption {
         }
 
         // An `Id` variant is purposely not included here.
-        // We first deserialize into a `String` to and then
+        // We first deserialize into a `String` and then
         // later parse it into an `Id` variant. This is done
-        // to prevent situations where an option string value
-        // is parsed as an `Id` variant, which omits leading zeros.
+        // to prevent situations where an option's string value
+        // is parsed as an `Id` variant, which omits features leading zeros.
         #[derive(Debug, Deserialize)]
         #[serde(untagged)]
         enum ValueEnvelope {

--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -83,12 +83,8 @@ impl<'de> Deserialize<'de> for CommandDataOption {
             Focused,
         }
 
-        // An `Id` variant is purposely not present here.
-        // We first deserialize into a `String` and then
-        // later parse it into an `Id` variant. This is done
-        // to prevent situations where an option's string value
-        // is parsed as an `Id` variant, which omits features leading zeros.
-        // The `Id` variant is only used when the type is an `Id`.
+        // An `Id` variant is purposely not present here to prevent wrongly
+        // parsing string options as numbers, trimming leading zeroes.
         #[derive(Debug, Deserialize)]
         #[serde(untagged)]
         enum ValueEnvelope {
@@ -203,7 +199,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             if let ValueEnvelope::String(id) = &val {
-                                CommandOptionValue::Attachment(id.parse().map_err(|_e| {
+                                CommandOptionValue::Attachment(id.parse().map_err(|_| {
                                     DeError::invalid_type(val.as_unexpected(), &"attachment id")
                                 })?)
                             } else {
@@ -226,7 +222,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             if let ValueEnvelope::String(id) = &val {
-                                CommandOptionValue::Channel(id.parse().map_err(|_e| {
+                                CommandOptionValue::Channel(id.parse().map_err(|_| {
                                     DeError::invalid_type(val.as_unexpected(), &"channel id")
                                 })?)
                             } else {
@@ -249,7 +245,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             if let ValueEnvelope::String(id) = &val {
-                                CommandOptionValue::Mentionable(id.parse().map_err(|_e| {
+                                CommandOptionValue::Mentionable(id.parse().map_err(|_| {
                                     DeError::invalid_type(val.as_unexpected(), &"mentionable id")
                                 })?)
                             } else {
@@ -285,7 +281,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             if let ValueEnvelope::String(id) = &val {
-                                CommandOptionValue::Role(id.parse().map_err(|_e| {
+                                CommandOptionValue::Role(id.parse().map_err(|_| {
                                     DeError::invalid_type(val.as_unexpected(), &"role id")
                                 })?)
                             } else {
@@ -309,7 +305,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                             let val = value_opt.ok_or_else(|| DeError::missing_field("value"))?;
 
                             if let ValueEnvelope::String(id) = &val {
-                                CommandOptionValue::User(id.parse().map_err(|_e| {
+                                CommandOptionValue::User(id.parse().map_err(|_| {
                                     DeError::invalid_type(val.as_unexpected(), &"user id")
                                 })?)
                             } else {

--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -83,7 +83,7 @@ impl<'de> Deserialize<'de> for CommandDataOption {
             Focused,
         }
 
-        // An `Id` variant is purposely placed below `String` here.
+        // An `Id` variant is purposely not present here.
         // We first deserialize into a `String` and then
         // later parse it into an `Id` variant. This is done
         // to prevent situations where an option's string value
@@ -96,7 +96,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
             Integer(i64),
             Number(f64),
             String(String),
-            Id(Id<GenericMarker>),
         }
 
         impl ValueEnvelope {
@@ -106,7 +105,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                     Self::Integer(i) => Unexpected::Signed(*i),
                     Self::Number(f) => Unexpected::Float(*f),
                     Self::String(s) => Unexpected::Str(s),
-                    Self::Id(_) => Unexpected::Other("ID"),
                 }
             }
         }
@@ -118,7 +116,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                     Self::Integer(i) => Display::fmt(i, f),
                     Self::Number(n) => Display::fmt(n, f),
                     Self::String(s) => Display::fmt(s, f),
-                    Self::Id(i) => Display::fmt(i, f),
                 }
             }
         }
@@ -211,7 +208,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                                         DeError::invalid_type(val.as_unexpected(), &"attachment id")
                                     })?)
                                 }
-                                ValueEnvelope::Id(id) => CommandOptionValue::Attachment(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
                                         val.as_unexpected(),
@@ -238,7 +234,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                                         DeError::invalid_type(val.as_unexpected(), &"channel id")
                                     })?)
                                 }
-                                ValueEnvelope::Id(id) => CommandOptionValue::Channel(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
                                         val.as_unexpected(),
@@ -268,7 +263,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                                         )
                                     })?)
                                 }
-                                ValueEnvelope::Id(id) => CommandOptionValue::Mentionable(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
                                         val.as_unexpected(),
@@ -308,7 +302,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                                         DeError::invalid_type(val.as_unexpected(), &"role id")
                                     })?)
                                 }
-                                ValueEnvelope::Id(id) => CommandOptionValue::Role(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
                                         val.as_unexpected(),
@@ -339,7 +332,6 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                                         DeError::invalid_type(val.as_unexpected(), &"user id")
                                     })?)
                                 }
-                                ValueEnvelope::Id(id) => CommandOptionValue::User(id.cast()),
                                 _ => {
                                     return Err(DeError::invalid_type(
                                         val.as_unexpected(),

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -533,6 +533,7 @@ mod tests {
             user: None,
         };
 
+        // TODO: switch the `assert_tokens` see #2190
         serde_test::assert_ser_tokens(
             &value,
             &[

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -533,7 +533,7 @@ mod tests {
             user: None,
         };
 
-        serde_test::assert_tokens(
+        serde_test::assert_ser_tokens(
             &value,
             &[
                 Token::Struct {


### PR DESCRIPTION
Because of the way [`ValueEnvelope`](https://github.com/twilight-rs/twilight/blob/c5f75d950162dceb997a5544bb8c9b86e9e7bdc1/twilight-model/src/application/interaction/application_command/option.rs#L91) is declared it automatically puts a higher precedence on deserializing to an `Id` rather than a `String`. 

This behavior is desired because currently, the deserialization of option values doesn't take the `kind` of the option JSON into account. So if an option *actually is* a snowflake type it would be serialized as such instead of becoming a `String`. This, however, does not account for situations where the string is a parseable Id, but is supposed to be represented as a `String` regardless.

As a result, this PR removes `ValueEnvelope::Id`. This means that means we *initially* deserialize any non-boolean or non-numeric values as `String`s. Later on, when checking against the option `kind` we disambiguate the previously deserialized string and parse into the appropriate `Id` corresponding to the `kind`.

Closes #2178