### PR TITLE
feat(http): add get guild role endpoint

### DIFF
--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -57,7 +57,7 @@ use crate::{
                 AddGuildMember, AddRoleToMember, GetGuildMembers, GetMember, RemoveMember,
                 RemoveRoleFromMember, SearchGuildMembers, UpdateGuildMember,
             },
-            role::{CreateRole, DeleteRole, GetGuildRoles, UpdateRole, UpdateRolePositions},
+            role::{CreateRole, DeleteRole, GetGuildRoles, GetRole, UpdateRole, UpdateRolePositions},
             sticker::{
                 CreateGuildSticker, DeleteGuildSticker, GetGuildSticker, GetGuildStickers,
                 UpdateGuildSticker,
@@ -1667,6 +1667,12 @@ impl Client {
     /// Get the roles of a guild.
     pub const fn roles(&self, guild_id: Id<GuildMarker>) -> GetGuildRoles<'_> {
         GetGuildRoles::new(self, guild_id)
+    }
+
+    /// Get a role of a guild by its id.
+    pub const fn role(&self, guild_id: Id<GuildMarker>,
+        role_id: Id<RoleMarker>,) -> GetRole<'_> {
+        GetRole::new(self, guild_id, role_id)
     }
 
     /// Create a role in a guild.

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -57,7 +57,9 @@ use crate::{
                 AddGuildMember, AddRoleToMember, GetGuildMembers, GetMember, RemoveMember,
                 RemoveRoleFromMember, SearchGuildMembers, UpdateGuildMember,
             },
-            role::{CreateRole, DeleteRole, GetGuildRoles, GetRole, UpdateRole, UpdateRolePositions},
+            role::{
+                CreateRole, DeleteRole, GetGuildRoles, GetRole, UpdateRole, UpdateRolePositions,
+            },
             sticker::{
                 CreateGuildSticker, DeleteGuildSticker, GetGuildSticker, GetGuildStickers,
                 UpdateGuildSticker,
@@ -1669,9 +1671,8 @@ impl Client {
         GetGuildRoles::new(self, guild_id)
     }
 
-    /// Get a role of a guild by its id.
-    pub const fn role(&self, guild_id: Id<GuildMarker>,
-        role_id: Id<RoleMarker>,) -> GetRole<'_> {
+    /// Get a role of a guild.
+    pub const fn role(&self, guild_id: Id<GuildMarker>, role_id: Id<RoleMarker>) -> GetRole<'_> {
         GetRole::new(self, guild_id, role_id)
     }
 

--- a/twilight-http/src/request/guild/role/get_role.rs
+++ b/twilight-http/src/request/guild/role/get_role.rs
@@ -1,0 +1,50 @@
+use crate::{
+    client::Client,
+    error::Error,
+    request::{Request, TryIntoRequest},
+    response::{marker::ListBody, Response, ResponseFuture},
+    routing::Route,
+};
+use std::future::IntoFuture;
+use twilight_model::{
+    guild::Role,
+    id::{marker::{GuildMarker, RoleMarker}, Id},
+};
+
+/// Get the roles of a guild.
+#[must_use = "requests must be configured and executed"]
+pub struct GetRole<'a> {
+    guild_id: Id<GuildMarker>,
+    role_id: Id<RoleMarker>,
+    http: &'a Client,
+}
+
+impl<'a> GetRole<'a> {
+    pub(crate) const fn new(http: &'a Client, guild_id: Id<GuildMarker>, role_id: Id<RoleMarker>) -> Self {
+        Self { guild_id, role_id, http }
+    }
+}
+
+impl IntoFuture for GetRole<'_> {
+    type Output = Result<Response<ListBody<Role>>, Error>;
+
+    type IntoFuture = ResponseFuture<ListBody<Role>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let http = self.http;
+
+        match self.try_into_request() {
+            Ok(request) => http.request(request),
+            Err(source) => ResponseFuture::error(source),
+        }
+    }
+}
+
+impl TryIntoRequest for GetRole<'_> {
+    fn try_into_request(self) -> Result<Request, Error> {
+        Ok(Request::from_route(&Route::GetRole {
+            guild_id: self.guild_id.get(),
+            role_id: self.role_id.get(),
+        }))
+    }
+}

--- a/twilight-http/src/request/guild/role/get_role.rs
+++ b/twilight-http/src/request/guild/role/get_role.rs
@@ -14,7 +14,7 @@ use twilight_model::{
     },
 };
 
-/// Get the roles of a guild.
+/// Get a role of a guild.
 #[must_use = "requests must be configured and executed"]
 pub struct GetRole<'a> {
     guild_id: Id<GuildMarker>,

--- a/twilight-http/src/request/guild/role/get_role.rs
+++ b/twilight-http/src/request/guild/role/get_role.rs
@@ -2,13 +2,16 @@ use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
-    response::{marker::ListBody, Response, ResponseFuture},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
 use twilight_model::{
     guild::Role,
-    id::{marker::{GuildMarker, RoleMarker}, Id},
+    id::{
+        marker::{GuildMarker, RoleMarker},
+        Id,
+    },
 };
 
 /// Get the roles of a guild.
