### PR TITLE
feat(util): add markdown format functions to util

### DIFF
--- a/twilight-util/Cargo.toml
+++ b/twilight-util/Cargo.toml
@@ -23,10 +23,11 @@ time = { default-features = false, features = ["formatting"], version = "0.3" }
 
 [features]
 builder = ["dep:twilight-model", "dep:twilight-validate"]
+format = []
 link = ["dep:twilight-model"]
 permission-calculator = ["dep:twilight-model"]
 snowflake = ["dep:twilight-model"]
-full = ["builder", "link", "permission-calculator", "snowflake"]
+full = ["builder", "format", "link", "permission-calculator", "snowflake"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/twilight-util/src/format.rs
+++ b/twilight-util/src/format.rs
@@ -1,0 +1,39 @@
+pub trait Format {
+    fn bold(self) -> Self;
+
+    fn inline_code(self) -> Self;
+
+    fn italic(self) -> Self;
+
+    fn relative_timestamp(self) -> Self;
+
+    fn underline(self) -> Self;
+
+    fn strikethrough(self) -> Self;
+}
+
+impl Format for &str {
+    fn bold(self) -> Self {
+        concat!("**", self, "**")
+    }
+
+    fn inline_code(self) -> Self {
+        concat!("`", self, "`")
+    }
+
+    fn italic(self) -> Self {
+        concat!("*", self, "*")
+    }
+
+    fn relative_timestamp(self) -> Self {
+        concat!("<t:", self, ":R>")
+    }
+
+    fn underline(self) -> Self {
+        concat!("__", self, "__")
+    }
+
+    fn strikethrough(self) -> Self {
+        concat!("~~", self, "~~")
+    }
+}

--- a/twilight-util/src/lib.rs
+++ b/twilight-util/src/lib.rs
@@ -15,6 +15,9 @@
 #[cfg(feature = "builder")]
 pub mod builder;
 
+#[cfg(feature = "format")]
+pub mod format;
+
 #[cfg(feature = "link")]
 pub mod link;
 


### PR DESCRIPTION
Closes #2279.

This draft PR explores a potential implementation for markdown formatting functions. It is expected that the implementation would be iterated on for a bit before this is actually merged into main.