### PR TITLE
feat(model): Add support for automod member profile words and member interactions

### DIFF
--- a/twilight-model/src/guild/auto_moderation/action.rs
+++ b/twilight-model/src/guild/auto_moderation/action.rs
@@ -49,6 +49,8 @@ pub enum AutoModerationActionType {
     /// [`Keyword`]: super::AutoModerationTriggerType::Keyword
     /// [`Permissions::MODERATE_MEMBERS`]: crate::guild::Permissions::MODERATE_MEMBERS
     Timeout,
+    /// Prevents a member from using text, voice, or other interactions.
+    BlockMemberInteraction,
     /// Variant value is unknown to the library.
     Unknown(u8),
 }
@@ -59,6 +61,7 @@ impl From<u8> for AutoModerationActionType {
             1 => Self::BlockMessage,
             2 => Self::SendAlertMessage,
             3 => Self::Timeout,
+            4 => Self::BlockMemberInteraction,
             _ => Self::Unknown(value),
         }
     }
@@ -70,6 +73,7 @@ impl From<AutoModerationActionType> for u8 {
             AutoModerationActionType::BlockMessage => 1,
             AutoModerationActionType::SendAlertMessage => 2,
             AutoModerationActionType::Timeout => 3,
+            AutoModerationActionType::BlockMemberInteraction => 4,
             AutoModerationActionType::Unknown(unknown) => unknown,
         }
     }
@@ -128,6 +132,10 @@ mod tests {
         assert_eq!(1, u8::from(AutoModerationActionType::BlockMessage));
         assert_eq!(2, u8::from(AutoModerationActionType::SendAlertMessage));
         assert_eq!(3, u8::from(AutoModerationActionType::Timeout));
+        assert_eq!(
+            4,
+            u8::from(AutoModerationActionType::BlockMemberInteraction)
+        );
         assert_eq!(250, u8::from(AutoModerationActionType::Unknown(250)));
     }
 }

--- a/twilight-model/src/guild/auto_moderation/event_type.rs
+++ b/twilight-model/src/guild/auto_moderation/event_type.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 pub enum AutoModerationEventType {
     /// When a member sends or edits a message in a guild.
     MessageSend,
+    /// When a member edits their profile.
+    MemberUpdate,
     /// Variant value is unknown to the library.
     Unknown(u8),
 }
@@ -14,6 +16,7 @@ impl From<u8> for AutoModerationEventType {
     fn from(value: u8) -> Self {
         match value {
             1 => Self::MessageSend,
+            2 => Self::MemberUpdate,
             _ => Self::Unknown(value),
         }
     }
@@ -23,6 +26,7 @@ impl From<AutoModerationEventType> for u8 {
     fn from(value: AutoModerationEventType) -> Self {
         match value {
             AutoModerationEventType::MessageSend => 1,
+            AutoModerationEventType::MemberUpdate => 2,
             AutoModerationEventType::Unknown(unknown) => unknown,
         }
     }
@@ -51,6 +55,7 @@ mod tests {
     #[test]
     fn values() {
         assert_eq!(1, u8::from(AutoModerationEventType::MessageSend));
+        assert_eq!(2, u8::from(AutoModerationEventType::MemberUpdate));
         assert_eq!(250, u8::from(AutoModerationEventType::Unknown(250)));
     }
 }

--- a/twilight-model/src/guild/auto_moderation/trigger_type.rs
+++ b/twilight-model/src/guild/auto_moderation/trigger_type.rs
@@ -18,6 +18,8 @@ pub enum AutoModerationTriggerType {
     KeywordPreset,
     /// Check if content contains more unique mentions than allowed.
     MentionSpam,
+    /// Check if member profile contains words from a user defined list of keywords.
+    MemberProfile,
     /// Variant value is unknown to the library.
     Unknown(u8),
 }
@@ -29,6 +31,7 @@ impl From<u8> for AutoModerationTriggerType {
             3 => Self::Spam,
             4 => Self::KeywordPreset,
             5 => Self::MentionSpam,
+            6 => Self::MemberProfile,
             _ => Self::Unknown(value),
         }
     }
@@ -41,6 +44,7 @@ impl From<AutoModerationTriggerType> for u8 {
             AutoModerationTriggerType::Spam => 3,
             AutoModerationTriggerType::KeywordPreset => 4,
             AutoModerationTriggerType::MentionSpam => 5,
+            AutoModerationTriggerType::MemberProfile => 6,
             AutoModerationTriggerType::Unknown(unknown) => unknown,
         }
     }
@@ -72,6 +76,7 @@ mod tests {
         assert_eq!(3, u8::from(AutoModerationTriggerType::Spam));
         assert_eq!(4, u8::from(AutoModerationTriggerType::KeywordPreset));
         assert_eq!(5, u8::from(AutoModerationTriggerType::MentionSpam));
+        assert_eq!(6, u8::from(AutoModerationTriggerType::MemberProfile));
         assert_eq!(250, u8::from(AutoModerationTriggerType::Unknown(250)));
     }
 }


### PR DESCRIPTION
Ref:
- https://github.com/discord/discord-api-docs/pull/6040