### PR TITLE
fix(model, cache): unavailable is optional and false and none equal

### DIFF
--- a/examples/cache-optimization/models/guild.rs
+++ b/examples/cache-optimization/models/guild.rs
@@ -42,7 +42,7 @@ impl CacheableGuild for MinimalCachedGuild {
         self.owner_id
     }
 
-    fn set_unavailable(&mut self, _unavailable: bool) {
+    fn set_unavailable(&mut self, _unavailable: Option<bool>) {
         // We don't store this information, so this is a no-op
     }
 

--- a/twilight-cache-inmemory/src/event/guild.rs
+++ b/twilight-cache-inmemory/src/event/guild.rs
@@ -96,7 +96,7 @@ impl<CacheModels: CacheableModels> InMemoryCache<CacheModels> {
         if self.wants(ResourceType::GUILD) {
             if unavailable {
                 if let Some(mut guild) = self.guilds.get_mut(&id) {
-                    guild.set_unavailable(true);
+                    guild.set_unavailable(Some(true));
                 }
             } else {
                 self.guilds.remove(&id);
@@ -335,7 +335,7 @@ mod tests {
             system_channel_flags: SystemChannelFlags::SUPPRESS_JOIN_NOTIFICATIONS,
             system_channel_id: None,
             threads,
-            unavailable: false,
+            unavailable: Some(false),
             vanity_url_code: None,
             verification_level: VerificationLevel::VeryHigh,
             voice_states: Vec::new(),
@@ -384,10 +384,15 @@ mod tests {
             },
         ));
         assert!(cache.unavailable_guilds.get(&guild.id).is_some());
-        assert!(cache.guilds.get(&guild.id).unwrap().unavailable);
+        assert!(cache.guilds.get(&guild.id).unwrap().unavailable.unwrap());
 
         cache.update(&GuildCreate::Available(guild.clone()));
-        assert!(!cache.guilds.get(&guild.id).unwrap().unavailable);
+        assert!(!cache
+            .guilds
+            .get(&guild.id)
+            .unwrap()
+            .unavailable
+            .unwrap_or(false));
         assert!(cache.unavailable_guilds.get(&guild.id).is_none());
     }
 
@@ -490,7 +495,7 @@ mod tests {
                 .map(|members| members.len())
                 .unwrap_or_default()
         );
-        assert!(cache.guild(guild_id).unwrap().unavailable);
+        assert!(cache.guild(guild_id).unwrap().unavailable.unwrap());
 
         cache.update(&GuildCreate::Available(guild));
 
@@ -501,6 +506,6 @@ mod tests {
                 .map(|members| members.len())
                 .unwrap_or_default()
         );
-        assert!(!cache.guild(guild_id).unwrap().unavailable);
+        assert!(!cache.guild(guild_id).unwrap().unavailable.unwrap_or(false));
     }
 }

