### PR TITLE
feat(mention): add mention for commands

### DIFF
--- a/twilight-mention/src/fmt.rs
+++ b/twilight-mention/src/fmt.rs
@@ -248,23 +248,22 @@ impl Mention<Id<UserMarker>> for User {
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CommandMention {
-    // Field order is the same as the mention format.
     Command {
-        name: String,
         id: Id<CommandMarker>,
+        name: String,
     },
 
     SubCommand {
+        id: Id<CommandMarker>,
         name: String,
         sub_command: String,
-        id: Id<CommandMarker>,
     },
 
     SubCommandGroup {
-        name: String,
-        sub_command_group: String,
-        sub_command: String,
         id: Id<CommandMarker>,
+        name: String,
+        sub_command: String,
+        sub_command_group: String,
     },
 }
 

--- a/twilight-mention/src/fmt.rs
+++ b/twilight-mention/src/fmt.rs
@@ -166,51 +166,6 @@ impl Mention<Id<ChannelMarker>> for Id<ChannelMarker> {
     }
 }
 
-/// Mention a command. This will format as `</NAME:COMMAND_ID>`.
-impl<N> Mention<CommandMention> for (N, Id<CommandMarker>)
-where
-    N: ToString,
-{
-    fn mention(&self) -> MentionFormat<CommandMention> {
-        MentionFormat(CommandMention::Command {
-            name: self.0.to_string(),
-            id: self.1,
-        })
-    }
-}
-
-/// Mention a subcommand. This will format as `</NAME SUBCOMMAND:ID>`.
-impl<N, S> Mention<CommandMention> for (N, S, Id<CommandMarker>)
-where
-    N: ToString,
-    S: ToString,
-{
-    fn mention(&self) -> MentionFormat<CommandMention> {
-        MentionFormat(CommandMention::SubCommand {
-            name: self.0.to_string(),
-            sub_command: self.1.to_string(),
-            id: self.2,
-        })
-    }
-}
-
-/// Mention a subcommand group. This will format as `</NAME SUBCOMMAND_GROUP SUBCOMMAND:ID>`.
-impl<N, G, S> Mention<CommandMention> for (N, G, S, Id<CommandMarker>)
-where
-    N: ToString,
-    G: ToString,
-    S: ToString,
-{
-    fn mention(&self) -> MentionFormat<CommandMention> {
-        MentionFormat(CommandMention::SubCommandGroup {
-            name: self.0.to_string(),
-            sub_command_group: self.1.to_string(),
-            sub_command: self.2.to_string(),
-            id: self.3,
-        })
-    }
-}
-
 /// Mention a channel. This will format as `<#ID>`.
 impl Mention<Id<ChannelMarker>> for Channel {
     fn mention(&self) -> MentionFormat<Id<ChannelMarker>> {

--- a/twilight-mention/src/fmt.rs
+++ b/twilight-mention/src/fmt.rs
@@ -173,6 +173,41 @@ impl Mention<Id<ChannelMarker>> for Channel {
     }
 }
 
+/// Mention a command.
+///
+/// This will format as:
+/// - `</NAME:COMMAND_ID>` for commands
+/// - `</NAME SUBCOMMAND:ID>` for subcommands
+/// - `</NAME SUBCOMMAND_GROUP SUBCOMMAND:ID>` for subcommand groups
+///
+/// # Cloning
+///
+/// This implementation uses [`clone`](Clone::clone) to construct a [`MentionFormat`] that owns the
+/// inner `CommandMention` as [`mention`](Mention::mention) takes a `&self`.
+/// The other implementations do this for types that are [`Copy`] and therefore do not need to use
+/// [`clone`](Clone::clone).
+///
+/// To avoid cloning use [`CommandMention::into_mention`].
+impl Mention<CommandMention> for CommandMention {
+    fn mention(&self) -> MentionFormat<CommandMention> {
+        MentionFormat(self.clone())
+    }
+}
+
+impl CommandMention {
+    /// Mention a command.
+    ///
+    /// This will format as:
+    /// - `</NAME:COMMAND_ID>` for commands
+    /// - `</NAME SUBCOMMAND:ID>` for subcommands
+    /// - `</NAME SUBCOMMAND_GROUP SUBCOMMAND:ID>` for subcommand groups
+    ///
+    /// This is a self-consuming alternative to [`CommandMention::mention`] and avoids cloning.
+    pub const fn into_mention(self) -> MentionFormat<CommandMention> {
+        MentionFormat(self)
+    }
+}
+
 /// Mention the current user. This will format as `<@ID>`.
 impl Mention<Id<UserMarker>> for CurrentUser {
     fn mention(&self) -> MentionFormat<Id<UserMarker>> {

--- a/twilight-mention/src/fmt.rs
+++ b/twilight-mention/src/fmt.rs
@@ -327,7 +327,8 @@ mod tests {
             MentionFormat(CommandMention::Command {
                 id: Id::<CommandMarker>::new(123),
                 name: "name".to_string()
-            }).to_string()
+            })
+            .to_string()
         );
     }
 
@@ -339,7 +340,8 @@ mod tests {
                 id: Id::<CommandMarker>::new(123),
                 name: "name".to_string(),
                 sub_command: "subcommand".to_string()
-            }).to_string()
+            })
+            .to_string()
         );
     }
 
