### PR TITLE
feat(gateway)!: swallow WebSocket errors

### DIFF
--- a/twilight-gateway/README.md
+++ b/twilight-gateway/README.md
@@ -87,12 +87,6 @@ async fn runner(mut shard: Shard) {
         let event = match item {
             Ok(Event::GatewayClose(_)) if SHUTDOWN.load(Ordering::Relaxed) => break,
             Ok(event) => event,
-            Err(source)
-                if SHUTDOWN.load(Ordering::Relaxed)
-                    && matches!(source.kind(), ReceiveMessageErrorType::WebSocket) =>
-            {
-                break
-            }
             Err(source) => {
                 tracing::warn!(?source, "error receiving event");
 

--- a/twilight-gateway/src/error.rs
+++ b/twilight-gateway/src/error.rs
@@ -175,14 +175,6 @@ impl ReceiveMessageError {
             source: Some(Box::new(source)),
         }
     }
-
-    /// Shortcut to create a new error for a websocket error.
-    pub(crate) fn from_websocket(source: tokio_websockets::Error) -> Self {
-        Self {
-            kind: ReceiveMessageErrorType::WebSocket,
-            source: Some(Box::new(source)),
-        }
-    }
 }
 
 impl Display for ReceiveMessageError {
@@ -197,7 +189,6 @@ impl Display for ReceiveMessageError {
                 f.write_str(event)
             }
             ReceiveMessageErrorType::Reconnect => f.write_str("failed to reconnect to the gateway"),
-            ReceiveMessageErrorType::WebSocket => f.write_str("websocket connection error"),
         }
     }
 }
@@ -228,8 +219,6 @@ pub enum ReceiveMessageErrorType {
     },
     /// Shard failed to reconnect to the gateway.
     Reconnect,
-    /// WebSocket connection error.
-    WebSocket,
 }
 
 #[cfg(test)]
@@ -243,7 +232,7 @@ mod tests {
 
     #[test]
     fn receive_message_error_display() {
-        let messages: [(ReceiveMessageErrorType, &str); 4] = [
+        let messages: [(ReceiveMessageErrorType, &str); 3] = [
             (
                 ReceiveMessageErrorType::Compression,
                 "binary message could not be decompressed",
@@ -258,7 +247,6 @@ mod tests {
                 ReceiveMessageErrorType::Reconnect,
                 "failed to reconnect to the gateway",
             ),
-            (ReceiveMessageErrorType::WebSocket, "websocket connection error"),
         ];
 
         for (kind, message) in messages {

--- a/twilight-gateway/src/message.rs
+++ b/twilight-gateway/src/message.rs
@@ -24,6 +24,9 @@ pub enum Message {
 }
 
 impl Message {
+    /// Close message indicating the connection was closed abnormally.
+    pub(crate) const ABNORMAL_CLOSE: Self = Self::Close(Some(CloseFrame::new(1006, "")));
+
     /// Whether the message is a close message.
     pub const fn is_close(&self) -> bool {
         matches!(self, Self::Close(_))


### PR DESCRIPTION
Reading received messages on shutdown requires verbosely matching on WebSocket errors to prevent the shard from automatically reconnecting. While potentially useful for debugging, my experience is that WebSocket errors are generally just noise, and as such they are replaced with close messages with a [status code of 1006](https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1) indicating abnormal closure. This has the secondary benefit of removing confusion about transport errors being somehow actionable (any internet connection may naturally error at any time for reasons outside of your control).