### PR TITLE
refactor(gateway): remove instrument from shard::poll_next

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,6 +19,7 @@ once_cell = "1.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 tokio = { default-features = false, features = ["macros", "signal", "rt-multi-thread"], version = "1.0" }
+tokio-util = "0.7"
 tracing = "0.1"
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log"], version = "0.3" }
 twilight-cache-inmemory = { path = "../twilight-cache-inmemory", features = ["permission-calculator"] }

--- a/twilight-gateway/Cargo.toml
+++ b/twilight-gateway/Cargo.toml
@@ -22,7 +22,7 @@ serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
 tokio = { default-features = false, features = ["net", "rt", "sync", "time"], version = "1.19" }
 tokio-websockets = { default-features = false, features = ["client", "fastrand", "sha1_smol", "simd"], version = "0.11" }
-tracing = { default-features = false, features = ["std", "attributes"], version = "0.1" }
+tracing = { default-features = false, features = ["std"], version = "0.1" }
 twilight-gateway-queue = { default-features = false, path = "../twilight-gateway-queue", version = "0.16.0" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.16.0" }
 
@@ -39,7 +39,7 @@ simd-json = { default-features = false, features = ["serde_impl", "swar-number-p
 anyhow = { default-features = false, features = ["std"], version = "1" }
 serde_test = { default-features = false, version = "1.0.136" }
 static_assertions = { default-features = false, version = "1" }
-tokio = { default-features = false, features = ["macros", "rt-multi-thread", "test-util"], version = "1.12" }
+tokio = { default-features = false, features = ["macros", "rt-multi-thread", "signal", "test-util"], version = "1.12" }
 tokio-stream = { default-features = false, version = "0.1" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log"], version = "0.3" }
 

--- a/twilight-gateway/README.md
+++ b/twilight-gateway/README.md
@@ -90,6 +90,7 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tracing::instrument(fields(shard = %shard.id()), skip_all)]
 async fn runner(mut shard: Shard) {
     while let Some(item) = shard.next_event(EventTypeFlags::all()).await {
         let event = match item {

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -806,6 +806,7 @@ impl<Q: Queue> Shard<Q> {
 impl<Q: Queue + Unpin> Stream for Shard<Q> {
     type Item = Result<Message, ReceiveMessageError>;
 
+    #[allow(clippy::too_many_lines)]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let message = loop {
             match self.state {

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -806,7 +806,6 @@ impl<Q: Queue> Shard<Q> {
 impl<Q: Queue + Unpin> Stream for Shard<Q> {
     type Item = Result<Message, ReceiveMessageError>;
 
-    #[tracing::instrument(fields(id = %self.id), name = "shard", skip_all)]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let message = loop {
             match self.state {


### PR DESCRIPTION
Shard instrumentation is necessary for following specific shards, but by adding it ourselves users are not able to hook into it, for example on errors. Some work around this by instrumenting their shard running function, but this may lead to duplication if they do not filter their subscriber. This was considered worthwhile, as it cleaned up user's logs at a time when many experienced issues with the gateway and instrumenting a stream combinator (like the old `ShardEventStream`) is difficult.

The `gateway-reshard` example needed to be migrated from using a stream combinator to spawning tasks (which also improves its performance).