### PR TITLE
build(gateway, lavalink): Update to tokio-websockets 0.7

### DIFF
--- a/book/src/versions/0.16/summary.md
+++ b/book/src/versions/0.16/summary.md
@@ -276,4 +276,4 @@ was removed.
 [hyper]: https://docs.rs/hyper/1.2.0/hyper/index.html
 [rustls]: https://docs.rs/rustls/0.22.2/rustls/index.html
 [tokio-tungstenite]: https://docs.rs/tokio-tungstenite/0.21.0/tokio_tungstenite/index.html
-[tokio-websockets]: https://docs.rs/tokio-websockets/0.5.1/tokio_websockets/index.html
+[tokio-websockets]: https://docs.rs/tokio-websockets/0.7.0/tokio_websockets/index.html

--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -21,7 +21,7 @@ futures-sink = { default-features = false, features = ["std"], version = "0.3" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.19" }
-tokio-websockets = { default-features = false, features = ["client", "fastrand", "sha1_smol", "simd"], version = "0.5" }
+tokio-websockets = { default-features = false, features = ["client", "fastrand", "sha1_smol", "simd"], version = "0.7" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-gateway-queue = { default-features = false, path = "../twilight-gateway-queue", version = "0.16.0-rc.1" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.16.0-rc.1" }

--- a/twilight-lavalink/Cargo.toml
+++ b/twilight-lavalink/Cargo.toml
@@ -20,7 +20,7 @@ http = { default-features = false, version = "1" }
 serde = { default-features = false, features = ["derive", "std"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["macros", "net", "rt", "sync", "time"], version = "1.0" }
-tokio-websockets = { default-features = false, features = ["client", "fastrand", "sha1_smol", "simd"], version = "0.5" }
+tokio-websockets = { default-features = false, features = ["client", "fastrand", "sha1_smol", "simd"], version = "0.7" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.16.0-rc.1" }
 


### PR DESCRIPTION
Fixes TLS issues when using a gateway proxy without TLS.