### PR TITLE
fix(ci, http): fix docs deploy

### DIFF
--- a/twilight-http/src/json.rs
+++ b/twilight-http/src/json.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "simd-json"))]
-pub use serde_json::{to_vec, Deserializer as JsonDeserializer, Error as JsonError};
+pub use serde_json::{to_vec, Error as JsonError};
 #[cfg(feature = "simd-json")]
-pub use simd_json::{to_vec, Deserializer as JsonDeserializer, Error as JsonError};
+pub use simd_json::{to_vec, Error as JsonError};
 
 use serde::de::DeserializeOwned;
 


### PR DESCRIPTION
This was not used anywhere so simply removing it should fix the docs build.