--- a/twilight-cache-inmemory/src/model/guild.rs
+++ b/twilight-cache-inmemory/src/model/guild.rs
@@ -57,7 +57,7 @@ pub struct CachedGuild {
     pub(crate) splash: Option<ImageHash>,
     pub(crate) system_channel_flags: SystemChannelFlags,
     pub(crate) system_channel_id: Option<Id<ChannelMarker>>,
-    pub(crate) unavailable: bool,
+    pub(crate) unavailable: Option<bool>,
     pub(crate) vanity_url_code: Option<String>,
     pub(crate) verification_level: VerificationLevel,
     pub(crate) widget_channel_id: Option<Id<ChannelMarker>>,
@@ -266,7 +266,7 @@ impl CachedGuild {
     }
 
     /// Whether the guild is unavailable due to an outage.
-    pub const fn unavailable(&self) -> bool {
+    pub const fn unavailable(&self) -> Option<bool> {
         self.unavailable
     }
 
@@ -436,7 +436,7 @@ impl CacheableGuild for CachedGuild {
         self.owner_id
     }
 
-    fn set_unavailable(&mut self, unavailable: bool) {
+    fn set_unavailable(&mut self, unavailable: Option<bool>) {
         self.unavailable = unavailable;
     }
 

--- a/twilight-cache-inmemory/src/permission.rs
+++ b/twilight-cache-inmemory/src/permission.rs
@@ -763,7 +763,7 @@ mod tests {
             system_channel_flags: SystemChannelFlags::SUPPRESS_JOIN_NOTIFICATIONS,
             threads: Vec::new(),
             rules_channel_id: None,
-            unavailable: false,
+            unavailable: Some(false),
             verification_level: VerificationLevel::VeryHigh,
             voice_states: Vec::new(),
             vanity_url_code: None,

--- a/twilight-cache-inmemory/src/test.rs
+++ b/twilight-cache-inmemory/src/test.rs
@@ -435,7 +435,7 @@ pub fn guild(id: Id<GuildMarker>, member_count: Option<u64>) -> Guild {
         system_channel_flags: SystemChannelFlags::empty(),
         system_channel_id: None,
         threads: Vec::new(),
-        unavailable: false,
+        unavailable: Some(false),
         vanity_url_code: None,
         verification_level: VerificationLevel::VeryHigh,
         voice_states: Vec::new(),

--- a/twilight-cache-inmemory/src/traits.rs
+++ b/twilight-cache-inmemory/src/traits.rs
@@ -206,7 +206,7 @@ pub trait CacheableGuild: From<Guild> + PartialEq<Guild> + PartialEq<Self> + Clo
     fn owner_id(&self) -> Id<UserMarker>;
 
     /// Set the guild's unavailable flag.
-    fn set_unavailable(&mut self, unavailable: bool);
+    fn set_unavailable(&mut self, unavailable: Option<bool>);
 
     /// Update the cached data with a [`GuildUpdate`] event. Fields containing other
     /// cached structures such as channels are cleared prior.

--- a/twilight-model/src/gateway/payload/incoming/guild_delete.rs
+++ b/twilight-model/src/gateway/payload/incoming/guild_delete.rs
@@ -1,17 +1,11 @@
 use crate::id::{marker::GuildMarker, Id};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct GuildDelete {
     pub id: Id<GuildMarker>,
-    // If `unavailable` is `None` the user was removed from the guild.
-    #[serde(default, deserialize_with = "nullable_unavailable")]
-    pub unavailable: bool,
-}
-
-#[allow(clippy::unnecessary_wraps)]
-fn nullable_unavailable<'de, D: Deserializer<'de>>(deserializer: D) -> Result<bool, D::Error> {
-    Ok(Deserialize::deserialize(deserializer).unwrap_or_default())
+    /// If `None` the user was removed from the guild.
+    pub unavailable: Option<bool>,
 }
 
 #[cfg(test)]
@@ -24,7 +18,7 @@ mod tests {
     fn guild_delete_available() {
         let expected = GuildDelete {
             id: Id::new(123),
-            unavailable: true,
+            unavailable: Some(true),
         };
 
         serde_test::assert_de_tokens(
@@ -38,6 +32,7 @@ mod tests {
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("123"),
                 Token::Str("unavailable"),
+                Token::Some,
                 Token::Bool(true),
                 Token::StructEnd,
             ],
@@ -53,6 +48,7 @@ mod tests {
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("123"),
                 Token::Str("unavailable"),
+                Token::Some,
                 Token::Bool(true),
                 Token::StructEnd,
             ],
@@ -63,7 +59,7 @@ mod tests {
     fn guild_delete_unavailable() {
         let expected = GuildDelete {
             id: Id::new(123),
-            unavailable: false,
+            unavailable: Some(false),
         };
 
         serde_test::assert_de_tokens(
@@ -77,6 +73,7 @@ mod tests {
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("123"),
                 Token::Str("unavailable"),
+                Token::Some,
                 Token::Bool(false),
                 Token::StructEnd,
             ],
@@ -92,6 +89,7 @@ mod tests {
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("123"),
                 Token::Str("unavailable"),
+                Token::Some,
                 Token::Bool(false),
                 Token::StructEnd,
             ],
@@ -102,7 +100,7 @@ mod tests {
     fn guild_delete_unavailable_null_default() {
         let expected = GuildDelete {
             id: Id::new(123),
-            unavailable: false,
+            unavailable: None,
         };
 
         serde_test::assert_de_tokens(
@@ -110,13 +108,11 @@ mod tests {
             &[
                 Token::Struct {
                     name: "GuildDelete",
-                    len: 2,
+                    len: 1,
                 },
                 Token::Str("id"),
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("123"),
-                Token::Str("unavailable"),
-                Token::None,
                 Token::StructEnd,
             ],
         );

--- a/twilight-model/src/guild/mod.rs
+++ b/twilight-model/src/guild/mod.rs
@@ -152,8 +152,15 @@ pub struct Guild {
     pub system_channel_id: Option<Id<ChannelMarker>>,
     #[serde(default)]
     pub threads: Vec<Channel>,
-    #[serde(default)]
-    pub unavailable: bool,
+    /// If the guild is unavailable.
+    ///
+    /// # Note:
+    ///
+    /// While it is not documented and may change in the future if
+    /// this field is not sent it is because the user joined a new
+    /// guild.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unavailable: Option<bool>,
     pub vanity_url_code: Option<String>,
     pub verification_level: VerificationLevel,
     #[serde(default)]
@@ -721,7 +728,6 @@ impl<'de> Deserialize<'de> for Guild {
                 let stickers = stickers.unwrap_or_default();
                 let system_channel_id = system_channel_id.unwrap_or_default();
                 let mut threads = threads.unwrap_or_default();
-                let unavailable = unavailable.unwrap_or_default();
                 let vanity_url_code = vanity_url_code.unwrap_or_default();
                 let mut voice_states = voice_states.unwrap_or_default();
                 let widget_channel_id = widget_channel_id.unwrap_or_default();
@@ -917,7 +923,7 @@ mod tests {
             system_channel_flags: SystemChannelFlags::SUPPRESS_PREMIUM_SUBSCRIPTIONS,
             system_channel_id: Some(Id::new(7)),
             threads: Vec::new(),
-            unavailable: false,
+            unavailable: None,
             vanity_url_code: Some("twilight".to_owned()),
             verification_level: VerificationLevel::Medium,
             voice_states: Vec::new(),
@@ -930,7 +936,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Guild",
-                    len: 48,
+                    len: 47,
                 },
                 Token::Str("afk_channel_id"),
                 Token::Some,
@@ -1053,8 +1059,6 @@ mod tests {
                 Token::Str("threads"),
                 Token::Seq { len: Some(0) },
                 Token::SeqEnd,
-                Token::Str("unavailable"),
-                Token::Bool(false),
                 Token::Str("vanity_url_code"),
                 Token::Some,
                 Token::Str("twilight"),


### PR DESCRIPTION
Unavailable would assume false if the field was false if it was not sent.

The ability to tell the difference can be used to tell the difference between a guild becoming available and joining a new guild.

Resolves #2372