### PR TITLE
Fix joined_at null

### DIFF
--- a/twilight-model/src/guild/member.rs
+++ b/twilight-model/src/guild/member.rs
@@ -23,7 +23,7 @@ pub struct Member {
     ///
     /// Defaults to an empty bitfield.
     pub flags: MemberFlags,
-    pub joined_at: Timestamp,
+    pub joined_at: Option<Timestamp>,
     pub mute: bool,
     pub nick: Option<String>,
     /// Whether the user has yet to pass the guild's [Membership Screening]


### PR DESCRIPTION
When I updated to the latest twilight release, I noticed that I forgot to PR this fix, as the errors started popping up again.