### PR TITLE
Lavalink broken in 0.16 rc

### DIFF
--- a/twilight-lavalink/src/node.rs
+++ b/twilight-lavalink/src/node.rs
@@ -619,13 +619,13 @@ fn connect_request(state: &NodeConfig) -> Result<ClientBuilder, NodeError> {
         })?
         .add_header(AUTHORIZATION, state.authorization.parse().unwrap())
         .add_header(
-            HeaderName::from_static("User-Id"),
+            HeaderName::from_static("user-id"),
             state.user_id.get().into(),
         );
 
     if state.resume.is_some() {
         builder = builder.add_header(
-            HeaderName::from_static("Resume-Key"),
+            HeaderName::from_static("resume-key"),
             state.address.to_string().parse().unwrap(),
         );
     }


### PR DESCRIPTION
Capitalization in a header is illegal and causes the bot to panic. I posted in discord and figured it out shortly after. https://docs.rs/http/latest/http/header/struct.HeaderName.html#method.from_static

> Panics
> This function panics when the static string is a invalid header.
>
> Until [Allow panicking in constants](https://github.com/rust-lang/rfcs/pull/2345) makes its way into stable, the panic message at > compile-time is going to look cryptic, but should at least point at your header value:

Steps to reproduce:

1. checkout latest branch
2. startup a 3.X.Y lavalink server locally
3. build example lavalink-basic-bot

It would panic immediately on connect. See attached log of the panic. [backtrace.log](https://github.com/twilight-rs/twilight/files/14488252/backtrace.log)