### PR TITLE
fix(models): add VanityUrl uses

### DIFF
--- a/twilight-model/src/guild/vanity_url.rs
+++ b/twilight-model/src/guild/vanity_url.rs
@@ -8,6 +8,8 @@ pub struct VanityUrl {
     /// For example, in an invite of `discord.gg/applejack`, the code is
     /// `applejack`.
     pub code: String,
+    /// Number of times the vanity URL has been used.
+    pub uses: u64,
 }
 
 #[cfg(test)]
@@ -19,16 +21,19 @@ mod tests {
     fn vanity_url() {
         let url = VanityUrl {
             code: "a".to_owned(),
+            uses: 12,
         };
         serde_test::assert_tokens(
             &url,
             &[
                 Token::Struct {
                     name: "VanityUrl",
-                    len: 1,
+                    len: 2,
                 },
                 Token::String("code"),
                 Token::String("a"),
+                Token::String("uses"),
+                Token::U64(12),
                 Token::StructEnd,
             ],
         );


### PR DESCRIPTION
The VanityUrl model used for the response from [/guilds/{guild.id}/vanity-url](https://discord.com/developers/docs/resources/guild#get-guild-vanity-url) is missing the `uses` field. 
Despite what the aforementioned docs say, the code will not be null if the vanity url is not set, instead, you get a `403` response, so I did not make any additional changes beyond adding the uses field.