### PR TITLE
fix(http): fix get invite query params

### DIFF
--- a/twilight-http/src/routing.rs
+++ b/twilight-http/src/routing.rs
@@ -1627,7 +1627,7 @@ impl<'a> Route<'a> {
 ///     with_counts: true,
 /// };
 ///
-/// assert_eq!("invites/twilight-rs?with-counts=true", route.to_string());
+/// assert_eq!("invites/twilight-rs?with_counts=true", route.to_string());
 /// ```
 ///
 /// [`GetInvite`]: Self::GetInvite
@@ -2608,7 +2608,7 @@ impl Display for Route<'_> {
                 f.write_str(code)?;
 
                 if *with_counts {
-                    f.write_str("?with-counts=true")?;
+                    f.write_str("?with_counts=true")?;
                 }
 
                 Ok(())
@@ -2623,11 +2623,11 @@ impl Display for Route<'_> {
                 f.write_str("?")?;
 
                 if *with_counts {
-                    f.write_str("with-counts=true")?;
+                    f.write_str("with_counts=true")?;
                 }
 
                 if *with_expiration {
-                    f.write_str("with-expiration=true")?;
+                    f.write_str("with_expiration=true")?;
                 }
 
                 Ok(())

--- a/twilight-http/src/routing.rs
+++ b/twilight-http/src/routing.rs
@@ -2627,11 +2627,7 @@ impl Display for Route<'_> {
                 }
 
                 if *with_expiration {
-                    if *with_counts {
-                        f.write_str("&")?;
-                    }
-
-                    f.write_str("with_expiration=true")?;
+                    f.write_str("&with_expiration=true")?;
                 }
 
                 Ok(())

--- a/twilight-http/src/routing.rs
+++ b/twilight-http/src/routing.rs
@@ -2627,6 +2627,10 @@ impl Display for Route<'_> {
                 }
 
                 if *with_expiration {
+                    if *with_counts {
+                        f.write_str("&")?;
+                    }
+
                     f.write_str("with_expiration=true")?;
                 }
 


### PR DESCRIPTION
Currently the GetInvite `with_counts()` and `with_expiration()` don't work as the query string they append uses `-` instead of `_` in the keys, as specified in the API docs - https://discord.com/developers/docs/resources/invite#get-invite-query-string-params. 