### PR TITLE
chore(clippy, minvers): resolve rust 1.83 issues

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -148,6 +148,9 @@ jobs:
       - name: Install cargo-minimal-versions
         uses: taiki-e/install-action@cargo-minimal-versions
 
+      - name: Work around old serde_derive version error
+        run: cargo add -p twilight-model serde_derive@1.0.113
+
       - name: Check minimal versions
         run: cargo minimal-versions check
 

--- a/twilight-cache-inmemory/src/lib.rs
+++ b/twilight-cache-inmemory/src/lib.rs
@@ -131,7 +131,7 @@ impl<K: Eq + Hash, V: Debug> Debug for Reference<'_, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash, V> Deref for Reference<'a, K, V> {
+impl<K: Eq + Hash, V> Deref for Reference<'_, K, V> {
     type Target = V;
 
     fn deref(&self) -> &Self::Target {

--- a/twilight-gateway/src/stream.rs
+++ b/twilight-gateway/src/stream.rs
@@ -104,8 +104,8 @@ mod private {
         }
     }
 
-    impl<'a, St: ?Sized + Stream<Item = Result<Message, ReceiveMessageError>> + Unpin> Future
-        for NextEvent<'a, St>
+    impl<St: ?Sized + Stream<Item = Result<Message, ReceiveMessageError>> + Unpin> Future
+        for NextEvent<'_, St>
     {
         type Output = Option<Result<Event, ReceiveMessageError>>;
 

--- a/twilight-http/src/routing.rs
+++ b/twilight-http/src/routing.rs
@@ -1187,7 +1187,7 @@ pub enum Route<'a> {
     UpdateCurrentUserApplication,
 }
 
-impl<'a> Route<'a> {
+impl Route<'_> {
     /// HTTP method of the route.
     ///
     /// # Examples

--- a/twilight-lavalink/src/lib.rs
+++ b/twilight-lavalink/src/lib.rs
@@ -9,7 +9,8 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::unnecessary_wraps
+    clippy::unnecessary_wraps,
+    clippy::used_underscore_items
 )]
 
 pub mod client;

--- a/twilight-mention/src/parse/iter.rs
+++ b/twilight-mention/src/parse/iter.rs
@@ -51,7 +51,7 @@ impl<'a, T> MentionIter<'a, T> {
     }
 }
 
-impl<'a, T: ParseMention> Iterator for MentionIter<'a, T> {
+impl<T: ParseMention> Iterator for MentionIter<'_, T> {
     /// Found mention followed by the start and ending indexes in the source
     /// string returned by [`as_str`].
     ///

--- a/twilight-model/src/gateway/event/dispatch.rs
+++ b/twilight-model/src/gateway/event/dispatch.rs
@@ -245,7 +245,7 @@ impl<'a> DispatchEventWithTypeDeserializer<'a> {
     }
 }
 
