### PR TITLE
fix(http): Use `default_message_seconds` as a json field for `create_ban`

### DIFF
--- a/twilight-http/src/request/guild/ban/create_ban.rs
+++ b/twilight-http/src/request/guild/ban/create_ban.rs
@@ -169,10 +169,11 @@ mod tests {
         let client = Client::new(String::new());
         let request = client
             .create_ban(GUILD_ID, USER_ID)
+            .delete_message_seconds(100)?
             .reason(REASON)?
             .try_into_request()?;
 
-        assert!(request.body().is_none());
+        assert!(request.body().is_some());
         assert!(request.form().is_none());
         assert_eq!(Method::Put, request.method());
 

--- a/twilight-http/src/request/guild/ban/create_ban.rs
+++ b/twilight-http/src/request/guild/ban/create_ban.rs
@@ -5,6 +5,7 @@ use crate::{
     response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
+use serde::Serialize;
 use std::future::IntoFuture;
 use twilight_model::id::{
     marker::{GuildMarker, UserMarker},
@@ -16,7 +17,9 @@ use twilight_validate::request::{
     ValidationError,
 };
 
+#[derive(Serialize)]
 struct CreateBanFields {
+    /// Number of seconds to delete messages for, between `0` and `604800`.
     delete_message_seconds: Option<u32>,
 }
 
@@ -127,10 +130,11 @@ impl IntoFuture for CreateBan<'_> {
 impl TryIntoRequest for CreateBan<'_> {
     fn try_into_request(self) -> Result<Request, Error> {
         let mut request = Request::builder(&Route::CreateBan {
-            delete_message_seconds: self.fields.delete_message_seconds,
             guild_id: self.guild_id.get(),
             user_id: self.user_id.get(),
         });
+
+        request = request.json(&self.fields)?;
 
         if let Some(reason) = self.reason.as_ref() {
             let header = request::audit_header(reason)?;

--- a/twilight-http/src/routing.rs
+++ b/twilight-http/src/routing.rs
@@ -33,9 +33,6 @@ pub enum Route<'a> {
     },
     /// Route information to create a ban on a user in a guild.
     CreateBan {
-        /// The number of seconds' worth of the user's messages to delete in the
-        /// guild's channels.
-        delete_message_seconds: Option<u32>,
         /// The ID of the guild.
         guild_id: u64,
         /// The ID of the user.
@@ -1695,23 +1692,11 @@ impl Display for Route<'_> {
 
                 f.write_str("/auto-moderation/rules")
             }
-            Route::CreateBan {
-                guild_id,
-                delete_message_seconds,
-                user_id,
-            } => {
+            Route::CreateBan { guild_id, user_id } => {
                 f.write_str("guilds/")?;
                 Display::fmt(guild_id, f)?;
                 f.write_str("/bans/")?;
-                Display::fmt(user_id, f)?;
-                f.write_str("?")?;
-
-                if let Some(delete_message_seconds) = delete_message_seconds {
-                    f.write_str("delete_message_seconds=")?;
-                    Display::fmt(delete_message_seconds, f)?;
-                }
-
-                Ok(())
+                Display::fmt(user_id, f)
             }
             Route::CreateChannel { guild_id }
             | Route::GetChannels { guild_id }
@@ -4346,7 +4331,6 @@ mod tests {
     fn create_ban() {
         let mut route = Route::CreateBan {
             guild_id: GUILD_ID,
-            delete_message_seconds: None,
             user_id: USER_ID,
         };
         assert_eq!(
@@ -4356,12 +4340,11 @@ mod tests {
 
         route = Route::CreateBan {
             guild_id: GUILD_ID,
-            delete_message_seconds: Some(259_200),
             user_id: USER_ID,
         };
         assert_eq!(
             route.to_string(),
-            format!("guilds/{GUILD_ID}/bans/{USER_ID}?delete_message_seconds=259200")
+            format!("guilds/{GUILD_ID}/bans/{USER_ID}")
         );
     }
 

--- a/twilight-http/src/routing.rs
+++ b/twilight-http/src/routing.rs
@@ -4331,7 +4331,7 @@ mod tests {
         };
         assert_eq!(
             route.to_string(),
-            format!("guilds/{GUILD_ID}/bans/{USER_ID}?")
+            format!("guilds/{GUILD_ID}/bans/{USER_ID}")
         );
 
         route = Route::CreateBan {

--- a/twilight-http/src/routing.rs
+++ b/twilight-http/src/routing.rs
@@ -1692,12 +1692,6 @@ impl Display for Route<'_> {
 
                 f.write_str("/auto-moderation/rules")
             }
-            Route::CreateBan { guild_id, user_id } => {
-                f.write_str("guilds/")?;
-                Display::fmt(guild_id, f)?;
-                f.write_str("/bans/")?;
-                Display::fmt(user_id, f)
-            }
             Route::CreateChannel { guild_id }
             | Route::GetChannels { guild_id }
             | Route::UpdateGuildChannels { guild_id } => {
@@ -1940,7 +1934,9 @@ impl Display for Route<'_> {
 
                 f.write_str("/crosspost")
             }
-            Route::DeleteBan { guild_id, user_id } | Route::GetBan { guild_id, user_id } => {
+            Route::DeleteBan { guild_id, user_id }
+            | Route::GetBan { guild_id, user_id }
+            | Route::CreateBan { guild_id, user_id } => {
                 f.write_str("guilds/")?;
                 Display::fmt(guild_id, f)?;
                 f.write_str("/bans/")?;


### PR DESCRIPTION
Closes #2271