### PR TITLE
build(gateway, http, lavalink)!: Rename native feature to native-tls

### DIFF
--- a/book/src/chapter_1_crates/section_2_http.md
+++ b/book/src/chapter_1_crates/section_2_http.md
@@ -1,9 +1,9 @@
 # HTTP
 
 `twilight-http` is an HTTP client wrapping all of the documented Discord HTTP API.
-It is built on top of [Reqwest], and supports taking any generic Reqwest client,
-allowing you to pick your own TLS backend. By default, it uses [RusTLS] a Rust TLS implementation,
-but it can be changed to use NativeTLS which uses the TLS native to the platform, and on Unix uses OpenSSL.
+It is built on top of [hyper], and allows you to pick your own TLS backend.
+By default, it uses [RusTLS] a Rust TLS implementation, but it can be changed to
+use NativeTLS, which uses the TLS native to the platform, and on Unix uses OpenSSL.
 
 Ratelimiting is included out-of-the-box, along with support for proxies.
 
@@ -34,9 +34,9 @@ rustflags = ["-C", "target-cpu=native"]
 
 These features are mutually exclusive. `rustls` is enabled by default.
 
-#### Native
+#### Native-TLS
 
-The `native` feature causes the client to use [`hyper-tls`]. This will use the
+The `native-tls` feature causes the client to use [`hyper-tls`]. This will use the
 native TLS backend, such as OpenSSL on Linux.
 
 #### RusTLS
@@ -76,7 +76,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
 *crates.io*: <https://crates.io/crates/twilight-http>
 
-[Reqwest]: https://github.com/seanmonstar/reqwest
+[hyper]: https://github.com/hyperium/hyper
 [RusTLS]: https://github.com/ctz/rustls
 [`hyper-rustls`]: https://crates.io/crates/hyper-rustls
 [`hyper-tls`]: https://crates.io/crates/hyper-tls

--- a/book/src/chapter_1_crates/section_3_gateway.md
+++ b/book/src/chapter_1_crates/section_3_gateway.md
@@ -34,13 +34,13 @@ rustflags = ["-C", "target-cpu=native"]
 
 ### TLS
 
-`twilight-gateway` has features to enable [`tokio-tungstenite`]'s TLS features.
+`twilight-gateway` has features to enable [`tokio-websockets`]' TLS features.
 These features are mutually exclusive. `rustls-native-roots` is enabled by
 default.
 
-#### Native
+#### Native-TLS
 
-The `native` feature enables [`tokio-tungstenite`]'s `native-tls` feature.
+The `native-tls` feature enables [`tokio-websockets`]' `native-tls` feature.
 
 #### RusTLS
 
@@ -48,15 +48,15 @@ RusTLS allows specifying from where certificate roots are retrieved from.
 
 ##### Native roots
 
-The `rustls-native-roots` feature enables [`tokio-tungstenite`]'s
-`rustls-tls-native-roots` feature.
+The `rustls-native-roots` feature enables [`tokio-websockets`]'
+`rustls-native-roots` feature.
 
 This is enabled by default.
 
 ##### Web PKI roots
 
-The `rustls-webpki-roots` feature enables [`tokio-tungstenite`]'s
-`rustls-tls-webpki-roots` feature.
+The `rustls-webpki-roots` feature enables [`tokio-websockets`]'
+`rustls-webpki-roots` feature.
 
 ### Zlib
 
@@ -130,4 +130,4 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 [`hyper-tls`]: https://crates.io/crates/hyper-tls
 [`serde_json`]: https://crates.io/crates/serde_json
 [`simd-json`]: https://crates.io/crates/simd-json
-[`tokio-tungstenite`]: https://crates.io/crates/tokio-tungstenite
+[`tokio-websockets`]: https://crates.io/crates/tokio-websockets

--- a/book/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
+++ b/book/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
@@ -19,13 +19,13 @@ This is enabled by default.
 
 ### TLS
 
-`twilight-lavalink` has features to enable [`tokio-tungstenite`]'s TLS features.
+`twilight-lavalink` has features to enable [`tokio-websockets`]' TLS features.
 These features are mutually exclusive. `rustls-native-roots` is enabled by
 default.
 
