### PR TITLE
refactor(model): simplify auto_archive_duration de/serialize

### DIFF
--- a/twilight-model/src/channel/thread/auto_archive_duration.rs
+++ b/twilight-model/src/channel/thread/auto_archive_duration.rs
@@ -1,11 +1,8 @@
-use crate::visitor::U16EnumVisitor;
-use serde::{
-    de::{Deserialize, Deserializer},
-    ser::{Serialize, Serializer},
-};
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[serde(from = "u16", into = "u16")]
 pub enum AutoArchiveDuration {
     Hour,
     Day,
@@ -47,23 +44,15 @@ impl From<u16> for AutoArchiveDuration {
     }
 }
 
+impl From<AutoArchiveDuration> for u16 {
+    fn from(value: AutoArchiveDuration) -> Self {
+        value.number()
+    }
+}
+
 impl From<AutoArchiveDuration> for Duration {
     fn from(value: AutoArchiveDuration) -> Self {
         Self::from_secs(u64::from(value.number()) * 60)
-    }
-}
-
-impl<'de> Deserialize<'de> for AutoArchiveDuration {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        deserializer
-            .deserialize_u16(U16EnumVisitor::new("auto archive duration"))
-            .map(u16::into)
-    }
-}
-
-impl Serialize for AutoArchiveDuration {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_u16(self.number())
     }
 }
 

--- a/twilight-model/src/visitor.rs
+++ b/twilight-model/src/visitor.rs
@@ -1,9 +1,3 @@
-use serde::de::{Error as DeError, Visitor};
-use std::{
-    fmt::{Formatter, Result as FmtResult},
-    marker::PhantomData,
-};
-
 /// Deserializers for optional nullable fields.
 ///
 /// Some booleans in the Discord API are null when true, and not present when
@@ -135,37 +129,5 @@ pub mod zeroable_id {
         deserializer.deserialize_any(ZeroableIdVisitor::<T> {
             phantom: PhantomData,
         })
-    }
-}
-
-pub struct U16EnumVisitor<'a> {
-    description: &'a str,
-    phantom: PhantomData<u16>,
-}
-
-impl<'a> U16EnumVisitor<'a> {
-    pub const fn new(description: &'a str) -> Self {
-        Self {
-            description,
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<'de> Visitor<'de> for U16EnumVisitor<'_> {
-    type Value = u16;
-
-    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_str(self.description)
-    }
-
-    fn visit_u16<E: DeError>(self, value: u16) -> Result<Self::Value, E> {
-        Ok(value)
-    }
-
-    fn visit_u64<E: DeError>(self, value: u64) -> Result<Self::Value, E> {
-        let smaller = u16::try_from(value).map_err(E::custom)?;
-
-        self.visit_u16(smaller)
     }
 }


### PR DESCRIPTION
This patch simplifies our implementation of `auto_archive_duration` this also solves the same issue we encountered with simd-json that was resolved in #2370.