### PR TITLE
fix(gateway): terminate zombied connections

### DIFF
--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -625,15 +625,15 @@ impl<Q: Queue> Shard<Q> {
                     tracing::info!("connection is failed or \"zombied\"");
 
                     return Poll::Ready(Err(WebsocketError::Io(io::ErrorKind::TimedOut.into())));
-                } else {
-                    tracing::debug!("sending heartbeat");
-                    self.pending = Pending::text(
-                        json::to_string(&Heartbeat::new(self.session().map(Session::sequence)))
-                            .expect("serialization cannot fail"),
-                        true,
-                    );
-                    self.heartbeat_interval_event = false;
                 }
+
+                tracing::debug!("sending heartbeat");
+                self.pending = Pending::text(
+                    json::to_string(&Heartbeat::new(self.session().map(Session::sequence)))
+                        .expect("serialization cannot fail"),
+                    true,
+                );
+                self.heartbeat_interval_event = false;
 
                 continue;
             }

--- a/twilight-gateway/src/shard.rs
+++ b/twilight-gateway/src/shard.rs
@@ -31,6 +31,7 @@ use std::{
     env::consts::OS,
     fmt,
     future::Future,
+    io,
     pin::Pin,
     str,
     task::{ready, Context, Poll},
@@ -622,7 +623,8 @@ impl<Q: Queue> Shard<Q> {
                 // have to be a heartbeat ACK.
                 if self.latency.sent().is_some() && !self.heartbeat_interval_event {
                     tracing::info!("connection is failed or \"zombied\"");
-                    self.disconnect(CloseInitiator::Shard(CloseFrame::RESUME));
+
+                    return Poll::Ready(Err(WebsocketError::Io(io::ErrorKind::TimedOut.into())));
                 } else {
                     tracing::debug!("sending heartbeat");
                     self.pending = Pending::text(


### PR DESCRIPTION
Zombied connections are unlikely to receive further messages, so there's little use in awaiting a response close frame.

Fixes an issue where dead TCP connections would never be polled to completion.
