### PR TITLE
feat(model, validate)!: Label components

### DIFF
--- a/twilight-model/src/channel/message/component/kind.rs
+++ b/twilight-model/src/channel/message/component/kind.rs
@@ -68,6 +68,11 @@ pub enum ComponentType {
     ///
     /// [`Container`]: super::Container
     Container,
+    /// Component is a [`Label`] that provides a label and an optional description
+    /// for modal components.
+    ///
+    /// [`Label`]: super::Label
+    Label,
     /// Variant value is unknown to the library.
     Unknown(u8),
 }
@@ -90,6 +95,7 @@ impl From<u8> for ComponentType {
             13 => ComponentType::File,
             14 => ComponentType::Separator,
             17 => ComponentType::Container,
+            18 => ComponentType::Label,
             unknown => ComponentType::Unknown(unknown),
         }
     }
@@ -113,6 +119,7 @@ impl From<ComponentType> for u8 {
             ComponentType::File => 13,
             ComponentType::Separator => 14,
             ComponentType::Container => 17,
+            ComponentType::Label => 18,
             ComponentType::Unknown(unknown) => unknown,
         }
     }
@@ -151,6 +158,7 @@ impl ComponentType {
             ComponentType::File => "File",
             ComponentType::Separator => "Separator",
             ComponentType::Container => "Container",
+            ComponentType::Label => "Label",
             ComponentType::Unknown(_) => "Unknown",
         }
     }
@@ -199,6 +207,7 @@ mod tests {
         serde_test::assert_tokens(&ComponentType::File, &[Token::U8(13)]);
         serde_test::assert_tokens(&ComponentType::Separator, &[Token::U8(14)]);
         serde_test::assert_tokens(&ComponentType::Container, &[Token::U8(17)]);
+        serde_test::assert_tokens(&ComponentType::Label, &[Token::U8(18)]);
         serde_test::assert_tokens(&ComponentType::Unknown(99), &[Token::U8(99)]);
     }
 
@@ -212,6 +221,14 @@ mod tests {
         assert_eq!("SelectMenu", ComponentType::MentionableSelectMenu.name());
         assert_eq!("SelectMenu", ComponentType::ChannelSelectMenu.name());
         assert_eq!("TextInput", ComponentType::TextInput.name());
+        assert_eq!("Section", ComponentType::Section.name());
+        assert_eq!("TextDisplay", ComponentType::TextDisplay.name());
+        assert_eq!("Thumbnail", ComponentType::Thumbnail.name());
+        assert_eq!("MediaGallery", ComponentType::MediaGallery.name());
+        assert_eq!("File", ComponentType::File.name());
+        assert_eq!("Separator", ComponentType::Separator.name());
+        assert_eq!("Container", ComponentType::Container.name());
+        assert_eq!("Label", ComponentType::Label.name());
         assert_eq!("Unknown", ComponentType::Unknown(99).name());
     }
 }

--- a/twilight-model/src/channel/message/component/label.rs
+++ b/twilight-model/src/channel/message/component/label.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+
+use super::Component;
+
+/// Top-level layout [`Component`].
+///
+/// Labels wrap modal components with text as a label and an optional description.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+pub struct Label {
+    /// Optional identifier for the label.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<i32>,
+    /// The label text; max 45 characters.
+    #[allow(clippy::struct_field_names)]
+    pub label: String,
+    /// An optional description text for the label; max 100 characters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// The component within the label.
+    pub component: Box<Component>,
+}

--- a/twilight-model/src/channel/message/component/mod.rs
+++ b/twilight-model/src/channel/message/component/mod.rs
@@ -26,6 +26,7 @@ pub use self::{
     container::Container,
     file_display::FileDisplay,
     kind::ComponentType,
+    label::Label,
     media_gallery::{MediaGallery, MediaGalleryItem},
     section::Section,
     select_menu::{SelectDefaultValue, SelectMenu, SelectMenuOption, SelectMenuType},
@@ -37,7 +38,6 @@ pub use self::{
 };
 
 use super::EmojiReactionType;
-use crate::channel::message::component::label::Label;
 use crate::{
     channel::ChannelType,
     id::{marker::SkuMarker, Id},

--- a/twilight-model/src/channel/message/component/mod.rs
+++ b/twilight-model/src/channel/message/component/mod.rs
@@ -1602,4 +1602,59 @@ mod tests {
             ],
         );
     }
