### PR TITLE
refactor: reformat code with rustfmt 1.6.0

### DIFF
--- a/twilight-gateway/src/json.rs
+++ b/twilight-gateway/src/json.rs
@@ -64,14 +64,14 @@ pub fn parse(
     wanted_event_types: EventTypeFlags,
 ) -> Result<Option<GatewayEvent>, ReceiveMessageError> {
     let Some(gateway_deserializer) = GatewayEventDeserializer::from_json(&event) else {
-            return Err(ReceiveMessageError {
-                kind: ReceiveMessageErrorType::Deserializing { event },
-                source: Some(Box::new(UnknownEventError {
-                    event_type: None,
-                    opcode: None,
-                })),
-            });
-        };
+        return Err(ReceiveMessageError {
+            kind: ReceiveMessageErrorType::Deserializing { event },
+            source: Some(Box::new(UnknownEventError {
+                event_type: None,
+                opcode: None,
+            })),
+        });
+    };
 
     let Some(opcode) = OpCode::from(gateway_deserializer.op()) else {
         let opcode = gateway_deserializer.op();

--- a/twilight-mention/src/parse/iter.rs
+++ b/twilight-mention/src/parse/iter.rs
@@ -63,7 +63,9 @@ impl<'a, T: ParseMention> Iterator for MentionIter<'a, T> {
         // chars here and not just individual bytes. We also want to not use
         // consuming methods of the iterator, so this will get a little weird.
         loop {
-            let (start, '<') = self.chars.next()? else { continue };
+            let (start, '<') = self.chars.next()? else {
+                continue;
+            };
 
             let mut found = false;
 


### PR DESCRIPTION
rustfmt 1.6.0 just released with support for let-else statements.
