### PR TITLE
convenience functions for `UnfurledMediaItem`

### DIFF
--- a/twilight-model/src/channel/message/component/unfurled_media.rs
+++ b/twilight-model/src/channel/message/component/unfurled_media.rs
@@ -21,3 +21,25 @@ pub struct UnfurledMediaItem {
     /// API as part of the response.
     pub content_type: Option<String>,
 }
+
+impl UnfurledMediaItem {
+    /// Create a new Unfurled Media Item for use in a request
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            proxy_url: None,
+            height: None,
+            width: None,
+            content_type: None,
+        }
+    }
+}
+
+impl<T> From<T> for UnfurledMediaItem
+where
+    T: Into<String>,
+{
+    fn from(url: T) -> Self {
+        Self::new(url)
+    }
+}

--- a/twilight-util/src/builder/message/thumbnail.rs
+++ b/twilight-util/src/builder/message/thumbnail.rs
@@ -7,10 +7,10 @@ pub struct ThumbnailBuilder(Thumbnail);
 
 impl ThumbnailBuilder {
     /// Create a new thumbnail builder.
-    pub const fn new(media: UnfurledMediaItem) -> Self {
+    pub fn new(media: impl Into<UnfurledMediaItem>) -> Self {
         Self(Thumbnail {
             id: None,
-            media,
+            media: media.into(),
             description: None,
             spoiler: None,
         })
@@ -60,21 +60,21 @@ mod tests {
 
     #[test]
     fn builder() {
-        let media = UnfurledMediaItem {
-            url: "http://www.example.com/example.png".to_string(),
-            proxy_url: None,
-            height: None,
-            width: None,
-            content_type: None,
-        };
+        let url = "http://www.example.com/example.png";
         let expected = Thumbnail {
             id: None,
-            media: media.clone(),
+            media: UnfurledMediaItem {
+                url: url.to_string(),
+                proxy_url: None,
+                height: None,
+                width: None,
+                content_type: None,
+            },
             description: None,
             spoiler: None,
         };
 
-        let actual = ThumbnailBuilder::new(media).build();
+        let actual = ThumbnailBuilder::new(url).build();
 
         assert_eq!(actual, expected);
     }


### PR DESCRIPTION
`UnfurledMediaItem` (at least in the context of `Thumbnails` I believe will only ever take a URL. The fields in the struct are only set on response, so when the user creates this object manually, I think you only ever need to provide a string.

As such, I added a `From<impl Into<String>>` method for `UnfurledMediaItem` and changed up the builder to allow for `Thumbnail` to be built starting from a string, which, again, I *think* is the only use case.