### PR TITLE
refactor(gateway): avoid recent latencies rotate

### DIFF
--- a/twilight-gateway/src/latency.rs
+++ b/twilight-gateway/src/latency.rs
@@ -100,7 +100,7 @@ impl Latency {
         self.periods += 1;
 
         self.latency_sum += period_latency;
-        self.recent.rotate_right(1);
+        self.recent.copy_within(..Self::RECENT_LEN - 1, 1);
         self.recent[0] = period_latency;
     }
 


### PR DESCRIPTION
[Rotate](https://github.com/rust-lang/rust/blob/37e74596c0b59e81b9ac58657f92297ef4ccb7ef/library/core/src/slice/rotate.rs) is a perhaps surprisingly expensive operation, when we really just want to move stuff one step to the right.

Inspired from a similar optimization in #2395 (tagged as a refactor since this doesn't measurably impact performance).