### PR TITLE
fix(http): List application emojis does not return a raw list

### DIFF
--- a/twilight-http/src/request/application/emoji/list_emojis.rs
+++ b/twilight-http/src/request/application/emoji/list_emojis.rs
@@ -7,7 +7,7 @@ use crate::{
     Client, Error, Response,
 };
 use twilight_model::{
-    application::emoji::EmojiList,
+    application::EmojiList,
     id::{marker::ApplicationMarker, Id},
 };
 

--- a/twilight-http/src/request/application/emoji/list_emojis.rs
+++ b/twilight-http/src/request/application/emoji/list_emojis.rs
@@ -2,12 +2,12 @@ use std::future::IntoFuture;
 
 use crate::{
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, ResponseFuture},
+    response::ResponseFuture,
     routing::Route,
     Client, Error, Response,
 };
 use twilight_model::{
-    guild::Emoji,
+    application::emoji::EmojiList,
     id::{marker::ApplicationMarker, Id},
 };
 
@@ -27,9 +27,9 @@ impl<'a> ListApplicationEmojis<'a> {
 }
 
 impl IntoFuture for ListApplicationEmojis<'_> {
-    type Output = Result<Response<ListBody<Emoji>>, Error>;
+    type Output = Result<Response<EmojiList>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Emoji>>;
+    type IntoFuture = ResponseFuture<EmojiList>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-model/src/application/emoji.rs
+++ b/twilight-model/src/application/emoji.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+use crate::guild::Emoji;
+
+/// List of application emojis
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
+pub struct EmojiList {
+    /// List of application emojis
+    pub items: Vec<Emoji>,
+}

--- a/twilight-model/src/application/mod.rs
+++ b/twilight-model/src/application/mod.rs
@@ -1,4 +1,6 @@
 pub mod command;
-pub mod emoji;
+mod emoji;
 pub mod interaction;
 pub mod monetization;
+
+pub use emoji::EmojiList;

--- a/twilight-model/src/application/mod.rs
+++ b/twilight-model/src/application/mod.rs
@@ -1,3 +1,4 @@
 pub mod command;
+pub mod emoji;
 pub mod interaction;
 pub mod monetization;


### PR DESCRIPTION
For some reason "List Application Emojis" returns a object with a single `items` key which caused our use of `ListBody` to fail here.

Resolves: #2373