### PR TITLE
feat(http): switch from trust-dns to hickory-dns

### DIFF
--- a/twilight-http/Cargo.toml
+++ b/twilight-http/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.15.4"
 hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
 hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.23" }
 hyper-tls = { default-features = false, optional = true, version = "0.5" }
-hyper-trust-dns = { default-features = false, optional = true, version = "0.5" }
+hyper-hickory = { default-features = false, optional = true, features = ["tokio"], version = "0.6" }
 percent-encoding = { default-features = false, version = "2" }
 rand = { default-features = false, features = ["std_rng", "std"], version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1" }
@@ -38,7 +38,7 @@ decompression = ["dep:brotli"]
 native = ["dep:hyper-tls"]
 rustls-native-roots = ["dep:hyper-rustls", "hyper-rustls?/native-tokio"]
 rustls-webpki-roots = ["dep:hyper-rustls", "hyper-rustls?/webpki-tokio"]
-trust-dns = ["dep:hyper-trust-dns"]
+hickory-dns = ["dep:hyper-hickory"]
 
 [dev-dependencies]
 serde_test = { default-features = false, version = "1" }

--- a/twilight-http/src/client/connector.rs
+++ b/twilight-http/src/client/connector.rs
@@ -10,11 +10,11 @@ type HttpsConnector<T> = hyper_rustls::HttpsConnector<T>;
 ))]
 type HttpsConnector<T> = hyper_tls::HttpsConnector<T>;
 
-/// HTTP connector using `trust-dns` as a DNS backend.
-#[cfg(feature = "trust-dns")]
-type HttpConnector = hyper_trust_dns::TrustDnsHttpConnector;
+/// HTTP connector using `hickory-dns` as a DNS backend.
+#[cfg(feature = "hickory-dns")]
+type HttpConnector = hyper_hickory::TokioHickoryHttpConnector;
 /// HTTP connector.
-#[cfg(not(feature = "trust-dns"))]
+#[cfg(not(feature = "hickory-dns"))]
 type HttpConnector = hyper::client::HttpConnector;
 
 /// Re-exported generic connector for use in the client.
@@ -34,10 +34,10 @@ pub type Connector = HttpConnector;
 
 /// Create a connector with the specified features.
 pub fn create() -> Connector {
-    #[cfg(not(feature = "trust-dns"))]
+    #[cfg(not(feature = "hickory-dns"))]
     let mut connector = hyper::client::HttpConnector::new();
-    #[cfg(feature = "trust-dns")]
-    let mut connector = hyper_trust_dns::TrustDnsResolver::default().into_http_connector();
+    #[cfg(feature = "hickory-dns")]
+    let mut connector = hyper_hickory::TokioHickoryResolver::default().into_http_connector();
 
     connector.enforce_http(false);
 


### PR DESCRIPTION
Essentially still the same crate, but it was rebranded as `hickory-dns`. Thus, further versions aren't released under trust-dns anymore.