@@ -352,7 +354,8 @@ mod tests {
                 name: "name".to_string(),
                 sub_command: "subcommand".to_string(),
                 sub_command_group: "subcommand_group".to_string()
-            }).to_string()
+            })
+            .to_string()
         );
     }
 

--- a/twilight-mention/src/fmt.rs
+++ b/twilight-mention/src/fmt.rs
@@ -324,9 +324,10 @@ mod tests {
     fn mention_format_command() {
         assert_eq!(
             "</name:123>",
-            ("name", Id::<CommandMarker>::new(123))
-                .mention()
-                .to_string()
+            MentionFormat(CommandMention::Command {
+                id: Id::<CommandMarker>::new(123),
+                name: "name".to_string()
+            }).to_string()
         );
     }
 
@@ -334,9 +335,11 @@ mod tests {
     fn mention_format_sub_command() {
         assert_eq!(
             "</name subcommand:123>",
-            ("name", "subcommand", Id::<CommandMarker>::new(123))
-                .mention()
-                .to_string()
+            MentionFormat(CommandMention::SubCommand {
+                id: Id::<CommandMarker>::new(123),
+                name: "name".to_string(),
+                sub_command: "subcommand".to_string()
+            }).to_string()
         );
     }
 
@@ -344,14 +347,12 @@ mod tests {
     fn mention_format_sub_command_group() {
         assert_eq!(
             "</name subcommand_group subcommand:123>",
-            (
-                "name",
-                "subcommand_group",
-                "subcommand",
-                Id::<CommandMarker>::new(123)
-            )
-                .mention()
-                .to_string()
+            MentionFormat(CommandMention::SubCommandGroup {
+                id: Id::<CommandMarker>::new(123),
+                name: "name".to_string(),
+                sub_command: "subcommand".to_string(),
+                sub_command_group: "subcommand_group".to_string()
+            }).to_string()
         );
     }
 

--- a/twilight-mention/src/parse/impl.rs
+++ b/twilight-mention/src/parse/impl.rs
@@ -355,19 +355,19 @@ fn match_command_mention_from_segments<'s>(
             })
         }
         (Some(name), None, None, None) => Ok(CommandMention::Command {
-            name: name.to_string(),
+            name: name.to_owned(),
             id,
         }),
         (Some(name), Some(sub_command), None, None) => Ok(CommandMention::SubCommand {
-            name: name.to_string(),
-            sub_command: sub_command.to_string(),
+            name: name.to_owned(),
+            sub_command: sub_command.to_owned(),
             id,
         }),
         (Some(name), Some(sub_command_group), Some(sub_command), None) => {
             Ok(CommandMention::SubCommandGroup {
-                name: name.to_string(),
-                sub_command: sub_command.to_string(),
-                sub_command_group: sub_command_group.to_string(),
+                name: name.to_owned(),
+                sub_command: sub_command.to_owned(),
+                sub_command_group: sub_command_group.to_owned(),
                 id,
             })
         }
@@ -583,7 +583,7 @@ mod tests {
 
         assert_eq!(
             CommandMention::Command {
-                name: "command".to_string(),
+                name: "command".to_owned(),
                 id: Id::new(123)
             },
             CommandMention::parse("</command:123>").unwrap()
@@ -591,8 +591,8 @@ mod tests {
 
         assert_eq!(
             CommandMention::SubCommand {
-                name: "command".to_string(),
-                sub_command: "subcommand".to_string(),
+                name: "command".to_owned(),
+                sub_command: "subcommand".to_owned(),
                 id: Id::new(123)
             },
             CommandMention::parse("</command subcommand:123>").unwrap()
@@ -601,8 +601,8 @@ mod tests {
         // this is more relaxed than the discord client
         assert_eq!(
             CommandMention::SubCommand {
-                name: "command".to_string(),
-                sub_command: "subcommand".to_string(),
+                name: "command".to_owned(),
+                sub_command: "subcommand".to_owned(),
                 id: Id::new(123)
             },
             CommandMention::parse("</command  subcommand:123>").unwrap()
@@ -610,9 +610,9 @@ mod tests {
 
         assert_eq!(
             CommandMention::SubCommandGroup {
-                name: "command".to_string(),
-                sub_command: "subcommand".to_string(),
-                sub_command_group: "subcommand_group".to_string(),
+                name: "command".to_owned(),
+                sub_command: "subcommand".to_owned(),
+                sub_command_group: "subcommand_group".to_owned(),
                 id: Id::new(123)
             },
             CommandMention::parse("</command subcommand_group subcommand:123>").unwrap()


### PR DESCRIPTION
I realized that the `mention` crate is missing `Display` implementations for commands. Commands are formatted like this:
- `</NAME:COMMAND_ID>` for commands
- `</NAME SUBCOMMAND:ID>` for subcommands
- `</NAME SUBCOMMAND_GROUP SUBCOMMAND:ID>` for subcommand groups

This is documented [here](https://discord.com/developers/docs/reference#message-formatting) and in the [changelog](https://discord.com/developers/docs/change-log#slash-command-mentions).

For the `Mention` implementation I checked what could be useful implementations. The tuples here are for convenience but maybe obsolete.

I considered implementing `Mention` for `model::application::command::Command` and `model::application::application_command::CommandData` but both them may contain mutiple subcommands or subcommand groups, therefore they are not feasible to implement.

Also the implementation needs not only the command id but also name (and maybe also subcommand and subcommand group). That's why I added the new enum. Three structs could also solve this but this was my personal preference.