### PR TITLE
build: bump MSRV to 1.67

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ edition = "2021"
 include = ["src/**/*.rs", "README.md"]
 license = "ISC"
 repository = "https://github.com/twilight-rs/twilight.git"
-rust-version = "1.64"
+rust-version = "1.67"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ functionality. Please use the individual crates listed below instead!
 
 ## Installation
 
-Twilight supports a MSRV of Rust 1.64+.
+Twilight supports a MSRV of Rust 1.67.
 
 We recommend that most users start out with these crates:
 
@@ -205,13 +205,12 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
-[docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [logo]: https://raw.githubusercontent.com/twilight-rs/twilight/main/logo.png
-[rust badge]: https://img.shields.io/badge/rust-1.64+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.67+-93450a.svg?style=for-the-badge&logo=rust
 [`twilight-cache-inmemory`]: https://twilight.rs/chapter_1_crates/section_4_cache_inmemory.html
 [`twilight-gateway-queue`]: https://twilight.rs/chapter_1_crates/section_7_first_party/section_5_gateway_queue.html
 [`twilight-gateway`]: https://twilight.rs/chapter_1_crates/section_3_gateway.html

--- a/twilight-cache-inmemory/README.md
+++ b/twilight-cache-inmemory/README.md
@@ -80,9 +80,8 @@ All first-party crates are licensed under [ISC][LICENSE.md]
 [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/
 [discord badge]: https://img.shields.io/discord/745809834183753828?color=%237289DA&label=discord%20server&logo=discord&style=for-the-badge
 [discord link]: https://discord.gg/7jj8n7D
-[docs:discord:sharding]: https://discord.com/developers/docs/topics/gateway#sharding
 [github badge]: https://img.shields.io/badge/github-twilight-6f42c1.svg?style=for-the-badge&logo=github
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.64+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.67+-93450a.svg?style=for-the-badge&logo=rust

--- a/twilight-cache-inmemory/src/event/member.rs
+++ b/twilight-cache-inmemory/src/event/member.rs
@@ -168,9 +168,7 @@ impl UpdateCache for MemberUpdate {
 
         let key = (self.guild_id, self.user.id);
 
-        let mut member = if let Some(member) = cache.members.get_mut(&key) {
-            member
-        } else {
+        let Some(mut member) = cache.members.get_mut(&key) else {
             return;
         };
 

--- a/twilight-cache-inmemory/src/event/reaction.rs
+++ b/twilight-cache-inmemory/src/event/reaction.rs
@@ -14,9 +14,7 @@ impl UpdateCache for ReactionAdd {
 
         let key = self.0.message_id;
 
-        let mut message = if let Some(message) = cache.messages.get_mut(&key) {
-            message
-        } else {
+        let Some(mut message) = cache.messages.get_mut(&key) else {
             return;
         };
 
@@ -55,9 +53,7 @@ impl UpdateCache for ReactionRemove {
             return;
         }
 
-        let mut message = if let Some(message) = cache.messages.get_mut(&self.0.message_id) {
-            message
-        } else {
+        let Some(mut message) = cache.messages.get_mut(&self.0.message_id) else {
             return;
         };
 
@@ -91,9 +87,7 @@ impl UpdateCache for ReactionRemoveAll {
             return;
         }
 
-        let mut message = if let Some(message) = cache.messages.get_mut(&self.message_id) {
-            message
-        } else {
+        let Some(mut message) = cache.messages.get_mut(&self.message_id) else {
             return;
         };
 
@@ -107,9 +101,7 @@ impl UpdateCache for ReactionRemoveEmoji {
             return;
         }
 
-        let mut message = if let Some(message) = cache.messages.get_mut(&self.message_id) {
-            message
-        } else {
+        let Some(mut message) = cache.messages.get_mut(&self.message_id) else {
             return;
         };
 

--- a/twilight-cache-inmemory/src/event/voice_state.rs
+++ b/twilight-cache-inmemory/src/event/voice_state.rs
@@ -10,9 +10,7 @@ impl InMemoryCache {
 
     fn cache_voice_state(&self, voice_state: VoiceState) {
         // This should always exist, but let's check just in case.
-        let guild_id = if let Some(id) = voice_state.guild_id {
-            id
-        } else {
+        let Some(guild_id) = voice_state.guild_id else {
             return;
         };
 

--- a/twilight-cache-inmemory/src/permission.rs
+++ b/twilight-cache-inmemory/src/permission.rs
@@ -533,9 +533,7 @@ impl<'a> InMemoryCachePermissions<'a> {
             return permissions;
         };
 
-        let absolute = if let Ok(absolute) = micros.try_into() {
-            absolute
-        } else {
+        let Ok(absolute) = micros.try_into() else {
             return permissions;
         };
 
@@ -576,9 +574,7 @@ impl<'a> InMemoryCachePermissions<'a> {
         let mut member_roles = Vec::with_capacity(member.roles.len());
 
         for role_id in &member.roles {
-            let role = if let Some(role) = self.cache.roles.get(role_id) {
-                role
-            } else {
+            let Some(role) = self.cache.roles.get(role_id) else {
                 return Err(MemberRolesErrorType::RoleMissing { role_id: *role_id });
             };
 

--- a/twilight-gateway/README.md
+++ b/twilight-gateway/README.md
@@ -143,4 +143,4 @@ There are a few additional examples located in the
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.64+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.67+-93450a.svg?style=for-the-badge&logo=rust

--- a/twilight-gateway/src/json.rs
+++ b/twilight-gateway/src/json.rs
@@ -63,10 +63,7 @@ pub fn parse(
     event: String,
     wanted_event_types: EventTypeFlags,
 ) -> Result<Option<GatewayEvent>, ReceiveMessageError> {
-    let gateway_deserializer =
-        if let Some(gateway_deserializer) = GatewayEventDeserializer::from_json(&event) {
-            gateway_deserializer
-        } else {
+    let Some(gateway_deserializer) = GatewayEventDeserializer::from_json(&event) else {
             return Err(ReceiveMessageError {
                 kind: ReceiveMessageErrorType::Deserializing { event },
                 source: Some(Box::new(UnknownEventError {
@@ -76,9 +73,7 @@ pub fn parse(
             });
         };
 
-    let opcode = if let Some(opcode) = OpCode::from(gateway_deserializer.op()) {
-        opcode
-    } else {
+    let Some(opcode) = OpCode::from(gateway_deserializer.op()) else {
         let opcode = gateway_deserializer.op();
 
         return Err(ReceiveMessageError {
@@ -92,9 +87,7 @@ pub fn parse(
 
     let event_type = gateway_deserializer.event_type();
 
-    let event_type = if let Ok(event_type) = EventTypeFlags::try_from((opcode, event_type)) {
-        event_type
-    } else {
+    let Ok(event_type) = EventTypeFlags::try_from((opcode, event_type)) else {
         let opcode = opcode as u8;
         let owned_event_type = event_type.map(ToOwned::to_owned);
 

--- a/twilight-http-ratelimiting/src/in_memory/bucket.rs
+++ b/twilight-http-ratelimiting/src/in_memory/bucket.rs
@@ -86,9 +86,7 @@ impl Bucket {
         let reset_after = self.reset_after();
         let maybe_started_at = *self.started_at.lock().expect("bucket poisoned");
 
-        let started_at = if let Some(started_at) = maybe_started_at {
-            started_at
-        } else {
+        let Some(started_at) = maybe_started_at else {
             return TimeRemaining::NotStarted;
         };
 
@@ -222,9 +220,7 @@ impl BucketQueueTask {
                 drop(self.global.0.lock().await);
             }
 
-            let ticket_headers = if let Some(ticket_headers) = queue_tx.available() {
-                ticket_headers
-            } else {
+            let Some(ticket_headers) = queue_tx.available() else {
                 continue;
             };
 

--- a/twilight-http/README.md
+++ b/twilight-http/README.md
@@ -107,4 +107,4 @@ async DNS resolver on the application level.
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.64+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.67+-93450a.svg?style=for-the-badge&logo=rust

--- a/twilight-lavalink/README.md
+++ b/twilight-lavalink/README.md
@@ -129,4 +129,4 @@ There is also an example of a basic bot located in the [root of the
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
 [node]: Node
 [process]: Lavalink::process
-[rust badge]: https://img.shields.io/badge/rust-1.64+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.67+-93450a.svg?style=for-the-badge&logo=rust

--- a/twilight-lavalink/src/node.rs
+++ b/twilight-lavalink/src/node.rs
@@ -570,9 +570,7 @@ impl Connection {
             }
         };
 
-        let event = if let Ok(event) = serde_json::from_str(&text) {
-            event
-        } else {
+        let Ok(event) = serde_json::from_str(&text) else {
             tracing::warn!("unknown message from lavalink node: {text}");
 
             return Ok(true);
@@ -594,9 +592,7 @@ impl Connection {
     }
 
     fn player_update(&self, update: &PlayerUpdate) -> Result<(), NodeError> {
-        let player = if let Some(player) = self.players.get(&update.guild_id) {
-            player
-        } else {
+        let Some(player) = self.players.get(&update.guild_id) else {
             tracing::warn!(
                 "invalid player update for guild {}: {update:?}",
                 update.guild_id,

--- a/twilight-mention/README.md
+++ b/twilight-mention/README.md
@@ -29,4 +29,4 @@ let message = format!("Hey there, {}!", user_id.mention());
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.64+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.67+-93450a.svg?style=for-the-badge&logo=rust

--- a/twilight-mention/src/parse/iter.rs
+++ b/twilight-mention/src/parse/iter.rs
@@ -63,10 +63,7 @@ impl<'a, T: ParseMention> Iterator for MentionIter<'a, T> {
         // chars here and not just individual bytes. We also want to not use
         // consuming methods of the iterator, so this will get a little weird.
         loop {
-            let start = match self.chars.next()? {
-                (idx, '<') => idx,
-                _ => continue,
-            };
+            let (start, '<') = self.chars.next()? else { continue };
 
             let mut found = false;
 
@@ -84,9 +81,7 @@ impl<'a, T: ParseMention> Iterator for MentionIter<'a, T> {
                 continue;
             }
 
-            let end = if let Some((idx, _)) = self.chars.find(|c| c.1 == '>') {
-                idx
-            } else {
+            let Some((end, _)) = self.chars.find(|c| c.1 == '>') else {
                 continue;
             };
 

--- a/twilight-model/README.md
+++ b/twilight-model/README.md
@@ -39,4 +39,4 @@ Some models have associated builders, which can be found in the
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.64+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.67+-93450a.svg?style=for-the-badge&logo=rust

--- a/twilight-standby/README.md
+++ b/twilight-standby/README.md
@@ -147,4 +147,4 @@ For more examples, check out each of the methods on [`Standby`].
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.64+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.67+-93450a.svg?style=for-the-badge&logo=rust

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -882,9 +882,7 @@ impl Standby {
     ) -> ProcessStatus {
         // We need to take the sender out because `OneshotSender`s consume
         // themselves when calling `OneshotSender::send`.
-        let sender = if let Some(sender) = bystander.sender.take() {
-            sender
-        } else {
+        let Some(sender) = bystander.sender.take() else {
             tracing::trace!("bystander has no sender, indicating for removal");
 
             return ProcessStatus::AlreadyComplete;

--- a/twilight-util/README.md
+++ b/twilight-util/README.md
@@ -35,5 +35,5 @@ structured information from [Discord snowflakes].
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.64+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.67+-93450a.svg?style=for-the-badge&logo=rust
 [Discord snowflakes]: https://discord.com/developers/docs/reference#snowflakes

--- a/twilight-validate/README.md
+++ b/twilight-validate/README.md
@@ -19,4 +19,4 @@ manually validating any models from [`twilight-model`].
 [github link]: https://github.com/twilight-rs/twilight
 [license badge]: https://img.shields.io/badge/license-ISC-blue.svg?style=for-the-badge&logo=pastebin
 [license link]: https://github.com/twilight-rs/twilight/blob/main/LICENSE.md
-[rust badge]: https://img.shields.io/badge/rust-1.64+-93450a.svg?style=for-the-badge&logo=rust
+[rust badge]: https://img.shields.io/badge/rust-1.67+-93450a.svg?style=for-the-badge&logo=rust


### PR DESCRIPTION
Bumps the MSRV from 1.64 to 1.67.

Utilizes `let else` statements whereever possible.

1.67 was chosen as it's the current stable - 2, which is not too recent but not too old. Specifically, it was necessary to bump the MSRV as our dependencies (in this case `time`) have a policy of supporting stable - 6 months (currently 1.65).
