### PR TITLE
refactor(model)!: make message and guild_id fields in MessageSnapshot public

### DIFF
--- a/twilight-model/src/channel/message/snapshot.rs
+++ b/twilight-model/src/channel/message/snapshot.rs
@@ -12,10 +12,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct MessageSnapshot {
     /// Subset of fields in the message object.
-    message: MessageSnapshotFields,
+    pub message: MessageSnapshotFields,
     /// ID of the origin message's guild.
     #[serde(skip_serializing_if = "Option::is_none")]
-    guild_id: Option<Id<GuildMarker>>,
+    pub guild_id: Option<Id<GuildMarker>>,
 }
 
 /// A subset of the fields for a message that has been snap-shotted.


### PR DESCRIPTION
This PR makes the `message` and `guild_id` fields of the `MessageSnapshot` struct public. This change allows external code to access these fields directly, enabling use of message snapshot data.