### PR TITLE
build(http, gateway, lavalink): Update to rustls 0.22, hyper 1.0, tokio-websockets 0.5

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,9 @@ anyhow = { default-features = false, features = ["std"], version = "1" }
 ed25519-dalek = "2"
 futures-util = { default-features = false, version = "0.3" }
 hex = "0.4"
-hyper = { features = ["client", "server", "http2", "runtime"], version = "0.14" }
+http-body-util = "0.1"
+hyper = { features = ["server"], version = "1" }
+hyper-util = { features = ["http1", "client-legacy"], version = "0.1" }
 log = { default-features = false, version = "0.4" }
 once_cell = "1.4"
 serde = { version = "1", features = ["derive"] }

--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -20,7 +20,7 @@ futures-util = { default-features = false, features = ["sink", "std"], version =
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.19" }
-tokio-websockets = { default-features = false, features = ["client", "fastrand", "sha1_smol", "simd"], version = "0.4" }
+tokio-websockets = { default-features = false, features = ["client", "fastrand", "sha1_smol", "simd"], version = "0.5" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-gateway-queue = { default-features = false, path = "../twilight-gateway-queue", version = "0.15.4" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.4" }
@@ -45,8 +45,8 @@ tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log
 [features]
 default = ["rustls-native-roots", "twilight-http", "zlib-stock"]
 native = ["tokio-websockets/native-tls", "tokio-websockets/openssl"]
-rustls-native-roots = ["tokio-websockets/rustls-native-roots"]
-rustls-webpki-roots = ["tokio-websockets/rustls-webpki-roots"]
+rustls-native-roots = ["tokio-websockets/ring", "tokio-websockets/rustls-native-roots"]
+rustls-webpki-roots = ["tokio-websockets/ring", "tokio-websockets/rustls-webpki-roots"]
 zlib-simd = ["dep:flate2", "flate2?/zlib-ng"]
 zlib-stock = ["dep:flate2", "flate2?/zlib"]
 

--- a/twilight-gateway/src/connection.rs
+++ b/twilight-gateway/src/connection.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use tokio::net::TcpStream;
-use tokio_websockets::{ClientBuilder, Connector, Limits, MaybeTlsStream, WebsocketStream};
+use tokio_websockets::{ClientBuilder, Connector, Limits, MaybeTlsStream, WebSocketStream};
 
 /// Query argument with zlib-stream enabled.
 #[cfg(any(feature = "zlib-stock", feature = "zlib-simd"))]
@@ -24,7 +24,7 @@ const GATEWAY_URL: &str = "wss://gateway.discord.gg";
 /// Connections are used by [`Shard`]s when reconnecting.
 ///
 /// [`Shard`]: crate::Shard
-pub type Connection = WebsocketStream<MaybeTlsStream<TcpStream>>;
+pub type Connection = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 /// Formatter for a gateway URL, with the API version and compression features
 /// specified.

--- a/twilight-http-ratelimiting/Cargo.toml
+++ b/twilight-http-ratelimiting/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { default-features = false, features = ["std", "attributes"], version 
 
 [dev-dependencies]
 criterion = { default-features = false, version = "0.4" }
-http = { version = "0.2", default-features = false }
+http = { version = "1", default-features = false }
 static_assertions = { default-features = false, version = "1.1.0" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
 

--- a/twilight-http/Cargo.toml
+++ b/twilight-http/Cargo.toml
@@ -15,10 +15,13 @@ version = "0.15.4"
 
 [dependencies]
 fastrand = { default-features = false, features = ["std"], version = "2" }
-hyper = { default-features = false, features = ["client", "http1", "http2", "runtime"], version = "0.14" }
-hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.24" }
-hyper-tls = { default-features = false, optional = true, version = "0.5" }
-hyper-hickory = { default-features = false, optional = true, features = ["tokio"], version = "0.6" }
+http = { default-features = false, version = "1" }
+http-body-util = { default-features = false, version = "0.1" }
+hyper = { default-features = false, version = "1" }
+hyper-util = { default-features = false, features = ["client-legacy", "http1", "http2", "tokio"], version = "0.1.2" }
+hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2", "ring"], version = "0.26" }
+hyper-tls = { default-features = false, optional = true, features = ["alpn"], version = "0.6" }
+hyper-hickory = { default-features = false, optional = true, version = "0.7" }
 percent-encoding = { default-features = false, version = "2" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }

--- a/twilight-http/src/client/builder.rs
+++ b/twilight-http/src/client/builder.rs
@@ -1,6 +1,7 @@
 use super::Token;
 use crate::{client::connector, Client};
-use hyper::header::HeaderMap;
+use http::header::HeaderMap;
+use hyper_util::rt::TokioExecutor;
 use std::{
     sync::{atomic::AtomicBool, Arc},
     time::Duration,
@@ -32,7 +33,8 @@ impl ClientBuilder {
     pub fn build(self) -> Client {
         let connector = connector::create();
 
-        let http = hyper::Client::builder().build(connector);
+        let http =
+            hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(connector);
 
         let token_invalidated = if self.remember_invalid_token {
             Some(Arc::new(AtomicBool::new(false)))

--- a/twilight-http/src/client/connector.rs
+++ b/twilight-http/src/client/connector.rs
@@ -15,7 +15,7 @@ type HttpsConnector<T> = hyper_tls::HttpsConnector<T>;
 type HttpConnector = hyper_hickory::TokioHickoryHttpConnector;
 /// HTTP connector.
 #[cfg(not(feature = "hickory"))]
-type HttpConnector = hyper::client::HttpConnector;
+type HttpConnector = hyper_util::client::legacy::connect::HttpConnector;
 
 /// Re-exported generic connector for use in the client.
 #[cfg(any(
@@ -35,7 +35,7 @@ pub type Connector = HttpConnector;
 /// Create a connector with the specified features.
 pub fn create() -> Connector {
     #[cfg(not(feature = "hickory"))]
-    let mut connector = hyper::client::HttpConnector::new();
+    let mut connector = HttpConnector::new();
     #[cfg(feature = "hickory")]
     let mut connector = hyper_hickory::TokioHickoryResolver::default().into_http_connector();
 
@@ -44,6 +44,7 @@ pub fn create() -> Connector {
     #[cfg(feature = "rustls-native-roots")]
     let connector = hyper_rustls::HttpsConnectorBuilder::new()
         .with_native_roots()
+        .expect("no native root certificates found")
         .https_or_http()
         .enable_http1()
         .enable_http2()

--- a/twilight-http/src/error.rs
+++ b/twilight-http/src/error.rs
@@ -1,5 +1,6 @@
 use crate::{api_error::ApiError, json::JsonError, response::StatusCode};
-use hyper::{Body, Response};
+use http::Response;
+use hyper::body::Incoming;
 use std::{
     error::Error as StdError,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -125,7 +126,7 @@ pub enum ErrorType {
     ///
     /// This may occur during Discord API stability incidents.
     ServiceUnavailable {
-        response: Response<Body>,
+        response: Response<Incoming>,
     },
     /// Token in use has become revoked or is otherwise invalid.
     ///

--- a/twilight-http/src/request/base.rs
+++ b/twilight-http/src/request/base.rs
@@ -3,7 +3,7 @@ use crate::{
     error::Error,
     routing::{Path, Route},
 };
-use hyper::header::{HeaderMap, HeaderName, HeaderValue};
+use http::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::Serialize;
 
 /// Builder to create a customized request.

--- a/twilight-http/src/request/guild/ban/create_ban.rs
+++ b/twilight-http/src/request/guild/ban/create_ban.rs
@@ -142,7 +142,7 @@ mod tests {
         client::Client,
         request::{AuditLogReason, TryIntoRequest, REASON_HEADER_NAME},
     };
-    use hyper::header::HeaderValue;
+    use http::header::HeaderValue;
     use std::error::Error;
     use twilight_http_ratelimiting::Method;
     use twilight_model::id::{

--- a/twilight-http/src/request/mod.rs
+++ b/twilight-http/src/request/mod.rs
@@ -75,7 +75,7 @@ pub use self::{
 pub use twilight_http_ratelimiting::request::Method;
 
 use crate::error::{Error, ErrorType};
-use hyper::header::{HeaderName, HeaderValue};
+use http::header::{HeaderName, HeaderValue};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use serde::Serialize;
 use std::iter;

--- a/twilight-http/src/response/future.rs
+++ b/twilight-http/src/response/future.rs
@@ -3,7 +3,8 @@ use crate::{
     api_error::ApiError,
     error::{Error, ErrorType},
 };
-use hyper::{client::ResponseFuture as HyperResponseFuture, StatusCode as HyperStatusCode};
+use http::StatusCode as HyperStatusCode;
+use hyper_util::client::legacy::ResponseFuture as HyperResponseFuture;
 use std::{
     future::Future,
     marker::PhantomData,
@@ -130,7 +131,7 @@ impl InFlight {
             let mut resp = resp;
             // Inaccurate since end-users can only access the decompressed body.
             #[cfg(feature = "decompression")]
-            resp.headers_mut().remove(hyper::header::CONTENT_LENGTH);
+            resp.headers_mut().remove(http::header::CONTENT_LENGTH);
 
             return InnerPoll::Ready(Ok(Response::new(resp)));
         }

--- a/twilight-lavalink/Cargo.toml
+++ b/twilight-lavalink/Cargo.toml
@@ -16,11 +16,11 @@ version = "0.15.3"
 [dependencies]
 dashmap = { default-features = false, version = "5.3" }
 futures-util = { default-features = false, features = ["bilock", "sink", "std", "unstable"], version = "0.3" }
-http = { default-features = false, version = "0.2" }
+http = { default-features = false, version = "1" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["macros", "net", "rt", "sync", "time"], version = "1.0" }
-tokio-websockets = { default-features = false, features = ["client", "fastrand", "sha1_smol", "simd"], version = "0.4" }
+tokio-websockets = { default-features = false, features = ["client", "fastrand", "sha1_smol", "simd"], version = "0.5" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.15.4" }
 
@@ -40,8 +40,8 @@ twilight-http = { default-features = false, features = ["rustls-native-roots"], 
 default = ["http-support", "rustls-native-roots"]
 http-support = ["dep:percent-encoding"]
 native = ["tokio-websockets/native-tls", "tokio-websockets/openssl"]
-rustls-native-roots = ["tokio-websockets/rustls-native-roots"]
-rustls-webpki-roots = ["tokio-websockets/rustls-webpki-roots"]
+rustls-native-roots = ["tokio-websockets/ring", "tokio-websockets/rustls-native-roots"]
+rustls-webpki-roots = ["tokio-websockets/ring", "tokio-websockets/rustls-webpki-roots"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/twilight-lavalink/src/node.rs
+++ b/twilight-lavalink/src/node.rs
@@ -41,7 +41,7 @@ use tokio::{
     time as tokio_time,
 };
 use tokio_websockets::{
-    upgrade, ClientBuilder, Error as WebsocketError, MaybeTlsStream, Message, WebsocketStream,
+    upgrade, ClientBuilder, Error as WebsocketError, MaybeTlsStream, Message, WebSocketStream,
 };
 use twilight_model::id::{marker::UserMarker, Id};
 
@@ -464,7 +464,7 @@ impl Node {
 
 struct Connection {
     config: NodeConfig,
-    stream: WebsocketStream<MaybeTlsStream<TcpStream>>,
+    stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
     node_from: UnboundedReceiver<OutgoingEvent>,
     node_to: UnboundedSender<IncomingEvent>,
     players: PlayerManager,
@@ -635,7 +635,7 @@ fn connect_request(state: &NodeConfig) -> Result<ClientBuilder, NodeError> {
 
 async fn reconnect(
     config: &NodeConfig,
-) -> Result<WebsocketStream<MaybeTlsStream<TcpStream>>, NodeError> {
+) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, NodeError> {
     let (mut stream, res) = backoff(config).await?;
 
     let headers = res.headers();
@@ -668,7 +668,7 @@ async fn backoff(
     config: &NodeConfig,
 ) -> Result<
     (
-        WebsocketStream<MaybeTlsStream<TcpStream>>,
+        WebSocketStream<MaybeTlsStream<TcpStream>>,
         upgrade::Response,
     ),
     NodeError,


### PR DESCRIPTION
This updates the following crates to their latest versions, which are compatible with rustls 0.22, http 1.x and hyper 1.x:
* http
* hyper
* hyper-hickory
* hyper-rustls
* hyper-tls
* tokio-websockets

It also changes the HTTP client to make use of `hyper-util`'s legacy client implementation.