### PR TITLE
feat(model, http): Make positions possible to create

### DIFF
--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -52,7 +52,6 @@ use crate::{
                 CreateGuildSticker, DeleteGuildSticker, GetGuildSticker, GetGuildStickers,
                 UpdateGuildSticker,
             },
-            update_guild_channel_positions::Position,
             update_guild_onboarding::{UpdateGuildOnboarding, UpdateGuildOnboardingFields},
             user::{UpdateCurrentUserVoiceState, UpdateUserVoiceState},
             CreateGuild, CreateGuildChannel, CreateGuildPrune, DeleteGuild, GetActiveThreads,
@@ -102,7 +101,7 @@ use twilight_http_ratelimiting::Ratelimiter;
 use twilight_model::{
     channel::{message::AllowedMentions, ChannelType},
     guild::{auto_moderation::AutoModerationEventType, scheduled_event::PrivacyLevel, MfaLevel},
-    http::permission_overwrite::PermissionOverwrite,
+    http::{channel_position::Position, permission_overwrite::PermissionOverwrite},
     id::{
         marker::{
             ApplicationMarker, AutoModerationRuleMarker, ChannelMarker, EmojiMarker, GuildMarker,
@@ -959,9 +958,6 @@ impl Client {
     /// Modify the positions of the channels.
     ///
     /// The minimum amount of channels to modify, is a swap between two channels.
-    ///
-    /// This function accepts an `Iterator` of `(Id<ChannelMarker>, u64)`. It also
-    /// accepts an `Iterator` of `Position`, which has extra fields.
     pub const fn update_guild_channel_positions<'a>(
         &'a self,
         guild_id: Id<GuildMarker>,

--- a/twilight-http/src/request/guild/update_guild_channel_positions.rs
+++ b/twilight-http/src/request/guild/update_guild_channel_positions.rs
@@ -5,41 +5,15 @@ use crate::{
     response::{marker::EmptyBody, Response, ResponseFuture},
     routing::Route,
 };
-use serde::Serialize;
 use std::future::IntoFuture;
-use twilight_model::id::{
-    marker::{ChannelMarker, GuildMarker},
-    Id,
+use twilight_model::{
+    http::channel_position::Position,
+    id::{marker::GuildMarker, Id},
 };
-
-#[derive(Serialize)]
-pub struct Position {
-    id: Id<ChannelMarker>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    lock_permissions: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    parent_id: Option<Id<ChannelMarker>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    position: Option<u64>,
-}
-
-impl From<(Id<ChannelMarker>, u64)> for Position {
-    fn from((id, position): (Id<ChannelMarker>, u64)) -> Self {
-        Self {
-            id,
-            lock_permissions: None,
-            parent_id: None,
-            position: Some(position),
-        }
-    }
-}
 
 /// Modify the positions of the channels.
 ///
 /// The minimum amount of channels to modify, is a swap between two channels.
-///
-/// This function accepts an `Iterator` of `(Id<ChannelMarker>, u64)`. It also accepts
-/// an `Iterator` of `Position`, which has extra fields.
 #[must_use = "requests must be configured and executed"]
 pub struct UpdateGuildChannelPositions<'a> {
     guild_id: Id<GuildMarker>,

--- a/twilight-model/src/http/channel_position.rs
+++ b/twilight-model/src/http/channel_position.rs
@@ -7,7 +7,8 @@ use crate::id::{marker::ChannelMarker, Id};
 /// Used to update the position of channels over HTTP.
 ///
 /// ## Note:
-/// The fields with `Option<Option<T>>` Will be `null` if they have
+///
+/// The fields with `Option<Option<T>>` will be `null` if they have
 /// the form `Some(None)`, `None` will be skipped.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Position {

--- a/twilight-model/src/http/channel_position.rs
+++ b/twilight-model/src/http/channel_position.rs
@@ -1,0 +1,37 @@
+//! Models used when setting the channel positions over HTTP.
+
+use serde::{Deserialize, Serialize};
+
+use crate::id::{marker::ChannelMarker, Id};
+
+/// Used to update the position of channels over HTTP.
+///
+/// ## Note:
+/// The fields with `Option<Option<T>>` Will be `null` if they have
+/// the form `Some(None)`, `None` will be skipped.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct Position {
+    /// Channel id
+    pub id: Id<ChannelMarker>,
+    /// syncs the permission overwrites with the new parent, if moving
+    /// to a new category
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lock_permissions: Option<Option<bool>>,
+    /// The new parent ID for the channel that is moved
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Option<Id<ChannelMarker>>>,
+    /// Sorting position of the channel
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<Option<u64>>,
+}
+
+impl From<(Id<ChannelMarker>, u64)> for Position {
+    fn from((id, position): (Id<ChannelMarker>, u64)) -> Self {
+        Self {
+            id,
+            lock_permissions: None,
+            parent_id: None,
+            position: Some(Some(position)),
+        }
+    }
+}

--- a/twilight-model/src/http/mod.rs
+++ b/twilight-model/src/http/mod.rs
@@ -1,5 +1,6 @@
 //! Models used when sending data to Discord.
 
 pub mod attachment;
+pub mod channel_position;
 pub mod interaction;
 pub mod permission_overwrite;


### PR DESCRIPTION
This PR moves the Position struct to the model crate.

It also fixes an issue where it was not possible to create null values in the fields that had the ability to be null or left out.

Resolves #2327 