### PR TITLE
feat(twilight-model)!: Implement additional select menu types

### DIFF
--- a/twilight-cache-inmemory/src/event/interaction.rs
+++ b/twilight-cache-inmemory/src/event/interaction.rs
@@ -65,10 +65,8 @@ mod tests {
         application::{
             command::CommandType,
             interaction::{
-                application_command::{
-                    CommandData, CommandInteractionDataResolved, InteractionMember,
-                },
-                Interaction, InteractionData, InteractionType,
+                application_command::CommandData, Interaction, InteractionData,
+                InteractionDataResolved, InteractionMember, InteractionType,
             },
         },
         channel::{
@@ -143,7 +141,7 @@ mod tests {
                 name: "command name".into(),
                 kind: CommandType::ChatInput, // This isn't actually a valid command, so just mark it as a slash command.
                 options: Vec::new(),
-                resolved: Some(CommandInteractionDataResolved {
+                resolved: Some(InteractionDataResolved {
                     attachments: HashMap::new(),
                     channels: HashMap::new(),
                     members: HashMap::from([(

--- a/twilight-cache-inmemory/src/event/member.rs
+++ b/twilight-cache-inmemory/src/event/member.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use std::borrow::Cow;
 use twilight_model::{
-    application::interaction::application_command::InteractionMember,
+    application::interaction::InteractionMember,
     gateway::payload::incoming::{MemberAdd, MemberChunk, MemberRemove, MemberUpdate},
     guild::{Member, PartialMember},
     id::{

--- a/twilight-cache-inmemory/src/model/member.rs
+++ b/twilight-cache-inmemory/src/model/member.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use twilight_model::{
-    application::interaction::application_command::InteractionMember,
+    application::interaction::InteractionMember,
     guild::{Member, MemberFlags, PartialMember},
     id::{
         marker::{RoleMarker, UserMarker},

--- a/twilight-model/src/application/interaction/application_command/mod.rs
+++ b/twilight-model/src/application/interaction/application_command/mod.rs
@@ -3,15 +3,11 @@
 //! [`ApplicationCommand`]: crate::application::interaction::InteractionType::ApplicationCommand
 
 mod option;
-mod resolved;
 
-pub use self::{
-    option::{CommandDataOption, CommandOptionValue},
-    resolved::{CommandInteractionDataResolved, InteractionChannel, InteractionMember},
-};
+pub use self::option::{CommandDataOption, CommandOptionValue};
 
 use crate::{
-    application::command::CommandType,
+    application::{command::CommandType, interaction::InteractionDataResolved},
     id::{
         marker::{CommandMarker, GenericMarker, GuildMarker},
         Id,
@@ -44,7 +40,7 @@ pub struct CommandData {
     pub options: Vec<CommandDataOption>,
     /// Resolved data from the interaction's options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub resolved: Option<CommandInteractionDataResolved>,
+    pub resolved: Option<InteractionDataResolved>,
     /// If this is a user or message command, the ID of the targeted user/message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_id: Option<Id<GenericMarker>>,

--- a/twilight-model/src/application/interaction/message_component.rs
+++ b/twilight-model/src/application/interaction/message_component.rs
@@ -75,12 +75,14 @@ mod tests {
             &[
                 Token::Struct {
                     name: "MessageComponentInteractionData",
-                    len: 3,
+                    len: 4,
                 },
                 Token::String("custom_id"),
                 Token::String("test"),
                 Token::String("component_type"),
                 Token::U8(ComponentType::Button.into()),
+                Token::String("resolved"),
+                Token::None,
                 Token::String("values"),
                 Token::Seq { len: Some(2) },
                 Token::String("1"),

--- a/twilight-model/src/application/interaction/message_component.rs
+++ b/twilight-model/src/application/interaction/message_component.rs
@@ -2,6 +2,7 @@
 //!
 //! [`MessageComponent`]: crate::application::interaction::InteractionType::MessageComponent
 
+use crate::application::interaction::InteractionDataResolved;
 use crate::channel::message::component::ComponentType;
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [`MessageComponent`]: crate::application::interaction::InteractionType::MessageComponent
 /// [Discord Docs/Message Component Data Structure]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-message-component-data-structure
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct MessageComponentInteractionData {
     /// User defined identifier for the component.
     ///
@@ -21,6 +22,12 @@ pub struct MessageComponentInteractionData {
     pub custom_id: String,
     /// Type of the component.
     pub component_type: ComponentType,
+    /// Converted users, roles, channels, or attachments.
+    ///
+    /// Only used for [`SelectMenu`] components.
+    ///
+    /// [`SelectMenu`]: crate::channel::message::component::SelectMenu
+    pub resolved: Option<InteractionDataResolved>,
     /// Values selected by the user.
     ///
     /// Only used for [`SelectMenu`] components.
@@ -37,7 +44,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serde_test::Token;
     use static_assertions::{assert_fields, assert_impl_all};
-    use std::{fmt::Debug, hash::Hash};
+    use std::fmt::Debug;
 
     assert_fields!(
         MessageComponentInteractionData: custom_id,
@@ -48,8 +55,6 @@ mod tests {
         MessageComponentInteractionData: Clone,
         Debug,
         Deserialize<'static>,
-        Eq,
-        Hash,
         PartialEq,
         Send,
         Serialize,
@@ -61,6 +66,7 @@ mod tests {
         let value = MessageComponentInteractionData {
             custom_id: "test".to_owned(),
             component_type: ComponentType::Button,
+            resolved: None,
             values: Vec::from(["1".to_owned(), "2".to_owned()]),
         };
 

--- a/twilight-model/src/application/interaction/message_component.rs
+++ b/twilight-model/src/application/interaction/message_component.rs
@@ -5,7 +5,7 @@
 use crate::channel::message::component::ComponentType;
 use serde::{Deserialize, Serialize};
 
-/// Data received when an [`MessageComponent`] interaction is executed.
+/// Data received when a [`MessageComponent`] interaction is executed.
 ///
 /// See [Discord Docs/Message Component Data Structure].
 ///
@@ -25,7 +25,7 @@ pub struct MessageComponentInteractionData {
     ///
     /// Only used for [`SelectMenu`] components.
     ///
-    /// [`SelectMenu`]: ComponentType::SelectMenu
+    /// [`SelectMenu`]: crate::channel::message::component::SelectMenu
     #[serde(default)]
     pub values: Vec<String>,
 }

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -9,8 +9,12 @@ pub mod message_component;
 pub mod modal;
 
 mod interaction_type;
+mod resolved;
 
-pub use self::interaction_type::InteractionType;
+pub use self::{
+    interaction_type::InteractionType,
+    resolved::{InteractionChannel, InteractionDataResolved, InteractionMember},
+};
 
 use self::{
     application_command::CommandData, message_component::MessageComponentInteractionData,
@@ -424,7 +428,7 @@ pub enum InteractionData {
     /// Data received for the [`MessageComponent`] interaction type.
     ///
     /// [`MessageComponent`]: InteractionType::MessageComponent
-    MessageComponent(MessageComponentInteractionData),
+    MessageComponent(Box<MessageComponentInteractionData>),
     /// Data received for the [`ModalSubmit`] interaction type.
     ///
     /// [`ModalSubmit`]: InteractionType::ModalSubmit
@@ -434,11 +438,8 @@ pub enum InteractionData {
 #[cfg(test)]
 mod tests {
     use super::{
-        application_command::{
-            CommandData, CommandDataOption, CommandInteractionDataResolved, CommandOptionValue,
-            InteractionMember,
-        },
-        Interaction, InteractionData, InteractionType,
+        application_command::{CommandData, CommandDataOption, CommandOptionValue},
+        Interaction, InteractionData, InteractionDataResolved, InteractionMember, InteractionType,
     };
     use crate::{
         application::command::{CommandOptionType, CommandType},
@@ -508,7 +509,7 @@ mod tests {
                     name: "member".into(),
                     value: CommandOptionValue::User(Id::new(600)),
                 }]),
-                resolved: Some(CommandInteractionDataResolved {
+                resolved: Some(InteractionDataResolved {
                     attachments: HashMap::new(),
                     channels: HashMap::new(),
                     members: IntoIterator::into_iter([(

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -653,7 +653,7 @@ mod tests {
                 Token::Str("resolved"),
                 Token::Some,
                 Token::Struct {
-                    name: "CommandInteractionDataResolved",
+                    name: "InteractionDataResolved",
                     len: 2,
                 },
                 Token::Str("members"),

--- a/twilight-model/src/application/interaction/resolved.rs
+++ b/twilight-model/src/application/interaction/resolved.rs
@@ -282,7 +282,7 @@ mod tests {
             &value,
             &[
                 Token::Struct {
-                    name: "CommandInteractionDataResolved",
+                    name: "InteractionDataResolved",
                     len: 6,
                 },
                 Token::Str("attachments"),

--- a/twilight-model/src/application/interaction/resolved.rs
+++ b/twilight-model/src/application/interaction/resolved.rs
@@ -18,7 +18,7 @@ use std::collections::hash_map::HashMap;
 /// [`ApplicationCommand`]: crate::application::interaction::InteractionType::ApplicationCommand
 /// [Discord Docs/Resolved Data Structure]: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct CommandInteractionDataResolved {
+pub struct InteractionDataResolved {
     /// Map of resolved attachments.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub attachments: HashMap<Id<AttachmentMarker>, Attachment>,
@@ -97,7 +97,7 @@ pub struct InteractionMember {
 
 #[cfg(test)]
 mod tests {
-    use super::{CommandInteractionDataResolved, InteractionChannel, InteractionMember};
+    use super::{InteractionChannel, InteractionDataResolved, InteractionMember};
     use crate::{
         channel::{
             message::{
@@ -122,7 +122,7 @@ mod tests {
         let timestamp = Timestamp::from_str("2020-02-02T02:02:02.020000+00:00")?;
         let flags = MemberFlags::BYPASSES_VERIFICATION | MemberFlags::DID_REJOIN;
 
-        let value = CommandInteractionDataResolved {
+        let value = InteractionDataResolved {
             attachments: IntoIterator::into_iter([(
                 Id::new(400),
                 Attachment {

--- a/twilight-model/src/channel/message/component/kind.rs
+++ b/twilight-model/src/channel/message/component/kind.rs
@@ -16,14 +16,30 @@ pub enum ComponentType {
     ///
     /// [`Button`]: super::Button
     Button,
-    /// Component is an [`SelectMenu`].
+    /// Component is a [`SelectMenu`] with custom string options.
     ///
     /// [`SelectMenu`]: super::SelectMenu
-    SelectMenu,
+    TextSelectMenu,
     /// Component is an [`TextInput`].
     ///
     /// [`TextInput`]: super::TextInput
     TextInput,
+    /// Component is a [`SelectMenu`] for users.
+    ///
+    /// [`SelectMenu`]: super::SelectMenu
+    UserSelectMenu,
+    /// Component is a [`SelectMenu`] for roles.
+    ///
+    /// [`SelectMenu`]: super::SelectMenu
+    RoleSelectMenu,
+    /// Component is a [`SelectMenu`] for mentionables.
+    ///
+    /// [`SelectMenu`]: super::SelectMenu
+    MentionableSelectMenu,
+    /// Component is a [`SelectMenu`] for channels.
+    ///
+    /// [`SelectMenu`]: super::SelectMenu
+    ChannelSelectMenu,
     /// Variant value is unknown to the library.
     Unknown(u8),
 }
@@ -33,8 +49,12 @@ impl From<u8> for ComponentType {
         match value {
             1 => ComponentType::ActionRow,
             2 => ComponentType::Button,
-            3 => ComponentType::SelectMenu,
+            3 => ComponentType::TextSelectMenu,
             4 => ComponentType::TextInput,
+            5 => ComponentType::UserSelectMenu,
+            6 => ComponentType::RoleSelectMenu,
+            7 => ComponentType::MentionableSelectMenu,
+            8 => ComponentType::ChannelSelectMenu,
             unknown => ComponentType::Unknown(unknown),
         }
     }
@@ -45,8 +65,12 @@ impl From<ComponentType> for u8 {
         match value {
             ComponentType::ActionRow => 1,
             ComponentType::Button => 2,
-            ComponentType::SelectMenu => 3,
+            ComponentType::TextSelectMenu => 3,
             ComponentType::TextInput => 4,
+            ComponentType::UserSelectMenu => 5,
+            ComponentType::RoleSelectMenu => 6,
+            ComponentType::MentionableSelectMenu => 7,
+            ComponentType::ChannelSelectMenu => 8,
             ComponentType::Unknown(unknown) => unknown,
         }
     }
@@ -72,7 +96,11 @@ impl ComponentType {
         match self {
             Self::ActionRow => "ActionRow",
             Self::Button => "Button",
-            Self::SelectMenu => "SelectMenu",
+            Self::TextSelectMenu
+            | Self::UserSelectMenu
+            | Self::RoleSelectMenu
+            | Self::MentionableSelectMenu
+            | Self::ChannelSelectMenu => "SelectMenu",
             Self::TextInput => "TextInput",
             Self::Unknown(_) => "Unknown",
         }
@@ -110,8 +138,12 @@ mod tests {
     fn variants() {
         serde_test::assert_tokens(&ComponentType::ActionRow, &[Token::U8(1)]);
         serde_test::assert_tokens(&ComponentType::Button, &[Token::U8(2)]);
-        serde_test::assert_tokens(&ComponentType::SelectMenu, &[Token::U8(3)]);
+        serde_test::assert_tokens(&ComponentType::TextSelectMenu, &[Token::U8(3)]);
         serde_test::assert_tokens(&ComponentType::TextInput, &[Token::U8(4)]);
+        serde_test::assert_tokens(&ComponentType::UserSelectMenu, &[Token::U8(5)]);
+        serde_test::assert_tokens(&ComponentType::RoleSelectMenu, &[Token::U8(6)]);
+        serde_test::assert_tokens(&ComponentType::MentionableSelectMenu, &[Token::U8(7)]);
+        serde_test::assert_tokens(&ComponentType::ChannelSelectMenu, &[Token::U8(8)]);
         serde_test::assert_tokens(&ComponentType::Unknown(99), &[Token::U8(99)]);
     }
 
@@ -119,7 +151,11 @@ mod tests {
     fn names() {
         assert_eq!("ActionRow", ComponentType::ActionRow.name());
         assert_eq!("Button", ComponentType::Button.name());
-        assert_eq!("SelectMenu", ComponentType::SelectMenu.name());
+        assert_eq!("SelectMenu", ComponentType::TextSelectMenu.name());
+        assert_eq!("SelectMenu", ComponentType::UserSelectMenu.name());
+        assert_eq!("SelectMenu", ComponentType::RoleSelectMenu.name());
+        assert_eq!("SelectMenu", ComponentType::MentionableSelectMenu.name());
+        assert_eq!("SelectMenu", ComponentType::ChannelSelectMenu.name());
         assert_eq!("TextInput", ComponentType::TextInput.name());
         assert_eq!("Unknown", ComponentType::Unknown(99).name());
     }

--- a/twilight-model/src/channel/message/component/mod.rs
+++ b/twilight-model/src/channel/message/component/mod.rs
@@ -15,11 +15,14 @@ pub use self::{
     action_row::ActionRow,
     button::{Button, ButtonStyle},
     kind::ComponentType,
-    select_menu::{SelectMenu, SelectMenuOption},
+    select_menu::{
+        ChannelSelectMenuData, SelectMenu, SelectMenuData, SelectMenuOption, TextSelectMenuData,
+    },
     text_input::{TextInput, TextInputStyle},
 };
 
 use super::ReactionType;
+use crate::channel::ChannelType;
 use serde::{
     de::{Deserializer, Error as DeError, IgnoredAny, MapAccess, Visitor},
     ser::SerializeStruct,
@@ -56,7 +59,10 @@ use std::fmt::{Formatter, Result as FmtResult};
 /// ```
 /// use twilight_model::{
 ///     channel::message::{
-///         component::{ActionRow, Component, SelectMenu, SelectMenuOption},
+///         component::{
+///             ActionRow, Component, SelectMenu, SelectMenuData, SelectMenuOption,
+///             TextSelectMenuData,
+///         },
 ///         ReactionType,
 ///     },
 ///     id::Id,
@@ -68,41 +74,45 @@ use std::fmt::{Formatter, Result as FmtResult};
 ///         disabled: false,
 ///         max_values: Some(3),
 ///         min_values: Some(1),
-///         options: Vec::from([
-///             SelectMenuOption {
-///                 default: false,
-///                 emoji: Some(ReactionType::Custom {
-///                     animated: false,
-///                     id: Id::new(625891304148303894),
-///                     name: Some("rogue".to_owned()),
-///                 }),
-///                 description: Some("Sneak n stab".to_owned()),
-///                 label: "Rogue".to_owned(),
-///                 value: "rogue".to_owned(),
-///             },
-///             SelectMenuOption {
-///                 default: false,
-///                 emoji: Some(ReactionType::Custom {
-///                     animated: false,
-///                     id: Id::new(625891304081063986),
-///                     name: Some("mage".to_owned()),
-///                 }),
-///                 description: Some("Turn 'em into a sheep".to_owned()),
-///                 label: "Mage".to_owned(),
-///                 value: "mage".to_owned(),
-///             },
-///             SelectMenuOption {
-///                 default: false,
-///                 emoji: Some(ReactionType::Custom {
-///                     animated: false,
-///                     id: Id::new(625891303795982337),
-///                     name: Some("priest".to_owned()),
-///                 }),
-///                 description: Some("You get heals when I'm done doing damage".to_owned()),
-///                 label: "Priest".to_owned(),
-///                 value: "priest".to_owned(),
-///             },
-///         ]),
+///         data: SelectMenuData::Text(Box::new(TextSelectMenuData {
+///             options: Vec::from([
+///                 SelectMenuOption {
+///                     default: false,
+///                     emoji: Some(ReactionType::Custom {
+///                         animated: false,
+///                         id: Id::new(625891304148303894),
+///                         name: Some("rogue".to_owned()),
+///                     }),
+///                     description: Some("Sneak n stab".to_owned()),
+///                     label: "Rogue".to_owned(),
+///                     value: "rogue".to_owned(),
+///                 },
+///                 SelectMenuOption {
+///                     default: false,
+///                     emoji: Some(ReactionType::Custom {
+///                         animated: false,
+///                         id: Id::new(625891304081063986),
+///                         name: Some("mage".to_owned()),
+///                     }),
+///                     description: Some("Turn 'em into a sheep".to_owned()),
+///                     label: "Mage".to_owned(),
+///                     value: "mage".to_owned(),
+///                 },
+///                 SelectMenuOption {
+///                     default: false,
+///                     emoji: Some(ReactionType::Custom {
+///                         animated: false,
+///                         id: Id::new(625891303795982337),
+///                         name: Some("priest".to_owned()),
+///                     }),
+///                     description: Some(
+///                         "You get heals when I'm done doing damage".to_owned(),
+///                     ),
+///                     label: "Priest".to_owned(),
+///                     value: "priest".to_owned(),
+///                 },
+///             ]),
+///         })),
 ///         placeholder: Some("Choose a class".to_owned()),
 ///     })],
 /// });
@@ -144,7 +154,26 @@ impl Component {
         match self {
             Self::ActionRow(_) => ComponentType::ActionRow,
             Self::Button(_) => ComponentType::Button,
-            Self::SelectMenu(_) => ComponentType::SelectMenu,
+            Self::SelectMenu(SelectMenu {
+                data: SelectMenuData::Text(_),
+                ..
+            }) => ComponentType::TextSelectMenu,
+            Self::SelectMenu(SelectMenu {
+                data: SelectMenuData::User,
+                ..
+            }) => ComponentType::UserSelectMenu,
+            Self::SelectMenu(SelectMenu {
+                data: SelectMenuData::Role,
+                ..
+            }) => ComponentType::RoleSelectMenu,
+            Self::SelectMenu(SelectMenu {
+                data: SelectMenuData::Mentionable,
+                ..
+            }) => ComponentType::MentionableSelectMenu,
+            Self::SelectMenu(SelectMenu {
+                data: SelectMenuData::Channel(_),
+                ..
+            }) => ComponentType::ChannelSelectMenu,
             Self::TextInput(_) => ComponentType::TextInput,
             Component::Unknown(unknown) => ComponentType::Unknown(*unknown),
         }
@@ -184,6 +213,7 @@ impl<'de> Deserialize<'de> for Component {
 #[derive(Debug, Deserialize)]
 #[serde(field_identifier, rename_all = "snake_case")]
 enum Field {
+    ChannelTypes,
     Components,
     CustomId,
     Disabled,
@@ -217,6 +247,7 @@ impl<'de> Visitor<'de> for ComponentVisitor {
         let mut components: Option<Vec<Component>> = None;
         let mut kind: Option<ComponentType> = None;
         let mut options: Option<Vec<SelectMenuOption>> = None;
+        let mut channel_types: Option<Vec<ChannelType>> = None;
         let mut style: Option<Value> = None;
 
         // Liminal fields.
@@ -260,6 +291,13 @@ impl<'de> Visitor<'de> for ComponentVisitor {
             };
 
             match key {
+                Field::ChannelTypes => {
+                    if channel_types.is_some() {
+                        return Err(DeError::duplicate_field("channel_types"));
+                    }
+
+                    channel_types = Some(map.next_value()?);
+                }
                 Field::Components => {
                     if components.is_some() {
                         return Err(DeError::duplicate_field("components"));
@@ -436,28 +474,47 @@ impl<'de> Visitor<'de> for ComponentVisitor {
             }
             // Required fields:
             // - custom_id
-            // - options
+            // - options (if this is a text select menu)
             //
             // Optional fields:
             // - disabled
             // - max_values
             // - min_values
             // - placeholder
-            ComponentType::SelectMenu => {
+            // - channel_types (if this is a channel select menu)
+            kind @ (ComponentType::TextSelectMenu
+            | ComponentType::UserSelectMenu
+            | ComponentType::RoleSelectMenu
+            | ComponentType::MentionableSelectMenu
+            | ComponentType::ChannelSelectMenu) => {
                 let custom_id = custom_id
                     .flatten()
                     .ok_or_else(|| DeError::missing_field("custom_id"))?
                     .deserialize_into()
                     .map_err(DeserializerError::into_error)?;
 
-                let options = options.ok_or_else(|| DeError::missing_field("options"))?;
+                let data = match kind {
+                    ComponentType::TextSelectMenu => {
+                        let options = options.ok_or_else(|| DeError::missing_field("options"))?;
+                        SelectMenuData::Text(Box::new(TextSelectMenuData { options }))
+                    }
+                    ComponentType::UserSelectMenu => SelectMenuData::User,
+                    ComponentType::RoleSelectMenu => SelectMenuData::Role,
+                    ComponentType::MentionableSelectMenu => SelectMenuData::Mentionable,
+                    ComponentType::ChannelSelectMenu => {
+                        SelectMenuData::Channel(Box::new(ChannelSelectMenuData { channel_types }))
+                    }
+                    // We'll only take the branch below if we added a type above and forgot to implement it here. I.e.,
+                    // we should never end up here.
+                    _ => panic!("missing select menu implementation"),
+                };
 
                 Self::Value::SelectMenu(SelectMenu {
                     custom_id,
+                    data,
                     disabled: disabled.unwrap_or_default(),
                     max_values: max_values.unwrap_or_default(),
                     min_values: min_values.unwrap_or_default(),
-                    options,
                     placeholder: placeholder.unwrap_or_default(),
                 })
             }
@@ -505,6 +562,7 @@ impl<'de> Visitor<'de> for ComponentVisitor {
 }
 
 impl Serialize for Component {
+    #[allow(clippy::too_many_lines)]
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let len = match self {
             // Required fields:
@@ -602,7 +660,27 @@ impl Serialize for Component {
                 }
             }
             Component::SelectMenu(select_menu) => {
-                state.serialize_field("type", &ComponentType::SelectMenu)?;
+                match &select_menu.data {
+                    SelectMenuData::Text(data) => {
+                        state.serialize_field("type", &ComponentType::TextSelectMenu)?;
+                        state.serialize_field("options", &data.options)?;
+                    }
+                    SelectMenuData::User => {
+                        state.serialize_field("type", &ComponentType::UserSelectMenu)?;
+                    }
+                    SelectMenuData::Role => {
+                        state.serialize_field("type", &ComponentType::RoleSelectMenu)?;
+                    }
+                    SelectMenuData::Mentionable => {
+                        state.serialize_field("type", &ComponentType::MentionableSelectMenu)?;
+                    }
+                    SelectMenuData::Channel(data) => {
+                        state.serialize_field("type", &ComponentType::ChannelSelectMenu)?;
+                        if data.channel_types.is_some() {
+                            state.serialize_field("channel_types", &data.channel_types)?;
+                        }
+                    }
+                }
 
                 // Due to `custom_id` being required in some variants and
                 // optional in others, serialize as an Option.
@@ -617,8 +695,6 @@ impl Serialize for Component {
                 if select_menu.min_values.is_some() {
                     state.serialize_field("min_values", &select_menu.min_values)?;
                 }
-
-                state.serialize_field("options", &select_menu.options)?;
 
                 if select_menu.placeholder.is_some() {
                     state.serialize_field("placeholder", &select_menu.placeholder)?;
@@ -700,13 +776,15 @@ mod tests {
                     disabled: false,
                     max_values: Some(25),
                     min_values: Some(5),
-                    options: Vec::from([SelectMenuOption {
-                        label: "test option label".into(),
-                        value: "test option value".into(),
-                        description: Some("test description".into()),
-                        emoji: None,
-                        default: false,
-                    }]),
+                    data: SelectMenuData::Text(Box::new(TextSelectMenuData {
+                        options: Vec::from([SelectMenuOption {
+                            label: "test option label".into(),
+                            value: "test option value".into(),
+                            description: Some("test description".into()),
+                            emoji: None,
+                            default: false,
+                        }]),
+                    })),
                     placeholder: Some("test placeholder".into()),
                 }),
             ]),
@@ -745,18 +823,7 @@ mod tests {
                     len: 6,
                 },
                 Token::Str("type"),
-                Token::U8(ComponentType::SelectMenu.into()),
-                Token::Str("custom_id"),
-                Token::Some,
-                Token::Str("test custom id 2"),
-                Token::Str("disabled"),
-                Token::Bool(false),
-                Token::Str("max_values"),
-                Token::Some,
-                Token::U8(25),
-                Token::Str("min_values"),
-                Token::Some,
-                Token::U8(5),
+                Token::U8(ComponentType::TextSelectMenu.into()),
                 Token::Str("options"),
                 Token::Seq { len: Some(1) },
                 Token::Struct {
@@ -774,6 +841,17 @@ mod tests {
                 Token::Str("test option value"),
                 Token::StructEnd,
                 Token::SeqEnd,
+                Token::Str("custom_id"),
+                Token::Some,
+                Token::Str("test custom id 2"),
+                Token::Str("disabled"),
+                Token::Bool(false),
+                Token::Str("max_values"),
+                Token::Some,
+                Token::U8(25),
+                Token::Str("min_values"),
+                Token::Some,
+                Token::U8(5),
                 Token::Str("placeholder"),
                 Token::Some,
                 Token::Str("test placeholder"),

--- a/twilight-model/src/channel/message/component/mod.rs
+++ b/twilight-model/src/channel/message/component/mod.rs
@@ -74,7 +74,7 @@ use std::fmt::{Formatter, Result as FmtResult};
 ///         disabled: false,
 ///         max_values: Some(3),
 ///         min_values: Some(1),
-///         data: SelectMenuData::Text(Box::new(TextSelectMenuData {
+///         data: SelectMenuData::Text(TextSelectMenuData {
 ///             options: Vec::from([
 ///                 SelectMenuOption {
 ///                     default: false,
@@ -110,7 +110,7 @@ use std::fmt::{Formatter, Result as FmtResult};
 ///                     value: "priest".to_owned(),
 ///                 },
 ///             ]),
-///         })),
+///         }),
 ///         placeholder: Some("Choose a class".to_owned()),
 ///     })],
 /// });
@@ -494,13 +494,13 @@ impl<'de> Visitor<'de> for ComponentVisitor {
                 let data = match kind {
                     ComponentType::TextSelectMenu => {
                         let options = options.ok_or_else(|| DeError::missing_field("options"))?;
-                        SelectMenuData::Text(Box::new(TextSelectMenuData { options }))
+                        SelectMenuData::Text(TextSelectMenuData { options })
                     }
                     ComponentType::UserSelectMenu => SelectMenuData::User,
                     ComponentType::RoleSelectMenu => SelectMenuData::Role,
                     ComponentType::MentionableSelectMenu => SelectMenuData::Mentionable,
                     ComponentType::ChannelSelectMenu => {
-                        SelectMenuData::Channel(Box::new(ChannelSelectMenuData { channel_types }))
+                        SelectMenuData::Channel(ChannelSelectMenuData { channel_types })
                     }
                     // We'll only take the branch below if we added a type above and forgot to implement it here. I.e.,
                     // we should never end up here.
@@ -774,7 +774,7 @@ mod tests {
                     disabled: false,
                     max_values: Some(25),
                     min_values: Some(5),
-                    data: SelectMenuData::Text(Box::new(TextSelectMenuData {
+                    data: SelectMenuData::Text(TextSelectMenuData {
                         options: Vec::from([SelectMenuOption {
                             label: "test option label".into(),
                             value: "test option value".into(),
@@ -782,7 +782,7 @@ mod tests {
                             emoji: None,
                             default: false,
                         }]),
-                    })),
+                    }),
                     placeholder: Some("test placeholder".into()),
                 }),
             ]),

--- a/twilight-model/src/channel/message/component/mod.rs
+++ b/twilight-model/src/channel/message/component/mod.rs
@@ -105,9 +105,7 @@ use std::fmt::{Formatter, Result as FmtResult};
 ///                         id: Id::new(625891303795982337),
 ///                         name: Some("priest".to_owned()),
 ///                     }),
-///                     description: Some(
-///                         "You get heals when I'm done doing damage".to_owned(),
-///                     ),
+///                     description: Some("You get heals when I'm done doing damage".to_owned()),
 ///                     label: "Priest".to_owned(),
 ///                     value: "priest".to_owned(),
 ///                 },
@@ -506,7 +504,7 @@ impl<'de> Visitor<'de> for ComponentVisitor {
                     }
                     // We'll only take the branch below if we added a type above and forgot to implement it here. I.e.,
                     // we should never end up here.
-                    _ => panic!("missing select menu implementation"),
+                    _ => unreachable!("missing select menu implementation"),
                 };
 
                 Self::Value::SelectMenu(SelectMenu {

--- a/twilight-model/src/channel/message/component/select_menu.rs
+++ b/twilight-model/src/channel/message/component/select_menu.rs
@@ -1,13 +1,18 @@
-use crate::channel::message::ReactionType;
+use crate::channel::{message::ReactionType, ChannelType};
 use serde::{Deserialize, Serialize};
 
-/// Dropdown-style [`Component`] that renders belew messages.
+/// Dropdown-style [`Component`] that renders below messages.
+///
+/// Use the `data` field to determine which kind of select menu you want. The kinds available at the moment are listed
+/// as [`SelectMenuData`]'s variants.
 ///
 /// [`Component`]: super::Component
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SelectMenu {
     /// Developer defined identifier.
     pub custom_id: String,
+    /// Data specific to this select menu's kind.
+    pub data: SelectMenuData,
     /// Whether the select menu is disabled.
     ///
     /// Defaults to `false`.
@@ -16,10 +21,61 @@ pub struct SelectMenu {
     pub max_values: Option<u8>,
     /// Minimum number of options that must be chosen.
     pub min_values: Option<u8>,
-    /// List of available choices.
-    pub options: Vec<SelectMenuOption>,
     /// Custom placeholder text if no option is selected.
     pub placeholder: Option<String>,
+}
+
+/// Data specific to a kind of [`SelectMenu`].
+///
+/// Choosing a variant of this enum implicitly sets the select menu's kind.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum SelectMenuData {
+    /// Data specific to text select menus.
+    ///
+    /// Choosing this variant for your select menu makes the menu a [`ComponentType::TextSelectMenu`].
+    ///
+    /// [`ComponentType::TextSelectMenu`]: super::ComponentType::TextSelectMenu
+    Text(Box<TextSelectMenuData>),
+    /// Data specific to user select menus.
+    ///
+    /// Choosing this variant for your select menu makes the menu a [`ComponentType::UserSelectMenu`].
+    ///
+    /// [`ComponentType::UserSelectMenu`]: super::ComponentType::UserSelectMenu
+    User,
+    /// Data specific to role select menus.
+    ///
+    /// Choosing this variant for your select menu makes the menu a [`ComponentType::RoleSelectMenu`].
+    ///
+    /// [`ComponentType::RoleSelectMenu`]: super::ComponentType::RoleSelectMenu
+    Role,
+    /// Data specific to mentionable select menus.
+    ///
+    /// Choosing this variant for your select menu makes the menu a [`ComponentType::MentionableSelectMenu`].
+    ///
+    /// [`ComponentType::MentionableSelectMenu`]: super::ComponentType::MentionableSelectMenu
+    Mentionable,
+    /// Data specific to channel select menus.
+    ///
+    /// Choosing this variant for your select menu makes the menu a [`ComponentType::ChannelSelectMenu`].
+    ///
+    /// [`ComponentType::ChannelSelectMenu`]: super::ComponentType::ChannelSelectMenu
+    Channel(Box<ChannelSelectMenuData>),
+}
+
+/// Data specific to text select menus.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct TextSelectMenuData {
+    /// A list of available choices for this select menu.
+    pub options: Vec<SelectMenuOption>,
+}
+
+/// Data specific to channel select menus.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ChannelSelectMenuData {
+    /// An optional list of channel types to include in this select menu.
+    ///
+    /// If `None`, the select menu will display all channel types.
+    pub channel_types: Option<Vec<ChannelType>>,
 }
 
 /// Dropdown options that are part of [`SelectMenu`].
@@ -49,13 +105,41 @@ mod tests {
 
     assert_fields!(
         SelectMenu: custom_id,
+        data,
         disabled,
         max_values,
         min_values,
-        options,
         placeholder
     );
     assert_impl_all!(SelectMenu: Clone, Debug, Eq, Hash, PartialEq, Send, Sync);
+
+    assert_impl_all!(
+        SelectMenuData: Clone,
+        Debug,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_impl_all!(
+        TextSelectMenuData: Clone,
+        Debug,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Sync
+    );
+    assert_impl_all!(
+        ChannelSelectMenuData: Clone,
+        Debug,
+        Eq,
+        Hash,
+        PartialEq,
+        Send,
+        Sync
+    );
 
     assert_impl_all!(
         SelectMenuOption: Clone,

--- a/twilight-model/src/channel/message/component/select_menu.rs
+++ b/twilight-model/src/channel/message/component/select_menu.rs
@@ -3,79 +3,55 @@ use serde::{Deserialize, Serialize};
 
 /// Dropdown-style [`Component`] that renders below messages.
 ///
-/// Use the `data` field to determine which kind of select menu you want. The kinds available at the moment are listed
-/// as [`SelectMenuData`]'s variants.
-///
 /// [`Component`]: super::Component
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SelectMenu {
+    /// An optional list of channel types.
+    ///
+    /// This option is only used for [channel select menus](SelectMenuType::Channel).
+    pub channel_types: Option<Vec<ChannelType>>,
     /// Developer defined identifier.
     pub custom_id: String,
-    /// Data specific to this select menu's kind.
-    pub data: SelectMenuData,
     /// Whether the select menu is disabled.
     ///
     /// Defaults to `false`.
     pub disabled: bool,
+    /// This select menu's type.
+    ///
+    /// [Text select menus](SelectMenuType::Text) *must* also set the `options` field.
+    pub kind: SelectMenuType,
     /// Maximum number of options that may be chosen.
     pub max_values: Option<u8>,
     /// Minimum number of options that must be chosen.
     pub min_values: Option<u8>,
+    /// A list of available options.
+    ///
+    /// This value is only used and required by [text select menus](SelectMenuType::Text).
+    pub options: Option<Vec<SelectMenuOption>>,
     /// Custom placeholder text if no option is selected.
     pub placeholder: Option<String>,
 }
 
-/// Data specific to a kind of [`SelectMenu`].
-///
-/// Choosing a variant of this enum implicitly sets the select menu's kind.
+/// A [`SelectMenu`]'s type.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum SelectMenuData {
-    /// Data specific to text select menus.
+#[non_exhaustive]
+pub enum SelectMenuType {
+    /// Select menus with a text-based `options` list.
     ///
-    /// Choosing this variant for your select menu makes the menu a [`ComponentType::TextSelectMenu`].
-    ///
-    /// [`ComponentType::TextSelectMenu`]: super::ComponentType::TextSelectMenu
-    Text(TextSelectMenuData),
-    /// Data specific to user select menus.
-    ///
-    /// Choosing this variant for your select menu makes the menu a [`ComponentType::UserSelectMenu`].
-    ///
-    /// [`ComponentType::UserSelectMenu`]: super::ComponentType::UserSelectMenu
+    /// Select menus of this `kind` *must* set the `options` field to specify the options users
+    /// can pick from.
+    Text,
+    /// User select menus.
     User,
-    /// Data specific to role select menus.
-    ///
-    /// Choosing this variant for your select menu makes the menu a [`ComponentType::RoleSelectMenu`].
-    ///
-    /// [`ComponentType::RoleSelectMenu`]: super::ComponentType::RoleSelectMenu
+    /// Role select menus.
     Role,
-    /// Data specific to mentionable select menus.
-    ///
-    /// Choosing this variant for your select menu makes the menu a [`ComponentType::MentionableSelectMenu`].
-    ///
-    /// [`ComponentType::MentionableSelectMenu`]: super::ComponentType::MentionableSelectMenu
+    /// Mentionable select menus.
     Mentionable,
-    /// Data specific to channel select menus.
+    /// Channel select menus.
     ///
-    /// Choosing this variant for your select menu makes the menu a [`ComponentType::ChannelSelectMenu`].
-    ///
-    /// [`ComponentType::ChannelSelectMenu`]: super::ComponentType::ChannelSelectMenu
-    Channel(ChannelSelectMenuData),
-}
-
-/// Data specific to text select menus.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct TextSelectMenuData {
-    /// A list of available choices for this select menu.
-    pub options: Vec<SelectMenuOption>,
-}
-
-/// Data specific to channel select menus.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct ChannelSelectMenuData {
-    /// An optional list of channel types to include in this select menu.
-    ///
-    /// If `None`, the select menu will display all channel types.
-    pub channel_types: Option<Vec<ChannelType>>,
+    /// Select menus of this `kind` *can* use the `channel_types` field to specify which types of
+    /// channels are selectable.
+    Channel,
 }
 
 /// Dropdown options that are part of [`SelectMenu`].
@@ -104,35 +80,19 @@ mod tests {
     use std::{fmt::Debug, hash::Hash};
 
     assert_fields!(
-        SelectMenu: custom_id,
-        data,
+        SelectMenu: channel_types,
+        custom_id,
         disabled,
+        kind,
         max_values,
         min_values,
+        options,
         placeholder
     );
     assert_impl_all!(SelectMenu: Clone, Debug, Eq, Hash, PartialEq, Send, Sync);
 
     assert_impl_all!(
-        SelectMenuData: Clone,
-        Debug,
-        Eq,
-        Hash,
-        PartialEq,
-        Send,
-        Sync
-    );
-    assert_impl_all!(
-        TextSelectMenuData: Clone,
-        Debug,
-        Eq,
-        Hash,
-        PartialEq,
-        Send,
-        Sync
-    );
-    assert_impl_all!(
-        ChannelSelectMenuData: Clone,
+        SelectMenuType: Clone,
         Debug,
         Eq,
         Hash,

--- a/twilight-model/src/channel/message/component/select_menu.rs
+++ b/twilight-model/src/channel/message/component/select_menu.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct SelectMenu {
     /// An optional list of channel types.
     ///
-    /// This option is only used for [channel select menus](SelectMenuType::Channel).
+    /// This is only applicable to [channel select menus](SelectMenuType::Channel).
     pub channel_types: Option<Vec<ChannelType>>,
     /// Developer defined identifier.
     pub custom_id: String,
@@ -17,8 +17,6 @@ pub struct SelectMenu {
     /// Defaults to `false`.
     pub disabled: bool,
     /// This select menu's type.
-    ///
-    /// [Text select menus](SelectMenuType::Text) *must* also set the `options` field.
     pub kind: SelectMenuType,
     /// Maximum number of options that may be chosen.
     pub max_values: Option<u8>,
@@ -26,7 +24,7 @@ pub struct SelectMenu {
     pub min_values: Option<u8>,
     /// A list of available options.
     ///
-    /// This value is only used and required by [text select menus](SelectMenuType::Text).
+    /// This is required by [text select menus](SelectMenuType::Text).
     pub options: Option<Vec<SelectMenuOption>>,
     /// Custom placeholder text if no option is selected.
     pub placeholder: Option<String>,
@@ -48,9 +46,6 @@ pub enum SelectMenuType {
     /// Mentionable select menus.
     Mentionable,
     /// Channel select menus.
-    ///
-    /// Select menus of this `kind` *can* use the `channel_types` field to specify which types of
-    /// channels are selectable.
     Channel,
 }
 

--- a/twilight-model/src/channel/message/component/select_menu.rs
+++ b/twilight-model/src/channel/message/component/select_menu.rs
@@ -35,7 +35,7 @@ pub enum SelectMenuData {
     /// Choosing this variant for your select menu makes the menu a [`ComponentType::TextSelectMenu`].
     ///
     /// [`ComponentType::TextSelectMenu`]: super::ComponentType::TextSelectMenu
-    Text(Box<TextSelectMenuData>),
+    Text(TextSelectMenuData),
     /// Data specific to user select menus.
     ///
     /// Choosing this variant for your select menu makes the menu a [`ComponentType::UserSelectMenu`].
@@ -59,7 +59,7 @@ pub enum SelectMenuData {
     /// Choosing this variant for your select menu makes the menu a [`ComponentType::ChannelSelectMenu`].
     ///
     /// [`ComponentType::ChannelSelectMenu`]: super::ComponentType::ChannelSelectMenu
-    Channel(Box<ChannelSelectMenuData>),
+    Channel(ChannelSelectMenuData),
 }
 
 /// Data specific to text select menus.

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -1193,13 +1193,14 @@ mod tests {
                 video_quality_mode: None,
             }),
             channel_id: None,
-            data: Some(InteractionData::MessageComponent(
+            data: Some(InteractionData::MessageComponent(Box::new(
                 MessageComponentInteractionData {
                     custom_id: String::from("Click"),
                     component_type: ComponentType::Button,
+                    resolved: None,
                     values: Vec::new(),
                 },
-            )),
+            ))),
             guild_id: Some(Id::new(3)),
             guild_locale: None,
             id: Id::new(4),

--- a/twilight-validate/src/component.rs
+++ b/twilight-validate/src/component.rs
@@ -1101,7 +1101,7 @@ mod tests {
             disabled: false,
             max_values: Some(2),
             min_values: Some(1),
-            data: SelectMenuData::Text(Box::new(TextSelectMenuData {
+            data: SelectMenuData::Text(TextSelectMenuData {
                 options: Vec::from([SelectMenuOption {
                     default: true,
                     description: Some("Book 1 of the Expanse".into()),
@@ -1109,7 +1109,7 @@ mod tests {
                     label: "Leviathan Wakes".into(),
                     value: "9780316129084".into(),
                 }]),
-            })),
+            }),
             placeholder: Some("Choose a book".into()),
         };
 


### PR DESCRIPTION
This merge request implements Discord's new select menu types (user, role, mentionable, and channel) using the fully-flattened approach outlined in [this RFC](https://github.com/twilight-rs/twilight/discussions/2217).

# General idea

The general idea is to implement all variant-specific fields as `Option`s inside the `SelectMenu` struct. While this might require runtime validation, it's more in line with the rest of the Twilight ecosystem. Moreover, it doesn't duplicate fields that an approach with separate structs would duplicate.

Notably, this differs from the RFC mentioned above. This RFC was indirectly denied with [this review](https://github.com/twilight-rs/twilight/pull/2219#pullrequestreview-1480445162).

# Breaking changes

This PR introduces multiple breaking changes:

- `ComponentType`'s `SelectMenu` variant was renamed, and the enum was extended (breaking as it's not `#[non_exhaustive]`).
- `SelectMenu`'s `options` field was wrapped in an `Option`.
- New `channel_types` and `kind` fields were introduced in `SelectMenu`.
- `twilight_model::application::interaction::application_command::{CommandInteractionDataResolved, InteractionChannel, InteractionMember}` were moved into `twilight_model::application::interaction`.
- `CommandInteractionDataResolved` was renamed to `InteractionDataResolved`.
- `MessageComponentInteractionData` no longer implements `Eq + Hash`.
- A new `resolved` field was introduced in `MessageComponent`.
- `InteractionData::MessageComponent`'s single field was `Box`-ed.

If I missed any breaking changes, please point them out.

# Related work

- This PR closes #2047.
- As mentioned above, this implements an idea outlined in #2217.
- The same feature was previously implemented in #2051, but that PR was seemingly abandoned.
- This feature is defined by [Discord's documentation](https://discord.com/developers/docs/interactions/message-components#select-menus)
- I created a throwaway bot to test this PR here: <https://github.com/archer-321/twilight-select-menus>.

# Tests

This PR only updates the existing tests. If you'd like me to add other tests to verify the behaviour introduced by this patch, please feel free to request changes.

# Signed commits

I'm unsure whether this is possible with Twilight's PR flow, but please ask me to squash any commits or edit commit messages if necessary. I prefer all commits attributed to me to be signed with my GPG key :nerd_face: 

# Labels

Based on the current state, I believe you should assign the `d-api` and `d-breaking` labels.