### PR TITLE
ci: switch API docs to modern GH Pages action

### DIFF
--- a/.github/workflows/deploy-lib.yml
+++ b/.github/workflows/deploy-lib.yml
@@ -1,6 +1,7 @@
 name: Deploy documentation
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -9,8 +10,18 @@ on:
       - "twilight*/**"
       - "Cargo.toml"
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency: "pages"
+
 jobs:
   deploy-docs:
+    environment:
+      name: api-documentation
+      url: ${{ steps.deployment.outputs.page_url }}
     name: Deploy docs to gh-pages
     runs-on: ubuntu-latest
 
@@ -37,13 +48,14 @@ jobs:
         run: |
           echo '<meta http-equiv="refresh" content="0;url=twilight/index.html">' > target/doc/index.html
 
-      - name: Deploy docs
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY_BOT }}
-          publish_branch: gh-pages
-          publish_dir: target/doc
-          allow_empty_commit: true
-          cname: api.twilight.rs
-          user_name: "github-actions[bot]"
-          user_email: "github-actions[bot]@users.noreply.github.com"
+          path: target/doc
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Switch the GH Pages API documentation workflow from deploying from a commit to deploying from an artifact.

Twilight currently has an extremely large `gh-pages` branch with all snapshots of our rustdoc rendered documentation for all crates as commits. Due to the nature of how Git stores commits, this ballons the branch's size (>200 MB!) and subsequently the whole repository's size. GitHub has since last year offered publishing to Pages from an uploaded artifact as an alternative to publishing from a branch which avoids storing the contents in Git.

Additionally, this renames the API documentation environment from "github-pages" to "api-documentation" which should make it more discoverable to new users.
