### PR TITLE
refactor(gateway): cleanup dispatch sequence handling

### DIFF
--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -1106,24 +1106,8 @@ impl Shard {
                     _ => {}
                 }
 
-                // READY *should* be the first received dispatch event (which
-                // initializes `self.session`), but it shouldn't matter that
-                // much if it's not.
                 if let Some(session) = self.session.as_mut() {
-                    let last_sequence = session.set_sequence(sequence);
-
-                    // If a sequence has been skipped then we may have missed a
-                    // message and should cause a reconnect so we can attempt to get
-                    // that message again.
-                    if sequence > last_sequence + 1 {
-                        tracing::info!(
-                            missed_events = sequence - (last_sequence + 1),
-                            "dispatch events have been missed",
-                        );
-                        self.next_action = Some(NextAction::CloseResume);
-                    }
-                } else {
-                    tracing::info!("unable to store sequence");
+                    session.set_sequence(sequence);
                 }
             }
             Some(OpCode::Heartbeat) => {


### PR DESCRIPTION
Aligns our code with the spec by removing questionable logic that, even if hit, was completely wrong. The code tried to resume with the *new* sequence (instead of the old) and it's not swallowing the, to be, duplicated event.
