### PR TITLE
build(http)!: Update trust-dns (now hickory)

### DIFF
--- a/twilight-http/Cargo.toml
+++ b/twilight-http/Cargo.toml
@@ -18,7 +18,7 @@ fastrand = { default-features = false, features = ["std"], version = "2" }
 hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
 hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.24" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
-hyper-trust-dns = { default-features = false, optional = true, version = "0.5" }
+hyper-hickory = { default-features = false, optional = true, features = ["tokio"], version = "0.6" }
 percent-encoding = { default-features = false, version = "2" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
@@ -38,7 +38,7 @@ decompression = ["dep:brotli"]
 native = ["dep:hyper-tls"]
 rustls-native-roots = ["dep:hyper-rustls", "hyper-rustls?/native-tokio"]
 rustls-webpki-roots = ["dep:hyper-rustls", "hyper-rustls?/webpki-tokio"]
-trust-dns = ["dep:hyper-trust-dns"]
+hickory = ["dep:hyper-hickory"]
 
 [dev-dependencies]
 serde_test = { default-features = false, version = "1" }

--- a/twilight-http/README.md
+++ b/twilight-http/README.md
@@ -84,19 +84,19 @@ This should be preferred over `rustls-native-roots` in Docker containers based o
 
 ### Trust-DNS
 
-The `trust-dns` enables [`hyper-trust-dns`], which replaces the default
-`GaiResolver` in [`hyper`]. [`hyper-trust-dns`] instead provides a fully
-async DNS resolver on the application level.
+The `hickory` feature enables [`hyper-hickory`], which replaces the default
+`GaiResolver` in [`hyper`]. [`hyper-hickory`] instead provides a fully async
+DNS resolver on the application level.
 
 [`brotli`]: https://github.com/dropbox/rust-brotli
 [`hyper`]: https://crates.io/crates/hyper
+[`hyper-hickory`]: https://crates.io/crates/hyper-hickory
 [`hyper-rustls`]: https://crates.io/crates/hyper-rustls
 [`hyper-tls`]: https://crates.io/crates/hyper-tls
 [`rustls`]: https://crates.io/crates/rustls
 [`rustls-native-certs`]: https://crates.io/crates/rustls-native-certs
 [`serde_json`]: https://crates.io/crates/serde_json
 [`simd-json`]: https://crates.io/crates/simd-json
-[`hyper-trust-dns`]: https://crates.io/crates/hyper-trust-dns
 [`webpki-roots`]: https://crates.io/crates/webpki-roots
 [codecov badge]: https://img.shields.io/codecov/c/gh/twilight-rs/twilight?logo=codecov&style=for-the-badge&token=E9ERLJL0L2
 [codecov link]: https://app.codecov.io/gh/twilight-rs/twilight/

--- a/twilight-http/src/client/connector.rs
+++ b/twilight-http/src/client/connector.rs
@@ -10,11 +10,11 @@ type HttpsConnector<T> = hyper_rustls::HttpsConnector<T>;
 ))]
 type HttpsConnector<T> = hyper_tls::HttpsConnector<T>;
 
-/// HTTP connector using `trust-dns` as a DNS backend.
-#[cfg(feature = "trust-dns")]
-type HttpConnector = hyper_trust_dns::TrustDnsHttpConnector;
+/// HTTP connector using `hickory` as a DNS backend.
+#[cfg(feature = "hickory")]
+type HttpConnector = hyper_hickory::TokioHickoryHttpConnector;
 /// HTTP connector.
-#[cfg(not(feature = "trust-dns"))]
+#[cfg(not(feature = "hickory"))]
 type HttpConnector = hyper::client::HttpConnector;
 
 /// Re-exported generic connector for use in the client.
@@ -34,10 +34,10 @@ pub type Connector = HttpConnector;
 
 /// Create a connector with the specified features.
 pub fn create() -> Connector {
-    #[cfg(not(feature = "trust-dns"))]
+    #[cfg(not(feature = "hickory"))]
     let mut connector = hyper::client::HttpConnector::new();
-    #[cfg(feature = "trust-dns")]
-    let mut connector = hyper_trust_dns::TrustDnsResolver::default().into_http_connector();
+    #[cfg(feature = "hickory")]
+    let mut connector = hyper_hickory::TokioHickoryResolver::default().into_http_connector();
 
     connector.enforce_http(false);
 


### PR DESCRIPTION
The `trust-dns` crate was renamed to `hickory`, so the hyper glue dependency and feature names had to be adjusted accordingly. The remaining changes are to account for `hickory`'s ability to work with any async runtime provider.