### PR TITLE
feat: Add DAVE support and implement V4 session resuming in lavalink client

### DIFF
--- a/examples/lavalink-basic-bot.rs
+++ b/examples/lavalink-basic-bot.rs
@@ -92,7 +92,7 @@ async fn main() -> anyhow::Result<()> {
     let user = http.current_user().await?.model().await?;
     let hyper = HyperClient::builder(TokioExecutor::new()).build_http();
     let lavalink = Lavalink::new(user.id, 1);
-    lavalink.add(lavalink_host, lavalink_auth).await?;
+    lavalink.add(lavalink_host, lavalink_auth, None).await?;
     let standby = Standby::new();
     context::initialize(http, hyper, lavalink, standby);
 

--- a/twilight-lavalink/README.md
+++ b/twilight-lavalink/README.md
@@ -87,44 +87,6 @@ This requires configuring a crypto provider.
 
 This should be preferred over `rustls-native-roots` in Docker containers based on `scratch`.
 
-## Session Resuming (Lavalink v4)
-
-Lavalink v4 supports session resuming, allowing your bot to reconnect without
-interrupting active music players. This is useful when:
-- Restarting your gateway process
-- Recovering from network interruptions
-- Deploying updates without stopping music
-
-### How it Works
-
-1. **Configure resuming timeout** via REST API after connecting:
-   ```rust
-   // After receiving Ready OP with session_id from IncomingEvents
-   let url = format!("http://{}/v4/sessions/{}", lavalink_host, session_id);
-   client.patch(&url)
-       .header("Authorization", lavalink_auth)
-       .json(&json!({"resuming": true, "timeout": 120}))
-       .send()
-       .await?;
-   ```
-
-2. **Store the session ID** (e.g., in Redis) for later retrieval
-
-3. **Resume on reconnect** by providing the old session ID:
-   ```rust
-   let old_session = retrieve_stored_session_id().await?;
-   lavalink.add_with_session_id(address, auth, old_session).await?;
-   ```
-
-4. **Check if resumed** via the Ready OP `resumed` field or response header `Session-Resumed`
-
-### Important Notes
-
-- Session resume is only possible within the configured timeout (default 60 seconds)
-- Players continue playing during disconnection
-- Events are queued and replayed upon resumption
-- If resuming fails, a new session is created automatically
-
 ## Examples
 
 Create a [client], add a [node], and give events to the client to [process]
@@ -155,7 +117,7 @@ async fn main() -> anyhow::Result<()> {
     let user_id = http.current_user().await?.model().await?.id;
 
     let lavalink = Lavalink::new(user_id, shard_count);
-    lavalink.add(lavalink_host, lavalink_auth).await?;
+    lavalink.add(lavalink_host, lavalink_auth, None).await?;
 
     let intents = Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES;
     let mut shard = Shard::new(ShardId::ONE, token, intents);

--- a/twilight-lavalink/README.md
+++ b/twilight-lavalink/README.md
@@ -87,6 +87,44 @@ This requires configuring a crypto provider.
 
 This should be preferred over `rustls-native-roots` in Docker containers based on `scratch`.
 
+## Session Resuming (Lavalink v4)
+
+Lavalink v4 supports session resuming, allowing your bot to reconnect without
+interrupting active music players. This is useful when:
+- Restarting your gateway process
+- Recovering from network interruptions
+- Deploying updates without stopping music
+
+### How it Works
+
+1. **Configure resuming timeout** via REST API after connecting:
+   ```rust
+   // After receiving Ready OP with session_id from IncomingEvents
+   let url = format!("http://{}/v4/sessions/{}", lavalink_host, session_id);
+   client.patch(&url)
+       .header("Authorization", lavalink_auth)
+       .json(&json!({"resuming": true, "timeout": 120}))
+       .send()
+       .await?;
+   ```
+
+2. **Store the session ID** (e.g., in Redis) for later retrieval
+
+3. **Resume on reconnect** by providing the old session ID:
+   ```rust
+   let old_session = retrieve_stored_session_id().await?;
+   lavalink.add_with_session_id(address, auth, old_session).await?;
+   ```
+
+4. **Check if resumed** via the Ready OP `resumed` field or response header `Session-Resumed`
+
+### Important Notes
+
+- Session resume is only possible within the configured timeout (default 60 seconds)
+- Players continue playing during disconnection
+- Events are queued and replayed upon resumption
+- If resuming fails, a new session is created automatically
+
 ## Examples
 
 Create a [client], add a [node], and give events to the client to [process]

--- a/twilight-lavalink/src/client.rs
+++ b/twilight-lavalink/src/client.rs
@@ -300,7 +300,9 @@ impl Lavalink {
     /// # let auth = "youshallnotpass";
     /// // Resume existing session
     /// let old_session_id = Some("existing-session-id".to_string());
-    /// lavalink.add_with_session_id(address, auth, old_session_id).await?;
+    /// lavalink
+    ///     .add_with_session_id(address, auth, old_session_id)
+    ///     .await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/twilight-lavalink/src/client.rs
+++ b/twilight-lavalink/src/client.rs
@@ -16,7 +16,7 @@ use twilight_model::{
     gateway::{ShardId, event::Event, payload::incoming::VoiceServerUpdate},
     id::{
         Id,
-        marker::{GuildMarker, UserMarker},
+        marker::{ChannelMarker, GuildMarker, UserMarker},
     },
 };
 
@@ -103,7 +103,7 @@ pub struct Lavalink {
     shard_count: u32,
     user_id: Id<UserMarker>,
     server_updates: DashMap<Id<GuildMarker>, VoiceServerUpdate>,
-    discord_sessions: DashMap<Id<GuildMarker>, Box<str>>,
+    discord_sessions: DashMap<Id<GuildMarker>, (Box<str>, Option<Id<ChannelMarker>>)>,
 }
 
 impl Lavalink {
@@ -202,8 +202,10 @@ impl Lavalink {
                         self.discord_sessions.remove(&guild_id);
                         self.server_updates.remove(&guild_id);
                     } else {
-                        self.discord_sessions
-                            .insert(guild_id, e.session_id.clone().into_boxed_str());
+                        self.discord_sessions.insert(
+                            guild_id,
+                            (e.session_id.clone().into_boxed_str(), e.channel_id),
+                        );
                     }
                     guild_id
                 } else {
@@ -222,11 +224,11 @@ impl Lavalink {
             match (server, session) {
                 (Some(server), Some(session)) => {
                     let server = server.value();
-                    let session = session.value();
+                    let (session_id, channel_id) = session.value();
                     tracing::debug!(
-                        "got both halves for {guild_id}: {server:?}; Session ID: {session:?}",
+                        "got both halves for {guild_id}: {server:?}; Session ID: {session_id:?}",
                     );
-                    VoiceUpdate::new(guild_id, session.as_ref(), server.clone())
+                    VoiceUpdate::new(guild_id, session_id.as_ref(), *channel_id, server.clone())
                 }
                 (Some(server), None) => {
                     tracing::debug!(

--- a/twilight-lavalink/src/client.rs
+++ b/twilight-lavalink/src/client.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     model::VoiceUpdate,
-    node::{IncomingEvents, Node, NodeConfig, NodeError, Resume},
+    node::{IncomingEvents, Node, NodeConfig, NodeError},
     player::{Player, PlayerManager},
 };
 use dashmap::DashMap;
@@ -99,7 +99,6 @@ pub enum ClientErrorType {
 pub struct Lavalink {
     nodes: DashMap<SocketAddr, Arc<Node>>,
     players: PlayerManager,
-    resume: Option<Resume>,
     shard_count: u32,
     user_id: Id<UserMarker>,
     server_updates: DashMap<Id<GuildMarker>, VoiceServerUpdate>,
@@ -113,35 +112,11 @@ impl Lavalink {
     /// runtime, and the client must be re-created. These parameters are
     /// automatically passed to new nodes created via [`add`].
     ///
-    /// See also [`new_with_resume`], which allows you to specify session resume
-    /// capability.
-    ///
     /// [`add`]: Self::add
-    /// [`new_with_resume`]: Self::new_with_resume
     pub fn new(user_id: Id<UserMarker>, shard_count: u32) -> Self {
-        Self::_new_with_resume(user_id, shard_count, None)
-    }
-
-    /// Like [`new`], but allows you to specify resume capability (if any).
-    ///
-    /// Provide `None` for the `resume` parameter to disable session resume
-    /// capability. See the [`Resume`] documentation for defaults.
-    ///
-    /// [`Resume`]: crate::node::Resume
-    /// [`new`]: Self::new
-    pub fn new_with_resume(
-        user_id: Id<UserMarker>,
-        shard_count: u32,
-        resume: impl Into<Option<Resume>>,
-    ) -> Self {
-        Self::_new_with_resume(user_id, shard_count, resume.into())
-    }
-
-    fn _new_with_resume(user_id: Id<UserMarker>, shard_count: u32, resume: Option<Resume>) -> Self {
         Self {
             nodes: DashMap::new(),
             players: PlayerManager::new(),
-            resume,
             shard_count,
             user_id,
             server_updates: DashMap::new(),
@@ -226,7 +201,7 @@ impl Lavalink {
                     let server = server.value();
                     let (session_id, channel_id) = session.value();
                     tracing::debug!(
-                        "got both halves for {guild_id}: {server:?}; Session ID: {session_id:?}",
+                        "got both halves for {guild_id}: {server:?}; Session ID: {session_id:?}; Channel ID: {channel_id:?}",
                     );
                     VoiceUpdate::new(guild_id, session_id.as_ref(), *channel_id, server.clone())
                 }
@@ -269,25 +244,17 @@ impl Lavalink {
     /// If a node already exists with the provided address, then it will be
     /// replaced.
     ///
-    /// # Errors
+    /// Pass `None` for `session_id` to create a fresh session. Pass
+    /// `Some(id)` to attempt resuming an existing Lavalink session. Resume
+    /// success is indicated by the `resumed` field on the
+    /// [`Ready`] event received via the returned [`IncomingEvents`] stream.
     ///
-    /// See the errors section of [`Node::connect`].
-    pub async fn add(
-        &self,
-        address: SocketAddr,
-        authorization: impl Into<String>,
-    ) -> Result<(Arc<Node>, IncomingEvents), NodeError> {
-        self.add_with_session_id(address, authorization, None).await
-    }
-
-    /// Add a new node with an optional session ID to resume.
+    /// If a `session_id` is provided and the session cannot be resumed,
+    /// the connection will fail with a [`Connecting`] error. The caller
+    /// can then retry with `session_id` set to `None` for a fresh session.
     ///
-    /// If `session_id` is provided, the client will attempt to resume the existing
-    /// Lavalink session instead of creating a new one. This allows reconnecting
-    /// without interrupting active players.
-    ///
-    /// If a node already exists with the provided address, then it will be
-    /// replaced.
+    /// [`Ready`]: crate::model::incoming::Ready
+    /// [`Connecting`]: crate::node::NodeErrorType::Connecting
     ///
     /// # Example
     ///
@@ -298,11 +265,12 @@ impl Lavalink {
     /// # let lavalink = Lavalink::new(Id::new(1), 1);
     /// # let address = "127.0.0.1:2333".parse()?;
     /// # let auth = "youshallnotpass";
-    /// // Resume existing session
+    /// // Fresh session (no resume)
+    /// let (node, events) = lavalink.add(address, auth, None).await?;
+    ///
+    /// // Resume an existing session
     /// let old_session_id = Some("existing-session-id".to_string());
-    /// lavalink
-    ///     .add_with_session_id(address, auth, old_session_id)
-    ///     .await?;
+    /// let (node, events) = lavalink.add(address, auth, old_session_id).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -310,7 +278,7 @@ impl Lavalink {
     /// # Errors
     ///
     /// See the errors section of [`Node::connect`].
-    pub async fn add_with_session_id(
+    pub async fn add(
         &self,
         address: SocketAddr,
         authorization: impl Into<String>,
@@ -319,7 +287,6 @@ impl Lavalink {
         let config = NodeConfig {
             address,
             authorization: authorization.into(),
-            resume: self.resume.clone(),
             user_id: self.user_id,
             enable_tls: cfg!(feature = "tls"),
             session_id,

--- a/twilight-lavalink/src/client.rs
+++ b/twilight-lavalink/src/client.rs
@@ -275,12 +275,50 @@ impl Lavalink {
         address: SocketAddr,
         authorization: impl Into<String>,
     ) -> Result<(Arc<Node>, IncomingEvents), NodeError> {
+        self.add_with_session_id(address, authorization, None).await
+    }
+
+    /// Add a new node with an optional session ID to resume.
+    ///
+    /// If `session_id` is provided, the client will attempt to resume the existing
+    /// Lavalink session instead of creating a new one. This allows reconnecting
+    /// without interrupting active players.
+    ///
+    /// If a node already exists with the provided address, then it will be
+    /// replaced.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use twilight_lavalink::Lavalink;
+    /// # use twilight_model::id::Id;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let lavalink = Lavalink::new(Id::new(1), 1);
+    /// # let address = "127.0.0.1:2333".parse()?;
+    /// # let auth = "youshallnotpass";
+    /// // Resume existing session
+    /// let old_session_id = Some("existing-session-id".to_string());
+    /// lavalink.add_with_session_id(address, auth, old_session_id).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// See the errors section of [`Node::connect`].
+    pub async fn add_with_session_id(
+        &self,
+        address: SocketAddr,
+        authorization: impl Into<String>,
+        session_id: Option<String>,
+    ) -> Result<(Arc<Node>, IncomingEvents), NodeError> {
         let config = NodeConfig {
             address,
             authorization: authorization.into(),
             resume: self.resume.clone(),
             user_id: self.user_id,
             enable_tls: cfg!(feature = "tls"),
+            session_id,
         };
 
         let (node, rx) = Node::connect(config, self.players.clone()).await?;

--- a/twilight-lavalink/src/model.rs
+++ b/twilight-lavalink/src/model.rs
@@ -391,6 +391,7 @@ mod lavalink_outgoing_model_tests {
         let voice = VoiceUpdate {
             guild_id: Id::<GuildMarker>::new(987_654_321),
             voice: Voice {
+                channel_id: None,
                 token: String::from("863ea8ef2ads8ef2"),
                 endpoint: String::from("eu-centra654863.discord.media:443"),
                 session_id: String::from("asdf5w1efa65feaf315e8a8effsa1e5f"),
@@ -399,6 +400,20 @@ mod lavalink_outgoing_model_tests {
         compare_json_payload(
             &voice,
             r#"{"voice":{"endpoint":"eu-centra654863.discord.media:443","sessionId":"asdf5w1efa65feaf315e8a8effsa1e5f","token":"863ea8ef2ads8ef2"}}"#,
+        );
+        
+        let voice_dave = VoiceUpdate {
+            guild_id: Id::<GuildMarker>::new(987_654_321),
+            voice: Voice {
+                channel_id: Some(Id::new(111_222_333)),
+                token: String::from("863ea8ef2ads8ef2"),
+                endpoint: String::from("eu-centra654863.discord.media:443"),
+                session_id: String::from("asdf5w1efa65feaf315e8a8effsa1e5f"),
+            },
+        };
+        compare_json_payload(
+            &voice_dave,
+            r#"{"voice":{"channelId":"111222333","endpoint":"eu-centra654863.discord.media:443","sessionId":"asdf5w1efa65feaf315e8a8effsa1e5f","token":"863ea8ef2ads8ef2"}}"#,
         );
     }
 

--- a/twilight-lavalink/src/model.rs
+++ b/twilight-lavalink/src/model.rs
@@ -401,7 +401,7 @@ mod lavalink_outgoing_model_tests {
             &voice,
             r#"{"voice":{"endpoint":"eu-centra654863.discord.media:443","sessionId":"asdf5w1efa65feaf315e8a8effsa1e5f","token":"863ea8ef2ads8ef2"}}"#,
         );
-        
+
         let voice_dave = VoiceUpdate {
             guild_id: Id::<GuildMarker>::new(987_654_321),
             voice: Voice {

--- a/twilight-lavalink/src/model.rs
+++ b/twilight-lavalink/src/model.rs
@@ -375,8 +375,15 @@ mod lavalink_outgoing_model_tests {
     use super::EqualizerBand;
     use super::outgoing::{OutgoingEvent, UpdatePlayerTrack, Voice, VoiceUpdate};
 
+    // Arbitrary fixture values used across tests.
+    const TEST_GUILD_ID: u64 = 987_654_321;
+    const TEST_CHANNEL_ID: u64 = 111_222_333;
+    const TEST_TOKEN: &str = "863ea8ef2ads8ef2";
+    const TEST_ENDPOINT: &str = "eu-centra654863.discord.media:443";
+    const TEST_SESSION_ID: &str = "asdf5w1efa65feaf315e8a8effsa1e5f";
+
     // For some of the outgoing we have fields that don't get deserialized. We only need
-    // to check weather the serialization is working.
+    // to check whether the serialization is working.
     fn compare_json_payload<T: serde::Serialize + std::fmt::Debug + std::cmp::PartialEq>(
         data_struct: &T,
         json_payload: &str,
@@ -389,12 +396,12 @@ mod lavalink_outgoing_model_tests {
     #[test]
     fn should_serialize_an_outgoing_voice_update() {
         let voice = VoiceUpdate {
-            guild_id: Id::<GuildMarker>::new(987_654_321),
+            guild_id: Id::<GuildMarker>::new(TEST_GUILD_ID),
             voice: Voice {
                 channel_id: None,
-                token: String::from("863ea8ef2ads8ef2"),
-                endpoint: String::from("eu-centra654863.discord.media:443"),
-                session_id: String::from("asdf5w1efa65feaf315e8a8effsa1e5f"),
+                token: String::from(TEST_TOKEN),
+                endpoint: String::from(TEST_ENDPOINT),
+                session_id: String::from(TEST_SESSION_ID),
             },
         };
         compare_json_payload(
@@ -403,12 +410,12 @@ mod lavalink_outgoing_model_tests {
         );
 
         let voice_dave = VoiceUpdate {
-            guild_id: Id::<GuildMarker>::new(987_654_321),
+            guild_id: Id::<GuildMarker>::new(TEST_GUILD_ID),
             voice: Voice {
-                channel_id: Some(Id::new(111_222_333)),
-                token: String::from("863ea8ef2ads8ef2"),
-                endpoint: String::from("eu-centra654863.discord.media:443"),
-                session_id: String::from("asdf5w1efa65feaf315e8a8effsa1e5f"),
+                channel_id: Some(Id::new(TEST_CHANNEL_ID)),
+                token: String::from(TEST_TOKEN),
+                endpoint: String::from(TEST_ENDPOINT),
+                session_id: String::from(TEST_SESSION_ID),
             },
         };
         compare_json_payload(
@@ -427,7 +434,7 @@ mod lavalink_outgoing_model_tests {
             end_time: Some(None),
             volume: None,
             paused: None,
-            guild_id: Id::<GuildMarker>::new(987_654_321),
+            guild_id: Id::<GuildMarker>::new(TEST_GUILD_ID),
             no_replace: true,
         });
         compare_json_payload(
@@ -442,7 +449,7 @@ mod lavalink_outgoing_model_tests {
             track: UpdatePlayerTrack {
                 track_string: TrackOption::Encoded(None),
             },
-            guild_id: Id::<GuildMarker>::new(987_654_321),
+            guild_id: Id::<GuildMarker>::new(TEST_GUILD_ID),
         });
         compare_json_payload(&stop, r#"{"track":{"encoded":null}}"#);
     }
@@ -451,7 +458,7 @@ mod lavalink_outgoing_model_tests {
     fn should_serialize_an_outgoing_pause() {
         let pause = OutgoingEvent::Pause(Pause {
             paused: true,
-            guild_id: Id::<GuildMarker>::new(987_654_321),
+            guild_id: Id::<GuildMarker>::new(TEST_GUILD_ID),
         });
         compare_json_payload(&pause, r#"{"guildId":"987654321","paused":true}"#);
     }
@@ -460,7 +467,7 @@ mod lavalink_outgoing_model_tests {
     fn should_serialize_an_outgoing_seek() {
         let seek = OutgoingEvent::Seek(Seek {
             position: 66000,
-            guild_id: Id::<GuildMarker>::new(987_654_321),
+            guild_id: Id::<GuildMarker>::new(TEST_GUILD_ID),
         });
         compare_json_payload(&seek, r#"{"position":66000}"#);
     }
@@ -469,7 +476,7 @@ mod lavalink_outgoing_model_tests {
     fn should_serialize_an_outgoing_volume() {
         let volume = OutgoingEvent::Volume(Volume {
             volume: 50,
-            guild_id: Id::<GuildMarker>::new(987_654_321),
+            guild_id: Id::<GuildMarker>::new(TEST_GUILD_ID),
         });
         compare_json_payload(&volume, r#"{"volume":50}"#);
     }
@@ -477,7 +484,7 @@ mod lavalink_outgoing_model_tests {
     #[test]
     fn should_serialize_an_outgoing_destroy_aka_leave() {
         let destroy = OutgoingEvent::Destroy(Destroy {
-            guild_id: Id::<GuildMarker>::new(987_654_321),
+            guild_id: Id::<GuildMarker>::new(TEST_GUILD_ID),
         });
         compare_json_payload(&destroy, r#"{"guildId":"987654321"}"#);
     }
@@ -486,7 +493,7 @@ mod lavalink_outgoing_model_tests {
     fn should_serialize_an_outgoing_equalize() {
         let equalize = OutgoingEvent::Equalizer(Equalizer {
             equalizer: vec![EqualizerBand::new(5, -0.15)],
-            guild_id: Id::<GuildMarker>::new(987_654_321),
+            guild_id: Id::<GuildMarker>::new(TEST_GUILD_ID),
         });
         compare_json_payload(&equalize, r#"{"equalizer":[{"band":5,"gain":-0.15}]}"#);
     }

--- a/twilight-lavalink/src/model/incoming.rs
+++ b/twilight-lavalink/src/model/incoming.rs
@@ -16,7 +16,7 @@ pub enum Opcode {
 }
 
 use serde::{Deserialize, Serialize};
-use twilight_model::id::{Id, marker::GuildMarker};
+use twilight_model::id::{Id, marker::{ChannelMarker, GuildMarker}};
 
 /// The levels of severity that an exception can have.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -99,6 +99,8 @@ impl From<Stats> for IncomingEvent {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct VoiceState {
+    /// The Discord voice channel id the bot is connected to.
+    pub channel_id: Option<Id<ChannelMarker>>,
     /// The Discord voice endpoint to connect to.
     pub endpoint: String,
     /// The Discord voice session id to authenticate with. Note this is separate

--- a/twilight-lavalink/src/model/incoming.rs
+++ b/twilight-lavalink/src/model/incoming.rs
@@ -16,7 +16,10 @@ pub enum Opcode {
 }
 
 use serde::{Deserialize, Serialize};
-use twilight_model::id::{Id, marker::{ChannelMarker, GuildMarker}};
+use twilight_model::id::{
+    Id,
+    marker::{ChannelMarker, GuildMarker},
+};
 
 /// The levels of severity that an exception can have.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/twilight-lavalink/src/model/outgoing.rs
+++ b/twilight-lavalink/src/model/outgoing.rs
@@ -2,7 +2,10 @@
 use serde::{Deserialize, Serialize};
 use twilight_model::{
     gateway::payload::incoming::VoiceServerUpdate,
-    id::{Id, marker::{ChannelMarker, GuildMarker}},
+    id::{
+        Id,
+        marker::{ChannelMarker, GuildMarker},
+    },
 };
 
 /// The track on the player. The encoded and identifier are mutually exclusive.
@@ -420,8 +423,13 @@ impl VoiceUpdate {
     }
 }
 
-impl<T: Into<String>> From<(Id<GuildMarker>, T, Option<Id<ChannelMarker>>, VoiceServerUpdate)>
-    for VoiceUpdate
+impl<T: Into<String>>
+    From<(
+        Id<GuildMarker>,
+        T,
+        Option<Id<ChannelMarker>>,
+        VoiceServerUpdate,
+    )> for VoiceUpdate
 {
     fn from(
         (guild_id, session_id, channel_id, event): (

--- a/twilight-lavalink/src/model/outgoing.rs
+++ b/twilight-lavalink/src/model/outgoing.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 use twilight_model::{
     gateway::payload::incoming::VoiceServerUpdate,
-    id::{Id, marker::GuildMarker},
+    id::{Id, marker::{ChannelMarker, GuildMarker}},
 };
 
 /// The track on the player. The encoded and identifier are mutually exclusive.
@@ -385,6 +385,9 @@ impl From<Id<GuildMarker>> for Stop {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Voice {
+    /// The Discord voice channel id the bot is connecting to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel_id: Option<Id<ChannelMarker>>,
     /// The Discord voice endpoint to connect to.
     pub endpoint: String,
     /// The Discord voice session id to authenticate with. This is separate from the session id of lavalink.
@@ -410,17 +413,28 @@ impl VoiceUpdate {
     pub fn new(
         guild_id: Id<GuildMarker>,
         session_id: impl Into<String>,
+        channel_id: Option<Id<ChannelMarker>>,
         event: VoiceServerUpdate,
     ) -> Self {
-        Self::from((guild_id, session_id, event))
+        Self::from((guild_id, session_id, channel_id, event))
     }
 }
 
-impl<T: Into<String>> From<(Id<GuildMarker>, T, VoiceServerUpdate)> for VoiceUpdate {
-    fn from((guild_id, session_id, event): (Id<GuildMarker>, T, VoiceServerUpdate)) -> Self {
+impl<T: Into<String>> From<(Id<GuildMarker>, T, Option<Id<ChannelMarker>>, VoiceServerUpdate)>
+    for VoiceUpdate
+{
+    fn from(
+        (guild_id, session_id, channel_id, event): (
+            Id<GuildMarker>,
+            T,
+            Option<Id<ChannelMarker>>,
+            VoiceServerUpdate,
+        ),
+    ) -> Self {
         Self {
             guild_id,
             voice: Voice {
+                channel_id,
                 token: event.token,
                 endpoint: event.endpoint.unwrap_or("NO_ENDPOINT_RETURNED".to_string()),
                 session_id: session_id.into(),

--- a/twilight-lavalink/src/node.rs
+++ b/twilight-lavalink/src/node.rs
@@ -257,6 +257,11 @@ pub struct NodeConfig {
     pub user_id: Id<UserMarker>,
     /// Weather or not to enable TLS
     pub enable_tls: bool,
+    /// Optional session ID to resume an existing Lavalink session.
+    ///
+    /// If provided, the client will attempt to resume this session instead of creating a new one.
+    /// This is only applicable for Lavalink v4+.
+    pub session_id: Option<String>,
 }
 
 impl Debug for NodeConfig {
@@ -278,6 +283,7 @@ impl Debug for NodeConfig {
             .field("resume", &self.resume)
             .field("user_id", &self.user_id)
             .field("enable_tls", &self.enable_tls)
+            .field("session_id", &self.session_id)
             .finish()
     }
 }
@@ -344,6 +350,7 @@ impl NodeConfig {
             resume,
             user_id,
             enable_tls,
+            session_id: None,
         }
     }
 }
@@ -742,20 +749,19 @@ fn connect_request(state: &NodeConfig) -> Result<ClientBuilder<'_>, NodeError> {
         )
         .expect("Unable to crate builder");
 
-    if state.resume.is_some() {
+    // Add Session-Id header if we have a previous session to resume (Lavalink v4)
+    if let Some(session_id) = &state.session_id {
         builder = builder
             .add_header(
-                HeaderName::from_static("resume-key"),
-                state
-                    .address
-                    .to_string()
+                HeaderName::from_static("session-id"),
+                session_id
                     .parse()
                     .map_err(|source| NodeError {
                         kind: NodeErrorType::BuildingConnectionRequest,
                         source: Some(Box::new(source)),
                     })?,
             )
-            .expect("Unable to build state header");
+            .expect("Unable to add Session-Id header");
     }
 
     Ok(builder)
@@ -764,35 +770,21 @@ fn connect_request(state: &NodeConfig) -> Result<ClientBuilder<'_>, NodeError> {
 async fn reconnect(
     config: &NodeConfig,
 ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, NodeError> {
-    let (mut stream, res) = backoff(config).await?;
+    let (stream, res) = backoff(config).await?;
 
     let headers = res.headers();
 
-    if let Some(resume) = config.resume.as_ref() {
-        let header = HeaderName::from_static("session-resumed");
-
-        if let Some(value) = headers.get(header) {
-            if value.as_bytes() == b"false" {
-                tracing::debug!("session to node {} didn't resume", config.address);
-
-                let payload = serde_json::json!({
-                    "op": "configureResuming",
-                    "key": config.address,
-                    "timeout": resume.timeout,
-                });
-                let msg = Message::text(
-                    serde_json::to_string(&payload).expect("serialize can't panic here"),
-                );
-
-                stream.send(msg).await.map_err(|source| NodeError {
-                    kind: NodeErrorType::Connecting,
-                    source: Some(Box::new(source)),
-                })?;
-            } else {
-                tracing::debug!("session to {} resumed", config.address);
-            }
+    // Check if session was resumed via response header (Lavalink v4)
+    let header = HeaderName::from_static("session-resumed");
+    if let Some(value) = headers.get(header) {
+        if value.as_bytes() == b"true" {
+            tracing::info!("Successfully resumed Lavalink session for node {}", config.address);
+        } else {
+            tracing::debug!("New Lavalink session created for node {} (did not resume)", config.address);
         }
     }
+    // Note: Session resume configuration is now done via REST API PATCH /v4/sessions/{sessionId}
+    // This should be called AFTER receiving the Ready OP with the new session ID
 
     Ok(stream)
 }
@@ -861,7 +853,7 @@ mod tests {
     };
     use twilight_model::id::Id;
 
-    assert_fields!(NodeConfig: address, authorization, resume, user_id, enable_tls);
+    assert_fields!(NodeConfig: address, authorization, resume, user_id, enable_tls, session_id);
     assert_impl_all!(NodeConfig: Clone, Debug, Send, Sync);
     assert_fields!(NodeErrorType::SerializingMessage: message);
     assert_fields!(NodeErrorType::Unauthorized: address, authorization);
@@ -879,6 +871,7 @@ mod tests {
             resume: None,
             user_id: Id::new(123),
             enable_tls: false,
+            session_id: None,
         };
 
         assert!(format!("{config:?}").contains("authorization: <redacted>"));

--- a/twilight-lavalink/src/node.rs
+++ b/twilight-lavalink/src/node.rs
@@ -248,13 +248,9 @@ pub struct NodeConfig {
     pub address: SocketAddr,
     /// The password to use when authenticating.
     pub authorization: String,
-    /// The details for resuming a Lavalink session, if any.
-    ///
-    /// Set this to `None` to disable resume capability.
-    pub resume: Option<Resume>,
     /// The user ID of the bot.
     pub user_id: Id<UserMarker>,
-    /// Weather or not to enable TLS
+    /// Whether or not to enable TLS.
     pub enable_tls: bool,
     /// Optional session ID to resume an existing Lavalink session.
     ///
@@ -279,36 +275,10 @@ impl Debug for NodeConfig {
         f.debug_struct("NodeConfig")
             .field("address", &self.address)
             .field("authorization", &Redacted)
-            .field("resume", &self.resume)
             .field("user_id", &self.user_id)
             .field("enable_tls", &self.enable_tls)
             .field("session_id", &self.session_id)
             .finish()
-    }
-}
-
-/// Configuration for a session which can be resumed.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub struct Resume {
-    /// The number of seconds that the Lavalink server will allow the session to
-    /// be resumed for after a disconnect.
-    ///
-    /// The default is 60.
-    pub timeout: u64,
-}
-
-impl Resume {
-    /// Configure resume capability, providing the number of seconds that the
-    /// Lavalink server should queue events for when the connection is resumed.
-    pub const fn new(seconds: u64) -> Self {
-        Self { timeout: seconds }
-    }
-}
-
-impl Default for Resume {
-    fn default() -> Self {
-        Self { timeout: 60 }
     }
 }
 
@@ -324,29 +294,20 @@ impl NodeConfig {
         user_id: Id<UserMarker>,
         address: impl Into<SocketAddr>,
         authorization: impl Into<String>,
-        resume: impl Into<Option<Resume>>,
         enable_tls: bool,
     ) -> Self {
-        Self::_new(
-            user_id,
-            address.into(),
-            authorization.into(),
-            resume.into(),
-            enable_tls,
-        )
+        Self::_new(user_id, address.into(), authorization.into(), enable_tls)
     }
 
     const fn _new(
         user_id: Id<UserMarker>,
         address: SocketAddr,
         authorization: String,
-        resume: Option<Resume>,
         enable_tls: bool,
     ) -> Self {
         Self {
             address,
             authorization,
-            resume,
             user_id,
             enable_tls,
             session_id: None,
@@ -736,7 +697,7 @@ fn connect_request(state: &NodeConfig) -> Result<ClientBuilder<'_>, NodeError> {
                 source: Some(Box::new(source)),
             })?,
         )
-        .expect("Unable to crate authorization header")
+        .expect("Unable to create authorization header")
         .add_header(
             HeaderName::from_static("user-id"),
             state.user_id.get().into(),
@@ -746,7 +707,7 @@ fn connect_request(state: &NodeConfig) -> Result<ClientBuilder<'_>, NodeError> {
             HeaderName::from_static("client-name"),
             HeaderValue::from_static(TWILIGHT_CLIENT_NAME),
         )
-        .expect("Unable to crate builder");
+        .expect("Unable to create builder");
 
     // Add Session-Id header if we have a previous session to resume (Lavalink v4)
     if let Some(session_id) = &state.session_id {
@@ -764,6 +725,20 @@ fn connect_request(state: &NodeConfig) -> Result<ClientBuilder<'_>, NodeError> {
     Ok(builder)
 }
 
+/// Reconnect to a Lavalink node via exponential backoff.
+///
+/// If `config.session_id` is set, the reconnection will attempt to resume
+/// the existing session. If the server indicates the session was not resumed
+/// (for example, via a `Session-Resumed: false` header or by omitting the
+/// `Session-Resumed` header entirely), this function returns a
+/// [`Connecting`] error. The caller can retry with `session_id` set to
+/// `None` to create a fresh session.
+///
+/// Note: Session resume configuration (timeout, etc.) is done via the
+/// Lavalink REST API `PATCH /v4/sessions/{sessionId}`. This should be
+/// called after receiving the `Ready` event with the new session ID.
+///
+/// [`Connecting`]: NodeErrorType::Connecting
 async fn reconnect(
     config: &NodeConfig,
 ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, NodeError> {
@@ -779,15 +754,28 @@ async fn reconnect(
                 "Successfully resumed Lavalink session for node {}",
                 config.address
             );
-        } else {
-            tracing::debug!(
-                "New Lavalink session created for node {} (did not resume)",
-                config.address
+        } else if config.session_id.is_some() {
+            tracing::warn!(
+                "Failed to resume Lavalink session for node {} (session not resumed)",
+                config.address,
             );
+            return Err(NodeError {
+                kind: NodeErrorType::Connecting,
+                source: None,
+            });
+        } else {
+            tracing::debug!("New Lavalink session created for node {}", config.address);
         }
+    } else if config.session_id.is_some() {
+        tracing::warn!(
+            "Session-Resumed header not present for node {}; resume may have failed",
+            config.address,
+        );
+        return Err(NodeError {
+            kind: NodeErrorType::Connecting,
+            source: None,
+        });
     }
-    // Note: Session resume configuration is now done via REST API PATCH /v4/sessions/{sessionId}
-    // This should be called AFTER receiving the Ready OP with the new session ID
 
     Ok(stream)
 }
@@ -847,7 +835,7 @@ async fn backoff(
 
 #[cfg(test)]
 mod tests {
-    use super::{Node, NodeConfig, NodeError, NodeErrorType, Resume};
+    use super::{Node, NodeConfig, NodeError, NodeErrorType};
     use static_assertions::{assert_fields, assert_impl_all};
     use std::{
         error::Error,
@@ -856,22 +844,19 @@ mod tests {
     };
     use twilight_model::id::Id;
 
-    assert_fields!(NodeConfig: address, authorization, resume, user_id, enable_tls, session_id);
+    assert_fields!(NodeConfig: address, authorization, user_id, enable_tls, session_id);
     assert_impl_all!(NodeConfig: Clone, Debug, Send, Sync);
     assert_fields!(NodeErrorType::SerializingMessage: message);
     assert_fields!(NodeErrorType::Unauthorized: address, authorization);
     assert_impl_all!(NodeErrorType: Debug, Send, Sync);
     assert_impl_all!(NodeError: Error, Send, Sync);
     assert_impl_all!(Node: Debug, Send, Sync);
-    assert_fields!(Resume: timeout);
-    assert_impl_all!(Resume: Clone, Debug, Default, Eq, PartialEq, Send, Sync);
 
     #[test]
     fn node_config_debug() {
         let config = NodeConfig {
             address: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1312)),
             authorization: "some auth".to_owned(),
-            resume: None,
             user_id: Id::new(123),
             enable_tls: false,
             session_id: None,

--- a/twilight-lavalink/src/node.rs
+++ b/twilight-lavalink/src/node.rs
@@ -23,7 +23,6 @@ use crate::{
 };
 use futures_util::{
     lock::BiLock,
-    sink::SinkExt,
     stream::{Stream, StreamExt},
 };
 use http::header::{AUTHORIZATION, HeaderName, HeaderValue};
@@ -754,12 +753,10 @@ fn connect_request(state: &NodeConfig) -> Result<ClientBuilder<'_>, NodeError> {
         builder = builder
             .add_header(
                 HeaderName::from_static("session-id"),
-                session_id
-                    .parse()
-                    .map_err(|source| NodeError {
-                        kind: NodeErrorType::BuildingConnectionRequest,
-                        source: Some(Box::new(source)),
-                    })?,
+                session_id.parse().map_err(|source| NodeError {
+                    kind: NodeErrorType::BuildingConnectionRequest,
+                    source: Some(Box::new(source)),
+                })?,
             )
             .expect("Unable to add Session-Id header");
     }
@@ -778,9 +775,15 @@ async fn reconnect(
     let header = HeaderName::from_static("session-resumed");
     if let Some(value) = headers.get(header) {
         if value.as_bytes() == b"true" {
-            tracing::info!("Successfully resumed Lavalink session for node {}", config.address);
+            tracing::info!(
+                "Successfully resumed Lavalink session for node {}",
+                config.address
+            );
         } else {
-            tracing::debug!("New Lavalink session created for node {} (did not resume)", config.address);
+            tracing::debug!(
+                "New Lavalink session created for node {} (did not resume)",
+                config.address
+            );
         }
     }
     // Note: Session resume configuration is now done via REST API PATCH /v4/sessions/{sessionId}


### PR DESCRIPTION
Updated the lavalink client for Lavalink v4 session resuming and DAVE protocol compatibility.

- Session resuming: Added add_with_session_id(), sends Session-Id header on connect, checks Session-Resumed on reconnect, and removed the deprecated v3 configureResuming WS op (now handled via REST PATCH /v4/sessions/{sessionId})
- DAVE support: Added channel_id to Voice/VoiceState structs and voice update flow, required for Discord's audio encryption protocol