-impl<'de, 'a> DeserializeSeed<'de> for DispatchEventWithTypeDeserializer<'a> {
+impl<'de> DeserializeSeed<'de> for DispatchEventWithTypeDeserializer<'_> {
     type Value = DispatchEvent;
 
     #[allow(clippy::too_many_lines)]

--- a/twilight-model/src/guild/permissions.rs
+++ b/twilight-model/src/guild/permissions.rs
@@ -89,7 +89,7 @@ bitflags! {
 
 struct PermissionsVisitor;
 
-impl<'de> Visitor<'de> for PermissionsVisitor {
+impl Visitor<'_> for PermissionsVisitor {
     type Value = Permissions;
 
     fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {

--- a/twilight-model/src/lib.rs
+++ b/twilight-model/src/lib.rs
@@ -3,7 +3,8 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::semicolon_if_nothing_returned
+    clippy::semicolon_if_nothing_returned,
+    clippy::used_underscore_items
 )]
 
 pub mod application;

--- a/twilight-model/src/user/mod.rs
+++ b/twilight-model/src/user/mod.rs
@@ -29,7 +29,7 @@ pub(crate) mod discriminator {
 
     struct DiscriminatorVisitor;
 
-    impl<'de> Visitor<'de> for DiscriminatorVisitor {
+    impl Visitor<'_> for DiscriminatorVisitor {
         type Value = u16;
 
         fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {

--- a/twilight-model/src/util/hex_color.rs
+++ b/twilight-model/src/util/hex_color.rs
@@ -72,7 +72,7 @@ impl FromStr for HexColor {
 
 struct HexColorVisitor;
 
-impl<'de> Visitor<'de> for HexColorVisitor {
+impl Visitor<'_> for HexColorVisitor {
     type Value = HexColor;
 
     fn expecting(&self, formatter: &mut Formatter) -> FmtResult {

--- a/twilight-model/src/util/mustbe.rs
+++ b/twilight-model/src/util/mustbe.rs
@@ -20,7 +20,7 @@ impl<'de, const T: bool> Deserialize<'de> for MustBeBool<T> {
     {
         struct MustBeBoolVisitor(bool);
 
-        impl<'de> Visitor<'de> for MustBeBoolVisitor {
+        impl Visitor<'_> for MustBeBoolVisitor {
             type Value = ();
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/twilight-model/src/visitor.rs
+++ b/twilight-model/src/visitor.rs
@@ -14,7 +14,7 @@ pub mod null_boolean {
 
     struct NullBooleanVisitor;
 
-    impl<'de> Visitor<'de> for NullBooleanVisitor {
+    impl Visitor<'_> for NullBooleanVisitor {
         type Value = bool;
 
         fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
@@ -111,7 +111,7 @@ pub mod zeroable_id {
 
     // Clippy will say this bool can be taken by value, but we need it to be
     // passed by reference because that's what serde does.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
+    #[allow(clippy::ref_option, clippy::trivially_copy_pass_by_ref)]
     pub fn serialize<S: Serializer, T>(
         value: &Option<Id<T>>,
         serializer: S,

--- a/twilight-util/src/lib.rs
+++ b/twilight-util/src/lib.rs
@@ -9,7 +9,8 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::unnecessary_wraps
+    clippy::unnecessary_wraps,
+    clippy::used_underscore_items
 )]
 
 #[cfg(feature = "builder")]

--- a/twilight-validate/src/command.rs
+++ b/twilight-validate/src/command.rs
@@ -360,10 +360,10 @@ pub fn command(value: &Command) -> Result<(), CommandValidationError> {
 /// Calculate the total character count of a command.
 pub fn command_characters(command: &Command) -> usize {
     let mut characters =
-        longest_localization_characters(&command.name, &command.name_localizations)
+        longest_localization_characters(&command.name, command.name_localizations.as_ref())
             + longest_localization_characters(
                 &command.description,
-                &command.description_localizations,
+                command.description_localizations.as_ref(),
             );
 
     for option in &command.options {
@@ -377,9 +377,11 @@ pub fn command_characters(command: &Command) -> usize {
 pub fn option_characters(option: &CommandOption) -> usize {
     let mut characters = 0;
 
-    characters += longest_localization_characters(&option.name, &option.name_localizations);
-    characters +=
-        longest_localization_characters(&option.description, &option.description_localizations);
+    characters += longest_localization_characters(&option.name, option.name_localizations.as_ref());
+    characters += longest_localization_characters(
+        &option.description,
+        option.description_localizations.as_ref(),
+    );
 
     match option.kind {
         CommandOptionType::String => {
@@ -388,7 +390,7 @@ pub fn option_characters(option: &CommandOption) -> usize {
                     if let CommandOptionChoiceValue::String(string_choice) = &choice.value {
                         characters += longest_localization_characters(
                             &choice.name,
-                            &choice.name_localizations,
+                            choice.name_localizations.as_ref(),
                         ) + string_choice.len();
                     }
                 }
@@ -415,7 +417,7 @@ pub fn option_characters(option: &CommandOption) -> usize {
 /// instead.
 fn longest_localization_characters(
     default: &str,
-    localizations: &Option<HashMap<String, String>>,
+    localizations: Option<&HashMap<String, String>>,
 ) -> usize {
     let mut characters = default.len();
 


### PR DESCRIPTION
* `serde_derive` < 1.0.113 no longer work with modern rustc versions.
* `used_underscore_items` is a false positive, see rust-lang/rust-clippy#13478
