### PR TITLE
feat(model, cache): add support for voice messages

### DIFF
--- a/twilight-cache-inmemory/src/model/message.rs
+++ b/twilight-cache-inmemory/src/model/message.rs
@@ -79,7 +79,7 @@ impl CachedMessageInteraction {
 /// Represents a cached [`Message`].
 ///
 /// [`Message`]: twilight_model::channel::Message
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct CachedMessage {
     activity: Option<MessageActivity>,
     application: Option<MessageApplication>,
@@ -399,7 +399,6 @@ mod tests {
     assert_impl_all!(
         CachedMessage: Clone,
         Debug,
-        Eq,
         From<Message>,
         PartialEq,
         Send,

--- a/twilight-model/src/application/interaction/application_command/resolved.rs
+++ b/twilight-model/src/application/interaction/application_command/resolved.rs
@@ -17,7 +17,7 @@ use std::collections::hash_map::HashMap;
 ///
 /// [`ApplicationCommand`]: crate::application::interaction::InteractionType::ApplicationCommand
 /// [Discord Docs/Resolved Data Structure]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct CommandInteractionDataResolved {
     /// Map of resolved attachments.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -130,11 +130,13 @@ mod tests {
                     ephemeral: true,
                     filename: "rainbow_dash.png".to_owned(),
                     description: None,
+                    duration_secs: None,
                     height: Some(2674),
                     id: Id::new(400),
                     proxy_url: "https://proxy.example.com/rainbow_dash.png".to_owned(),
                     size: 13370,
                     url: "https://example.com/rainbow_dash.png".to_owned(),
+                    waveform: None,
                     width: Some(1337),
                 },
             )])

--- a/twilight-model/src/channel/attachment.rs
+++ b/twilight-model/src/channel/attachment.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Attachment {
     /// Attachment's [media type].
     ///
@@ -17,6 +17,9 @@ pub struct Attachment {
     /// available as long as the message itself exists.
     #[serde(default, skip_serializing_if = "is_false")]
     pub ephemeral: bool,
+    /// The duration of the audio file (currently for voice messages).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_secs: Option<f64>,
     pub filename: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -26,6 +29,9 @@ pub struct Attachment {
     pub proxy_url: String,
     pub size: u64,
     pub url: String,
+    /// Base64 encoded bytearray representing a sampled waveform (currently for voice messages).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub waveform: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<u64>,
 }
@@ -37,7 +43,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serde_test::Token;
     use static_assertions::{assert_fields, assert_impl_all};
-    use std::{fmt::Debug, hash::Hash};
+    use std::fmt::Debug;
 
     assert_fields!(
         Attachment: content_type,
@@ -55,8 +61,6 @@ mod tests {
         Attachment: Clone,
         Debug,
         Deserialize<'static>,
-        Eq,
-        Hash,
         PartialEq,
         Serialize
     );
@@ -68,11 +72,13 @@ mod tests {
             ephemeral: false,
             filename: "a.png".to_owned(),
             description: Some("a image".to_owned()),
+            duration_secs: Some(3.2),
             height: Some(184),
             id: Id::new(700_000_000_000_000_000),
             proxy_url: "https://cdn.example.com/1.png".to_owned(),
             size: 13_593,
             url: "https://example.com/1.png".to_owned(),
+            waveform: Some(String::from("waveform")),
             width: Some(184),
         };
 
@@ -81,11 +87,14 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Attachment",
-                    len: 9,
+                    len: 11,
                 },
                 Token::Str("content_type"),
                 Token::Some,
                 Token::Str("image/png"),
+                Token::Str("duration_secs"),
+                Token::Some,
+                Token::F64(3.2),
                 Token::Str("filename"),
                 Token::Str("a.png"),
                 Token::Str("description"),
@@ -103,6 +112,9 @@ mod tests {
                 Token::U64(13_593),
                 Token::Str("url"),
                 Token::Str("https://example.com/1.png"),
+                Token::Str("waveform"),
+                Token::Some,
+                Token::Str("waveform"),
                 Token::Str("width"),
                 Token::Some,
                 Token::U64(184),

--- a/twilight-model/src/channel/attachment.rs
+++ b/twilight-model/src/channel/attachment.rs
@@ -17,7 +17,7 @@ pub struct Attachment {
     /// available as long as the message itself exists.
     #[serde(default, skip_serializing_if = "is_false")]
     pub ephemeral: bool,
-    /// The duration of the audio file (currently for voice messages).
+    /// Duration of the audio file (currently for voice messages).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration_secs: Option<f64>,
     pub filename: String,

--- a/twilight-model/src/channel/message/flags.rs
+++ b/twilight-model/src/channel/message/flags.rs
@@ -33,6 +33,8 @@ bitflags! {
         const FAILED_TO_MENTION_SOME_ROLES_IN_THREAD  = 1 << 8;
         /// This message will not trigger push and desktop notifications.
         const SUPPRESS_NOTIFICATIONS = 1 << 12;
+        /// This message is a voice message.
+        const IS_VOICE_MESSAGE = 1 << 13;
     }
 }
 

--- a/twilight-model/src/channel/message/mod.rs
+++ b/twilight-model/src/channel/message/mod.rs
@@ -48,7 +48,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 /// Text message sent in a [`Channel`].
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Message {
     /// Present with Rich Presence-related chat embeds.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/twilight-model/src/gateway/payload/incoming/message_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/message_create.rs
@@ -2,7 +2,7 @@ use crate::channel::Message;
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct MessageCreate(pub Message);
 
 impl Deref for MessageCreate {

--- a/twilight-model/src/gateway/payload/incoming/message_update.rs
+++ b/twilight-model/src/gateway/payload/incoming/message_update.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct MessageUpdate {
     /// List of attachments.
     ///

--- a/twilight-model/src/guild/permissions.rs
+++ b/twilight-model/src/guild/permissions.rs
@@ -72,6 +72,8 @@ bitflags! {
         const VIEW_CREATOR_MONETIZATION_ANALYTICS = 1 << 41;
         /// Allows for using soundboard in a voice channel
         const USE_SOUNDBOARD = 1 << 42;
+        /// Allows sending voice messages
+        const SEND_VOICE_MESSAGES = 1 << 46;
     }
 }
 


### PR DESCRIPTION
Adds the `waveform` and `duration_secs` to the `Attachment` structure. In addition, the new `SEND_VOICE_MESSAGES` permission has been added.

Ref:
- https://github.com/discord/discord-api-docs/pull/6082