### PR TITLE
chore(gateway): Deprecate `MessageSender` in favour of `MessageQueue`

### DIFF
--- a/examples/lavalink-basic-bot.rs
+++ b/examples/lavalink-basic-bot.rs
@@ -3,7 +3,7 @@ use hyper::{
     Body, Request,
 };
 use std::{env, future::Future, net::SocketAddr, str::FromStr, sync::Arc};
-use twilight_gateway::{Event, Intents, MessageSender, Shard, ShardId};
+use twilight_gateway::{Event, Intents, MessageQueue, Shard, ShardId};
 use twilight_http::Client as HttpClient;
 use twilight_lavalink::{
     http::LoadedTracks,
@@ -23,7 +23,7 @@ struct StateRef {
     http: HttpClient,
     lavalink: Lavalink,
     hyper: HyperClient<HttpConnector>,
-    sender: MessageSender,
+    sender: MessageQueue,
     standby: Standby,
 }
 

--- a/twilight-gateway/src/channel.rs
+++ b/twilight-gateway/src/channel.rs
@@ -44,12 +44,9 @@ impl MessageChannel {
             command: self.command_tx.clone(),
         }
     }
-    
+
     /// Clone of the senders.
-    #[deprecated(
-        since = "0.15.3",
-        note = "renamed to `queue()`, use that instead"
-    )]
+    #[deprecated(since = "0.15.3", note = "renamed to `queue()`, use that instead")]
     pub fn sender(&self) -> MessageQueue {
         MessageQueue {
             close: self.close_tx.clone(),
@@ -142,10 +139,7 @@ impl MessageQueue {
 /// frames which are sent as long as the shard is connected to the Websocket).
 ///
 /// [`Shard`]: crate::Shard
-#[deprecated(
-    since = "0.15.3",
-    note = "renamed to `MessageQueue`, use that instead"
-)]
+#[deprecated(since = "0.15.3", note = "renamed to `MessageQueue`, use that instead")]
 pub type MessageSender = MessageQueue;
 
 #[cfg(test)]

--- a/twilight-gateway/src/channel.rs
+++ b/twilight-gateway/src/channel.rs
@@ -38,7 +38,7 @@ impl MessageChannel {
     }
 
     /// Clone of the queues.
-    pub fn queue(&self) -> MessageQueue {
+    pub fn message_queue(&self) -> MessageQueue {
         MessageQueue {
             close: self.close_tx.clone(),
             command: self.command_tx.clone(),
@@ -46,7 +46,7 @@ impl MessageChannel {
     }
 
     /// Clone of the senders.
-    #[deprecated(since = "0.15.3", note = "renamed to `queue()`, use that instead")]
+    #[deprecated(since = "0.15.3", note = "renamed to `message_queue()`, use that instead")]
     pub fn sender(&self) -> MessageQueue {
         MessageQueue {
             close: self.close_tx.clone(),

--- a/twilight-gateway/src/channel.rs
+++ b/twilight-gateway/src/channel.rs
@@ -46,7 +46,10 @@ impl MessageChannel {
     }
 
     /// Clone of the senders.
-    #[deprecated(since = "0.15.3", note = "renamed to `message_queue()`, use that instead")]
+    #[deprecated(
+        since = "0.15.3",
+        note = "renamed to `message_queue()`, use that instead"
+    )]
     pub fn sender(&self) -> MessageQueue {
         MessageQueue {
             close: self.close_tx.clone(),

--- a/twilight-gateway/src/lib.rs
+++ b/twilight-gateway/src/lib.rs
@@ -34,7 +34,7 @@ mod tls;
 #[cfg(any(feature = "zlib-stock", feature = "zlib-simd"))]
 pub use self::inflater::Inflater;
 pub use self::{
-    channel::MessageQueue,
+    channel::{MessageQueue, MessageSender},
     command::Command,
     config::{Config, ConfigBuilder},
     event::EventTypeFlags,

--- a/twilight-gateway/src/lib.rs
+++ b/twilight-gateway/src/lib.rs
@@ -34,7 +34,7 @@ mod tls;
 #[cfg(any(feature = "zlib-stock", feature = "zlib-simd"))]
 pub use self::inflater::Inflater;
 pub use self::{
-    channel::MessageSender,
+    channel::MessageQueue,
     command::Command,
     config::{Config, ConfigBuilder},
     event::EventTypeFlags,

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -948,7 +948,10 @@ impl Shard {
     ///
     /// This is primarily useful for sending to other tasks and threads where
     /// the shard won't be available.
-    #[deprecated(since = "0.15.3", note = "renamed to `message_queue()`, use that instead")]
+    #[deprecated(
+        since = "0.15.3",
+        note = "renamed to `message_queue()`, use that instead"
+    )]
     pub fn sender(&self) -> MessageQueue {
         self.user_channel.message_queue()
     }

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -939,7 +939,7 @@ impl Shard {
     ///
     /// This is primarily useful for sending to other tasks and threads where
     /// the shard won't be available.
-    pub fn queue(&self) -> MessageQueue {
+    pub fn message_queue(&self) -> MessageQueue {
         self.user_channel.queue()
     }
 
@@ -948,7 +948,7 @@ impl Shard {
     ///
     /// This is primarily useful for sending to other tasks and threads where
     /// the shard won't be available.
-    #[deprecated(since = "0.15.3", note = "renamed to `queue()`, use that instead")]
+    #[deprecated(since = "0.15.3", note = "renamed to `message_queue()`, use that instead")]
     pub fn sender(&self) -> MessageQueue {
         self.user_channel.queue()
     }

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -940,7 +940,7 @@ impl Shard {
     /// This is primarily useful for sending to other tasks and threads where
     /// the shard won't be available.
     pub fn message_queue(&self) -> MessageQueue {
-        self.user_channel.queue()
+        self.user_channel.message_queue()
     }
 
     /// Retrieve a channel to send outgoing gateway events over the shard to the
@@ -950,7 +950,7 @@ impl Shard {
     /// the shard won't be available.
     #[deprecated(since = "0.15.3", note = "renamed to `message_queue()`, use that instead")]
     pub fn sender(&self) -> MessageQueue {
-        self.user_channel.queue()
+        self.user_channel.message_queue()
     }
 
     /// Send a Websocket close frame indicating whether to also invalidate the

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -948,10 +948,7 @@ impl Shard {
     ///
     /// This is primarily useful for sending to other tasks and threads where
     /// the shard won't be available.
-    #[deprecated(
-        since = "0.15.3",
-        note = "renamed to `queue()`, use that instead"
-    )]
+    #[deprecated(since = "0.15.3", note = "renamed to `queue()`, use that instead")]
     pub fn sender(&self) -> MessageQueue {
         self.user_channel.queue()
     }


### PR DESCRIPTION
This Pull Request renames `MessageSender` to `MessageQueue`, and provides a deprecated typealias of `MessageSender` as `MessageQueue`; renames functions that returns `MessageQueue` from `sender()` to `message_queue()` and deprecates existing pre-renamed functions. An example has also been updated to reflect this change.

As of [this discussion on Discord](https://canary.discord.com/channels/745809834183753828/745815089067851807/1132277959231799376), it has been agreed upon that `MessageQueue` would be a better name that fits the use case of the structure.

The deprecated items, `MessageSender`, `MessageChannel#sender` and `Shard#sender`,  introduced in this Pull Request is scheduled for removal in the next major version, `0.16`, in favour of `MessageQueue`, `MessageChannel#message_queue` and `Shard#message_queue`.