### PR TITLE
feat(model): add support for attachment flags

### DIFF
--- a/twilight-model/src/application/interaction/application_command/resolved.rs
+++ b/twilight-model/src/application/interaction/application_command/resolved.rs
@@ -129,6 +129,7 @@ mod tests {
                     content_type: Some("image/png".to_owned()),
                     ephemeral: true,
                     filename: "rainbow_dash.png".to_owned(),
+                    flags: None,
                     description: None,
                     duration_secs: None,
                     height: Some(2674),

--- a/twilight-model/src/channel/attachment.rs
+++ b/twilight-model/src/channel/attachment.rs
@@ -4,6 +4,8 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
+use super::AttachmentFlags;
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Attachment {
     /// Attachment's [media type].
@@ -21,6 +23,9 @@ pub struct Attachment {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration_secs: Option<f64>,
     pub filename: String,
+    // Flags for this attachment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flags: Option<AttachmentFlags>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -39,7 +44,7 @@ pub struct Attachment {
 #[cfg(test)]
 mod tests {
     use super::Attachment;
-    use crate::id::Id;
+    use crate::{channel::AttachmentFlags, id::Id};
     use serde::{Deserialize, Serialize};
     use serde_test::Token;
     use static_assertions::{assert_fields, assert_impl_all};
@@ -71,6 +76,7 @@ mod tests {
             content_type: Some("image/png".to_owned()),
             ephemeral: false,
             filename: "a.png".to_owned(),
+            flags: Some(AttachmentFlags::IS_REMIX),
             description: Some("a image".to_owned()),
             duration_secs: Some(3.2),
             height: Some(184),
@@ -87,7 +93,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Attachment",
-                    len: 11,
+                    len: 12,
                 },
                 Token::Str("content_type"),
                 Token::Some,
@@ -97,6 +103,9 @@ mod tests {
                 Token::F64(3.2),
                 Token::Str("filename"),
                 Token::Str("a.png"),
+                Token::Str("flags"),
+                Token::Some,
+                Token::U64(4),
                 Token::Str("description"),
                 Token::Some,
                 Token::Str("a image"),

--- a/twilight-model/src/channel/attachment.rs
+++ b/twilight-model/src/channel/attachment.rs
@@ -1,10 +1,9 @@
+use super::AttachmentFlags;
 use crate::{
     id::{marker::AttachmentMarker, Id},
     util::is_false,
 };
 use serde::{Deserialize, Serialize};
-
-use super::AttachmentFlags;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Attachment {

--- a/twilight-model/src/channel/attachment_flags.rs
+++ b/twilight-model/src/channel/attachment_flags.rs
@@ -1,0 +1,85 @@
+use bitflags::bitflags;
+use serde::{
+    de::{Deserialize, Deserializer},
+    ser::{Serialize, Serializer},
+};
+
+bitflags! {
+  pub struct AttachmentFlags: u64 {
+    /// This attachment has been edited using the remix feature on mobile
+    const IS_REMIX = 1 << 2;
+  }
+}
+
+impl<'de> Deserialize<'de> for AttachmentFlags {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self::from_bits_truncate(u64::deserialize(deserializer)?))
+    }
+}
+
+impl Serialize for AttachmentFlags {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(self.bits())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AttachmentFlags;
+    use serde::{Deserialize, Serialize};
+    use serde_test::Token;
+    use static_assertions::{assert_impl_all, const_assert_eq};
+    use std::{
+        fmt::{Binary, Debug, LowerHex, Octal, UpperHex},
+        hash::Hash,
+        ops::{
+            BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not, Sub, SubAssign,
+        },
+    };
+
+    assert_impl_all!(
+        AttachmentFlags: Binary,
+        BitAnd,
+        BitAndAssign,
+        BitOr,
+        BitOrAssign,
+        BitXor,
+        BitXorAssign,
+        Clone,
+        Copy,
+        Debug,
+        Deserialize<'static>,
+        Eq,
+        Extend<AttachmentFlags>,
+        FromIterator<AttachmentFlags>,
+        Hash,
+        LowerHex,
+        Not,
+        Octal,
+        Ord,
+        PartialEq,
+        PartialOrd,
+        Send,
+        Serialize,
+        Sub,
+        SubAssign,
+        Sync,
+        UpperHex
+    );
+
+    const_assert_eq!(AttachmentFlags::IS_REMIX.bits(), 4);
+
+    #[test]
+    fn serde() {
+        serde_test::assert_tokens(
+            &AttachmentFlags::IS_REMIX,
+            &[Token::U64(AttachmentFlags::IS_REMIX.bits())],
+        );
+
+        // Deserialization truncates unknown bits.
+        serde_test::assert_de_tokens(&AttachmentFlags::empty(), &[Token::U64(1 << 63)]);
+    }
+}

--- a/twilight-model/src/channel/attachment_flags.rs
+++ b/twilight-model/src/channel/attachment_flags.rs
@@ -5,10 +5,10 @@ use serde::{
 };
 
 bitflags! {
-  pub struct AttachmentFlags: u64 {
-    /// This attachment has been edited using the remix feature on mobile
-    const IS_REMIX = 1 << 2;
-  }
+    pub struct AttachmentFlags: u64 {
+        /// This attachment has been edited using the remix feature on mobile
+        const IS_REMIX = 1 << 2;
+    }
 }
 
 impl<'de> Deserialize<'de> for AttachmentFlags {

--- a/twilight-model/src/channel/mod.rs
+++ b/twilight-model/src/channel/mod.rs
@@ -6,6 +6,7 @@ pub mod thread;
 pub mod webhook;
 
 mod attachment;
+mod attachment_flags;
 mod channel_mention;
 mod channel_type;
 mod flags;
@@ -14,6 +15,7 @@ mod video_quality_mode;
 
 pub use self::{
     attachment::Attachment,
+    attachment_flags::AttachmentFlags,
     channel_mention::ChannelMention,
     channel_type::ChannelType,
     flags::ChannelFlags,


### PR DESCRIPTION
Ref:
- https://github.com/discord/discord-api-docs/pull/6272