### PR TITLE
ci: Run minimal crate versions with MSRV

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install cargo-minimal-versions
         uses: taiki-e/install-action@cargo-minimal-versions
 
-      - run: cargo minimal-versions check --all-features --all-targets
+      - run: cargo minimal-versions check --all-features
 
   # Check documentation
   build-docs:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   # Run MSRV first to save Actions time if the code doesn't compile at all.
   MSRV:
-    name: Minimum supported Rust version
+    name: Minimal crate versions with MSRV
     runs-on: ubuntu-latest
 
     steps:
@@ -27,6 +27,9 @@ jobs:
 
       - name: Retrieve rust-version
         run: echo rust-version=$(awk '/rust-version/{print $NF}' Cargo.toml | tr -d '"') >> $GITHUB_ENV
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Install toolchain (${{ env.rust-version }})
         uses: dtolnay/rust-toolchain@master
@@ -42,7 +45,13 @@ jobs:
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"
 
-      - run: cargo check --all-features --all-targets
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Install cargo-minimal-versions
+        uses: taiki-e/install-action@cargo-minimal-versions
+
+      - run: cargo minimal-versions check --all-features --all-targets
 
   # Check documentation
   build-docs:
@@ -120,36 +129,6 @@ jobs:
 
       - name: Check code formatting
         run: cargo fmt --all -- --check --unstable-features --config format_code_in_doc_comments=true
-
-  min-vers:
-    name: Minimal crate versions
-    needs: [MSRV]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Add problem matchers
-        run: echo "::add-matcher::.github/rust.json"
-
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-
-      - name: Install cargo-minimal-versions
-        uses: taiki-e/install-action@cargo-minimal-versions
-
-      - name: Check minimal versions
-        run: cargo minimal-versions check
 
   # Tests
   test:

--- a/twilight-cache-inmemory/src/permission.rs
+++ b/twilight-cache-inmemory/src/permission.rs
@@ -544,7 +544,7 @@ impl<'a> InMemoryCachePermissions<'a> {
             return permissions;
         }
 
-        permissions.intersection(MEMBER_COMMUNICATION_DISABLED_ALLOWLIST)
+        permissions & MEMBER_COMMUNICATION_DISABLED_ALLOWLIST
     }
 
     /// Determine whether a given user is the owner of a guild.


### PR DESCRIPTION
Our dependencies might make breaking MSRV changes in newer versions, while the older ones still fulfil our MSRV guarantees and are within our version ranges. Therefore we should run minimal crate version checks on the MSRV.

Draft because I'm probably gonna have to fix the pipeline.