### PR TITLE
feat(http, model): add setting flags for forum threads

### DIFF
--- a/twilight-http/src/request/channel/thread/update_thread.rs
+++ b/twilight-http/src/request/channel/thread/update_thread.rs
@@ -8,7 +8,7 @@ use crate::{
 use serde::Serialize;
 use std::future::IntoFuture;
 use twilight_model::{
-    channel::{Channel, thread::AutoArchiveDuration},
+    channel::{Channel, ChannelFlags, thread::AutoArchiveDuration},
     id::{
         Id,
         marker::{ChannelMarker, TagMarker},
@@ -30,6 +30,8 @@ struct UpdateThreadFields<'a> {
     archived: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     auto_archive_duration: Option<AutoArchiveDuration>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    flags: Option<Nullable<ChannelFlags>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     invitable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -60,6 +62,7 @@ impl<'a> UpdateThread<'a> {
                 applied_tags: None,
                 archived: None,
                 auto_archive_duration: None,
+                flags: None,
                 invitable: None,
                 locked: None,
                 name: None,
@@ -104,6 +107,15 @@ impl<'a> UpdateThread<'a> {
     ) -> Self {
         if let Ok(fields) = self.fields.as_mut() {
             fields.auto_archive_duration = Some(auto_archive_duration);
+        }
+
+        self
+    }
+
+    /// Sets the thread's flags.
+    pub const fn flags(mut self, flags: Option<ChannelFlags>) -> Self {
+        if let Ok(fields) = self.fields.as_mut() {
+            fields.flags = Some(Nullable(flags));
         }
 
         self
@@ -243,6 +255,7 @@ mod tests {
             applied_tags: None,
             archived: None,
             auto_archive_duration: None,
+            flags: None,
             invitable: None,
             locked: None,
             name: None,

--- a/twilight-model/src/channel/flags.rs
+++ b/twilight-model/src/channel/flags.rs
@@ -11,6 +11,8 @@ bitflags! {
         const PINNED = 1 << 1;
         /// New threads in a forum channel require a tag.
         const REQUIRE_TAG = 1 << 4;
+        /// Hide the download options for this post in a media channel.
+        const HIDE_MEDIA_DOWNLOAD_OPTIONS = 1 << 15;
     }
 }
 


### PR DESCRIPTION
Fixes #2494.

[Discord API Docs](https://discord.com/developers/docs/resources/channel#modify-channel-json-params-thread)