### PR TITLE
fix(gateway): handle repeat recv errors

### DIFF
--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -27,12 +27,6 @@ use crate::{
 use futures_core::Stream;
 use futures_sink::Sink;
 use serde::{de::DeserializeOwned, Deserialize};
-#[cfg(any(
-    feature = "native-tls",
-    feature = "rustls-native-roots",
-    feature = "rustls-platform-verifier",
-    feature = "rustls-webpki-roots"
-))]
 use std::{
     env::consts::OS,
     fmt,

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -940,11 +940,10 @@ impl<Q: Queue + Unpin> Stream for Shard<Q> {
                         break message;
                     }
                 }
+                Some(Err(_)) if self.state.is_disconnected() => {}
                 Some(Err(_)) => {
-                    if !self.state.is_disconnected() {
-                        self.disconnect(CloseInitiator::Transport);
-                        return Poll::Ready(Some(Ok(Message::ABNORMAL_CLOSE)));
-                    }
+                    self.disconnect(CloseInitiator::Transport);
+                    return Poll::Ready(Some(Ok(Message::ABNORMAL_CLOSE)));
                 }
                 None => {
                     _ = ready!(Pin::new(self.connection.as_mut().unwrap()).poll_close(cx));


### PR DESCRIPTION
We should not return more than one `ABNORMAL_CLOSE` messages per connection. Specializing for Discord's incorrect WS implementation is no longer needed since we no longer forward transport errors (and Discord's closure error occurs after exchanging close messages).