### PR TITLE
fix(gw-queue, http, model): Fix clippy up to 1.69.0

### DIFF
--- a/twilight-gateway-queue/src/large_bot_queue.rs
+++ b/twilight-gateway-queue/src/large_bot_queue.rs
@@ -98,8 +98,7 @@ impl Queue for LargeBotQueue {
 
             tracing::info!("waiting for allowance on shard {}", shard_id[0]);
 
-            #[allow(clippy::let_underscore_untyped)]
-            let _ = rx.await;
+            _ = rx.await;
         })
     }
 }

--- a/twilight-gateway-queue/src/large_bot_queue.rs
+++ b/twilight-gateway-queue/src/large_bot_queue.rs
@@ -98,6 +98,7 @@ impl Queue for LargeBotQueue {
 
             tracing::info!("waiting for allowance on shard {}", shard_id[0]);
 
+            #[allow(clippy::let_underscore_untyped)]
             let _ = rx.await;
         })
     }

--- a/twilight-gateway-queue/src/lib.rs
+++ b/twilight-gateway-queue/src/lib.rs
@@ -122,6 +122,7 @@ impl Queue for LocalQueue {
 
             tracing::info!("shard {id}/{total} waiting for allowance");
 
+            #[allow(clippy::let_underscore_untyped)]
             let _ = rx.await;
         })
     }

--- a/twilight-gateway-queue/src/lib.rs
+++ b/twilight-gateway-queue/src/lib.rs
@@ -122,8 +122,7 @@ impl Queue for LocalQueue {
 
             tracing::info!("shard {id}/{total} waiting for allowance");
 
-            #[allow(clippy::let_underscore_untyped)]
-            let _ = rx.await;
+            _ = rx.await;
         })
     }
 }

--- a/twilight-http/src/request/application/command/mod.rs
+++ b/twilight-http/src/request/application/command/mod.rs
@@ -98,7 +98,7 @@ mod tests {
             options: Vec::new(),
             version: Id::new(1),
         };
-
+        #[allow(clippy::let_underscore_untyped)]
         let _ = CommandBorrowed {
             application_id: command.application_id,
             default_member_permissions: command.default_member_permissions,

--- a/twilight-http/src/request/application/command/mod.rs
+++ b/twilight-http/src/request/application/command/mod.rs
@@ -98,8 +98,7 @@ mod tests {
             options: Vec::new(),
             version: Id::new(1),
         };
-        #[allow(clippy::let_underscore_untyped)]
-        let _ = CommandBorrowed {
+        _ = CommandBorrowed {
             application_id: command.application_id,
             default_member_permissions: command.default_member_permissions,
             dm_permission: command.dm_permission,

--- a/twilight-model/src/id/mod.rs
+++ b/twilight-model/src/id/mod.rs
@@ -499,6 +499,7 @@ mod tests {
     /// Test that creating an ID via [`Id::new`] with a value of zero panics.
     #[should_panic]
     #[test]
+    #[allow(clippy::let_underscore_untyped)]
     const fn test_new_checked_zero() {
         let _ = Id::<GenericMarker>::new(0);
     }

--- a/twilight-model/src/id/mod.rs
+++ b/twilight-model/src/id/mod.rs
@@ -499,9 +499,8 @@ mod tests {
     /// Test that creating an ID via [`Id::new`] with a value of zero panics.
     #[should_panic]
     #[test]
-    #[allow(clippy::let_underscore_untyped)]
     const fn test_new_checked_zero() {
-        let _ = Id::<GenericMarker>::new(0);
+        _ = Id::<GenericMarker>::new(0);
     }
 
     /// Test that casting IDs maintains the original value.


### PR DESCRIPTION
allow clippy::let-underscore-untyped