### PR TITLE
fix(http): fix automoderation rule update request

### DIFF
--- a/twilight-http/src/request/guild/auto_moderation/update_auto_moderation_rule.rs
+++ b/twilight-http/src/request/guild/auto_moderation/update_auto_moderation_rule.rs
@@ -21,12 +21,19 @@ use twilight_validate::request::{ValidationError, audit_reason as validate_audit
 
 #[derive(Serialize)]
 struct UpdateAutoModerationRuleFields<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
     actions: Option<&'a [AutoModerationAction]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     event_type: Option<AutoModerationEventType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     exempt_channels: Option<&'a [Id<ChannelMarker>]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     exempt_roles: Option<&'a [Id<RoleMarker>]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     trigger_metadata: Option<&'a AutoModerationTriggerMetadata>,
 }
 


### PR DESCRIPTION
The [Automoderation Rule Update Endpoint](https://discord.com/developers/docs/resources/auto-moderation#modify-auto-moderation-rule) is a patch endpoint and should skip fields that have not been modified.