### PR TITLE
fix(http)!: fix `UpdateFollowup` falsely returning an `EmptyBody` (#2203)

### DIFF
--- a/twilight-http/src/request/application/interaction/update_followup.rs
+++ b/twilight-http/src/request/application/interaction/update_followup.rs
@@ -12,9 +12,8 @@ use crate::{
 };
 use serde::Serialize;
 use std::future::IntoFuture;
-use twilight_model::channel::Message;
 use twilight_model::{
-    channel::message::{AllowedMentions, Component, Embed},
+    channel::message::{AllowedMentions, Component, Embed, Message},
     http::attachment::Attachment,
     id::{
         marker::{ApplicationMarker, AttachmentMarker, MessageMarker},

--- a/twilight-http/src/request/application/interaction/update_followup.rs
+++ b/twilight-http/src/request/application/interaction/update_followup.rs
@@ -7,11 +7,12 @@ use crate::{
         attachment::{AttachmentManager, PartialAttachment},
         Nullable, Request, TryIntoRequest,
     },
-    response::{marker::EmptyBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
 use std::future::IntoFuture;
+use twilight_model::channel::Message;
 use twilight_model::{
     channel::message::{AllowedMentions, Component, Embed},
     http::attachment::Attachment,
@@ -132,7 +133,7 @@ impl<'a> UpdateFollowup<'a> {
     /// # Errors
     ///
     /// Returns an error of type [`AttachmentDescriptionTooLarge`] if
-    /// the attachments's description is too large.
+    /// the attachments' description is too large.
     ///
     /// Returns an error of type [`AttachmentFilename`] if any filename is
     /// invalid.
@@ -313,15 +314,15 @@ impl<'a> UpdateFollowup<'a> {
     }
 
     #[deprecated(since = "0.14.0", note = "use `.await` or `into_future` instead")]
-    pub fn exec(self) -> ResponseFuture<EmptyBody> {
+    pub fn exec(self) -> ResponseFuture<Message> {
         self.into_future()
     }
 }
 
 impl IntoFuture for UpdateFollowup<'_> {
-    type Output = Result<Response<EmptyBody>, Error>;
+    type Output = Result<Response<Message>, Error>;
 
-    type IntoFuture = ResponseFuture<EmptyBody>;
+    type IntoFuture = ResponseFuture<Message>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;


### PR DESCRIPTION
closes #2203

also silently fixes a small typo in `attachments's`