### PR TITLE
fix(model, http)!: fix role position update payload and allow audit log reason

### DIFF
--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -100,7 +100,10 @@ use tokio::time;
 use twilight_http_ratelimiting::Ratelimiter;
 use twilight_model::{
     channel::{message::AllowedMentions, ChannelType},
-    guild::{auto_moderation::AutoModerationEventType, scheduled_event::PrivacyLevel, MfaLevel},
+    guild::{
+        auto_moderation::AutoModerationEventType, scheduled_event::PrivacyLevel, MfaLevel,
+        RolePosition,
+    },
     http::{channel_position::Position, permission_overwrite::PermissionOverwrite},
     id::{
         marker::{
@@ -1680,7 +1683,7 @@ impl Client {
     pub const fn update_role_positions<'a>(
         &'a self,
         guild_id: Id<GuildMarker>,
-        roles: &'a [(Id<RoleMarker>, u64)],
+        roles: &'a [RolePosition],
     ) -> UpdateRolePositions<'a> {
         UpdateRolePositions::new(self, guild_id, roles)
     }

--- a/twilight-http/src/request/audit_reason.rs
+++ b/twilight-http/src/request/audit_reason.rs
@@ -34,7 +34,7 @@ mod private {
             emoji::{CreateEmoji, DeleteEmoji, UpdateEmoji},
             integration::DeleteGuildIntegration,
             member::{AddRoleToMember, RemoveMember, RemoveRoleFromMember, UpdateGuildMember},
-            role::{CreateRole, DeleteRole, UpdateRole},
+            role::{CreateRole, DeleteRole, UpdateRole, UpdateRolePositions},
             sticker::{CreateGuildSticker, UpdateGuildSticker},
             update_guild_onboarding::UpdateGuildOnboarding,
             CreateGuildChannel, CreateGuildPrune, UpdateCurrentMember, UpdateGuild, UpdateGuildMfa,
@@ -95,6 +95,7 @@ mod private {
     impl Sealed for UpdateGuildSticker<'_> {}
     impl Sealed for UpdateGuildWidgetSettings<'_> {}
     impl Sealed for UpdateRole<'_> {}
+    impl Sealed for UpdateRolePositions<'_> {}
     impl Sealed for UpdateThread<'_> {}
     impl Sealed for UpdateWebhook<'_> {}
 }
@@ -115,7 +116,7 @@ mod tests {
             emoji::{CreateEmoji, DeleteEmoji, UpdateEmoji},
             integration::DeleteGuildIntegration,
             member::{AddRoleToMember, RemoveMember, RemoveRoleFromMember, UpdateGuildMember},
-            role::{CreateRole, DeleteRole, UpdateRole},
+            role::{CreateRole, DeleteRole, UpdateRole, UpdateRolePositions},
             sticker::{CreateGuildSticker, UpdateGuildSticker},
             CreateGuildChannel, CreateGuildPrune, UpdateCurrentMember, UpdateGuild,
         },
@@ -157,5 +158,6 @@ mod tests {
     assert_impl_all!(UpdateGuildMember<'_>: AuditLogReason<'static>);
     assert_impl_all!(UpdateGuildSticker<'_>: AuditLogReason<'static>);
     assert_impl_all!(UpdateRole<'_>: AuditLogReason<'static>);
+    assert_impl_all!(UpdateRolePositions<'_>: AuditLogReason<'static>);
     assert_impl_all!(UpdateWebhook<'_>: AuditLogReason<'static>);
 }

--- a/twilight-model/src/guild/mod.rs
+++ b/twilight-model/src/guild/mod.rs
@@ -37,6 +37,7 @@ mod preview;
 mod prune;
 mod role;
 mod role_flags;
+mod role_position;
 mod role_tags;
 mod system_channel_flags;
 mod unavailable_guild;
@@ -54,9 +55,10 @@ pub use self::{
     integration_expire_behavior::IntegrationExpireBehavior, integration_type::GuildIntegrationType,
     member::Member, member_flags::MemberFlags, mfa_level::MfaLevel, partial_guild::PartialGuild,
     partial_member::PartialMember, premium_tier::PremiumTier, preview::GuildPreview,
-    prune::GuildPrune, role::Role, role_flags::RoleFlags, role_tags::RoleTags,
-    system_channel_flags::SystemChannelFlags, unavailable_guild::UnavailableGuild,
-    vanity_url::VanityUrl, verification_level::VerificationLevel, widget::GuildWidget,
+    prune::GuildPrune, role::Role, role_flags::RoleFlags, role_position::RolePosition,
+    role_tags::RoleTags, system_channel_flags::SystemChannelFlags,
+    unavailable_guild::UnavailableGuild, vanity_url::VanityUrl,
+    verification_level::VerificationLevel, widget::GuildWidget,
 };
 
 use super::gateway::presence::PresenceListDeserializer;

--- a/twilight-model/src/guild/role_position.rs
+++ b/twilight-model/src/guild/role_position.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 /// Data used to update the positions of roles.
 pub struct RolePosition {
-    /// The role ID.
+    /// Role identifier.
     pub id: Id<RoleMarker>,
-    /// The new position of the role.
+    /// Sorting position of the role.
     pub position: u64,
 }
 

--- a/twilight-model/src/guild/role_position.rs
+++ b/twilight-model/src/guild/role_position.rs
@@ -1,0 +1,41 @@
+use crate::id::{marker::RoleMarker, Id};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+/// Data used to update the positions of roles.
+pub struct RolePosition {
+    /// The role ID.
+    pub id: Id<RoleMarker>,
+    /// The new position of the role.
+    pub position: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Id, RolePosition};
+    use serde_test::Token;
+
+    #[test]
+    fn role_position() {
+        let role_position = RolePosition {
+            id: Id::new(123),
+            position: 12,
+        };
+
+        serde_test::assert_tokens(
+            &role_position,
+            &[
+                Token::Struct {
+                    name: "RolePosition",
+                    len: 2,
+                },
+                Token::Str("id"),
+                Token::NewtypeStruct { name: "Id" },
+                Token::Str("123"),
+                Token::Str("position"),
+                Token::U64(12),
+                Token::StructEnd,
+            ],
+        );
+    }
+}


### PR DESCRIPTION
Closes #2338 and adds audit log reason support for this endpoint.