@@ -20,15 +23,23 @@ pub struct GetRole<'a> {
 }
 
 impl<'a> GetRole<'a> {
-    pub(crate) const fn new(http: &'a Client, guild_id: Id<GuildMarker>, role_id: Id<RoleMarker>) -> Self {
-        Self { guild_id, role_id, http }
+    pub(crate) const fn new(
+        http: &'a Client,
+        guild_id: Id<GuildMarker>,
+        role_id: Id<RoleMarker>,
+    ) -> Self {
+        Self {
+            guild_id,
+            role_id,
+            http,
+        }
     }
 }
 
 impl IntoFuture for GetRole<'_> {
-    type Output = Result<Response<ListBody<Role>>, Error>;
+    type Output = Result<Response<Role>, Error>;
 
-    type IntoFuture = ResponseFuture<ListBody<Role>>;
+    type IntoFuture = ResponseFuture<Role>;
 
     fn into_future(self) -> Self::IntoFuture {
         let http = self.http;

--- a/twilight-http/src/request/guild/role/mod.rs
+++ b/twilight-http/src/request/guild/role/mod.rs
@@ -1,10 +1,11 @@
 mod create_role;
 mod delete_role;
 mod get_guild_roles;
+mod get_role;
 mod update_role;
 mod update_role_positions;
 
 pub use self::{
     create_role::CreateRole, delete_role::DeleteRole, get_guild_roles::GetGuildRoles,
-    update_role::UpdateRole, update_role_positions::UpdateRolePositions,
+    get_role::GetRole, update_role::UpdateRole, update_role_positions::UpdateRolePositions,
 };

--- a/twilight-http/src/request/try_into_request.rs
+++ b/twilight-http/src/request/try_into_request.rs
@@ -66,7 +66,9 @@ mod private {
                 AddGuildMember, AddRoleToMember, GetGuildMembers, GetMember, RemoveMember,
                 RemoveRoleFromMember, SearchGuildMembers, UpdateGuildMember,
             },
-            role::{CreateRole, DeleteRole, GetGuildRoles, UpdateRole, UpdateRolePositions},
+            role::{
+                CreateRole, DeleteRole, GetGuildRoles, GetRole, UpdateRole, UpdateRolePositions,
+            },
             sticker::{
                 CreateGuildSticker, DeleteGuildSticker, GetGuildSticker, GetGuildStickers,
                 UpdateGuildSticker,
@@ -236,6 +238,7 @@ mod private {
     impl Sealed for GetPublicArchivedThreads<'_> {}
     impl Sealed for GetReactions<'_> {}
     impl Sealed for GetResponse<'_> {}
+    impl Sealed for GetRole<'_> {}
     impl Sealed for GetSKUs<'_> {}
     impl Sealed for GetStageInstance<'_> {}
     impl Sealed for GetSticker<'_> {}

--- a/twilight-http/src/routing.rs
+++ b/twilight-http/src/routing.rs
@@ -642,7 +642,7 @@ pub enum Route<'a> {
         /// pruned.
         include_roles: &'a [Id<RoleMarker>],
     },
-    /// Route information to get a guild's roles.
+    /// Route information to get guild's roles.
     GetGuildRoles {
         /// The ID of the guild.
         guild_id: u64,
@@ -829,6 +829,13 @@ pub enum Route<'a> {
         message_id: u64,
         /// The type of reactions to fetch.
         kind: Option<u8>,
+    },
+    /// Route information to get a guild's role.
+    GetRole {
+        /// The ID of the guild.
+        guild_id: u64,
+        /// The ID of the role.
+        role_id: u64,
     },
     GetSKUs {
         /// The ID of the application.
@@ -1301,6 +1308,7 @@ impl Route<'_> {
             | Self::GetPrivateArchivedThreads { .. }
             | Self::GetPublicArchivedThreads { .. }
             | Self::GetReactionUsers { .. }
+            | Self::GetRole { .. }
             | Self::GetSKUs { .. }
             | Self::GetStageInstance { .. }
             | Self::GetSticker { .. }
@@ -1574,6 +1582,7 @@ impl Route<'_> {
                 Path::ChannelsIdPermissionsOverwriteId(channel_id)
             }
             Self::DeleteRole { guild_id, .. }
+            | Self::GetRole { guild_id, .. }
             | Self::UpdateRole { guild_id, .. }
             | Self::UpdateRolePositions { guild_id } => Path::GuildsIdRolesId(guild_id),
             Self::DeleteTemplate {
@@ -2307,7 +2316,9 @@ impl Display for Route<'_> {
 
                 Display::fmt(user_id, f)
             }
-            Route::DeleteRole { guild_id, role_id } | Route::UpdateRole { guild_id, role_id } => {
+            Route::DeleteRole { guild_id, role_id }
+            | Route::GetRole { guild_id, role_id }
+            | Route::UpdateRole { guild_id, role_id } => {
                 f.write_str("guilds/")?;
                 Display::fmt(guild_id, f)?;
                 f.write_str("/roles/")?;


### PR DESCRIPTION
Discord supports an endpoint that allows to fetch a single guild role.
- https://github.com/discord/discord-api-docs/pull/7074