### PR TITLE
chore(gateway): update tokio-tungstenite to v0.20

### DIFF
--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -20,7 +20,7 @@ rand = { default-features = false, features = ["std", "std_rng"], version = "0.8
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.19" }
-tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.18" }
+tokio-tungstenite = { default-features = false, features = ["connect"], version = "0.20.1" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-gateway-queue = { default-features = false, path = "../twilight-gateway-queue", version = "0.15.4" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.4" }
@@ -38,7 +38,7 @@ simd-json = { default-features = false, features = ["serde_impl", "swar-number-p
 # They are needed to track what is used in tokio-tungstenite
 native-tls = { default-features = false, optional = true, version = "0.2.8" }
 rustls-native-certs = { default-features = false, optional = true, version = "0.6" }
-rustls-tls = { default-features = false, optional = true, package = "rustls", version = "0.20" }
+rustls-tls = { default-features = false, optional = true, package = "rustls", version = "0.21" }
 webpki-roots = { default-features = false, optional = true, version = "0.22" }
 
 [dev-dependencies]

--- a/twilight-gateway/src/connection.rs
+++ b/twilight-gateway/src/connection.rs
@@ -26,11 +26,14 @@ const GATEWAY_URL: &str = "wss://gateway.discord.gg";
 /// defaults.
 ///
 /// [`GuildCreate`]: twilight_model::gateway::payload::incoming::GuildCreate
+#[allow(deprecated)]
 const WEBSOCKET_CONFIG: WebSocketConfig = WebSocketConfig {
     accept_unmasked_frames: false,
     max_frame_size: None,
     max_message_size: None,
     max_send_queue: None,
+    write_buffer_size: 128 * 1024,
+    max_write_buffer_size: usize::MAX,
 };
 
 /// [`tokio_tungstenite`] library Websocket connection.

--- a/twilight-gateway/src/tls.rs
+++ b/twilight-gateway/src/tls.rs
@@ -34,7 +34,7 @@ mod r#impl {
         config: WebSocketConfig,
         _tls: &TlsContainer,
     ) -> Result<Connection, ReceiveMessageError> {
-        let (stream, _) = tokio_tungstenite::connect_async_with_config(url, Some(config))
+        let (stream, _) = tokio_tungstenite::connect_async_with_config(url, Some(config), false)
             .await
             .map_err(|source| ReceiveMessageError {
                 kind: ReceiveMessageErrorType::Reconnect,
@@ -89,13 +89,17 @@ mod r#impl {
         config: WebSocketConfig,
         tls: &TlsContainer,
     ) -> Result<Connection, ReceiveMessageError> {
-        let (stream, _) =
-            tokio_tungstenite::connect_async_tls_with_config(url, Some(config), tls.connector())
-                .await
-                .map_err(|source| ReceiveMessageError {
-                    kind: ReceiveMessageErrorType::Reconnect,
-                    source: Some(Box::new(source)),
-                })?;
+        let (stream, _) = tokio_tungstenite::connect_async_tls_with_config(
+            url,
+            Some(config),
+            false,
+            tls.connector(),
+        )
+        .await
+        .map_err(|source| ReceiveMessageError {
+            kind: ReceiveMessageErrorType::Reconnect,
+            source: Some(Box::new(source)),
+        })?;
 
         Ok(stream)
     }
@@ -154,7 +158,7 @@ mod r#impl {
 
         #[cfg(feature = "rustls-webpki-roots")]
         {
-            roots.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+            roots.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
                 rustls_tls::OwnedTrustAnchor::from_subject_spki_name_constraints(
                     ta.subject,
                     ta.spki,
@@ -179,13 +183,17 @@ mod r#impl {
         config: WebSocketConfig,
         tls: &TlsContainer,
     ) -> Result<Connection, ReceiveMessageError> {
-        let (stream, _) =
-            tokio_tungstenite::connect_async_tls_with_config(url, Some(config), tls.connector())
-                .await
-                .map_err(|source| ReceiveMessageError {
-                    kind: ReceiveMessageErrorType::Reconnect,
-                    source: Some(Box::new(source)),
-                })?;
+        let (stream, _) = tokio_tungstenite::connect_async_tls_with_config(
+            url,
+            Some(config),
+            false,
+            tls.connector(),
+        )
+        .await
+        .map_err(|source| ReceiveMessageError {
+            kind: ReceiveMessageErrorType::Reconnect,
+            source: Some(Box::new(source)),
+        })?;
 
         Ok(stream)
     }


### PR DESCRIPTION
There has recently been a CVE for tungstenite which can be fixed by updating from v0.18 to the latest v0.20.1.
