### PR TITLE
fix: new rust CI errors

### DIFF
--- a/examples/gateway-reshard.rs
+++ b/examples/gateway-reshard.rs
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
         // Run `gateway_runner` and `reshard` concurrently until the first one
         // finishes.
         tokio::select! {
-            // Gateway_runner only finises on errors, so break the loop and exit
+            // Gateway_runner only finishes on errors, so break the loop and exit
             // the program.
             _ = gateway_runner(Arc::clone(&client), shards) => break,
             // Resharding complete! Time to run `gateway_runner` with the new

--- a/twilight-cache-inmemory/src/lib.rs
+++ b/twilight-cache-inmemory/src/lib.rs
@@ -861,7 +861,7 @@ impl UpdateCache for Event {
             Event::GuildStickersUpdate(v) => c.update(v),
             Event::GuildUpdate(v) => c.update(v.deref()),
             Event::IntegrationCreate(v) => c.update(v.deref()),
-            Event::IntegrationDelete(v) => c.update(v.deref()),
+            Event::IntegrationDelete(v) => c.update(v),
             Event::IntegrationUpdate(v) => c.update(v.deref()),
             Event::InteractionCreate(v) => c.update(v.deref()),
             Event::MemberAdd(v) => c.update(v.deref()),

--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -64,7 +64,7 @@ pub struct Config {
     /// Session information to resume a shard on initialization.
     session: Option<Session>,
     /// TLS connector for Websocket connections.
-    // We need this to be public so [`stream`] can re-use TLS on multiple shards
+    // We need this to be public so [`stream`] can reuse TLS on multiple shards
     // if unconfigured.
     tls: TlsContainer,
     /// Token used to authenticate when identifying with the gateway.

--- a/twilight-http/CHANGELOG.md
+++ b/twilight-http/CHANGELOG.md
@@ -1581,7 +1581,7 @@ Replace references to `Path::WebhooksIdTokenMessageId` with
 `CreateInvite::{max_age, max_uses}` now return validation errors, so the results
 returned from them need to be handled.
 
-Don't re-use `hyper` clients via the builder. If you need to configure the
+Don't reuse `hyper` clients via the builder. If you need to configure the
 underlying `hyper` client please create an issue with the reason why.
 
 Errors are no longer enums and don't expose their concrete underlying error
@@ -1632,7 +1632,7 @@ Return validation errors for `CreateInvite::max_age` and
 Remove ability to get current user's DM channels ([#782] - [@vivian]).
 
 Remove `ClientBuilder::hyper_client` and `From<HyperClient> for Client` which
-were available to re-use `hyper` clients ([#768] - [@vivian]).
+were available to reuse `hyper` clients ([#768] - [@vivian]).
 
 Return updated copy of member when updating a member ([#758] - [@vivian]).
 

--- a/twilight-mention/src/timestamp.rs
+++ b/twilight-mention/src/timestamp.rs
@@ -163,7 +163,7 @@ impl Ord for Timestamp {
 
 impl PartialOrd for Timestamp {
     fn partial_cmp(&self, other: &Timestamp) -> Option<Ordering> {
-        self.unix.partial_cmp(&other.unix)
+        Some(self.cmp(other))
     }
 }
 

--- a/twilight-model/src/id/mod.rs
+++ b/twilight-model/src/id/mod.rs
@@ -382,7 +382,7 @@ impl<T> PartialEq<Id<T>> for u64 {
 
 impl<T> PartialOrd for Id<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.value.partial_cmp(&other.value)
+        Some(self.cmp(other))
     }
 }
 

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -849,7 +849,7 @@ impl Standby {
         //
         // A form of enumeration can't be used because sometimes the index
         // doesn't advance; iterators would continue to provide incrementing
-        // enumeration indexes while we sometimes want to re-use an index.
+        // enumeration indexes while we sometimes want to reuse an index.
         let mut index = 0;
         let mut results = ProcessResults::new();
 


### PR DESCRIPTION
- Because the CI seems to be using the latest rust version, a redundant `deref()` was removed as the compiler gave a warning.
- The CI for spell checks seems to have an updated dictionary. The new spelling errors found have been corrected in this PR.
- Clippy was throwing an error for inconsistent `PartialOrd` implementations. This was also fixed. 

