### PR TITLE
fix(model)!: incoming heartbeat has null data

### DIFF
--- a/twilight-cache-inmemory/src/lib.rs
+++ b/twilight-cache-inmemory/src/lib.rs
@@ -1027,7 +1027,7 @@ impl<CacheModels: CacheableModels> UpdateCache<CacheModels> for Event {
             | Event::EntitlementDelete(_)
             | Event::EntitlementUpdate(_)
             | Event::GatewayClose(_)
-            | Event::GatewayHeartbeat(_)
+            | Event::GatewayHeartbeat
             | Event::GatewayHeartbeatAck
             | Event::GatewayHello(_)
             | Event::GatewayInvalidateSession(_)

--- a/twilight-model/src/gateway/event/mod.rs
+++ b/twilight-model/src/gateway/event/mod.rs
@@ -59,8 +59,8 @@ pub enum Event {
     /// Close message with an optional frame including information about the
     /// reason for the close.
     GatewayClose(Option<CloseFrame<'static>>),
-    /// A heartbeat was sent to or received from the gateway.
-    GatewayHeartbeat(u64),
+    /// A heartbeat was received from the gateway.
+    GatewayHeartbeat,
     /// A heartbeat acknowledgement was received from the gateway.
     GatewayHeartbeatAck,
     /// A "hello" packet was received from the gateway.
@@ -250,7 +250,7 @@ impl Event {
             | Event::EntitlementCreate(_)
             | Event::EntitlementDelete(_)
             | Event::EntitlementUpdate(_)
-            | Event::GatewayHeartbeat(_)
+            | Event::GatewayHeartbeat
             | Event::GatewayHeartbeatAck
             | Event::GatewayHello(_)
             | Event::GatewayInvalidateSession(_)
@@ -278,7 +278,7 @@ impl Event {
             Self::EntitlementDelete(_) => EventType::EntitlementDelete,
             Self::EntitlementUpdate(_) => EventType::EntitlementUpdate,
             Self::GatewayClose(_) => EventType::GatewayClose,
-            Self::GatewayHeartbeat(_) => EventType::GatewayHeartbeat,
+            Self::GatewayHeartbeat => EventType::GatewayHeartbeat,
             Self::GatewayHeartbeatAck => EventType::GatewayHeartbeatAck,
             Self::GatewayHello(_) => EventType::GatewayHello,
             Self::GatewayInvalidateSession(_) => EventType::GatewayInvalidateSession,
@@ -422,7 +422,7 @@ impl From<GatewayEvent> for Event {
     fn from(event: GatewayEvent) -> Self {
         match event {
             GatewayEvent::Dispatch(_, e) => Self::from(e),
-            GatewayEvent::Heartbeat(interval) => Self::GatewayHeartbeat(interval),
+            GatewayEvent::Heartbeat => Self::GatewayHeartbeat,
             GatewayEvent::HeartbeatAck => Self::GatewayHeartbeatAck,
             GatewayEvent::Hello(interval) => Self::GatewayHello(interval),
             GatewayEvent::InvalidateSession(r) => Self::GatewayInvalidateSession(r),


### PR DESCRIPTION
My shard received a heartbeat event and apparently we model that wrongly. Discord documents this event as containing data, but that's only when sent to the gateway.

```
2025-02-14T15:50:16.796316Z DEBUG twilight_gateway::shard: received heartbeat
2025-02-14T15:50:16.796359Z  WARN gateway_request_members: error receiving event source=ReceiveMessageError { kind: Deserializing { event: "{\"t\":null,\"s\":null,\"op\":1,\"d\":null}" }, source: Some(Error("invalid type: null, expected u64", line: 1, column: 34)) }
```