### PR TITLE
feat(model, cache): add `channel` field to `Interaction`

### DIFF
--- a/twilight-cache-inmemory/src/event/interaction.rs
+++ b/twilight-cache-inmemory/src/event/interaction.rs
@@ -76,7 +76,7 @@ mod tests {
                 sticker::{MessageSticker, StickerFormatType},
                 MessageFlags, MessageType,
             },
-            Message,
+            Channel, ChannelType, Message,
         },
         gateway::payload::incoming::InteractionCreate,
         guild::{MemberFlags, PartialMember, Permissions, Role},
@@ -85,7 +85,7 @@ mod tests {
         util::{image_hash::ImageHashParseError, ImageHash, Timestamp},
     };
 
-    #[allow(clippy::too_many_lines)]
+    #[allow(clippy::too_many_lines, deprecated)]
     #[test]
     fn interaction_create() -> Result<(), ImageHashParseError> {
         let timestamp = Timestamp::from_secs(1_632_072_645).expect("non zero");
@@ -99,6 +99,43 @@ mod tests {
         cache.update(&InteractionCreate(Interaction {
             app_permissions: Some(Permissions::SEND_MESSAGES),
             application_id: Id::new(1),
+            channel: Some(Channel {
+                bitrate: None,
+                guild_id: None,
+                id: Id::new(400),
+                kind: ChannelType::GuildText,
+                last_message_id: None,
+                last_pin_timestamp: None,
+                name: None,
+                nsfw: None,
+                owner_id: None,
+                parent_id: None,
+                permission_overwrites: None,
+                position: None,
+                rate_limit_per_user: None,
+                recipients: None,
+                rtc_region: None,
+                topic: None,
+                user_limit: None,
+                application_id: None,
+                applied_tags: None,
+                available_tags: None,
+                default_auto_archive_duration: None,
+                default_forum_layout: None,
+                default_reaction_emoji: None,
+                default_sort_order: None,
+                default_thread_rate_limit_per_user: None,
+                flags: None,
+                icon: None,
+                invitable: None,
+                managed: None,
+                member: None,
+                member_count: None,
+                message_count: None,
+                newly_created: None,
+                thread_metadata: None,
+                video_quality_mode: None,
+            }),
             channel_id: Some(Id::new(2)),
             data: Some(InteractionData::ApplicationCommand(Box::new(CommandData {
                 guild_id: None,

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -1071,7 +1071,10 @@ mod tests {
             message_component::MessageComponentInteractionData, Interaction, InteractionData,
             InteractionType,
         },
-        channel::message::{component::ComponentType, Message, MessageType, ReactionType},
+        channel::{
+            message::{component::ComponentType, Message, MessageType, ReactionType},
+            Channel, ChannelType,
+        },
         gateway::{
             payload::incoming::{InteractionCreate, MessageCreate, ReactionAdd, Ready, RoleDelete},
             GatewayReaction, ShardId,
@@ -1149,11 +1152,49 @@ mod tests {
         }
     }
 
+    #[allow(deprecated)]
     fn button() -> Interaction {
         Interaction {
             app_permissions: Some(Permissions::SEND_MESSAGES),
             application_id: Id::new(1),
-            channel_id: Some(Id::new(2)),
+            channel: Some(Channel {
+                bitrate: None,
+                guild_id: None,
+                id: Id::new(400),
+                kind: ChannelType::GuildText,
+                last_message_id: None,
+                last_pin_timestamp: None,
+                name: None,
+                nsfw: None,
+                owner_id: None,
+                parent_id: None,
+                permission_overwrites: None,
+                position: None,
+                rate_limit_per_user: None,
+                recipients: None,
+                rtc_region: None,
+                topic: None,
+                user_limit: None,
+                application_id: None,
+                applied_tags: None,
+                available_tags: None,
+                default_auto_archive_duration: None,
+                default_forum_layout: None,
+                default_reaction_emoji: None,
+                default_sort_order: None,
+                default_thread_rate_limit_per_user: None,
+                flags: None,
+                icon: None,
+                invitable: None,
+                managed: None,
+                member: None,
+                member_count: None,
+                message_count: None,
+                newly_created: None,
+                thread_metadata: None,
+                video_quality_mode: None,
+            }),
+            channel_id: None,
             data: Some(InteractionData::MessageComponent(
                 MessageComponentInteractionData {
                     custom_id: String::from("Click"),


### PR DESCRIPTION
This adds support for the new `channel` field sent in interactions. This is used in favor of `channel_id` which is deprecated and will be removed.

Ref:
- https://github.com/discord/discord-api-docs/pull/6051