### PR TITLE
feat(http): add `default_forum_layout` option for channel creation

### DIFF
--- a/twilight-http/src/request/guild/create_guild_channel.rs
+++ b/twilight-http/src/request/guild/create_guild_channel.rs
@@ -152,9 +152,7 @@ impl<'a> CreateGuildChannel<'a> {
         self
     }
 
-    /// Set the default forum layout for newly created forum channels.
-    ///
-    /// This is only valid for forum channels.
+    /// Set the default forum layout for new forum channels.
     pub const fn default_forum_layout(mut self, default_forum_layout: ForumLayout) -> Self {
         self.fields.default_forum_layout = Some(default_forum_layout);
 

--- a/twilight-http/src/request/guild/create_guild_channel.rs
+++ b/twilight-http/src/request/guild/create_guild_channel.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use std::future::IntoFuture;
 use twilight_model::{
     channel::{
-        forum::{DefaultReaction, ForumSortOrder, ForumTag},
+        forum::{DefaultReaction, ForumLayout, ForumSortOrder, ForumTag},
         permission_overwrite::PermissionOverwrite,
         thread::AutoArchiveDuration,
         Channel, ChannelType, VideoQualityMode,
@@ -36,6 +36,8 @@ struct CreateGuildChannelFields<'a> {
     bitrate: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_auto_archive_duration: Option<AutoArchiveDuration>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_forum_layout: Option<ForumLayout>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_reaction_emoji: Option<&'a DefaultReaction>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -88,6 +90,7 @@ impl<'a> CreateGuildChannel<'a> {
                 available_tags: None,
                 bitrate: None,
                 default_auto_archive_duration: None,
+                default_forum_layout: None,
                 default_reaction_emoji: None,
                 default_sort_order: None,
                 kind: None,
@@ -145,6 +148,15 @@ impl<'a> CreateGuildChannel<'a> {
         auto_archive_duration: AutoArchiveDuration,
     ) -> Self {
         self.fields.default_auto_archive_duration = Some(auto_archive_duration);
+
+        self
+    }
+
+    /// Set the default forum layout for newly created forum channels.
+    ///
+    /// This is only valid for forum channels.
+    pub const fn default_forum_layout(mut self, default_forum_layout: ForumLayout) -> Self {
+        self.fields.default_forum_layout = Some(default_forum_layout);
 
         self
     }


### PR DESCRIPTION
Ref:
- https://github.com/discord/discord-api-docs/pull/5994