### PR TITLE
fix(ci): Target haswell for docs deploy

### DIFF
--- a/.github/workflows/deploy-lib.yml
+++ b/.github/workflows/deploy-lib.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build docs
         env:
           RUSTDOCFLAGS: --cfg docsrs
-          RUSTFLAGS: -C target-cpu=native
+          RUSTFLAGS: -C target-cpu=haswell
         run: cargo doc --no-deps --all-features --workspace --exclude book
 
       - name: Prepare docs


### PR DESCRIPTION
`-C target-cpu=native` causes illegal instructions when using actions cache due to Github Actions' wide range of CPU targets. `haswell` is the earliest target level with mandatory AVX2 and will work fine with everything more recent than that. This also matches our flags in other workflows.