### PR TITLE
feat(model, cache): add support for super reactions

### DIFF
--- a/twilight-cache-inmemory/src/event/reaction.rs
+++ b/twilight-cache-inmemory/src/event/reaction.rs
@@ -1,6 +1,6 @@
 use crate::{config::ResourceType, InMemoryCache, UpdateCache};
 use twilight_model::{
-    channel::message::{Reaction, ReactionType},
+    channel::message::{Reaction, ReactionCountDetails, ReactionType},
     gateway::payload::incoming::{
         ReactionAdd, ReactionRemove, ReactionRemoveAll, ReactionRemoveEmoji,
     },
@@ -39,9 +39,15 @@ impl UpdateCache for ReactionAdd {
                 .unwrap_or_default();
 
             message.reactions.push(Reaction {
+                burst_colors: Vec::new(),
                 count: 1,
+                count_details: ReactionCountDetails {
+                    burst: 0,
+                    normal: 1,
+                },
                 emoji: self.0.emoji.clone(),
                 me,
+                me_burst: false,
             });
         }
     }

--- a/twilight-model/src/channel/message/mod.rs
+++ b/twilight-model/src/channel/message/mod.rs
@@ -196,6 +196,7 @@ pub struct Message {
 #[cfg(test)]
 mod tests {
     use super::{
+        reaction::ReactionCountDetails,
         sticker::{MessageSticker, StickerFormatType},
         Message, MessageActivity, MessageActivityType, MessageApplication, MessageFlags,
         MessageReference, MessageType, Reaction, ReactionType,
@@ -478,11 +479,17 @@ mod tests {
             mentions: Vec::new(),
             pinned: false,
             reactions: vec![Reaction {
+                burst_colors: Vec::new(),
                 count: 7,
+                count_details: ReactionCountDetails {
+                    burst: 0,
+                    normal: 7,
+                },
                 emoji: ReactionType::Unicode {
                     name: "a".to_owned(),
                 },
                 me: true,
+                me_burst: false,
             }],
             reference: Some(MessageReference {
                 channel_id: Some(Id::new(1)),
@@ -653,10 +660,23 @@ mod tests {
                 Token::Seq { len: Some(1) },
                 Token::Struct {
                     name: "Reaction",
-                    len: 3,
+                    len: 6,
                 },
+                Token::Str("burst_colors"),
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
                 Token::Str("count"),
                 Token::U64(7),
+                Token::Str("count_details"),
+                Token::Struct {
+                    name: "ReactionCountDetails",
+                    len: 2,
+                },
+                Token::Str("burst"),
+                Token::U64(0),
+                Token::Str("normal"),
+                Token::U64(7),
+                Token::StructEnd,
                 Token::Str("emoji"),
                 Token::Struct {
                     name: "ReactionType",
@@ -667,6 +687,8 @@ mod tests {
                 Token::StructEnd,
                 Token::Str("me"),
                 Token::Bool(true),
+                Token::Str("me_burst"),
+                Token::Bool(false),
                 Token::StructEnd,
                 Token::SeqEnd,
                 Token::Str("message_reference"),

--- a/twilight-model/src/channel/message/mod.rs
+++ b/twilight-model/src/channel/message/mod.rs
@@ -26,7 +26,7 @@ pub use self::{
     interaction::MessageInteraction,
     kind::MessageType,
     mention::Mention,
-    reaction::{Reaction, ReactionType},
+    reaction::{Reaction, ReactionCountDetails, ReactionType},
     reference::MessageReference,
     role_subscription_data::RoleSubscriptionData,
     sticker::Sticker,

--- a/twilight-model/src/channel/message/reaction.rs
+++ b/twilight-model/src/channel/message/reaction.rs
@@ -1,11 +1,14 @@
-use crate::id::{marker::EmojiMarker, Id};
+use crate::{
+    id::{marker::EmojiMarker, Id},
+    util::HexColor,
+};
 use serde::{Deserialize, Serialize};
 
 /// Reaction below a message.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Reaction {
     /// HEX colors used for super reaction.
-    pub burst_colors: Vec<String>,
+    pub burst_colors: Vec<HexColor>,
     /// Amount of reactions this emoji has.
     pub count: u64,
     /// Reaction count details for each type of reaction.
@@ -64,13 +67,13 @@ pub struct ReactionCountDetails {
 #[cfg(test)]
 mod tests {
     use super::{Reaction, ReactionCountDetails, ReactionType};
-    use crate::id::Id;
+    use crate::{id::Id, util::HexColor};
     use serde_test::Token;
 
     #[test]
     fn message_reaction_unicode() {
         let value = Reaction {
-            burst_colors: Vec::new(),
+            burst_colors: Vec::from([HexColor(255, 255, 255)]),
             count: 7,
             count_details: ReactionCountDetails {
                 burst: 0,
@@ -91,7 +94,8 @@ mod tests {
                     len: 6,
                 },
                 Token::Str("burst_colors"),
-                Token::Seq { len: Some(0) },
+                Token::Seq { len: Some(1) },
+                Token::Str("#FFFFFF"),
                 Token::SeqEnd,
                 Token::Str("count"),
                 Token::U64(7),

--- a/twilight-model/src/util/hex_color.rs
+++ b/twilight-model/src/util/hex_color.rs
@@ -6,8 +6,16 @@ use std::str::FromStr;
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+/// Represents a color in the RGB format using hexadecimal notation.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct HexColor(pub u8, pub u8, pub u8);
+pub struct HexColor(
+    /// Red component of the color.
+    pub u8,
+    /// Green component of the color.
+    pub u8,
+    /// Blue component of the color.
+    pub u8,
+);
 
 impl Display for HexColor {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {

--- a/twilight-model/src/util/hex_color.rs
+++ b/twilight-model/src/util/hex_color.rs
@@ -1,0 +1,122 @@
+use std::fmt::Formatter;
+use std::fmt::{Display, Result as FmtResult};
+use std::num::ParseIntError;
+use std::str::FromStr;
+
+use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct HexColor(pub u8, pub u8, pub u8);
+
+impl Display for HexColor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_fmt(format_args!("#{:02X}{:02X}{:02X}", self.0, self.1, self.2))
+    }
+}
+
+impl Serialize for HexColor {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+pub enum HexColorParseError {
+    InvalidLength,
+    InvalidFormat,
+    InvalidCharacter(ParseIntError),
+}
+
+impl From<ParseIntError> for HexColorParseError {
+    fn from(err: ParseIntError) -> Self {
+        Self::InvalidCharacter(err)
+    }
+}
+
+impl FromStr for HexColor {
+    type Err = HexColorParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if !s.starts_with('#') {
+            return Err(HexColorParseError::InvalidFormat);
+        }
+
+        let s = s.trim_start_matches('#');
+
+        let (r, g, b) = match s.len() {
+            3 => (
+                u8::from_str_radix(&s[0..1], 16)?,
+                u8::from_str_radix(&s[1..2], 16)?,
+                u8::from_str_radix(&s[2..3], 16)?,
+            ),
+            6 => (
+                u8::from_str_radix(&s[0..2], 16)?,
+                u8::from_str_radix(&s[2..4], 16)?,
+                u8::from_str_radix(&s[4..6], 16)?,
+            ),
+            _ => return Err(HexColorParseError::InvalidLength),
+        };
+
+        Ok(Self(r, g, b))
+    }
+}
+
+struct HexColorVisitor;
+
+impl<'de> Visitor<'de> for HexColorVisitor {
+    type Value = HexColor;
+
+    fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+        formatter.write_str("a hex color string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        HexColor::from_str(v).map_err(|_| E::custom("invalid hex color"))
+    }
+}
+
+impl<'de> Deserialize<'de> for HexColor {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_str(HexColorVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HexColor;
+
+    #[test]
+    fn hex_color_display() {
+        let hex_color = HexColor(255, 255, 255);
+        assert_eq!(hex_color.to_string(), "#FFFFFF");
+    }
+
+    #[test]
+    fn serialize() {
+        let hex_color = HexColor(252, 177, 3);
+        let serialized = serde_json::to_string(&hex_color).unwrap();
+        assert_eq!(serialized, "\"#FCB103\"");
+    }
+
+    #[test]
+    fn serialize_2() {
+        let hex_color = HexColor(255, 255, 255);
+        let serialized = serde_json::to_string(&hex_color).unwrap();
+        assert_eq!(serialized, "\"#FFFFFF\"");
+    }
+
+    #[test]
+    fn deserialize() {
+        let deserialized: HexColor = serde_json::from_str("\"#FFFFFF\"").unwrap();
+        assert_eq!(deserialized, HexColor(255, 255, 255));
+    }
+
+    #[test]
+    fn deserialize_invalid() {
+        let deserialized: Result<HexColor, _> = serde_json::from_str("\"#GGGGGG\"");
+        assert!(deserialized.is_err());
+    }
+}

--- a/twilight-model/src/util/mod.rs
+++ b/twilight-model/src/util/mod.rs
@@ -1,9 +1,10 @@
 //! Utilities for efficiently parsing and representing data from Discord's API.
 
 pub mod datetime;
+pub mod hex_color;
 pub mod image_hash;
 
-pub use self::{datetime::Timestamp, image_hash::ImageHash};
+pub use self::{datetime::Timestamp, hex_color::HexColor, image_hash::ImageHash};
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
 pub(crate) fn is_false(value: &bool) -> bool {


### PR DESCRIPTION
Ref:
- https://github.com/discord/discord-api-docs/pull/6056

This PR also adds a new `HexColor` struct for efficiently storing hex strings.