### PR TITLE
build(gateway, http): Allow simd-json 0.8 and 0.9

### DIFF
--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -32,7 +32,7 @@ twilight-model = { default-features = false, path = "../twilight-model", version
 # https://github.com/alexcrichton/flate2-rs/issues/217
 flate2 = { default-features = false, optional = true, version = "1.0.24" }
 twilight-http = { default-features = false, optional = true, path = "../twilight-http", version = "0.15.1" }
-simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = ">=0.4, <0.8" }
+simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = ">=0.4, <0.10" }
 
 # TLS libraries
 # They are needed to track what is used in tokio-tungstenite

--- a/twilight-http/Cargo.toml
+++ b/twilight-http/Cargo.toml
@@ -30,7 +30,7 @@ twilight-validate = { default-features = false, path = "../twilight-validate", v
 
 # Optional dependencies.
 brotli = { default-features = false, features = ["std"], optional = true, version = "3.0.0" }
-simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = ">=0.4, <0.8" }
+simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = ">=0.4, <0.10" }
 
 [features]
 default = ["decompression", "rustls-native-roots"]


### PR DESCRIPTION
These versions seem to be API compatible with 0.7 (for our usage)