### PR TITLE
feat(model): remove `tracing`

### DIFF
--- a/twilight-model/Cargo.toml
+++ b/twilight-model/Cargo.toml
@@ -18,7 +18,6 @@ serde = { default-features = false, features = ["derive", "std"], version = "1.0
 serde-value = { default-features = false, version = "0.7" }
 serde_repr = { default-features = false, version = "0.1.5" }
 time = { default-features = false, features = ["parsing", "std"], version = "0.3" }
-tracing = { default-features = false, version = "0.1.16" }
 
 [dev-dependencies]
 criterion = { default-features = false, version = "0.4" }

--- a/twilight-model/src/application/command/permissions.rs
+++ b/twilight-model/src/application/command/permissions.rs
@@ -93,16 +93,11 @@ impl<'de> Deserialize<'de> for CommandPermission {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let data = CommandPermissionData::deserialize(deserializer)?;
 
-        let span = tracing::trace_span!("deserializing command permission");
-        let _span_enter = span.enter();
-
         let id = match data.kind {
             CommandPermissionDataType::Role => CommandPermissionType::Role(data.id.cast()),
             CommandPermissionDataType::User => CommandPermissionType::User(data.id.cast()),
             CommandPermissionDataType::Channel => CommandPermissionType::Channel(data.id.cast()),
         };
-
-        tracing::trace!(id = %data.id, kind = ?data.kind);
 
         Ok(Self {
             id,

--- a/twilight-model/src/application/interaction/application_command/option.rs
+++ b/twilight-model/src/application/interaction/application_command/option.rs
@@ -137,10 +137,8 @@ impl<'de> Deserialize<'de> for CommandDataOption {
                     let key = match map.next_key() {
                         Ok(Some(key)) => key,
                         Ok(None) => break,
-                        Err(why) => {
+                        Err(_) => {
                             map.next_value::<IgnoredAny>()?;
-
-                            tracing::trace!("ran into an unknown key: {why:?}");
 
                             continue;
                         }

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -211,25 +211,12 @@ impl<'de> Visitor<'de> for InteractionVisitor {
         let mut token: Option<String> = None;
         let mut user: Option<User> = None;
 
-        let span = tracing::trace_span!("deserializing interaction");
-        let _span_enter = span.enter();
-
         loop {
-            let span_child = tracing::trace_span!("iterating over interaction");
-            let _span_child_enter = span_child.enter();
-
             let key = match map.next_key() {
-                Ok(Some(key)) => {
-                    tracing::trace!(?key, "found key");
-
-                    key
-                }
+                Ok(Some(key)) => key,
                 Ok(None) => break,
-                Err(why) => {
-                    // Encountered when we run into an unknown key.
+                Err(_) => {
                     map.next_value::<IgnoredAny>()?;
-
-                    tracing::trace!("ran into an unknown key: {why:?}");
 
                     continue;
                 }
@@ -346,14 +333,6 @@ impl<'de> Visitor<'de> for InteractionVisitor {
         let id = id.ok_or_else(|| DeError::missing_field("id"))?;
         let token = token.ok_or_else(|| DeError::missing_field("token"))?;
         let kind = kind.ok_or_else(|| DeError::missing_field("kind"))?;
-
-        tracing::trace!(
-            %application_id,
-            %id,
-            %token,
-            ?kind,
-            "common fields of all variants exist"
-        );
 
         let data = match kind {
             InteractionType::Ping => None,

--- a/twilight-model/src/channel/message/component/mod.rs
+++ b/twilight-model/src/channel/message/component/mod.rs
@@ -235,25 +235,12 @@ impl<'de> Visitor<'de> for ComponentVisitor {
         let mut url: Option<Option<String>> = None;
         let mut value: Option<Option<String>> = None;
 
-        let span = tracing::trace_span!("deserializing component");
-        let _span_enter = span.enter();
-
         loop {
-            let span_child = tracing::trace_span!("iterating over element");
-            let _span_child_enter = span_child.enter();
-
             let key = match map.next_key() {
-                Ok(Some(key)) => {
-                    tracing::trace!(?key, "found key");
-
-                    key
-                }
+                Ok(Some(key)) => key,
                 Ok(None) => break,
-                Err(why) => {
-                    // Encountered when we run into an unknown key.
+                Err(_) => {
                     map.next_value::<IgnoredAny>()?;
-
-                    tracing::trace!("ran into an unknown key: {why:?}");
 
                     continue;
                 }
@@ -374,25 +361,6 @@ impl<'de> Visitor<'de> for ComponentVisitor {
                 }
             };
         }
-
-        tracing::trace!(
-            ?components,
-            ?custom_id,
-            ?disabled,
-            ?emoji,
-            ?label,
-            ?max_length,
-            ?max_values,
-            ?min_length,
-            ?min_values,
-            ?options,
-            ?placeholder,
-            ?required,
-            ?style,
-            ?kind,
-            ?url,
-            ?value
-        );
 
         let kind = kind.ok_or_else(|| DeError::missing_field("type"))?;
 

--- a/twilight-model/src/gateway/event/gateway.rs
+++ b/twilight-model/src/gateway/event/gateway.rs
@@ -211,13 +211,9 @@ impl GatewayEventVisitor<'_> {
     }
 
     fn ignore_all<'de, V: MapAccess<'de>>(map: &mut V) -> Result<(), V::Error> {
-        tracing::trace!("ignoring all other fields");
-
         while let Ok(Some(_)) | Err(_) = map.next_key::<Field>() {
             map.next_value::<IgnoredAny>()?;
         }
-
-        tracing::trace!("ignored all other fields");
 
         Ok(())
     }
@@ -245,14 +241,9 @@ impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
             "RECONNECT",
         ];
 
-        let span = tracing::trace_span!("deserializing gateway event");
-        let _span_enter = span.enter();
-        tracing::trace!(event_type=?self.2, op=self.0, seq=?self.1);
-
         let op_deser: U8Deserializer<V::Error> = self.0.into_deserializer();
 
         let op = OpCode::deserialize(op_deser).ok().ok_or_else(|| {
-            tracing::trace!(op = self.0, "unknown opcode");
             let unexpected = Unexpected::Unsigned(u64::from(self.0));
 
             DeError::invalid_value(unexpected, &"an opcode")
@@ -264,26 +255,15 @@ impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
                     .2
                     .ok_or_else(|| DeError::custom("event type not provided beforehand"))?;
 
-                tracing::trace!("deserializing gateway dispatch");
-
                 let mut d = None;
                 let mut s = None;
 
                 loop {
-                    let span_child = tracing::trace_span!("iterating over element");
-                    let _span_child_enter = span_child.enter();
-
                     let key = match map.next_key() {
-                        Ok(Some(key)) => {
-                            tracing::trace!(?key, "found key");
-
-                            key
-                        }
+                        Ok(Some(key)) => key,
                         Ok(None) => break,
-                        Err(why) => {
+                        Err(_) => {
                             map.next_value::<IgnoredAny>()?;
-
-                            tracing::trace!("ran into an unknown key: {why:?}");
 
                             continue;
                         }
@@ -308,8 +288,6 @@ impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
                         }
                         Field::Op | Field::T => {
                             map.next_value::<IgnoredAny>()?;
-
-                            tracing::trace!(key=?key, "ignoring key");
                         }
                     }
                 }
@@ -320,34 +298,26 @@ impl<'de> Visitor<'de> for GatewayEventVisitor<'_> {
                 GatewayEvent::Dispatch(s, d)
             }
             OpCode::Heartbeat => {
-                tracing::trace!("deserializing gateway heartbeat");
                 let seq = Self::field(&mut map, Field::D)?;
-                tracing::trace!(seq = %seq);
 
                 Self::ignore_all(&mut map)?;
 
                 GatewayEvent::Heartbeat(seq)
             }
             OpCode::HeartbeatAck => {
-                tracing::trace!("deserializing gateway heartbeat ack");
-
                 Self::ignore_all(&mut map)?;
 
                 GatewayEvent::HeartbeatAck
             }
             OpCode::Hello => {
-                tracing::trace!("deserializing gateway hello");
                 let hello = Self::field::<Hello, _>(&mut map, Field::D)?;
-                tracing::trace!(hello = ?hello);
 
                 Self::ignore_all(&mut map)?;
 
                 GatewayEvent::Hello(hello)
             }
             OpCode::InvalidSession => {
-                tracing::trace!("deserializing invalid session");
                 let invalidate = Self::field::<bool, _>(&mut map, Field::D)?;
-                tracing::trace!(invalidate = %invalidate);
 
                 Self::ignore_all(&mut map)?;
 

--- a/twilight-model/src/gateway/payload/incoming/member_chunk.rs
+++ b/twilight-model/src/gateway/payload/incoming/member_chunk.rs
@@ -56,25 +56,12 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
         let mut not_found = None;
         let mut presences = None;
 
-        let span = tracing::trace_span!("deserializing member chunk");
-        let _span_enter = span.enter();
-
         loop {
-            let span_child = tracing::trace_span!("iterating over element");
-            let _span_child_enter = span_child.enter();
-
             let key = match map.next_key() {
-                Ok(Some(key)) => {
-                    tracing::trace!(?key, "found key");
-
-                    key
-                }
+                Ok(Some(key)) => key,
                 Ok(None) => break,
-                Err(why) => {
-                    // Encountered when we run into an unknown key.
+                Err(_) => {
                     map.next_value::<IgnoredAny>()?;
-
-                    tracing::trace!("ran into an unknown key: {why:?}");
 
                     continue;
                 }
@@ -141,15 +128,6 @@ impl<'de> Visitor<'de> for MemberChunkVisitor {
         let members = members.ok_or_else(|| DeError::missing_field("members"))?;
         let not_found = not_found.unwrap_or_default();
         let mut presences = presences.unwrap_or_default();
-
-        tracing::trace!(
-            %chunk_count,
-            %chunk_index,
-            ?guild_id,
-            ?members,
-            ?not_found,
-            ?presences,
-        );
 
         for presence in &mut presences {
             presence.guild_id = guild_id;

--- a/twilight-model/src/gateway/presence/activity_button.rs
+++ b/twilight-model/src/gateway/presence/activity_button.rs
@@ -120,25 +120,12 @@ impl<'de> Visitor<'de> for ActivityButtonVisitor {
         let mut label = None;
         let mut url = None;
 
-        let span = tracing::trace_span!("deserializing activity button");
-        let _span_enter = span.enter();
-
         loop {
-            let span_child = tracing::trace_span!("iterating over element");
-            let _span_child_enter = span_child.enter();
-
             let key = match map.next_key() {
-                Ok(Some(key)) => {
-                    tracing::trace!(?key, "found key");
-
-                    key
-                }
+                Ok(Some(key)) => key,
                 Ok(None) => break,
-                Err(why) => {
-                    // Encountered when we run into an unknown key.
+                Err(_) => {
                     map.next_value::<IgnoredAny>()?;
-
-                    tracing::trace!("ran into an unknown key: {why:?}");
 
                     continue;
                 }
@@ -164,11 +151,6 @@ impl<'de> Visitor<'de> for ActivityButtonVisitor {
 
         let label = label.ok_or_else(|| DeError::missing_field("label"))?;
         let url = url.ok_or_else(|| DeError::missing_field("url"))?;
-
-        tracing::trace!(
-            %label,
-            ?url,
-        );
 
         Ok(ActivityButton::Link(ActivityButtonLink { label, url }))
     }

--- a/twilight-model/src/guild/mod.rs
+++ b/twilight-model/src/guild/mod.rs
@@ -272,25 +272,12 @@ impl<'de> Deserialize<'de> for Guild {
                 let mut widget_channel_id = None::<Option<_>>;
                 let mut widget_enabled = None::<Option<_>>;
 
-                let span = tracing::trace_span!("deserializing guild");
-                let _span_enter = span.enter();
-
                 loop {
-                    let span_child = tracing::trace_span!("iterating over element");
-                    let _span_child_enter = span_child.enter();
-
                     let key = match map.next_key() {
-                        Ok(Some(key)) => {
-                            tracing::trace!(?key, "found key");
-
-                            key
-                        }
+                        Ok(Some(key)) => key,
                         Ok(None) => break,
-                        Err(why) => {
-                            // Encountered when we run into an unknown key.
+                        Err(_) => {
                             map.next_value::<IgnoredAny>()?;
-
-                            tracing::trace!("ran into an unknown key: {why:?}");
 
                             continue;
                         }
@@ -706,61 +693,6 @@ impl<'de> Deserialize<'de> for Guild {
                 let mut voice_states = voice_states.unwrap_or_default();
                 let widget_channel_id = widget_channel_id.unwrap_or_default();
                 let widget_enabled = widget_enabled.unwrap_or_default();
-
-                tracing::trace!(
-                    ?afk_channel_id,
-                    ?afk_timeout,
-                    ?application_id,
-                    ?approximate_member_count,
-                    ?approximate_presence_count,
-                    ?banner,
-                    ?channels,
-                    ?default_message_notifications,
-                    ?description,
-                    ?discovery_splash,
-                    ?emojis,
-                    ?explicit_content_filter,
-                    ?features,
-                    ?icon,
-                    %id,
-                    ?large,
-                    ?joined_at,
-                    ?max_members,
-                    ?max_presences,
-                    ?max_video_channel_users,
-                    ?member_count,
-                    ?members,
-                    ?mfa_level,
-                    %name,
-                    %owner_id,
-                    ?owner,
-                    ?permissions,
-                    ?preferred_locale,
-                    ?premium_progress_bar_enabled,
-                );
-
-                // Split in two due to generic impl only going up to 32.
-                tracing::trace!(
-                    ?premium_subscription_count,
-                    ?premium_tier,
-                    ?presences,
-                    ?public_updates_channel_id,
-                    ?rules_channel_id,
-                    ?roles,
-                    ?safety_alerts_channel_id,
-                    ?splash,
-                    ?stage_instances,
-                    ?stickers,
-                    ?system_channel_flags,
-                    ?system_channel_id,
-                    ?threads,
-                    ?unavailable,
-                    ?vanity_url_code,
-                    ?voice_states,
-                    ?widget_channel_id,
-                    ?widget_enabled,
-                    ?verification_level,
-                );
 
                 for channel in &mut channels {
                     channel.guild_id = Some(id);


### PR DESCRIPTION
The `tracing` ecosystem of crates allow for recording events which can then be viewed when debugging. Most `twilight` crates therefore record useful data with it, but its unnecessary for `twilight-model` to do so. This is because deserializers most necessary data on deserialization error for troubleshooting. Including further details is left to dependants. `twilight-gateway`, for example, includes the full gateway event in `ReceiveMessageError`.