### PR TITLE
perf(gateway): optimize `CommandRatelimiter` size

### DIFF
--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -42,12 +42,10 @@ impl CommandRatelimiter {
     /// Create a new ratelimiter with some capacity reserved for heartbeating.
     pub(crate) fn new(heartbeat_interval: Duration) -> Self {
         let allotted = nonreserved_commands_per_reset(heartbeat_interval);
-        let mut queue = VecDeque::new();
-        queue.reserve_exact(usize::from(allotted) - 1);
 
         Self {
             delay: Box::pin(tokio::time::sleep_until(Instant::now())),
-            queue,
+            queue: VecDeque::with_capacity(usize::from(allotted) - 1),
         }
     }
 

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -83,7 +83,7 @@ impl CommandRatelimiter {
         ready!(self.poll_available(cx));
 
         let now = Instant::now();
-        if self.queue.len() == self.queue.capacity() {
+        if now >= self.delay.deadline() {
             if let Some(new_deadline_index) = self.next_acquired_position(now) {
                 self.rebase(new_deadline_index);
             } else {

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -130,8 +130,7 @@ impl CommandRatelimiter {
             .position(|deadline| deadline > now)
     }
 
-    /// Resets delay to a new deadline and updates acquired permits relative
-    /// release timestamps.
+    /// Resets to a new deadline and updates acquired permits' relative timestamp.
     fn rebase(&mut self, new_deadline_index: usize) {
         let duration = Duration::from_millis(self.queue[new_deadline_index].into());
         let new_deadline = self.delay.deadline() + duration;

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -41,10 +41,12 @@ impl CommandRatelimiter {
     /// Create a new ratelimiter with some capacity reserved for heartbeating.
     pub(crate) fn new(heartbeat_interval: Duration) -> Self {
         let allotted = nonreserved_commands_per_reset(heartbeat_interval);
+        let mut queue = Vec::new();
+        queue.reserve_exact(usize::from(allotted) - 1);
 
         Self {
             delay: Box::pin(tokio::time::sleep_until(Instant::now())),
-            queue: Vec::with_capacity(usize::from(allotted) - 1),
+            queue,
         }
     }
 

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -83,7 +83,7 @@ impl CommandRatelimiter {
         ready!(self.poll_available(cx));
 
         let now = Instant::now();
-        if now >= self.delay.deadline() {
+        if self.queue.len() == self.queue.capacity() {
             if let Some(new_deadline_index) = self.next_acquired_position(now) {
                 self.rebase(new_deadline_index);
             } else {

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -100,6 +100,7 @@ impl CommandRatelimiter {
         }
 
         let releases = (now + PERIOD) - self.delay.deadline();
+        debug_assert_ne!(self.queue.capacity(), self.queue.len());
         self.queue.push_back(releases.as_millis() as u16);
 
         if self.queue.len() == self.queue.capacity() {

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -180,7 +180,7 @@ fn nonreserved_commands_per_reset(heartbeat_interval: Duration) -> u8 {
 mod tests {
     use super::{nonreserved_commands_per_reset, CommandRatelimiter, PERIOD};
     use static_assertions::assert_impl_all;
-    use std::{fmt::Debug, future::poll_fn, task::Poll, time::Duration};
+    use std::{fmt::Debug, future::poll_fn, time::Duration};
     use tokio::time;
 
     assert_impl_all!(CommandRatelimiter: Debug, Send, Sync);
@@ -264,29 +264,6 @@ mod tests {
 
         poll_fn(|cx| ratelimiter.poll_acquire(cx)).await;
         assert_eq!(max, ratelimiter.max());
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn spurious_poll() {
-        let mut ratelimiter = CommandRatelimiter::new(HEARTBEAT_INTERVAL);
-
-        for _ in 0..ratelimiter.max() {
-            poll_fn(|cx| ratelimiter.poll_acquire(cx)).await;
-        }
-        assert_eq!(ratelimiter.available(), 0);
-
-        // Spuriously poll after registering the waker but before the timer has
-        // fired.
-        poll_fn(|cx| {
-            if ratelimiter.poll_available(cx).is_ready() {
-                return Poll::Ready(());
-            };
-            let deadline = ratelimiter.delay.deadline();
-            assert!(ratelimiter.poll_available(cx).is_pending());
-            assert_eq!(deadline, ratelimiter.delay.deadline(), "deadline was reset");
-            Poll::Pending
-        })
-        .await;
     }
 
     #[tokio::test(start_paused = true)]

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -135,10 +135,7 @@ impl CommandRatelimiter {
         let duration = Duration::from_millis(self.queue[new_deadline_index].into());
         let new_deadline = self.delay.deadline() + duration;
 
-        // Rotate to [acquired, ..., released, ..., new_deadline]
-        self.queue.rotate_left(new_deadline_index + 1);
-        let new_acquired = self.queue.len() - (new_deadline_index + 1);
-        self.queue.truncate(new_acquired);
+        self.queue.drain(..=new_deadline_index);
 
         for timestamp in &mut self.queue {
             let deadline = self.delay.deadline() + Duration::from_millis((*timestamp).into());

--- a/twilight-gateway/src/ratelimiter.rs
+++ b/twilight-gateway/src/ratelimiter.rs
@@ -42,10 +42,14 @@ impl CommandRatelimiter {
     /// Create a new ratelimiter with some capacity reserved for heartbeating.
     pub(crate) fn new(heartbeat_interval: Duration) -> Self {
         let allotted = nonreserved_commands_per_reset(heartbeat_interval);
+        let queue = VecDeque::with_capacity(usize::from(allotted) - 1);
+        if queue.capacity() != usize::from(allotted) - 1 {
+            unreachable!("Global allocator should always be exact")
+        }
 
         Self {
             delay: Box::pin(tokio::time::sleep_until(Instant::now())),
-            queue: VecDeque::with_capacity(usize::from(allotted) - 1),
+            queue,
         }
     }
 

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -838,10 +838,9 @@ impl<Q: Queue + Unpin> Stream for Shard<Q> {
                 }
             }
 
-            let not_ratelimited = self
-                .ratelimiter
-                .as_mut()
-                .map_or(true, |ratelimiter| ratelimiter.poll_ready(cx).is_ready());
+            let not_ratelimited = self.ratelimiter.as_mut().map_or(true, |ratelimiter| {
+                ratelimiter.poll_available(cx).is_ready()
+            });
 
             if not_ratelimited {
                 if let Some(Poll::Ready(canceled)) = self


### PR DESCRIPTION
Switches from storing absolute timestamps to relative ones to `delay` as milliseconds (tokio's timer resolution). This reduces the item size from 12 bytes to just 2 (as 60,000 ms fits in a `u16`) and adds a negligible amount of bookkeeping work in rebasing the timestamps on `delay` elapsing. From this I also made the first relative timestamp implicit from whether `delay` is elapsed or not (instead of being zero).

Additionally, this PR fixes the following minor bugs:

* always store waker in `poll_pending` (always call `Sleep::poll`)
* `slice::partition_point` may return any matching element, but we depend upon the first being returned (it should be impossible to acquire two permits at the same time in practice, since we send a gateway command between each acquisition)
* `Vec::with_capacity` being allowed to allocate more than the requested amount whereas we require the amount to be exact (the current implementation is exact, however)

TODO:
- [x] Update doc comments
- [x] ~~Explain algorithm more in code comments, the logic is complex~~ split logic into self-explanatory methods
- [x] add more tests for new edge cases.
