### PR TITLE
build(gateway, http, lavalink): Dependency updates for rustls 0.21

### DIFF
--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -20,7 +20,7 @@ rand = { default-features = false, features = ["std", "std_rng"], version = "0.8
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.8" }
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.18" }
+tokio-tungstenite = { default-features = false, features = ["connect"], git = "https://github.com/snapview/tokio-tungstenite.git" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-gateway-queue = { default-features = false, path = "../twilight-gateway-queue", version = "0.15.1" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.1" }
@@ -38,8 +38,8 @@ simd-json = { default-features = false, features = ["serde_impl", "swar-number-p
 # They are needed to track what is used in tokio-tungstenite
 native-tls = { default-features = false, optional = true, version = "0.2.8" }
 rustls-native-certs = { default-features = false, optional = true, version = "0.6" }
-rustls-tls = { default-features = false, optional = true, package = "rustls", version = "0.20" }
-webpki-roots = { default-features = false, optional = true, version = "0.22" }
+rustls-tls = { default-features = false, optional = true, package = "rustls", version = "0.21" }
+webpki-roots = { default-features = false, optional = true, version = "0.23" }
 
 [dev-dependencies]
 anyhow = { default-features = false, features = ["std"], version = "1" }

--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -20,7 +20,7 @@ rand = { default-features = false, features = ["std", "std_rng"], version = "0.8
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.8" }
-tokio-tungstenite = { default-features = false, features = ["connect"], git = "https://github.com/snapview/tokio-tungstenite.git" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.19" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-gateway-queue = { default-features = false, path = "../twilight-gateway-queue", version = "0.15.1" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.1" }

--- a/twilight-gateway/src/tls.rs
+++ b/twilight-gateway/src/tls.rs
@@ -34,7 +34,7 @@ mod r#impl {
         config: WebSocketConfig,
         _tls: &TlsContainer,
     ) -> Result<Connection, ReceiveMessageError> {
-        let (stream, _) = tokio_tungstenite::connect_async_with_config(url, Some(config))
+        let (stream, _) = tokio_tungstenite::connect_async_with_config(url, Some(config), false)
             .await
             .map_err(|source| ReceiveMessageError {
                 kind: ReceiveMessageErrorType::Reconnect,
@@ -89,13 +89,17 @@ mod r#impl {
         config: WebSocketConfig,
         tls: &TlsContainer,
     ) -> Result<Connection, ReceiveMessageError> {
-        let (stream, _) =
-            tokio_tungstenite::connect_async_tls_with_config(url, Some(config), tls.connector())
-                .await
-                .map_err(|source| ReceiveMessageError {
-                    kind: ReceiveMessageErrorType::Reconnect,
-                    source: Some(Box::new(source)),
-                })?;
+        let (stream, _) = tokio_tungstenite::connect_async_tls_with_config(
+            url,
+            Some(config),
+            false,
+            tls.connector(),
+        )
+        .await
+        .map_err(|source| ReceiveMessageError {
+            kind: ReceiveMessageErrorType::Reconnect,
+            source: Some(Box::new(source)),
+        })?;
 
         Ok(stream)
     }
@@ -179,13 +183,17 @@ mod r#impl {
         config: WebSocketConfig,
         tls: &TlsContainer,
     ) -> Result<Connection, ReceiveMessageError> {
-        let (stream, _) =
-            tokio_tungstenite::connect_async_tls_with_config(url, Some(config), tls.connector())
-                .await
-                .map_err(|source| ReceiveMessageError {
-                    kind: ReceiveMessageErrorType::Reconnect,
-                    source: Some(Box::new(source)),
-                })?;
+        let (stream, _) = tokio_tungstenite::connect_async_tls_with_config(
+            url,
+            Some(config),
+            false,
+            tls.connector(),
+        )
+        .await
+        .map_err(|source| ReceiveMessageError {
+            kind: ReceiveMessageErrorType::Reconnect,
+            source: Some(Box::new(source)),
+        })?;
 
         Ok(stream)
     }

--- a/twilight-http/Cargo.toml
+++ b/twilight-http/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.15.1"
 
 [dependencies]
 hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
-hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.23" }
+hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.24" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
 hyper-trust-dns = { default-features = false, optional = true, version = "0.5" }
 percent-encoding = { default-features = false, version = "2" }

--- a/twilight-lavalink/Cargo.toml
+++ b/twilight-lavalink/Cargo.toml
@@ -20,7 +20,7 @@ http = { default-features = false, version = "0.2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["macros", "net", "rt", "sync", "time"], version = "1.0" }
-tokio-tungstenite = { default-features = false, features = ["connect"], git = "https://github.com/snapview/tokio-tungstenite.git" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.19" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.1" }
 

--- a/twilight-lavalink/Cargo.toml
+++ b/twilight-lavalink/Cargo.toml
@@ -20,7 +20,7 @@ http = { default-features = false, version = "0.2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["macros", "net", "rt", "sync", "time"], version = "1.0" }
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.18" }
+tokio-tungstenite = { default-features = false, features = ["connect"], git = "https://github.com/snapview/tokio-tungstenite.git" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.1" }
 


### PR DESCRIPTION
PR goes to next because it is not advisable to have two different versions of `rustls` in the dependency tree and we shouldn't force it upon users in a patch release.