### PR TITLE
fix(http): Add missing @ symbol in REST path

### DIFF
--- a/twilight-http-ratelimiting/src/request.rs
+++ b/twilight-http-ratelimiting/src/request.rs
@@ -338,7 +338,7 @@ impl FromStr for Path {
         let parts = s.split('/').skip(skip).collect::<Vec<&str>>();
 
         Ok(match parts[..] {
-            ["applications", "me"] => ApplicationsMe,
+            ["applications", "@me"] => ApplicationsMe,
             ["applications", id, "commands"] => ApplicationCommand(parse_id(id)?),
             ["applications", id, "commands", _] => ApplicationCommandId(parse_id(id)?),
             ["applications", id, "entitlements"] => ApplicationIdEntitlements(parse_id(id)?),


### PR DESCRIPTION
Whilst using the http-proxy, I discovered that the http-ratelimiting crate was missing a `@` symbol in one of the route paths.