### PR TITLE
refactor(gateway): remove ratelimiter sleep from new

### DIFF
--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -18,7 +18,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::time::{sleep, Duration, Instant, Sleep};
+use tokio::time::{sleep_until, Duration, Instant, Sleep};
 
 /// Number of commands allowed in a [`PERIOD`].
 const COMMANDS_PER_PERIOD: u8 = 120;
@@ -40,10 +40,11 @@ impl CommandRatelimiter {
     pub(crate) fn new(heartbeat_interval: Duration) -> Self {
         let allotted = nonreserved_commands_per_reset(heartbeat_interval);
 
-        let mut delay = Box::pin(sleep(Duration::ZERO));
+        let now = Instant::now();
+        let mut delay = Box::pin(sleep_until(now));
 
         // Hack to register the timer.
-        delay.as_mut().reset(Instant::now());
+        delay.as_mut().reset(now);
 
         Self {
             delay,

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -1062,7 +1062,7 @@ impl Shard {
                 tracing::debug!(?heartbeat_interval, ?jitter, "received hello");
 
                 if self.config().ratelimit_messages() {
-                    self.ratelimiter = Some(CommandRatelimiter::new(heartbeat_interval).await);
+                    self.ratelimiter = Some(CommandRatelimiter::new(heartbeat_interval));
                 }
 
                 let mut interval = time::interval_at(Instant::now() + jitter, heartbeat_interval);


### PR DESCRIPTION
This timer registration hack is slightly less horrible.