+
+    #[test]
+    fn label() {
+        let value = Component::Label(Label {
+            id: None,
+            label: "The label".to_owned(),
+            description: Some("The description".to_owned()),
+            component: Box::new(Component::TextInput(TextInput {
+                id: None,
+                custom_id: "The custom id".to_owned(),
+                label: "The text input label".to_owned(),
+                max_length: None,
+                min_length: None,
+                placeholder: None,
+                required: None,
+                style: TextInputStyle::Paragraph,
+                value: None,
+            })),
+        });
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "Component",
+                    len: 4,
+                },
+                Token::String("type"),
+                Token::U8(ComponentType::Label.into()),
+                Token::String("label"),
+                Token::Some,
+                Token::String("The label"),
+                Token::String("description"),
+                Token::Some,
+                Token::String("The description"),
+                Token::String("component"),
+                Token::Struct {
+                    name: "Component",
+                    len: 4,
+                },
+                Token::String("type"),
+                Token::U8(ComponentType::TextInput.into()),
+                Token::String("custom_id"),
+                Token::Some,
+                Token::String("The custom id"),
+                Token::String("label"),
+                Token::Some,
+                Token::String("The text input label"),
+                Token::String("style"),
+                Token::U8(TextInputStyle::Paragraph as u8),
+                Token::StructEnd,
+                Token::StructEnd,
+            ],
+        );
+    }
 }

