### PR TITLE
feat(model, http)!: Add support for super reaction types

### DIFF
--- a/twilight-cache-inmemory/src/event/reaction.rs
+++ b/twilight-cache-inmemory/src/event/reaction.rs
@@ -4,7 +4,7 @@ use crate::{
     CacheableModels, InMemoryCache, UpdateCache,
 };
 use twilight_model::{
-    channel::message::{Reaction, ReactionCountDetails, ReactionType},
+    channel::message::{EmojiReactionType, Reaction, ReactionCountDetails},
     gateway::payload::incoming::{
         ReactionAdd, ReactionRemove, ReactionRemoveAll, ReactionRemoveEmoji,
     },
@@ -124,14 +124,16 @@ impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for ReactionRemoveEm
     }
 }
 
-fn reactions_eq(a: &ReactionType, b: &ReactionType) -> bool {
+fn reactions_eq(a: &EmojiReactionType, b: &EmojiReactionType) -> bool {
     match (a, b) {
-        (ReactionType::Custom { id: id_a, .. }, ReactionType::Custom { id: id_b, .. }) => {
-            id_a == id_b
-        }
-        (ReactionType::Unicode { name: name_a }, ReactionType::Unicode { name: name_b }) => {
-            name_a == name_b
-        }
+        (
+            EmojiReactionType::Custom { id: id_a, .. },
+            EmojiReactionType::Custom { id: id_b, .. },
+        ) => id_a == id_b,
+        (
+            EmojiReactionType::Unicode { name: name_a },
+            EmojiReactionType::Unicode { name: name_b },
+        ) => name_a == name_b,
         _ => false,
     }
 }
@@ -141,7 +143,7 @@ mod tests {
     use super::reactions_eq;
     use crate::{model::CachedMessage, test};
     use twilight_model::{
-        channel::message::{Reaction, ReactionType},
+        channel::message::{EmojiReactionType, Reaction},
         gateway::{
             payload::incoming::{ReactionRemove, ReactionRemoveAll, ReactionRemoveEmoji},
             GatewayReaction,
@@ -153,7 +155,7 @@ mod tests {
         msg.reactions.iter().find(|&r| {
             reactions_eq(
                 &r.emoji,
-                &ReactionType::Custom {
+                &EmojiReactionType::Custom {
                     animated: false,
                     id: Id::new(6),
                     name: None,
@@ -172,11 +174,11 @@ mod tests {
         let world_react = msg
             .reactions
             .iter()
-            .find(|&r| matches!(&r.emoji, ReactionType::Unicode {name} if name == "🗺️"));
+            .find(|&r| matches!(&r.emoji, EmojiReactionType::Unicode {name} if name == "🗺️"));
         let smiley_react = msg
             .reactions
             .iter()
-            .find(|&r| matches!(&r.emoji, ReactionType::Unicode {name} if name == "😀"));
+            .find(|&r| matches!(&r.emoji, EmojiReactionType::Unicode {name} if name == "😀"));
         let custom_react = find_custom_react(&msg);
 
         assert!(world_react.is_some());
@@ -191,8 +193,10 @@ mod tests {
     fn reaction_remove() {
         let cache = test::cache_with_message_and_reactions();
         cache.update(&ReactionRemove(GatewayReaction {
+            burst: false,
+            burst_colors: Vec::new(),
             channel_id: Id::new(2),
-            emoji: ReactionType::Unicode {
+            emoji: EmojiReactionType::Unicode {
                 name: "😀".to_owned(),
             },
             guild_id: Some(Id::new(1)),
@@ -202,8 +206,10 @@ mod tests {
             user_id: Id::new(5),
         }));
         cache.update(&ReactionRemove(GatewayReaction {
+            burst: false,
+            burst_colors: Vec::new(),
             channel_id: Id::new(2),
-            emoji: ReactionType::Custom {
+            emoji: EmojiReactionType::Custom {
                 animated: false,
                 id: Id::new(6),
                 name: None,
@@ -222,11 +228,11 @@ mod tests {
         let world_react = msg
             .reactions
             .iter()
-            .find(|&r| matches!(&r.emoji, ReactionType::Unicode {name} if name == "🗺️"));
+            .find(|&r| matches!(&r.emoji, EmojiReactionType::Unicode {name} if name == "🗺️"));
         let smiley_react = msg
             .reactions
             .iter()
-            .find(|&r| matches!(&r.emoji, ReactionType::Unicode {name} if name == "😀"));
+            .find(|&r| matches!(&r.emoji, EmojiReactionType::Unicode {name} if name == "😀"));
         let custom_react = find_custom_react(&msg);
 
         assert!(world_react.is_some());
@@ -255,7 +261,7 @@ mod tests {
         let cache = test::cache_with_message_and_reactions();
         cache.update(&ReactionRemoveEmoji {
             channel_id: Id::new(2),
-            emoji: ReactionType::Unicode {
+            emoji: EmojiReactionType::Unicode {
                 name: "😀".to_owned(),
             },
             guild_id: Id::new(1),
@@ -263,7 +269,7 @@ mod tests {
         });
         cache.update(&ReactionRemoveEmoji {
             channel_id: Id::new(2),
-            emoji: ReactionType::Custom {
+            emoji: EmojiReactionType::Custom {
                 animated: false,
                 id: Id::new(6),
                 name: None,
@@ -279,11 +285,11 @@ mod tests {
         let world_react = msg
             .reactions
             .iter()
-            .find(|&r| matches!(&r.emoji, ReactionType::Unicode {name} if name == "🗺️"));
+            .find(|&r| matches!(&r.emoji, EmojiReactionType::Unicode {name} if name == "🗺️"));
         let smiley_react = msg
             .reactions
             .iter()
-            .find(|&r| matches!(&r.emoji, ReactionType::Unicode {name} if name == "😀"));
+            .find(|&r| matches!(&r.emoji, EmojiReactionType::Unicode {name} if name == "😀"));
         let custom_react = find_custom_react(&msg);
 
         assert!(world_react.is_some());

--- a/twilight-cache-inmemory/src/test.rs
+++ b/twilight-cache-inmemory/src/test.rs
@@ -3,7 +3,7 @@ use twilight_model::{
     channel::{
         message::{
             sticker::{Sticker, StickerFormatType, StickerType},
-            Message, MessageFlags, MessageType, ReactionType,
+            EmojiReactionType, Message, MessageFlags, MessageType,
         },
         Channel, ChannelType,
     },
@@ -102,8 +102,10 @@ pub fn cache_with_message_and_reactions() -> DefaultInMemoryCache {
     cache.update(&MessageCreate(msg));
 
     let mut reaction = ReactionAdd(GatewayReaction {
+        burst: false,
+        burst_colors: Vec::new(),
         channel_id: Id::new(2),
-        emoji: ReactionType::Unicode {
+        emoji: EmojiReactionType::Unicode {
             name: "😀".to_owned(),
         },
         guild_id: Some(Id::new(1)),
@@ -183,13 +185,13 @@ pub fn cache_with_message_and_reactions() -> DefaultInMemoryCache {
 
     cache.update(&reaction);
 
-    reaction.emoji = ReactionType::Unicode {
+    reaction.emoji = EmojiReactionType::Unicode {
         name: "🗺️".to_owned(),
     };
 
     cache.update(&reaction);
 
-    reaction.emoji = ReactionType::Custom {
+    reaction.emoji = EmojiReactionType::Custom {
         animated: true,
         id: Id::new(6),
         name: Some("custom".to_owned()),

--- a/twilight-http/src/request/channel/reaction/get_reactions.rs
+++ b/twilight-http/src/request/channel/reaction/get_reactions.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use std::future::IntoFuture;
 use twilight_model::{
+    channel::message::ReactionType,
     id::{
         marker::{ChannelMarker, MessageMarker, UserMarker},
         Id,
@@ -21,6 +22,7 @@ use twilight_validate::request::{
 struct GetReactionsFields {
     after: Option<Id<UserMarker>>,
     limit: Option<u16>,
+    kind: Option<ReactionType>,
 }
 
 /// Get a list of users that reacted to a message with an `emoji`.
@@ -49,6 +51,7 @@ impl<'a> GetReactions<'a> {
             fields: Ok(GetReactionsFields {
                 after: None,
                 limit: None,
+                kind: None,
             }),
             http,
             message_id,
@@ -85,6 +88,17 @@ impl<'a> GetReactions<'a> {
 
         self
     }
+
+    /// Set the kind of reaction to retrieve.
+    ///
+    /// This can be either a super reaction or a normal reaction.
+    pub fn kind(mut self, kind: ReactionType) -> Self {
+        if let Ok(fields) = self.fields.as_mut() {
+            fields.kind = Some(kind);
+        }
+
+        self
+    }
 }
 
 impl IntoFuture for GetReactions<'_> {
@@ -112,6 +126,7 @@ impl TryIntoRequest for GetReactions<'_> {
             emoji: self.emoji,
             limit: fields.limit,
             message_id: self.message_id.get(),
+            kind: fields.kind.map(Into::into),
         }))
     }
 }

--- a/twilight-http/src/routing.rs
+++ b/twilight-http/src/routing.rs
@@ -751,6 +751,8 @@ pub enum Route<'a> {
         limit: Option<u16>,
         /// The ID of the message.
         message_id: u64,
+        /// The type of reactions to fetch.
+        kind: Option<u8>,
     },
     /// Route information to get a stage instance.
     GetStageInstance {
@@ -2738,6 +2740,7 @@ impl Display for Route<'_> {
                 emoji,
                 limit,
                 message_id,
+                kind,
             } => {
                 f.write_str("channels/")?;
                 Display::fmt(channel_id, f)?;
@@ -2755,6 +2758,11 @@ impl Display for Route<'_> {
                 if let Some(limit) = limit {
                     f.write_str("&limit=")?;
                     Display::fmt(limit, f)?;
+                }
+
+                if let Some(kind) = kind {
+                    f.write_str("&type=")?;
+                    Display::fmt(kind, f)?;
                 }
 
                 Ok(())

--- a/twilight-model/src/channel/message/component/button.rs
+++ b/twilight-model/src/channel/message/component/button.rs
@@ -1,4 +1,4 @@
-use crate::channel::message::ReactionType;
+use crate::channel::message::EmojiReactionType;
 use serde::{Deserialize, Serialize};
 
 /// Clickable [`Component`] below messages.
@@ -20,7 +20,7 @@ pub struct Button {
     /// Defaults to `false`.
     pub disabled: bool,
     /// Visual emoji for clients to display with the button.
-    pub emoji: Option<ReactionType>,
+    pub emoji: Option<EmojiReactionType>,
     /// Text appearing on the button.
     pub label: Option<String>,
     /// Style variant of the button.

--- a/twilight-model/src/channel/message/component/mod.rs
+++ b/twilight-model/src/channel/message/component/mod.rs
@@ -19,7 +19,7 @@ pub use self::{
     text_input::{TextInput, TextInputStyle},
 };
 
-use super::ReactionType;
+use super::EmojiReactionType;
 use crate::channel::ChannelType;
 use serde::{
     de::{Deserializer, Error as DeError, IgnoredAny, MapAccess, Visitor},
@@ -239,7 +239,7 @@ impl<'de> Visitor<'de> for ComponentVisitor {
         let mut channel_types: Option<Vec<ChannelType>> = None;
         let mut default_values: Option<Vec<SelectDefaultValue>> = None;
         let mut disabled: Option<bool> = None;
-        let mut emoji: Option<Option<ReactionType>> = None;
+        let mut emoji: Option<Option<EmojiReactionType>> = None;
         let mut max_length: Option<Option<u16>> = None;
         let mut max_values: Option<Option<u8>> = None;
         let mut min_length: Option<Option<u16>> = None;
@@ -899,7 +899,7 @@ mod tests {
         let value = Component::Button(Button {
             custom_id: Some("test".to_owned()),
             disabled: false,
-            emoji: Some(ReactionType::Unicode {
+            emoji: Some(EmojiReactionType::Unicode {
                 name: FLAG.to_owned(),
             }),
             label: Some("Test".to_owned()),
@@ -922,7 +922,7 @@ mod tests {
                 Token::String("emoji"),
                 Token::Some,
                 Token::Struct {
-                    name: "ReactionType",
+                    name: "EmojiReactionType",
                     len: 1,
                 },
                 Token::String("name"),

--- a/twilight-model/src/channel/message/component/mod.rs
+++ b/twilight-model/src/channel/message/component/mod.rs
@@ -58,7 +58,7 @@ use std::fmt::{Formatter, Result as FmtResult};
 /// use twilight_model::{
 ///     channel::message::{
 ///         component::{ActionRow, Component, SelectMenu, SelectMenuOption, SelectMenuType},
-///         ReactionType,
+///         EmojiReactionType,
 ///     },
 ///     id::Id,
 /// };
@@ -75,7 +75,7 @@ use std::fmt::{Formatter, Result as FmtResult};
 ///         options: Some(Vec::from([
 ///             SelectMenuOption {
 ///                 default: false,
-///                 emoji: Some(ReactionType::Custom {
+///                 emoji: Some(EmojiReactionType::Custom {
 ///                     animated: false,
 ///                     id: Id::new(625891304148303894),
 ///                     name: Some("rogue".to_owned()),
@@ -86,7 +86,7 @@ use std::fmt::{Formatter, Result as FmtResult};
 ///             },
 ///             SelectMenuOption {
 ///                 default: false,
-///                 emoji: Some(ReactionType::Custom {
+///                 emoji: Some(EmojiReactionType::Custom {
 ///                     animated: false,
 ///                     id: Id::new(625891304081063986),
 ///                     name: Some("mage".to_owned()),
@@ -97,7 +97,7 @@ use std::fmt::{Formatter, Result as FmtResult};
 ///             },
 ///             SelectMenuOption {
 ///                 default: false,
-///                 emoji: Some(ReactionType::Custom {
+///                 emoji: Some(EmojiReactionType::Custom {
 ///                     animated: false,
 ///                     id: Id::new(625891303795982337),
 ///                     name: Some("priest".to_owned()),

--- a/twilight-model/src/channel/message/component/select_menu.rs
+++ b/twilight-model/src/channel/message/component/select_menu.rs
@@ -1,4 +1,4 @@
-use crate::channel::{message::ReactionType, ChannelType};
+use crate::channel::{message::EmojiReactionType, ChannelType};
 use crate::id::marker::{ChannelMarker, RoleMarker, UserMarker};
 use crate::id::Id;
 use serde::{Deserialize, Serialize};
@@ -65,7 +65,7 @@ pub struct SelectMenuOption {
     /// Emoji associated with the option. Appears left of the label and
     /// description.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub emoji: Option<ReactionType>,
+    pub emoji: Option<EmojiReactionType>,
     /// User-facing name.
     pub label: String,
     /// Developer defined value.

--- a/twilight-model/src/channel/message/mod.rs
+++ b/twilight-model/src/channel/message/mod.rs
@@ -13,6 +13,7 @@ mod interaction;
 mod kind;
 mod mention;
 mod reaction;
+mod reaction_type;
 mod reference;
 mod role_subscription_data;
 
@@ -26,7 +27,8 @@ pub use self::{
     interaction::MessageInteraction,
     kind::MessageType,
     mention::Mention,
-    reaction::{Reaction, ReactionCountDetails, ReactionType},
+    reaction::{EmojiReactionType, Reaction, ReactionCountDetails},
+    reaction_type::ReactionType,
     reference::MessageReference,
     role_subscription_data::RoleSubscriptionData,
     sticker::Sticker,
@@ -198,8 +200,8 @@ mod tests {
     use super::{
         reaction::ReactionCountDetails,
         sticker::{MessageSticker, StickerFormatType},
-        Message, MessageActivity, MessageActivityType, MessageApplication, MessageFlags,
-        MessageReference, MessageType, Reaction, ReactionType,
+        EmojiReactionType, Message, MessageActivity, MessageActivityType, MessageApplication,
+        MessageFlags, MessageReference, MessageType, Reaction,
     };
     use crate::{
         channel::{ChannelMention, ChannelType},
@@ -486,7 +488,7 @@ mod tests {
                     burst: 0,
                     normal: 7,
                 },
-                emoji: ReactionType::Unicode {
+                emoji: EmojiReactionType::Unicode {
                     name: "a".to_owned(),
                 },
                 me: true,
@@ -681,7 +683,7 @@ mod tests {
                 Token::StructEnd,
                 Token::Str("emoji"),
                 Token::Struct {
-                    name: "ReactionType",
+                    name: "EmojiReactionType",
                     len: 1,
                 },
                 Token::Str("name"),

--- a/twilight-model/src/channel/message/reaction.rs
+++ b/twilight-model/src/channel/message/reaction.rs
@@ -14,17 +14,17 @@ pub struct Reaction {
     /// Reaction count details for each type of reaction.
     pub count_details: ReactionCountDetails,
     /// Emoji of this reaction.
-    pub emoji: ReactionType,
+    pub emoji: EmojiReactionType,
     /// Whether the current user has reacted with this emoji.
     pub me: bool,
     /// Whether the current user super-reacted using this emoji
     pub me_burst: bool,
 }
 
-/// Type of [`Reaction`].
+/// Type of emoji in a [`Reaction`].
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum ReactionType {
+pub enum EmojiReactionType {
     /// Custom [`Emoji`].
     ///
     /// [`Emoji`]: crate::guild::Emoji
@@ -66,7 +66,7 @@ pub struct ReactionCountDetails {
 
 #[cfg(test)]
 mod tests {
-    use super::{Reaction, ReactionCountDetails, ReactionType};
+    use super::{EmojiReactionType, Reaction, ReactionCountDetails};
     use crate::{id::Id, util::HexColor};
     use serde_test::Token;
 
@@ -79,7 +79,7 @@ mod tests {
                 burst: 0,
                 normal: 7,
             },
-            emoji: ReactionType::Unicode {
+            emoji: EmojiReactionType::Unicode {
                 name: "a".to_owned(),
             },
             me: true,
@@ -111,7 +111,7 @@ mod tests {
                 Token::StructEnd,
                 Token::Str("emoji"),
                 Token::Struct {
-                    name: "ReactionType",
+                    name: "EmojiReactionType",
                     len: 1,
                 },
                 Token::Str("name"),
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn custom() {
-        let value = ReactionType::Custom {
+        let value = EmojiReactionType::Custom {
             animated: false,
             id: Id::new(1337),
             name: Some("foo".to_owned()),
@@ -138,7 +138,7 @@ mod tests {
             &value,
             &[
                 Token::Struct {
-                    name: "ReactionType",
+                    name: "EmojiReactionType",
                     len: 3,
                 },
                 Token::Str("animated"),
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn unicode() {
-        let value = ReactionType::Unicode {
+        let value = EmojiReactionType::Unicode {
             name: "\u{1f643}".to_owned(),
         };
 
@@ -183,7 +183,7 @@ mod tests {
             &value,
             &[
                 Token::Struct {
-                    name: "ReactionType",
+                    name: "EmojiReactionType",
                     len: 1,
                 },
                 Token::Str("name"),

--- a/twilight-model/src/channel/message/reaction_type.rs
+++ b/twilight-model/src/channel/message/reaction_type.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(from = "u8", into = "u8")]
+/// The kind of reaction.
+pub enum ReactionType {
+    /// A non-burst/super reaction.
+    Normal,
+    /// A super reaction.
+    Burst,
+    /// An unknown reaction type.
+    Unknown(u8),
+}
+
+impl From<u8> for ReactionType {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => Self::Normal,
+            1 => Self::Burst,
+            unknown => Self::Unknown(unknown),
+        }
+    }
+}
+
+impl From<ReactionType> for u8 {
+    fn from(value: ReactionType) -> Self {
+        match value {
+            ReactionType::Normal => 0,
+            ReactionType::Burst => 1,
+            ReactionType::Unknown(unknown) => unknown,
+        }
+    }
+}
+
+impl ReactionType {
+    /// The name of the reaction type.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Normal => "Normal",
+            Self::Burst => "Burst",
+            Self::Unknown(_) => "Unknown",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReactionType;
+    use serde_test::Token;
+
+    #[test]
+    fn variants() {
+        serde_test::assert_tokens(&ReactionType::Normal, &[Token::U8(0)]);
+        serde_test::assert_tokens(&ReactionType::Burst, &[Token::U8(1)]);
+        serde_test::assert_tokens(&ReactionType::Unknown(255), &[Token::U8(255)]);
+    }
+
+    #[test]
+    fn names() {
+        assert_eq!(ReactionType::Normal.name(), "Normal");
+        assert_eq!(ReactionType::Burst.name(), "Burst");
+        assert_eq!(ReactionType::Unknown(255).name(), "Unknown");
+    }
+}

--- a/twilight-model/src/gateway/payload/incoming/reaction_remove_emoji.rs
+++ b/twilight-model/src/gateway/payload/incoming/reaction_remove_emoji.rs
@@ -1,5 +1,5 @@
 use crate::{
-    channel::message::ReactionType,
+    channel::message::EmojiReactionType,
     id::{
         marker::{ChannelMarker, GuildMarker, MessageMarker},
         Id,
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ReactionRemoveEmoji {
     pub channel_id: Id<ChannelMarker>,
-    pub emoji: ReactionType,
+    pub emoji: EmojiReactionType,
     pub guild_id: Id<GuildMarker>,
     pub message_id: Id<MessageMarker>,
 }

--- a/twilight-model/src/gateway/reaction.rs
+++ b/twilight-model/src/gateway/reaction.rs
@@ -1,17 +1,25 @@
 use crate::{
-    channel::message::ReactionType,
+    channel::message::EmojiReactionType,
     guild::Member,
     id::{
         marker::{ChannelMarker, GuildMarker, MessageMarker, UserMarker},
         Id,
     },
+    util::HexColor,
 };
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct GatewayReaction {
+    /// True if this is a super-reaction.
+    pub burst: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// Colors used for super-reaction animation in hex format.
+    ///
+    /// This is only present when super-reactions are added.
+    pub burst_colors: Vec<HexColor>,
     pub channel_id: Id<ChannelMarker>,
-    pub emoji: ReactionType,
+    pub emoji: EmojiReactionType,
     pub guild_id: Option<Id<GuildMarker>>,
     pub member: Option<Member>,
     /// ID of the user who authored the message which was reacted to.
@@ -25,12 +33,12 @@ pub struct GatewayReaction {
 mod tests {
     use super::GatewayReaction;
     use crate::{
-        channel::message::ReactionType,
+        channel::message::EmojiReactionType,
         guild::{Member, MemberFlags},
         id::Id,
         test::image_hash,
         user::User,
-        util::Timestamp,
+        util::{HexColor, Timestamp},
     };
     use serde_test::Token;
     use std::str::FromStr;
@@ -40,10 +48,16 @@ mod tests {
     fn reaction_with_member() {
         let joined_at = Some(Timestamp::from_str("2020-01-01T00:00:00.000000+00:00").unwrap());
         let flags = MemberFlags::BYPASSES_VERIFICATION | MemberFlags::DID_REJOIN;
+        let burst_colors = ["#F200FF"];
 
         let value = GatewayReaction {
+            burst: true,
+            burst_colors: burst_colors
+                .iter()
+                .map(|c| HexColor::from_str(c).unwrap())
+                .collect(),
             channel_id: Id::new(2),
-            emoji: ReactionType::Unicode {
+            emoji: EmojiReactionType::Unicode {
                 name: "a".to_owned(),
             },
             guild_id: Some(Id::new(1)),
@@ -88,14 +102,20 @@ mod tests {
             &[
                 Token::Struct {
                     name: "GatewayReaction",
-                    len: 7,
+                    len: 9,
                 },
+                Token::Str("burst"),
+                Token::Bool(true),
+                Token::Str("burst_colors"),
+                Token::Seq { len: Some(1) },
+                Token::Str(burst_colors[0]),
+                Token::SeqEnd,
                 Token::Str("channel_id"),
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("2"),
                 Token::Str("emoji"),
                 Token::Struct {
-                    name: "ReactionType",
+                    name: "EmojiReactionType",
                     len: 1,
                 },
                 Token::Str("name"),
@@ -178,8 +198,10 @@ mod tests {
     #[test]
     fn reaction_without_member() {
         let value = GatewayReaction {
+            burst: false,
+            burst_colors: Vec::new(),
             channel_id: Id::new(2),
-            emoji: ReactionType::Unicode {
+            emoji: EmojiReactionType::Unicode {
                 name: "a".to_owned(),
             },
             guild_id: None,
@@ -194,14 +216,16 @@ mod tests {
             &[
                 Token::Struct {
                     name: "GatewayReaction",
-                    len: 7,
+                    len: 8,
                 },
+                Token::Str("burst"),
+                Token::Bool(false),
                 Token::Str("channel_id"),
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("2"),
                 Token::Str("emoji"),
                 Token::Struct {
-                    name: "ReactionType",
+                    name: "EmojiReactionType",
                     len: 1,
                 },
                 Token::Str("name"),

--- a/twilight-model/src/util/hex_color.rs
+++ b/twilight-model/src/util/hex_color.rs
@@ -29,6 +29,7 @@ impl Serialize for HexColor {
     }
 }
 
+#[derive(Debug)]
 pub enum HexColorParseError {
     InvalidLength,
     InvalidFormat,

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -582,7 +582,7 @@ impl Standby {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use tokio_stream::StreamExt;
     /// use twilight_model::{
-    ///     channel::message::ReactionType,
+    ///     channel::message::EmojiReactionType,
     ///     gateway::payload::incoming::ReactionAdd,
     ///     id::Id,
     /// };
@@ -593,7 +593,7 @@ impl Standby {
     /// let message_id = Id::new(123);
     ///
     /// let mut reactions = standby.wait_for_reaction_stream(message_id, |event: &ReactionAdd| {
-    ///     matches!(&event.emoji, ReactionType::Unicode { name } if name == "🤠")
+    ///     matches!(&event.emoji, EmojiReactionType::Unicode { name } if name == "🤠")
     /// });
     ///
     /// while let Some(reaction) = reactions.next().await {

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -1066,7 +1066,7 @@ mod tests {
             InteractionType,
         },
         channel::{
-            message::{component::ComponentType, Message, MessageType, ReactionType},
+            message::{component::ComponentType, EmojiReactionType, Message, MessageType},
             Channel, ChannelType,
         },
         gateway::{
@@ -1137,8 +1137,10 @@ mod tests {
 
     fn reaction() -> GatewayReaction {
         GatewayReaction {
+            burst: false,
+            burst_colors: Vec::new(),
             channel_id: Id::new(2),
-            emoji: ReactionType::Unicode {
+            emoji: EmojiReactionType::Unicode {
                 name: "🍎".to_owned(),
             },
             guild_id: Some(Id::new(1)),

--- a/twilight-validate/src/component.rs
+++ b/twilight-validate/src/component.rs
@@ -1190,7 +1190,7 @@ fn component_text_input_value(value: impl AsRef<str>) -> Result<(), ComponentVal
 mod tests {
     use super::*;
     use static_assertions::{assert_fields, assert_impl_all};
-    use twilight_model::channel::message::ReactionType;
+    use twilight_model::channel::message::EmojiReactionType;
 
     assert_fields!(ComponentValidationErrorType::ActionRowComponentCount: count);
     assert_fields!(ComponentValidationErrorType::ComponentCount: count);
@@ -1221,7 +1221,7 @@ mod tests {
         let button = Button {
             custom_id: None,
             disabled: false,
-            emoji: Some(ReactionType::Unicode {
+            emoji: Some(EmojiReactionType::Unicode {
                 name: "📚".into()
             }),
             label: Some("Read".into()),


### PR DESCRIPTION
Refs:
- https://github.com/discord/discord-api-docs/pull/6375
- https://github.com/discord/discord-api-docs/pull/6377

This PR renames the old `ReactionType` to `EmojiReactionType` as the concept of a reaction type now exists in the API.