### PR TITLE
refactor(http-ratelimiting): clean up actor

### DIFF
--- a/twilight-http-ratelimiting/src/lib.rs
+++ b/twilight-http-ratelimiting/src/lib.rs
@@ -191,6 +191,11 @@ impl RateLimitHeaders {
             reset_at: Instant::now() + Duration::from_secs(retry_after.into()),
         }
     }
+
+    /// Duration until the bucket resets.
+    pub(crate) fn reset_after(&self) -> Duration {
+        self.reset_at.saturating_duration_since(Instant::now())
+    }
 }
 
 /// Permit to send a Discord HTTP API request to the acquired endpoint.


### PR DESCRIPTION
Extracts some code into separate methods and uses let-chaining to shrink the main actor function length.

Depends upon #2469