### PR TITLE
refactor(http): remove unnecessary conversion 

### DIFF
--- a/twilight-http/src/response/mod.rs
+++ b/twilight-http/src/response/mod.rs
@@ -503,7 +503,7 @@ impl<T: DeserializeOwned + Unpin> Future for ModelFuture<T> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match Pin::new(&mut self.future).poll(cx) {
             Poll::Ready(Ok(bytes)) => Poll::Ready(
-                crate::json::from_bytes(&Bytes::from(bytes)).map_err(|source| {
+                crate::json::from_bytes(&bytes).map_err(|source| {
                     DeserializeBodyError {
                         kind: DeserializeBodyErrorType::Deserializing,
                         source: Some(Box::new(source)),

--- a/twilight-http/src/response/mod.rs
+++ b/twilight-http/src/response/mod.rs
@@ -502,14 +502,14 @@ impl<T: DeserializeOwned + Unpin> Future for ModelFuture<T> {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match Pin::new(&mut self.future).poll(cx) {
-            Poll::Ready(Ok(bytes)) => Poll::Ready(
-                crate::json::from_bytes(&bytes).map_err(|source| {
+            Poll::Ready(Ok(bytes)) => {
+                Poll::Ready(crate::json::from_bytes(&bytes).map_err(|source| {
                     DeserializeBodyError {
                         kind: DeserializeBodyErrorType::Deserializing,
                         source: Some(Box::new(source)),
                     }
-                }),
-            ),
+                }))
+            }
             Poll::Ready(Err(source)) => Poll::Ready(Err(source)),
             Poll::Pending => Poll::Pending,
         }


### PR DESCRIPTION
The conversion is no longer necessary since the decompression changes.

Ref:
- https://github.com/twilight-rs/twilight/pull/1104