-#### Native
+#### Native-TLS
 
-The `native` feature enables [`tokio-tungstenite`]'s `native-tls` feature.
+The `native-tls` feature enables [`tokio-websockets`]' `native-tls` feature.
 
 #### RusTLS
 
@@ -33,15 +33,15 @@ RusTLS allows specifying from where certificate roots are retrieved from.
 
 ##### Native roots
 
-The `rustls-native-roots` feature enables [`tokio-tungstenite`]'s
-`rustls-tls-native-roots` feature.
+The `rustls-native-roots` feature enables [`tokio-websockets`]'
+`rustls-native-roots` feature.
 
 This is enabled by default.
 
 ##### Web PKI roots
 
-The `rustls-webpki-roots` feature enables [`tokio-tungstenite`]'s
-`rustls-tls-webpki-roots` feature.
+The `rustls-webpki-roots` feature enables [`tokio-websockets`]'
+`rustls-webpki-roots` feature.
 
 ## Examples
 
@@ -110,4 +110,4 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 [model]: ../section_1_model.html
 [node]: https://twilight-rs.github.io/twilight/twilight_lavalink/node/struct.Node.html
 [process]: https://twilight-rs.github.io/twilight/twilight_lavalink/client/struct.Lavalink.html#method.process
-[`tokio-tungstenite`]: https://crates.io/crates/tokio-tungstenite
+[`tokio-websockets`]: https://crates.io/crates/tokio-websockets

--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -44,7 +44,7 @@ tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log
 
 [features]
 default = ["rustls-native-roots", "twilight-http", "zlib-stock"]
-native = ["tokio-websockets/native-tls", "tokio-websockets/openssl"]
+native-tls = ["tokio-websockets/native-tls", "tokio-websockets/openssl"]
 rustls-native-roots = ["tokio-websockets/ring", "tokio-websockets/rustls-native-roots"]
 rustls-webpki-roots = ["tokio-websockets/ring", "tokio-websockets/rustls-webpki-roots"]
 zlib-simd = ["dep:flate2", "flate2?/zlib-ng"]

--- a/twilight-gateway/README.md
+++ b/twilight-gateway/README.md
@@ -18,7 +18,7 @@ Using the `stream` module, shards can be easily managed in groups.
 * `simd-json`: use [`simd-json`] instead of [`serde_json`] for deserializing
   events
 * TLS (mutually exclusive)
-  * `native`: platform's native TLS implementation via [`native-tls`]
+  * `native-tls`: platform's native TLS implementation via [`native-tls`]
   * `rustls-native-roots` (*default*): [`rustls`] using native root certificates
   * `rustls-webpki-roots`: [`rustls`] using [`webpki-roots`] for root
     certificates, useful for `scratch` containers

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -73,7 +73,7 @@ use crate::{
 use futures_util::{stream::Stream, SinkExt};
 use serde::{de::DeserializeOwned, Deserialize};
 #[cfg(any(
-    feature = "native",
+    feature = "native-tls",
     feature = "rustls-native-roots",
     feature = "rustls-webpki-roots"
 ))]
@@ -968,7 +968,7 @@ impl<Q: Queue> Shard<Q> {
                 // connection is considered unusable after encountering an io
                 // error, returning `None`.
                 #[cfg(any(
-                    feature = "native",
+                    feature = "native-tls",
                     feature = "rustls-native-roots",
                     feature = "rustls-webpki-roots"
                 ))]

