### PR TITLE
fix(model): Derive Copy on PermissionOverwrite

### DIFF
--- a/twilight-model/src/channel/permission_overwrite.rs
+++ b/twilight-model/src/channel/permission_overwrite.rs
@@ -5,7 +5,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 /// Permission overwrite data for a role or member.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct PermissionOverwrite {
     pub allow: Permissions,
     pub deny: Permissions,


### PR DESCRIPTION
Permission overwrites are very small stack allocatables. They should be Copy.