### PR TITLE
feat(gateway)!: turn `Queue` into a generic type

### DIFF
--- a/examples/gateway-queue-http.rs
+++ b/examples/gateway-queue-http.rs
@@ -1,7 +1,7 @@
 use hyper::client::{Client, HttpConnector};
-use std::{env, sync::Arc};
+use std::env;
 use tokio::sync::oneshot;
-use twilight_gateway::{queue::Queue, Config, Intents, Shard, ShardId};
+use twilight_gateway::{queue::Queue, ConfigBuilder, Intents, Shard, ShardId};
 
 #[derive(Debug)]
 struct HttpQueue(Client<HttpConnector>);
@@ -35,8 +35,8 @@ async fn main() -> anyhow::Result<()> {
     let token = env::var("DISCORD_TOKEN")?;
     let intents = Intents::GUILDS | Intents::GUILD_VOICE_STATES;
 
-    let config = Config::builder(token, intents)
-        .queue(Arc::new(HttpQueue(Client::new())))
+    let config = ConfigBuilder::new(token, intents)
+        .queue(HttpQueue(Client::new()))
         .build();
 
     let mut shard = Shard::with_config(ShardId::ONE, config);

--- a/twilight-gateway-queue/src/in_memory.rs
+++ b/twilight-gateway-queue/src/in_memory.rs
@@ -168,7 +168,7 @@ impl InMemoryQueue {
         assert!(total >= remaining);
         let (tx, rx) = mpsc::unbounded_channel();
 
-        tokio::spawn(runner(
+        let fut = runner(
             rx,
             Settings {
                 max_concurrency,
@@ -176,7 +176,9 @@ impl InMemoryQueue {
                 reset_after,
                 total,
             },
-        ));
+        );
+
+        tokio::spawn(fut);
 
         Self { tx }
     }

--- a/twilight-gateway-queue/src/in_memory.rs
+++ b/twilight-gateway-queue/src/in_memory.rs
@@ -168,7 +168,7 @@ impl InMemoryQueue {
         assert!(total >= remaining);
         let (tx, rx) = mpsc::unbounded_channel();
 
-        let fut = runner(
+        tokio::spawn(runner(
             rx,
             Settings {
                 max_concurrency,
@@ -176,9 +176,7 @@ impl InMemoryQueue {
                 reset_after,
                 total,
             },
-        );
-
-        tokio::spawn(fut);
+        ));
 
         Self { tx }
     }

--- a/twilight-gateway-queue/src/lib.rs
+++ b/twilight-gateway-queue/src/lib.rs
@@ -12,7 +12,6 @@ mod in_memory;
 
 pub use in_memory::InMemoryQueue;
 
-use std::fmt::Debug;
 use tokio::{sync::oneshot, time::Duration};
 
 /// Period between buckets.
@@ -23,10 +22,7 @@ pub const IDENTIFY_DELAY: Duration = Duration::from_secs(5);
 pub const LIMIT_PERIOD: Duration = Duration::from_secs(60 * 60 * 24);
 
 /// Abstraction for types processing gateway identify requests.
-///
-/// For convenience in twilight-gateway, implementers must also implement
-/// [`Debug`].
-pub trait Queue: Debug {
+pub trait Queue {
     /// Enqueue a shard with this ID.
     ///
     /// Send `()` to signal the shard to proceed. Note that shards may have
@@ -48,9 +44,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::Queue;
-    use static_assertions::{assert_impl_all, assert_obj_safe};
-    use std::fmt::Debug;
+    use static_assertions::assert_obj_safe;
 
-    assert_impl_all!(dyn Queue: Debug);
     assert_obj_safe!(Queue);
 }

--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -125,7 +125,7 @@ impl<Q> Config<Q> {
     }
 
     /// Immutable reference to the queue in use by the shard.
-    pub fn queue(&self) -> &Q {
+    pub const fn queue(&self) -> &Q {
         &self.queue
     }
 
@@ -222,13 +222,13 @@ impl<Q> ConfigBuilder<Q> {
     /// ```no_run
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use std::env::{self, consts::OS};
-    /// use twilight_gateway::{Config, Intents, Shard};
+    /// use twilight_gateway::{ConfigBuilder, Intents, Shard};
     /// use twilight_model::gateway::payload::outgoing::identify::IdentifyProperties;
     ///
     /// let token = env::var("DISCORD_TOKEN")?;
     /// let properties = IdentifyProperties::new("twilight.rs", "twilight.rs", OS);
     ///
-    /// let config = Config::builder(token, Intents::empty())
+    /// let config = ConfigBuilder::new(token, Intents::empty())
     ///     .identify_properties(properties)
     ///     .build();
     /// # Ok(()) }
@@ -289,7 +289,7 @@ impl<Q> ConfigBuilder<Q> {
     ///
     /// ```no_run
     /// use std::env;
-    /// use twilight_gateway::{Config, Intents, Shard, ShardId};
+    /// use twilight_gateway::{ConfigBuilder, Intents, Shard, ShardId};
     /// use twilight_model::gateway::{
     ///     payload::outgoing::update_presence::UpdatePresencePayload,
     ///     presence::{ActivityType, MinimalActivity, Status},
@@ -297,7 +297,7 @@ impl<Q> ConfigBuilder<Q> {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let config = Config::builder(env::var("DISCORD_TOKEN")?, Intents::empty())
+    /// let config = ConfigBuilder::new(env::var("DISCORD_TOKEN")?, Intents::empty())
     ///     .presence(UpdatePresencePayload::new(
     ///         vec![MinimalActivity {
     ///             kind: ActivityType::Playing,

--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -1,9 +1,6 @@
 //! User configuration for shards.
 
-use crate::{
-    queue::{InMemoryQueue, Queue},
-    EventTypeFlags, Session,
-};
+use crate::{queue::InMemoryQueue, EventTypeFlags, Session};
 use std::{
     fmt::{Debug, Formatter, Result as FmtResult},
     sync::Arc,
@@ -44,7 +41,7 @@ impl Debug for Token {
 /// different config by turning it into to a [`ConfigBuilder`] through the
 /// [`From<Config>`] implementation and then rebuilding it into a rew config.
 #[derive(Clone, Debug)]
-pub struct Config {
+pub struct Config<Q = InMemoryQueue> {
     /// Event type flags.
     event_types: EventTypeFlags,
     /// Identification properties the shard will use.
@@ -59,7 +56,7 @@ pub struct Config {
     /// Gateway proxy URL.
     proxy_url: Option<Box<str>>,
     /// Queue in use by the shard.
-    queue: Arc<dyn Queue + Send + Sync>,
+    queue: Q,
     /// Whether [outgoing message] ratelimiting is enabled.
     ///
     /// [outgoing message]: crate::Shard::send
@@ -87,18 +84,11 @@ impl Config {
     ///
     /// Panics if loading TLS certificates fails.
     pub fn new(token: String, intents: Intents) -> Self {
-        Self::builder(token, intents).build()
+        ConfigBuilder::new(token, intents).build()
     }
+}
 
-    /// Create a builder to customize a shard's configuration.
-    ///
-    /// # Panics
-    ///
-    /// Panics if loading TLS certificates fails.
-    pub fn builder(token: String, intents: Intents) -> ConfigBuilder {
-        ConfigBuilder::new(token, intents)
-    }
-
+impl<Q> Config<Q> {
     /// Event type flags.
     pub const fn event_types(&self) -> EventTypeFlags {
         self.event_types
@@ -135,7 +125,7 @@ impl Config {
     }
 
     /// Immutable reference to the queue in use by the shard.
-    pub fn queue(&self) -> &Arc<dyn Queue + Send + Sync> {
+    pub fn queue(&self) -> &Q {
         &self.queue
     }
 
@@ -166,9 +156,9 @@ impl Config {
 /// Builder to customize the operation of a shard.
 #[derive(Debug)]
 #[must_use = "builder must be completed to be used"]
-pub struct ConfigBuilder {
+pub struct ConfigBuilder<Q = InMemoryQueue> {
     /// Inner configuration being modified.
-    inner: Config,
+    inner: Config<Q>,
 }
 
 impl ConfigBuilder {
@@ -192,7 +182,7 @@ impl ConfigBuilder {
                 large_threshold: 50,
                 presence: None,
                 proxy_url: None,
-                queue: Arc::new(InMemoryQueue::default()),
+                queue: InMemoryQueue::default(),
                 ratelimit_messages: true,
                 session: None,
                 tls: Arc::new(Connector::new().unwrap()),
@@ -200,16 +190,12 @@ impl ConfigBuilder {
             },
         }
     }
+}
 
-    /// Create a new builder from an existing configuration.
-    #[deprecated(since = "0.15.3", note = "use From<Config> instead")]
-    pub const fn with_config(config: Config) -> Self {
-        Self { inner: config }
-    }
-
+impl<Q> ConfigBuilder<Q> {
     /// Consume the builder, constructing a shard.
     #[allow(clippy::missing_const_for_fn)]
-    pub fn build(self) -> Config {
+    pub fn build(self) -> Config<Q> {
         self.inner
     }
 
@@ -355,10 +341,36 @@ impl ConfigBuilder {
     ///
     /// Note that [`InMemoryQueue`] with a `max_concurrency` of `0` effectively
     /// turns itself into a no-op.
-    pub fn queue(mut self, queue: Arc<dyn Queue + Send + Sync>) -> Self {
-        self.inner.queue = queue;
+    pub fn queue<NewQ>(self, queue: NewQ) -> ConfigBuilder<NewQ> {
+        let Config {
+            event_types,
+            identify_properties,
+            intents,
+            large_threshold,
+            presence,
+            proxy_url,
+            queue: _,
+            ratelimit_messages,
+            session,
+            tls,
+            token,
+        } = self.inner;
 
-        self
+        ConfigBuilder {
+            inner: Config {
+                event_types,
+                identify_properties,
+                intents,
+                large_threshold,
+                presence,
+                proxy_url,
+                queue,
+                ratelimit_messages,
+                session,
+                tls,
+                token,
+            },
+        }
     }
 
     /// Set whether or not outgoing messages will be ratelimited.
@@ -389,8 +401,8 @@ impl ConfigBuilder {
     }
 }
 
-impl From<Config> for ConfigBuilder {
-    fn from(value: Config) -> Self {
+impl<Q> From<Config<Q>> for ConfigBuilder<Q> {
+    fn from(value: Config<Q>) -> Self {
         Self { inner: value }
     }
 }

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -294,7 +294,7 @@ enum NextAction {
 ///
 /// ```no_run
 /// use std::env;
-/// use twilight_gateway::{Config, Event, EventTypeFlags, Intents, Shard, ShardId};
+/// use twilight_gateway::{ConfigBuilder, Event, EventTypeFlags, Intents, Shard, ShardId};
 ///
 /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// // Use the value of the "DISCORD_TOKEN" environment variable as the bot's
@@ -303,7 +303,7 @@ enum NextAction {
 /// let token = env::var("DISCORD_TOKEN")?;
 /// let event_types = EventTypeFlags::MESSAGE_CREATE | EventTypeFlags::MESSAGE_DELETE;
 ///
-/// let config = Config::builder(token, Intents::GUILD_MESSAGES)
+/// let config = ConfigBuilder::new(token, Intents::GUILD_MESSAGES)
 ///     .event_types(event_types)
 ///     .build();
 /// let mut shard = Shard::with_config(ShardId::ONE, config);


### PR DESCRIPTION
By making `Config`, and its dependants, generic over the queue we avoid an unnecessary pointer indirection through `Arc<dyn Queue>` which has been a pet peeve of mine for some time. This furthers allows dropping the `Debug` requirement from `Queue`, another of my pet peeves.

As everyone not running multi-process bots should be using the `InMemoryQueue`, `Config`, `ConfigBuilder`, and `Shard` default to it. I.e. `Shard` is equivalent to `Shard<InMemoryQueue>`. This might, however, not be ideal if further queues are added. For example, a `SelfRefillableQueue` implementation that calls the "Get Gateway Bot" endpoint in the background at some interval could prove very popular in which case defaulting to any type might not be that useful.
