### PR TITLE
Resolve GHSA-8qv2-5vq6-g2g7 by upgrading tokio-tungstenite

### DIFF
--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -20,7 +20,7 @@ rand = { default-features = false, features = ["std", "std_rng"], version = "0.8
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.19" }
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.18" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.20" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-gateway-queue = { default-features = false, path = "../twilight-gateway-queue", version = "0.15.2" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.2" }
@@ -38,8 +38,8 @@ simd-json = { default-features = false, features = ["serde_impl", "swar-number-p
 # They are needed to track what is used in tokio-tungstenite
 native-tls = { default-features = false, optional = true, version = "0.2.8" }
 rustls-native-certs = { default-features = false, optional = true, version = "0.6" }
-rustls-tls = { default-features = false, optional = true, package = "rustls", version = "0.20" }
-webpki-roots = { default-features = false, optional = true, version = "0.22" }
+rustls-tls = { default-features = false, optional = true, package = "rustls", version = "0.21" }
+webpki-roots = { default-features = false, optional = true, version = "0.23" }
 
 [dev-dependencies]
 anyhow = { default-features = false, features = ["std"], version = "1" }

--- a/twilight-gateway/src/connection.rs
+++ b/twilight-gateway/src/connection.rs
@@ -25,12 +25,17 @@ const GATEWAY_URL: &str = "wss://gateway.discord.gg";
 /// `accept_unmasked_frames` and `max_send_queue` are set to their
 /// defaults.
 ///
+/// `write_buffer_size` is set to 8KiB, `max_write_buffer_size` is set to 1MiB
+///
 /// [`GuildCreate`]: twilight_model::gateway::payload::incoming::GuildCreate
+#[allow(deprecated)] // max_send_queue is deprecated.
 const WEBSOCKET_CONFIG: WebSocketConfig = WebSocketConfig {
     accept_unmasked_frames: false,
     max_frame_size: None,
     max_message_size: None,
     max_send_queue: None,
+    write_buffer_size: 1024 * 1024,
+    max_write_buffer_size: 1024 * 8,
 };
 
 /// [`tokio_tungstenite`] library Websocket connection.

--- a/twilight-gateway/src/tls.rs
+++ b/twilight-gateway/src/tls.rs
@@ -34,7 +34,7 @@ mod r#impl {
         config: WebSocketConfig,
         _tls: &TlsContainer,
     ) -> Result<Connection, ReceiveMessageError> {
-        let (stream, _) = tokio_tungstenite::connect_async_with_config(url, Some(config))
+        let (stream, _) = tokio_tungstenite::connect_async_with_config(url, Some(config), false)
             .await
             .map_err(|source| ReceiveMessageError {
                 kind: ReceiveMessageErrorType::Reconnect,
@@ -89,13 +89,17 @@ mod r#impl {
         config: WebSocketConfig,
         tls: &TlsContainer,
     ) -> Result<Connection, ReceiveMessageError> {
-        let (stream, _) =
-            tokio_tungstenite::connect_async_tls_with_config(url, Some(config), tls.connector())
-                .await
-                .map_err(|source| ReceiveMessageError {
-                    kind: ReceiveMessageErrorType::Reconnect,
-                    source: Some(Box::new(source)),
-                })?;
+        let (stream, _) = tokio_tungstenite::connect_async_tls_with_config(
+            url,
+            Some(config),
+            false,
+            tls.connector(),
+        )
+        .await
+        .map_err(|source| ReceiveMessageError {
+            kind: ReceiveMessageErrorType::Reconnect,
+            source: Some(Box::new(source)),
+        })?;
 
         Ok(stream)
     }
@@ -154,7 +158,7 @@ mod r#impl {
 
         #[cfg(feature = "rustls-webpki-roots")]
         {
-            roots.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+            roots.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
                 rustls_tls::OwnedTrustAnchor::from_subject_spki_name_constraints(
                     ta.subject,
                     ta.spki,
@@ -179,13 +183,17 @@ mod r#impl {
         config: WebSocketConfig,
         tls: &TlsContainer,
     ) -> Result<Connection, ReceiveMessageError> {
-        let (stream, _) =
-            tokio_tungstenite::connect_async_tls_with_config(url, Some(config), tls.connector())
-                .await
-                .map_err(|source| ReceiveMessageError {
-                    kind: ReceiveMessageErrorType::Reconnect,
-                    source: Some(Box::new(source)),
-                })?;
+        let (stream, _) = tokio_tungstenite::connect_async_tls_with_config(
+            url,
+            Some(config),
+            false,
+            tls.connector(),
+        )
+        .await
+        .map_err(|source| ReceiveMessageError {
+            kind: ReceiveMessageErrorType::Reconnect,
+            source: Some(Box::new(source)),
+        })?;
 
         Ok(stream)
     }

--- a/twilight-http/Cargo.toml
+++ b/twilight-http/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.15.2"
 
 [dependencies]
 hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
-hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.23" }
+hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.24" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
 hyper-trust-dns = { default-features = false, optional = true, version = "0.5" }
 percent-encoding = { default-features = false, version = "2" }

--- a/twilight-lavalink/Cargo.toml
+++ b/twilight-lavalink/Cargo.toml
@@ -20,7 +20,7 @@ http = { default-features = false, version = "0.2" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["macros", "net", "rt", "sync", "time"], version = "1.0" }
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.18" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.20" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.2" }
 

--- a/twilight-validate/src/command.rs
+++ b/twilight-validate/src/command.rs
@@ -635,9 +635,7 @@ pub fn choice(choice: &CommandOptionChoice) -> Result<(), CommandValidationError
 /// [`OptionNameCharacterInvalid`]: CommandValidationErrorType::OptionNameCharacterInvalid
 pub fn option(option: &CommandOption) -> Result<(), CommandValidationError> {
     let description_len = option.description.chars().count();
-    if description_len > OPTION_DESCRIPTION_LENGTH_MAX
-        && description_len < OPTION_DESCRIPTION_LENGTH_MIN
-    {
+    if !(OPTION_DESCRIPTION_LENGTH_MIN..=OPTION_DESCRIPTION_LENGTH_MAX).contains(&description_len) {
         return Err(CommandValidationError {
             kind: CommandValidationErrorType::OptionDescriptionInvalid,
         });

--- a/twilight-validate/src/request.rs
+++ b/twilight-validate/src/request.rs
@@ -920,13 +920,12 @@ pub fn scheduled_event_description(description: impl AsRef<str>) -> Result<(), V
 /// [`ScheduledEventGetUsers`]: ValidationErrorType::ScheduledEventGetUsers
 /// [this documentation entry]: https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users-query-string-params
 pub const fn scheduled_event_get_users(limit: u16) -> Result<(), ValidationError> {
-    if limit <= SCHEDULED_EVENT_GET_USERS_MIN && limit >= SCHEDULED_EVENT_GET_USERS_MAX {
-        Ok(())
-    } else {
+    if !(SCHEDULED_EVENT_GET_USERS_MIN..=SCHEDULED_EVENT_GET_USERS_MAX).contains(&limit) {
         Err(ValidationError {
             kind: ValidationErrorType::ScheduledEventGetUsers { limit },
         })
     }
+    Ok(())
 }
 
 /// Ensure that a scheduled event's name is correct.

--- a/twilight-validate/src/request.rs
+++ b/twilight-validate/src/request.rs
@@ -920,7 +920,7 @@ pub fn scheduled_event_description(description: impl AsRef<str>) -> Result<(), V
 /// [`ScheduledEventGetUsers`]: ValidationErrorType::ScheduledEventGetUsers
 /// [this documentation entry]: https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users-query-string-params
 pub const fn scheduled_event_get_users(limit: u16) -> Result<(), ValidationError> {
-    if (SCHEDULED_EVENT_GET_USERS_MIN..=SCHEDULED_EVENT_GET_USERS_MAX).contains(&limit) {
+    if limit < SCHEDULED_EVENT_GET_USERS_MIN || limit > SCHEDULED_EVENT_GET_USERS_MAX  {
         Ok(())
     } else {
         Err(ValidationError {

--- a/twilight-validate/src/request.rs
+++ b/twilight-validate/src/request.rs
@@ -920,7 +920,7 @@ pub fn scheduled_event_description(description: impl AsRef<str>) -> Result<(), V
 /// [`ScheduledEventGetUsers`]: ValidationErrorType::ScheduledEventGetUsers
 /// [this documentation entry]: https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users-query-string-params
 pub const fn scheduled_event_get_users(limit: u16) -> Result<(), ValidationError> {
-    if limit < SCHEDULED_EVENT_GET_USERS_MIN || limit > SCHEDULED_EVENT_GET_USERS_MAX  {
+    if limit < SCHEDULED_EVENT_GET_USERS_MIN || limit > SCHEDULED_EVENT_GET_USERS_MAX {
         Ok(())
     } else {
         Err(ValidationError {

--- a/twilight-validate/src/request.rs
+++ b/twilight-validate/src/request.rs
@@ -920,12 +920,13 @@ pub fn scheduled_event_description(description: impl AsRef<str>) -> Result<(), V
 /// [`ScheduledEventGetUsers`]: ValidationErrorType::ScheduledEventGetUsers
 /// [this documentation entry]: https://discord.com/developers/docs/resources/guild-scheduled-event#get-guild-scheduled-event-users-query-string-params
 pub const fn scheduled_event_get_users(limit: u16) -> Result<(), ValidationError> {
-    if !(SCHEDULED_EVENT_GET_USERS_MIN..=SCHEDULED_EVENT_GET_USERS_MAX).contains(&limit) {
+    if (SCHEDULED_EVENT_GET_USERS_MIN..=SCHEDULED_EVENT_GET_USERS_MAX).contains(&limit) {
+        Ok(())
+    } else {
         Err(ValidationError {
             kind: ValidationErrorType::ScheduledEventGetUsers { limit },
         })
     }
-    Ok(())
 }
 
 /// Ensure that a scheduled event's name is correct.


### PR DESCRIPTION
This PR upgrades `tokio-tungstenite` to 0.20, fixing GHSA-8qv2-5vq6-g2g7. It also upgrades hyper-rustls in twilight-http to keep the whole project on a consistent rustls version.