### PR TITLE
refactor(http)!: avoid copying the reponse body on utf8 error

### DIFF
--- a/twilight-http/src/response/mod.rs
+++ b/twilight-http/src/response/mod.rs
@@ -558,9 +558,6 @@ impl Future for TextFuture {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match Pin::new(&mut self.0).poll(cx) {
             Poll::Ready(Ok(bytes)) => Poll::Ready(String::from_utf8(bytes).map_err(|source| {
-                // This is a very cold path. Converting a response body to a
-                // UTF-8 valid string should basically never fail anyway; it's
-                // worth it to have the context readily available for the user.
                 let utf8_error = source.utf8_error();
                 let bytes = source.into_bytes();
 

--- a/twilight-http/src/response/mod.rs
+++ b/twilight-http/src/response/mod.rs
@@ -561,11 +561,12 @@ impl Future for TextFuture {
                 // This is a very cold path. Converting a response body to a
                 // UTF-8 valid string should basically never fail anyway; it's
                 // worth it to have the context readily available for the user.
-                let copy = source.as_bytes().to_owned();
+                let utf8_error = source.utf8_error();
+                let bytes = source.into_bytes();
 
                 DeserializeBodyError {
-                    kind: DeserializeBodyErrorType::BodyNotUtf8 { bytes: copy },
-                    source: Some(Box::new(source)),
+                    kind: DeserializeBodyErrorType::BodyNotUtf8 { bytes },
+                    source: Some(Box::new(utf8_error)),
                 }
             })),
             Poll::Ready(Err(source)) => Poll::Ready(Err(source)),


### PR DESCRIPTION
The `TextFuture` now returns `std::str::Utf8Error` as source error if the body is not a valid UTF-8 string.

There is no need to provide the bytes with the error kind variant and as part of the source error.