--- a/twilight-http/Cargo.toml
+++ b/twilight-http/Cargo.toml
@@ -38,7 +38,7 @@ simd-json = { default-features = false, features = ["serde_impl", "swar-number-p
 [features]
 default = ["decompression", "rustls-native-roots"]
 decompression = ["dep:brotli"]
-native = ["dep:hyper-tls"]
+native-tls = ["dep:hyper-tls"]
 rustls-native-roots = ["dep:hyper-rustls", "hyper-rustls?/native-tokio"]
 rustls-webpki-roots = ["dep:hyper-rustls", "hyper-rustls?/webpki-tokio"]
 hickory = ["dep:hyper-hickory"]

--- a/twilight-http/README.md
+++ b/twilight-http/README.md
@@ -55,11 +55,11 @@ Discord's API is HTTPS only.
 `twilight-http` has features to enable HTTPS connectivity with [`hyper`]. These
 features are mutually exclusive. `rustls-native-roots` is enabled by default.
 
-#### `native`
+#### `native-tls`
 
-The `native` feature uses a HTTPS connector provided by [`hyper-tls`].
+The `native-tls` feature uses a HTTPS connector provided by [`hyper-tls`].
 
-To enable `native`, do something like this in your `Cargo.toml`:
+To enable `native-tls`, do something like this in your `Cargo.toml`:
 
 ```toml
 [dependencies]

--- a/twilight-http/src/client/connector.rs
+++ b/twilight-http/src/client/connector.rs
@@ -5,7 +5,7 @@
 type HttpsConnector<T> = hyper_rustls::HttpsConnector<T>;
 /// HTTPS connector using `hyper-tls` as a TLS backend.
 #[cfg(all(
-    feature = "native",
+    feature = "native-tls",
     not(any(feature = "rustls-native-roots", feature = "rustls-webpki-roots"))
 ))]
 type HttpsConnector<T> = hyper_tls::HttpsConnector<T>;
@@ -19,14 +19,14 @@ type HttpConnector = hyper_util::client::legacy::connect::HttpConnector;
 
 /// Re-exported generic connector for use in the client.
 #[cfg(any(
-    feature = "native",
+    feature = "native-tls",
     feature = "rustls-native-roots",
     feature = "rustls-webpki-roots"
 ))]
 pub type Connector = HttpsConnector<HttpConnector>;
 /// Re-exported generic connector for use in the client.
 #[cfg(not(any(
-    feature = "native",
+    feature = "native-tls",
     feature = "rustls-native-roots",
     feature = "rustls-webpki-roots"
 )))]
@@ -57,7 +57,7 @@ pub fn create() -> Connector {
         .enable_http2()
         .wrap_connector(connector);
     #[cfg(all(
-        feature = "native",
+        feature = "native-tls",
         not(feature = "rustls-native-roots"),
         not(feature = "rustls-webpki-roots")
     ))]

--- a/twilight-lavalink/Cargo.toml
+++ b/twilight-lavalink/Cargo.toml
@@ -39,7 +39,7 @@ twilight-http = { default-features = false, features = ["rustls-native-roots"], 
 [features]
 default = ["http-support", "rustls-native-roots"]
 http-support = ["dep:percent-encoding"]
-native = ["tokio-websockets/native-tls", "tokio-websockets/openssl"]
+native-tls = ["tokio-websockets/native-tls", "tokio-websockets/openssl"]
 rustls-native-roots = ["tokio-websockets/ring", "tokio-websockets/rustls-native-roots"]
 rustls-webpki-roots = ["tokio-websockets/ring", "tokio-websockets/rustls-webpki-roots"]
 

--- a/twilight-lavalink/README.md
+++ b/twilight-lavalink/README.md
@@ -26,15 +26,15 @@ request types from the [`http`] crate. This is enabled by default.
 features. These features are mutually exclusive. `rustls-native-roots` is enabled by
 default.
 
-#### `native`
+#### `native-tls`
 
-The `native` feature enables [`tokio-websockets`]' `native-tls` feature.
+The `native-tls` feature enables [`tokio-websockets`]' `native-tls` feature.
 
-To enable `native`, do something like this in your `Cargo.toml`:
+To enable `native-tls`, do something like this in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-twilight-lavalink = { default-features = false, features = ["native"], version = "0.2" }
+twilight-lavalink = { default-features = false, features = ["native-tls"], version = "0.2" }
 ```
 
 #### `rustls-native-roots`


### PR DESCRIPTION
The `native` name is very unconcise. `native` what? CPU target? TLS implementation? Renaming it to `native-tls` makes it more self-explanatory and users less prone to erraneously enabling two TLS features.