### PR TITLE
feat(model): add attachment titles

### DIFF
--- a/twilight-model/src/application/interaction/resolved.rs
+++ b/twilight-model/src/application/interaction/resolved.rs
@@ -136,6 +136,7 @@ mod tests {
                     id: Id::new(400),
                     proxy_url: "https://proxy.example.com/rainbow_dash.png".to_owned(),
                     size: 13370,
+                    title: None,
                     url: "https://example.com/rainbow_dash.png".to_owned(),
                     waveform: None,
                     width: Some(1337),

--- a/twilight-model/src/channel/attachment.rs
+++ b/twilight-model/src/channel/attachment.rs
@@ -32,6 +32,9 @@ pub struct Attachment {
     pub id: Id<AttachmentMarker>,
     pub proxy_url: String,
     pub size: u64,
+    /// The title of the file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     pub url: String,
     /// Base64 encoded bytearray representing a sampled waveform (currently for voice messages).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -82,6 +85,7 @@ mod tests {
             id: Id::new(700_000_000_000_000_000),
             proxy_url: "https://cdn.example.com/1.png".to_owned(),
             size: 13_593,
+            title: Some("a title".to_owned()),
             url: "https://example.com/1.png".to_owned(),
             waveform: Some(String::from("waveform")),
             width: Some(184),
@@ -118,6 +122,7 @@ mod tests {
                 Token::Str("https://cdn.example.com/1.png"),
                 Token::Str("size"),
                 Token::U64(13_593),
+                Token::Str("title"),
                 Token::Str("url"),
                 Token::Str("https://example.com/1.png"),
                 Token::Str("waveform"),

--- a/twilight-model/src/channel/attachment.rs
+++ b/twilight-model/src/channel/attachment.rs
@@ -96,7 +96,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Attachment",
-                    len: 12,
+                    len: 13,
                 },
                 Token::Str("content_type"),
                 Token::Some,
@@ -123,6 +123,8 @@ mod tests {
                 Token::Str("size"),
                 Token::U64(13_593),
                 Token::Str("title"),
+                Token::Some,
+                Token::Str("a title"),
                 Token::Str("url"),
                 Token::Str("https://example.com/1.png"),
                 Token::Str("waveform"),


### PR DESCRIPTION
Ref:
- https://github.com/discord/discord-api-docs/pull/6945