### PR TITLE
feat(gateway): Allow setting initial resume_url

### DIFF
--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -57,6 +57,8 @@ pub struct Config<Q = InMemoryQueue> {
     ///
     /// [outgoing message]: crate::Shard::send
     ratelimit_messages: bool,
+    /// URL to connect to if the shard resumes on initialization.
+    resume_url:Option<Box<str>>,
     /// Session information to resume a shard on initialization.
     session: Option<Session>,
     /// TLS connector for Websocket connections.
@@ -130,6 +132,11 @@ impl<Q> Config<Q> {
         &self.token.inner
     }
 
+    /// Url to connect to if the shard resumes on initialization.
+    pub(crate) fn take_resume_url(&mut self) -> Option<Box<str>> {
+        self.resume_url.take()
+    }
+
     /// Session information to resume a shard on initialization.
     pub(crate) fn take_session(&mut self) -> Option<Session> {
         self.session.take()
@@ -166,6 +173,7 @@ impl ConfigBuilder {
                 proxy_url: None,
                 queue: InMemoryQueue::default(),
                 ratelimit_messages: true,
+                resume_url: None,
                 session: None,
                 tls: Arc::new(Connector::new().unwrap()),
                 token: Token::new(token.into_boxed_str()),
@@ -321,6 +329,7 @@ impl<Q> ConfigBuilder<Q> {
             proxy_url,
             queue: _,
             ratelimit_messages,
+            resume_url,
             session,
             tls,
             token,
@@ -335,6 +344,7 @@ impl<Q> ConfigBuilder<Q> {
                 proxy_url,
                 queue,
                 ratelimit_messages,
+                resume_url,
                 session,
                 tls,
                 token,
@@ -350,6 +360,18 @@ impl<Q> ConfigBuilder<Q> {
     /// Defaults to being enabled.
     pub const fn ratelimit_messages(mut self, ratelimit_messages: bool) -> Self {
         self.inner.ratelimit_messages = ratelimit_messages;
+
+        self
+    }
+
+    /// Set the resume URL to use when the initial shard connection resumes an old session.
+    ///
+    /// This is only used if the initial shard connection resumes instead of identifying and only affects the first session.
+    ///
+    /// This only has an effect if [`session`] is also set.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn resume_url(mut self, resume_url:String) -> Self{
+        self.inner.resume_url=Some(resume_url.into_boxed_str());
 
         self
     }

--- a/twilight-gateway/src/config.rs
+++ b/twilight-gateway/src/config.rs
@@ -58,7 +58,7 @@ pub struct Config<Q = InMemoryQueue> {
     /// [outgoing message]: crate::Shard::send
     ratelimit_messages: bool,
     /// URL to connect to if the shard resumes on initialization.
-    resume_url:Option<Box<str>>,
+    resume_url: Option<Box<str>>,
     /// Session information to resume a shard on initialization.
     session: Option<Session>,
     /// TLS connector for Websocket connections.
@@ -368,10 +368,10 @@ impl<Q> ConfigBuilder<Q> {
     ///
     /// This is only used if the initial shard connection resumes instead of identifying and only affects the first session.
     ///
-    /// This only has an effect if [`session`] is also set.
+    /// This only has an effect if [`ConfigBuilder::session`] is also set.
     #[allow(clippy::missing_const_for_fn)]
-    pub fn resume_url(mut self, resume_url:String) -> Self{
-        self.inner.resume_url=Some(resume_url.into_boxed_str());
+    pub fn resume_url(mut self, resume_url: String) -> Self {
+        self.inner.resume_url = Some(resume_url.into_boxed_str());
 
         self
     }

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -325,7 +325,11 @@ impl<Q> Shard<Q> {
     /// Create a new shard with the provided configuration.
     pub fn with_config(shard_id: ShardId, mut config: Config<Q>) -> Self {
         let session = config.take_session();
-        let resume_url = config.take_resume_url();
+        let mut resume_url = config.take_resume_url();
+        //ensure resume_url is only used if we have a session to resume
+        if session.is_none(){
+            resume_url=None;
+        }
 
         Self {
             config,

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -327,8 +327,8 @@ impl<Q> Shard<Q> {
         let session = config.take_session();
         let mut resume_url = config.take_resume_url();
         //ensure resume_url is only used if we have a session to resume
-        if session.is_none(){
-            resume_url=None;
+        if session.is_none() {
+            resume_url = None;
         }
 
         Self {

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -393,7 +393,8 @@ impl<Q> Shard<Q> {
 
     /// Immutable reference to the gateways current resume URL.
     ///
-    /// A resume URL might not be present if the shard had its session invalidated and has not yet reconnected.
+    /// A resume URL might not be present if the shard had its session
+    /// invalidated and has not yet reconnected.
     pub fn resume_url(&self) -> Option<&str> {
         self.resume_url.as_deref()
     }

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -325,6 +325,7 @@ impl<Q> Shard<Q> {
     /// Create a new shard with the provided configuration.
     pub fn with_config(shard_id: ShardId, mut config: Config<Q>) -> Self {
         let session = config.take_session();
+        let resume_url = config.take_resume_url();
 
         Self {
             config,
@@ -339,7 +340,7 @@ impl<Q> Shard<Q> {
             pending: None,
             latency: Latency::new(),
             ratelimiter: None,
-            resume_url: None,
+            resume_url,
             session,
             state: ShardState::Disconnected {
                 reconnect_attempts: 0,
@@ -388,6 +389,13 @@ impl<Q> Shard<Q> {
     /// [`ConfigBuilder::ratelimit_messages`]: crate::ConfigBuilder::ratelimit_messages
     pub const fn ratelimiter(&self) -> Option<&CommandRatelimiter> {
         self.ratelimiter.as_ref()
+    }
+
+    /// Immutable reference to the gateways current resume URL.
+    ///
+    /// A resume URL might not be present if the shard had its session invalidated and has not yet reconnected.
+    pub fn resume_url(&self) -> Option<&str> {
+        self.resume_url.as_deref()
     }
 
     /// Immutable reference to the active gateway session.


### PR DESCRIPTION
Adds equivalents to the existing session related functions for resume_url to Config, ConfigBuilder and Shard

closes #2324 