### PR TITLE
ci: Don't downgrade tokio

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,9 +36,6 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
 
-      - name: Lower Tokio version to keep MSRV at 1.67
-        run: cargo add "tokio@>=1.19.0,<1.39.0" -p twilight-gateway
-
       - name: Output processor info
         run: cat /proc/cpuinfo
 


### PR DESCRIPTION
This was an unintended change caused by merging an older PR after the MSRV bump without accounting for it.