### PR TITLE
fix(http): update role icon and unicode_emoji using nullable strings

### DIFF
--- a/twilight-http/src/request/guild/role/update_role.rs
+++ b/twilight-http/src/request/guild/role/update_role.rs
@@ -23,7 +23,7 @@ struct UpdateRoleFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<&'a [u8]>,
+    icon: Option<Nullable<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     mentionable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -31,7 +31,7 @@ struct UpdateRoleFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     permissions: Option<Permissions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    unicode_emoji: Option<&'a str>,
+    unicode_emoji: Option<Nullable<&'a str>>,
 }
 
 /// Update a role by guild id and its id.
@@ -94,8 +94,8 @@ impl<'a> UpdateRole<'a> {
     /// See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn icon(mut self, icon: &'a [u8]) -> Self {
-        self.fields.icon = Some(icon);
+    pub const fn icon(mut self, icon: Option<&'a str>) -> Self {
+        self.fields.icon = Some(Nullable(icon));
 
         self
     }
@@ -122,8 +122,8 @@ impl<'a> UpdateRole<'a> {
     }
 
     /// Set the unicode emoji of a role.
-    pub const fn unicode_emoji(mut self, unicode_emoji: &'a str) -> Self {
-        self.fields.unicode_emoji = Some(unicode_emoji);
+    pub const fn unicode_emoji(mut self, unicode_emoji: Option<&'a str>) -> Self {
+        self.fields.unicode_emoji = Some(Nullable(unicode_emoji));
 
         self
     }

--- a/twilight-http/src/request/guild/role/update_role.rs
+++ b/twilight-http/src/request/guild/role/update_role.rs
@@ -94,6 +94,36 @@ impl<'a> UpdateRole<'a> {
     /// See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
+    ///
+    /// # Editing
+    ///
+    /// Pass [`None`] to clear the existing icon.
+    ///
+    /// **Warning**: If the existing unicode emoji isn't cleared when setting the icon, it might
+    /// cause undefined behavior.
+    ///
+    /// # Examples
+    ///
+    /// Sets a role icon. The unicode emoji should always be cleared to ensure the icon can be
+    /// set correctly.
+    ///
+    /// ```no_run
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use twilight_http::Client;
+    /// use twilight_model::id::Id;
+    ///
+    /// let client = Client::new("token".to_owned());
+    /// let guild_id = Id::new(1);
+    /// let role_id = Id::new(1);
+    /// let icon = "data:image/png;base64,BASE64_ENCODED_PNG_IMAGE_DATA";
+    ///
+    /// client
+    ///     .update_role(guild_id, role_id)
+    ///     .icon(Some(icon))
+    ///     .unicode_emoji(None)
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
     pub const fn icon(mut self, icon: Option<&'a str>) -> Self {
         self.fields.icon = Some(Nullable(icon));
 
@@ -122,6 +152,37 @@ impl<'a> UpdateRole<'a> {
     }
 
     /// Set the unicode emoji of a role.
+    ///
+    /// Only works if the guild has the `ROLE_ICONS` feature.
+    ///
+    /// # Editing
+    ///
+    /// Pass [`None`] to clear the existing unicode emoji.
+    ///
+    /// **Warning**: If the existing icon isn't cleared when setting the unicode emoji, it might
+    /// cause undefined behavior.
+    ///
+    /// # Examples
+    ///
+    /// Sets a role unicode emoji. The icon should always be cleared to ensure the unicode emoji
+    /// can be set correctly.
+    ///
+    /// ```no_run
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use twilight_http::Client;
+    /// use twilight_model::id::Id;
+    ///
+    /// let client = Client::new("token".to_owned());
+    /// let guild_id = Id::new(1);
+    /// let role_id = Id::new(1);
+    ///
+    /// client
+    ///     .update_role(guild_id, role_id)
+    ///     .icon(None)
+    ///     .unicode_emoji(Some("🦀"))
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
     pub const fn unicode_emoji(mut self, unicode_emoji: Option<&'a str>) -> Self {
         self.fields.unicode_emoji = Some(Nullable(unicode_emoji));
 

--- a/twilight-http/src/request/guild/role/update_role.rs
+++ b/twilight-http/src/request/guild/role/update_role.rs
@@ -100,7 +100,7 @@ impl<'a> UpdateRole<'a> {
     /// Pass [`None`] to clear the existing icon.
     ///
     /// **Warning**: If the existing unicode emoji isn't cleared when setting the icon, it might
-    /// cause undefined behavior.
+    /// cause incorrect behavior.
     ///
     /// # Examples
     ///
@@ -160,7 +160,7 @@ impl<'a> UpdateRole<'a> {
     /// Pass [`None`] to clear the existing unicode emoji.
     ///
     /// **Warning**: If the existing icon isn't cleared when setting the unicode emoji, it might
-    /// cause undefined behavior.
+    /// cause incorrect behavior.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
According to [Discord docs](https://discord.com/developers/docs/resources/guild#modify-guild-role), `UpdateRoleFields::icon` is Image Data in [Data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme) format. Basically, it must be a string. An example Data URI format is:

```
data:image/jpeg;base64,BASE64_ENCODED_JPEG_IMAGE_DATA
```

Additionally, people should be able to set `UpdateRoleFields::icon` and `UpdateRoleFields::unicode_emoji` to null to remove the role icon (if needed).

Briefly describe this pr, it makes `UpdateRoleFields::icon` and `UpdateRoleFields::unicode_emoji` nullable strings.