### PR TITLE
ci: add clippy component to clippy job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
@@ -110,10 +112,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-          toolchain: nightly
 
       - name: Add problem matchers
         run: echo "::add-matcher::.github/rust.json"


### PR DESCRIPTION
Caught by ubuntu-24.04 no longer shipping clippy
