### PR TITLE
feat(gateway): impl `From<Config>` for ConfigBuilder

### DIFF
--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -39,8 +39,7 @@ impl Debug for Token {
 /// May be reused by cloning, also reusing the hidden TLS context---reducing
 /// memory usage. The TLS context may still be reused with an otherwise
 /// different config by turning it into to a [`ConfigBuilder`] through the
-/// [`ConfigBuilder::with_config`] function and then rebuilding it into a new
-/// config.
+/// [`From<Config>`] implementation and then rebuilding it into a rew config.
 #[derive(Clone, Debug)]
 pub struct Config {
     /// Event type flags.
@@ -200,6 +199,7 @@ impl ConfigBuilder {
     }
 
     /// Create a new builder from an existing configuration.
+    #[deprecated(since = "0.15.3", note = "use From<Config> instead")]
     pub const fn with_config(config: Config) -> Self {
         Self { inner: config }
     }
@@ -384,6 +384,12 @@ impl ConfigBuilder {
         self.inner.session = Some(session);
 
         self
+    }
+}
+
+impl From<Config> for ConfigBuilder {
+    fn from(value: Config) -> Self {
+        Self { inner: value }
     }
 }
 

--- a/twilight-gateway/src/stream.rs
+++ b/twilight-gateway/src/stream.rs
@@ -402,7 +402,7 @@ pub fn create_bucket<F: Fn(ShardId, ConfigBuilder) -> Config>(
 
     (bucket_id..total).step_by(concurrency).map(move |index| {
         let id = ShardId::new(index, total);
-        let config = per_shard_config(id, ConfigBuilder::with_config(config.clone()));
+        let config = per_shard_config(id, config.clone().into());
 
         Shard::with_config(id, config)
     })
@@ -451,7 +451,7 @@ pub fn create_range<F: Fn(ShardId, ConfigBuilder) -> Config>(
 
     range.map(move |index| {
         let id = ShardId::new(index, total);
-        let config = per_shard_config(id, ConfigBuilder::with_config(config.clone()));
+        let config = per_shard_config(id, config.clone().into());
 
         Shard::with_config(id, config)
     })


### PR DESCRIPTION
A `From` implementation is in this case more idiomatic than a free-standing constructor. It loosing `const` is irrelevant as `Config` cannot be built in `const` either way.

Deprecates `ConfigBuilder::with_config` as it's no longer needed.
