### PR TITLE
fix(model): Deserialize unavailable guilds in GUILD_CREATE.

### DIFF
--- a/examples/gateway-request-members.rs
+++ b/examples/gateway-request-members.rs
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
         match event {
             Event::GuildCreate(guild) => {
                 // Let's request all of the guild's members for caching.
-                shard.command(&RequestGuildMembers::builder(guild.id).query("", None));
+                shard.command(&RequestGuildMembers::builder(guild.id()).query("", None));
             }
             Event::Ready(_) => {
                 // You can also specify an individual member within a guild.

--- a/twilight-cache-inmemory/src/event/guild.rs
+++ b/twilight-cache-inmemory/src/event/guild.rs
@@ -136,7 +136,12 @@ impl<CacheModels: CacheableModels> InMemoryCache<CacheModels> {
 
 impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for GuildCreate {
     fn update(&self, cache: &InMemoryCache<CacheModels>) {
-        cache.cache_guild(self.0.clone());
+        match self {
+            GuildCreate::Available(g) => cache.cache_guild(g.clone()),
+            GuildCreate::Unavailable(g) => {
+                cache.unavailable_guilds.insert(g.id);
+            }
+        }
     }
 }
 
@@ -350,7 +355,7 @@ mod tests {
         let cache = DefaultInMemoryCache::new();
         let guild = test::guild(Id::new(1), None);
 
-        cache.update(&GuildCreate(guild.clone()));
+        cache.update(&GuildCreate::Available(guild.clone()));
 
         let mutation = PartialGuild {
             id: guild.id,
@@ -406,7 +411,7 @@ mod tests {
         let member = test::member(user_id);
         let guild = test::guild(guild_id, Some(1));
 
-        cache.update(&GuildCreate(guild));
+        cache.update(&GuildCreate::Available(guild));
         cache.update(&MemberAdd { guild_id, member });
 
         assert_eq!(cache.guild(guild_id).unwrap().member_count, Some(2));
@@ -425,7 +430,7 @@ mod tests {
         let mut guild = test::guild(guild_id, Some(1));
         guild.members.push(member);
 
-        cache.update(&GuildCreate(guild.clone()));
+        cache.update(&GuildCreate::Available(guild.clone()));
 
         assert_eq!(
             1,
@@ -446,7 +451,7 @@ mod tests {
         );
         assert!(cache.guild(guild_id).unwrap().unavailable);
 
-        cache.update(&GuildCreate(guild));
+        cache.update(&GuildCreate::Available(guild));
 
         assert_eq!(
             1,

--- a/twilight-cache-inmemory/src/event/guild.rs
+++ b/twilight-cache-inmemory/src/event/guild.rs
@@ -139,7 +139,7 @@ impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for GuildCreate {
         match self {
             GuildCreate::Available(g) => cache.cache_guild(g.clone()),
             GuildCreate::Unavailable(g) => {
-                cache.unavailable_guilds.insert(g.id);
+                cache.unavailable_guild(g.id);
             }
         }
     }

--- a/twilight-cache-inmemory/src/event/guild.rs
+++ b/twilight-cache-inmemory/src/event/guild.rs
@@ -351,6 +351,37 @@ mod tests {
     }
 
     #[test]
+    fn unavailable_available_guild() {
+        let cache = DefaultInMemoryCache::new();
+        let guild = test::guild(Id::new(1), None);
+
+        cache.update(&GuildCreate::Unavailable(
+            twilight_model::guild::UnavailableGuild {
+                id: guild.id,
+                unavailable: true,
+            },
+        ));
+        assert!(cache.unavailable_guilds.get(&guild.id).is_some());
+
+        cache.update(&GuildCreate::Available(guild.clone()));
+        assert_eq!(*cache.guilds.get(&guild.id).unwrap(), guild);
+        assert!(cache.unavailable_guilds.get(&guild.id).is_none());
+
+        cache.update(&GuildCreate::Unavailable(
+            twilight_model::guild::UnavailableGuild {
+                id: guild.id,
+                unavailable: true,
+            },
+        ));
+        assert!(cache.unavailable_guilds.get(&guild.id).is_some());
+        assert!(cache.guilds.get(&guild.id).unwrap().unavailable);
+
+        cache.update(&GuildCreate::Available(guild.clone()));
+        assert!(!cache.guilds.get(&guild.id).unwrap().unavailable);
+        assert!(cache.unavailable_guilds.get(&guild.id).is_none());
+    }
+
+    #[test]
     fn guild_update() {
         let cache = DefaultInMemoryCache::new();
         let guild = test::guild(Id::new(1), None);

--- a/twilight-cache-inmemory/src/permission.rs
+++ b/twilight-cache-inmemory/src/permission.rs
@@ -1088,7 +1088,7 @@ mod tests {
             everyone_permissions,
         )]);
 
-        cache.update(&GuildCreate::Availableg(guild));
+        cache.update(&GuildCreate::Available(guild));
         let mut member = test::member(USER_ID);
         member.communication_disabled_until = Some(in_future);
         cache.update(&MemberAdd {

--- a/twilight-cache-inmemory/src/permission.rs
+++ b/twilight-cache-inmemory/src/permission.rs
@@ -923,7 +923,7 @@ mod tests {
         let cache = DefaultInMemoryCache::new();
         let permissions = cache.permissions();
 
-        cache.update(&GuildCreate(base_guild()));
+        cache.update(&GuildCreate::Available(base_guild()));
         cache.update(&MemberAdd {
             guild_id: GUILD_ID,
             member: test::member(USER_ID),
@@ -969,7 +969,7 @@ mod tests {
         let cache = DefaultInMemoryCache::new();
         let permissions = cache.permissions();
 
-        cache.update(&GuildCreate(base_guild()));
+        cache.update(&GuildCreate::Available(base_guild()));
         assert!(matches!(
             permissions.in_channel(USER_ID, CHANNEL_ID).unwrap_err().kind(),
             ChannelErrorType::ChannelUnavailable { channel_id: c_id }
@@ -1030,7 +1030,7 @@ mod tests {
     fn owner() -> Result<(), Box<dyn Error>> {
         let cache = DefaultInMemoryCache::new();
         let permissions = cache.permissions();
-        cache.update(&GuildCreate(base_guild()));
+        cache.update(&GuildCreate::Available(base_guild()));
 
         assert!(permissions.root(OWNER_ID, GUILD_ID)?.is_all());
 
@@ -1088,7 +1088,7 @@ mod tests {
             everyone_permissions,
         )]);
 
-        cache.update(&GuildCreate(guild));
+        cache.update(&GuildCreate::Availableg(guild));
         let mut member = test::member(USER_ID);
         member.communication_disabled_until = Some(in_future);
         cache.update(&MemberAdd {

--- a/twilight-model/src/gateway/event/mod.rs
+++ b/twilight-model/src/gateway/event/mod.rs
@@ -183,7 +183,7 @@ impl Event {
             Event::ChannelUpdate(e) => e.0.guild_id,
             Event::CommandPermissionsUpdate(e) => Some(e.0.guild_id),
             Event::GuildAuditLogEntryCreate(e) => e.0.guild_id,
-            Event::GuildCreate(e) => Some(e.0.id),
+            Event::GuildCreate(e) => Some(e.id()),
             Event::GuildDelete(e) => Some(e.id),
             Event::GuildEmojisUpdate(e) => Some(e.guild_id),
             Event::GuildIntegrationsUpdate(e) => Some(e.guild_id),

--- a/twilight-model/src/gateway/payload/incoming/guild_create.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_create.rs
@@ -12,7 +12,7 @@ pub enum GuildCreate {
 }
 
 impl GuildCreate {
-    /// Extract guild id.
+    /// ID of the guild.
     pub const fn id(&self) -> Id<GuildMarker> {
         match self {
             GuildCreate::Available(g) => g.id,
@@ -36,11 +36,8 @@ mod tests {
             unavailable: true,
         });
 
-        // Note: This looks a bit strange because it does not use
-        //       Token::TupleVariant, this is because it will
-        //       serialize back into a struct, and thus make it
-        //       fails. This also tests that the enum is transparent
-        //       for serde.
+        // Note: serde(untagged) makes the enum transparent which is
+        //       the reason we don't use the variant here.
         serde_test::assert_tokens(
             &expected,
             &[


### PR DESCRIPTION
This changes `GuildCreate` from being a tuple struct to being a enum that can either be available or unavailable, and containing either a full `Guild` or a `UnavailableGuild`.