--- a/twilight-model/src/channel/message/component/mod.rs
+++ b/twilight-model/src/channel/message/component/mod.rs
@@ -740,6 +740,7 @@ impl<'de> Visitor<'de> for ComponentVisitor {
                     .deserialize_into()
                     .map_err(DeserializerError::into_error)?;
 
+                #[allow(deprecated)]
                 Self::Value::TextInput(TextInput {
                     custom_id,
                     label: label.unwrap_or_default(),
@@ -886,6 +887,7 @@ impl Serialize for Component {
             // - placeholder
             // - required
             // - value
+            #[allow(deprecated)]
             Component::TextInput(text_input) => {
                 3 + usize::from(text_input.label.is_some())
                     + usize::from(text_input.max_length.is_some())
@@ -1093,6 +1095,7 @@ impl Serialize for Component {
                 // variants and optional in others, serialize as an Option.
                 state.serialize_field("custom_id", &Some(&text_input.custom_id))?;
 
+                #[allow(deprecated)]
                 if text_input.label.is_some() {
                     state.serialize_field("label", &text_input.label)?;
                 }
@@ -1524,6 +1527,7 @@ mod tests {
 
     #[test]
     fn text_input() {
+        #[allow(deprecated)]
         let value = Component::TextInput(TextInput {
             custom_id: "test".to_owned(),
             label: Some("The label".to_owned()),
@@ -1608,6 +1612,7 @@ mod tests {
 
     #[test]
     fn label() {
+        #[allow(deprecated)]
         let value = Component::Label(Label {
             id: None,
             label: "The label".to_owned(),

--- a/twilight-model/src/channel/message/component/text_input.rs
+++ b/twilight-model/src/channel/message/component/text_input.rs
@@ -10,6 +10,7 @@ pub struct TextInput {
     /// User defined identifier for the input text.
     pub custom_id: String,
     /// Text appearing over the input field.
+    #[deprecated = "Deprecated by Discord in favor of label and description on the Label component."]
     pub label: Option<String>,
     /// The maximum length of the text.
     pub max_length: Option<u16>,
@@ -41,6 +42,7 @@ pub enum TextInputStyle {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};

--- a/twilight-model/src/channel/message/component/text_input.rs
+++ b/twilight-model/src/channel/message/component/text_input.rs
@@ -10,7 +10,7 @@ pub struct TextInput {
     /// User defined identifier for the input text.
     pub custom_id: String,
     /// Text appearing over the input field.
-    pub label: String,
+    pub label: Option<String>,
     /// The maximum length of the text.
     pub max_length: Option<u16>,
     /// The minimum length of the text.

--- a/twilight-validate/src/component.rs
+++ b/twilight-validate/src/component.rs
@@ -945,6 +945,7 @@ pub fn select_menu(select_menu: &SelectMenu) -> Result<(), ComponentValidationEr
 pub fn text_input(text_input: &TextInput) -> Result<(), ComponentValidationError> {
     self::component_custom_id(&text_input.custom_id)?;
 
+    #[allow(deprecated)]
     if let Some(label) = &text_input.label {
         self::component_text_input_label(label)?;
     }

--- a/twilight-validate/src/component.rs
+++ b/twilight-validate/src/component.rs
@@ -944,7 +944,10 @@ pub fn select_menu(select_menu: &SelectMenu) -> Result<(), ComponentValidationEr
 /// [`TextInputValueLength`]: ComponentValidationErrorType::TextInputValueLength
 pub fn text_input(text_input: &TextInput) -> Result<(), ComponentValidationError> {
     self::component_custom_id(&text_input.custom_id)?;
-    self::component_text_input_label(&text_input.label)?;
+
+    if let Some(label) = &text_input.label {
+        self::component_text_input_label(label)?;
+    }
 
     if let Some(max_length) = text_input.max_length {
         self::component_text_input_max(max_length)?;

--- a/twilight-validate/src/component/component_v2.rs
+++ b/twilight-validate/src/component/component_v2.rs
@@ -342,3 +342,67 @@ pub fn label_description(value: impl AsRef<str>) -> Result<(), ComponentValidati
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::iter;
+    use twilight_model::channel::message::component::{
+        Button, ButtonStyle, Label, SelectMenu, SelectMenuType,
+    };
+    use twilight_model::channel::message::Component;
+
+    #[test]
+    fn component_label() {
+        let button = Component::Button(Button {
+            custom_id: None,
+            disabled: false,
+            emoji: None,
+            label: Some("Press me".into()),
+            style: ButtonStyle::Danger,
+            url: None,
+            sku_id: None,
+            id: None,
+        });
+
+        let select_menu = Component::SelectMenu(SelectMenu {
+            channel_types: None,
+            custom_id: String::from("my_select"),
+            default_values: None,
+            disabled: false,
+            kind: SelectMenuType::User,
+            max_values: None,
+            min_values: None,
+            options: None,
+            placeholder: None,
+            id: None,
+        });
+
+        let valid_label = Label {
+            id: None,
+            label: "Label".to_string(),
+            description: Some("This is a description".to_owned()),
+            component: Box::new(select_menu),
+        };
+
+        let label_invalid_child = Label {
+            component: Box::new(button),
+            ..valid_label.clone()
+        };
+
+        let label_too_long_description = Label {
+            description: Some(iter::repeat_n('a', 101).collect()),
+            ..valid_label.clone()
+        };
+
+        let label_too_long_label = Label {
+            label: iter::repeat_n('a', 46).collect(),
+            ..valid_label.clone()
+        };
+
+        assert!(label(&valid_label).is_ok());
+        assert!(label(&label_invalid_child).is_err());
+        assert!(label(&label_too_long_description).is_err());
+        assert!(label(&label_too_long_label).is_err());
+    }
+}

--- a/twilight-validate/src/component/component_v2.rs
+++ b/twilight-validate/src/component/component_v2.rs
@@ -108,9 +108,9 @@ pub fn label(label: &Label) -> Result<(), ComponentValidationError> {
                 kind: label.component.kind(),
             },
         }),
-        Component::SelectMenu(select_menu) => self::select_menu(&select_menu),
-        Component::TextInput(text_input) => self::text_input(&text_input),
-        Component::TextDisplay(text_display) => self::text_display(&text_display),
+        Component::SelectMenu(select_menu) => self::select_menu(select_menu),
+        Component::TextInput(text_input) => self::text_input(text_input),
+        Component::TextDisplay(text_display) => self::text_display(text_display),
         Component::Unknown(unknown) => Err(ComponentValidationError {
             kind: ComponentValidationErrorType::InvalidChildComponent {
                 kind: ComponentType::Unknown(*unknown),


### PR DESCRIPTION
[Label components](https://discord.com/developers/docs/components/reference#label) are the new recommended way to add components to modals.

This also includes a change to `TextInput`: since labels should now be added using the label component, the `label` field on text input components are deprecated by Discord and now optional in the `TextInput` type.

Not yet tested with an actual bot. 