### PR TITLE
Revert "feat(http): Add WASI request building support (#2513)"

### DIFF
--- a/twilight-http-ratelimiting/Cargo.toml
+++ b/twilight-http-ratelimiting/Cargo.toml
@@ -15,14 +15,10 @@ version = "0.17.1"
 
 [dependencies]
 hashbrown = { default-features = false, version = "0.16" }
-tracing = { default-features = false, features = ["std"], version = "0.1.23" }
-
-[target.'cfg(not(target_os = "wasi"))'.dependencies]
 tokio = { default-features = false, features = ["macros", "rt", "sync", "time"], version = "1.29" }
 tokio-util = { default-features = false, features = ["time"], version = "0.7.11" }
+tracing = { default-features = false, features = ["std"], version = "0.1.23" }
 
 [dev-dependencies]
 static_assertions = { default-features = false, version = "1.1.0" }
-
-[target.'cfg(not(target_os = "wasi"))'.dev-dependencies]
 tokio = { default-features = false, features = ["test-util"], version = "1.0" }

--- a/twilight-http-ratelimiting/src/actor.rs
+++ b/twilight-http-ratelimiting/src/actor.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "wasi"))]
-
 //! Rate limiting state manager.
 
 use crate::{Endpoint, GLOBAL_LIMIT_PERIOD, RateLimitHeaders};

--- a/twilight-http-ratelimiting/src/lib.rs
+++ b/twilight-http-ratelimiting/src/lib.rs
@@ -10,7 +10,6 @@
 
 mod actor;
 
-#[cfg(not(target_os = "wasi"))]
 use std::{
     future::Future,
     hash::{Hash as _, Hasher},
@@ -18,16 +17,13 @@ use std::{
     task::{Context, Poll},
     time::{Duration, Instant},
 };
-#[cfg(not(target_os = "wasi"))]
 use tokio::sync::{mpsc, oneshot};
 
 /// Duration from the first globally limited request until the remaining count
 /// resets to the global limit count.
-#[cfg(not(target_os = "wasi"))]
 pub const GLOBAL_LIMIT_PERIOD: Duration = Duration::from_secs(1);
 
 /// User actionable description that the actor panicked.
-#[cfg(not(target_os = "wasi"))]
 const ACTOR_PANIC_MESSAGE: &str =
     "actor task panicked: report its panic message to the maintainers";
 
@@ -89,7 +85,6 @@ impl Method {
 /// # });
 /// ```
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg(not(target_os = "wasi"))]
 pub struct Endpoint {
     /// Method of the endpoint.
     pub method: Method,
@@ -99,7 +94,6 @@ pub struct Endpoint {
     pub path: String,
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl Endpoint {
     /// Whether the endpoint is properly structured.
     pub(crate) fn is_valid(&self) -> bool {
@@ -164,7 +158,6 @@ impl Endpoint {
 /// the [`Permit`] with [`RateLimitHeaders::shared`], but are not required to
 /// since these limits do not count towards the invalid request limit.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg(not(target_os = "wasi"))]
 pub struct RateLimitHeaders {
     /// Bucket identifier.
     pub bucket: Vec<u8>,
@@ -176,7 +169,6 @@ pub struct RateLimitHeaders {
     pub reset_at: Instant,
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl RateLimitHeaders {
     /// Lowercased name for the bucket header.
     pub const BUCKET: &'static str = "x-ratelimit-bucket";
@@ -208,10 +200,8 @@ impl RateLimitHeaders {
 /// Permit to send a Discord HTTP API request to the acquired endpoint.
 #[derive(Debug)]
 #[must_use = "dropping the permit immediately cancels itself"]
-#[cfg(not(target_os = "wasi"))]
 pub struct Permit(oneshot::Sender<Option<RateLimitHeaders>>);
 
-#[cfg(not(target_os = "wasi"))]
 impl Permit {
     /// Update the [`RateLimiter`] based on the response headers.
     ///
@@ -226,10 +216,8 @@ impl Permit {
 /// Future that completes when a permit is ready.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-#[cfg(not(target_os = "wasi"))]
 pub struct PermitFuture(oneshot::Receiver<oneshot::Sender<Option<RateLimitHeaders>>>);
 
-#[cfg(not(target_os = "wasi"))]
 impl Future for PermitFuture {
     type Output = Permit;
 
@@ -245,10 +233,8 @@ impl Future for PermitFuture {
 /// Future that completes when a permit is ready or cancelled.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-#[cfg(not(target_os = "wasi"))]
 pub struct MaybePermitFuture(oneshot::Receiver<oneshot::Sender<Option<RateLimitHeaders>>>);
 
-#[cfg(not(target_os = "wasi"))]
 impl Future for MaybePermitFuture {
     type Output = Option<Permit>;
 
@@ -261,7 +247,6 @@ impl Future for MaybePermitFuture {
 /// [`RateLimitHeaders`].
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg(not(target_os = "wasi"))]
 pub struct Bucket {
     /// Total number of permits until the bucket becomes exhausted.
     pub limit: u16,
@@ -272,7 +257,6 @@ pub struct Bucket {
 }
 
 /// Actor run closure pre-enqueue for early [`MaybePermitFuture`] cancellation.
-#[cfg(not(target_os = "wasi"))]
 type Predicate = Box<dyn FnOnce(Option<Bucket>) -> bool + Send>;
 
 /// Discord HTTP client API rate limiter.
@@ -283,13 +267,11 @@ type Predicate = Box<dyn FnOnce(Option<Bucket>) -> bool + Send>;
 /// Cloning a [`RateLimiter`] increments just the amount of senders for the actor.
 /// The actor completes when there are no senders and non-completed permits left.
 #[derive(Clone, Debug)]
-#[cfg(not(target_os = "wasi"))]
 pub struct RateLimiter {
     /// Actor message sender.
     tx: mpsc::UnboundedSender<(actor::Message, Option<Predicate>)>,
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl RateLimiter {
     /// Create a new [`RateLimiter`] with a custom global limit.
     pub fn new(global_limit: u16) -> Self {
@@ -389,7 +371,6 @@ impl RateLimiter {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl Default for RateLimiter {
     /// Create a new [`RateLimiter`] with Discord's default global limit.
     ///

--- a/twilight-http/Cargo.toml
+++ b/twilight-http/Cargo.toml
@@ -17,12 +17,16 @@ version = "0.17.1"
 fastrand = { default-features = false, features = ["std"], version = "2" }
 http = { default-features = false, version = "1" }
 http-body-util = { default-features = false, version = "0.1" }
+hyper = { default-features = false, version = "1" }
+hyper-util = { default-features = false, features = ["client-legacy", "http1", "http2", "tokio"], version = "0.1.2" }
+hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.27.7" }
 hyper-tls = { default-features = false, optional = true, features = ["alpn"], version = "0.6" }
 hyper-hickory = { default-features = false, optional = true, features = ["tokio"], version = "0.8" }
 percent-encoding = { default-features = false, version = "2" }
 rustls = { default-features = false, optional = true, version = "0.23" }
 serde = { default-features = false, features = ["derive"], version = "1" }
 serde_json = { default-features = false, features = ["std"], version = "1" }
+tokio = { default-features = false, features = ["sync", "time"], version = "1.0" }
 tracing = { default-features = false, features = ["std", "attributes"], version = "0.1.36" }
 twilight-http-ratelimiting = { default-features = false, path = "../twilight-http-ratelimiting", version = "0.17.0" }
 twilight-model = { default-features = false, path = "../twilight-model", version = "0.17.0" }
@@ -31,12 +35,6 @@ twilight-validate = { default-features = false, path = "../twilight-validate", v
 # Optional dependencies.
 brotli-decompressor = { default-features = false, features = ["std"], optional = true, version = "5" }
 simd-json = { default-features = false, features = ["serde_impl", "swar-number-parsing"], optional = true, version = "0.17" }
-
-[target.'cfg(not(target_os = "wasi"))'.dependencies]
-hyper = { default-features = false, version = "1" }
-hyper-util = { default-features = false, features = ["client-legacy", "http1", "http2", "tokio"], version = "0.1.2" }
-hyper-rustls = { default-features = false, optional = true, features = ["http1", "http2"], version = "0.27.7" }
-tokio = { default-features = false, features = ["sync", "time"], version = "1.0" }
 
 [features]
 default = ["decompression", "rustls-platform-verifier"]
@@ -52,6 +50,4 @@ rustls = { default-features = false, features = ["ring"], version = "0.23" }
 serde_test = { default-features = false, version = "1" }
 static_assertions = { default-features = false, version = "1.1.0" }
 twilight-util = { default-features = false, features = ["builder"], path = "../twilight-util", version = "0.17.0" }
-
-[target.'cfg(not(target_os = "wasi"))'.dev-dependencies]
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }

--- a/twilight-http/src/client/builder.rs
+++ b/twilight-http/src/client/builder.rs
@@ -1,23 +1,17 @@
-#[cfg(not(target_os = "wasi"))]
 use super::Token;
-use crate::Client;
-#[cfg(not(target_os = "wasi"))]
-use crate::client::connector;
+use crate::{Client, client::connector};
 use http::header::HeaderMap;
-#[cfg(not(target_os = "wasi"))]
 use hyper_util::rt::TokioExecutor;
 use std::{
     sync::{Arc, atomic::AtomicBool},
     time::Duration,
 };
-#[cfg(not(target_os = "wasi"))]
 use twilight_http_ratelimiting::RateLimiter;
 use twilight_model::channel::message::AllowedMentions;
 
 /// A builder for [`Client`].
 #[derive(Debug)]
 #[must_use = "has no effect if not built into a Client"]
-#[cfg(not(target_os = "wasi"))]
 pub struct ClientBuilder {
     pub(crate) default_allowed_mentions: Option<AllowedMentions>,
     pub(crate) proxy: Option<Box<str>>,
@@ -29,14 +23,6 @@ pub struct ClientBuilder {
     pub(crate) use_http: bool,
 }
 
-/// A builder for [`Client`].
-#[derive(Debug)]
-#[must_use = "has no effect if not built into a Client"]
-#[cfg(target_os = "wasi")]
-pub struct ClientBuilder {
-    pub(crate) default_allowed_mentions: Option<AllowedMentions>,
-}
-
 impl ClientBuilder {
     /// Create a new builder to create a [`Client`].
     pub fn new() -> Self {
@@ -44,7 +30,6 @@ impl ClientBuilder {
     }
 
     /// Build the [`Client`].
-    #[cfg(not(target_os = "wasi"))]
     pub fn build(self) -> Client {
         let connector = connector::create();
 
@@ -67,14 +52,6 @@ impl ClientBuilder {
             token: self.token,
             default_allowed_mentions: self.default_allowed_mentions,
             use_http: self.use_http,
-        }
-    }
-
-    /// Build the [`Client`].
-    #[cfg(target_os = "wasi")]
-    pub fn build(self) -> Client {
-        Client {
-            default_allowed_mentions: self.default_allowed_mentions,
         }
     }
 
@@ -106,7 +83,6 @@ impl ClientBuilder {
     /// ```
     ///
     /// [twilight's HTTP proxy server]: https://github.com/twilight-rs/http-proxy
-    #[cfg(not(target_os = "wasi"))]
     pub fn proxy(mut self, proxy_url: String, use_http: bool) -> Self {
         self.proxy.replace(proxy_url.into_boxed_str());
         self.use_http = use_http;
@@ -122,7 +98,6 @@ impl ClientBuilder {
     /// If not called, then a default [`RateLimiter`] will be created by
     /// [`ClientBuilder::build`].
     #[allow(clippy::missing_const_for_fn)]
-    #[cfg(not(target_os = "wasi"))]
     pub fn ratelimiter(mut self, ratelimiter: Option<RateLimiter>) -> Self {
         self.ratelimiter = ratelimiter;
 
@@ -132,7 +107,6 @@ impl ClientBuilder {
     /// Set the timeout for HTTP requests.
     ///
     /// The default is 10 seconds.
-    #[cfg(not(target_os = "wasi"))]
     pub const fn timeout(mut self, duration: Duration) -> Self {
         self.timeout = duration;
 
@@ -140,7 +114,6 @@ impl ClientBuilder {
     }
 
     /// Set a group headers which are sent in every request.
-    #[cfg(not(target_os = "wasi"))]
     pub fn default_headers(mut self, headers: HeaderMap) -> Self {
         self.default_headers.replace(headers);
 
@@ -154,7 +127,6 @@ impl ClientBuilder {
     /// will not process future requests.
     ///
     /// Defaults to true.
-    #[cfg(not(target_os = "wasi"))]
     pub const fn remember_invalid_token(mut self, remember: bool) -> Self {
         self.remember_invalid_token = remember;
 
@@ -162,7 +134,6 @@ impl ClientBuilder {
     }
 
     /// Set the token to use for HTTP requests.
-    #[cfg(not(target_os = "wasi"))]
     pub fn token(mut self, mut token: String) -> Self {
         let is_bot = token.starts_with("Bot ");
         let is_bearer = token.starts_with("Bearer ");
@@ -180,7 +151,6 @@ impl ClientBuilder {
 }
 
 impl Default for ClientBuilder {
-    #[cfg(not(target_os = "wasi"))]
     fn default() -> Self {
         Self {
             default_allowed_mentions: None,
@@ -191,13 +161,6 @@ impl Default for ClientBuilder {
             timeout: Duration::from_secs(10),
             token: None,
             use_http: false,
-        }
-    }
-
-    #[cfg(target_os = "wasi")]
-    fn default() -> Self {
-        Self {
-            default_allowed_mentions: None,
         }
     }
 }

--- a/twilight-http/src/client/connector.rs
+++ b/twilight-http/src/client/connector.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "wasi"))]
-
 //! HTTP connectors with different features.
 
 /// HTTPS connector using `rustls` as a TLS backend.

--- a/twilight-http/src/client/mod.rs
+++ b/twilight-http/src/client/mod.rs
@@ -20,6 +20,7 @@ use crate::request::{
 #[allow(deprecated)]
 use crate::{
     API_VERSION,
+    client::connector::Connector,
     error::{Error, ErrorType},
     request::{
         GetCurrentAuthorizationInformation, GetGateway, GetUserApplicationInfo, GetVoiceRegions,
@@ -96,16 +97,13 @@ use crate::{
             UpdateCurrentUser,
         },
     },
+    response::ResponseFuture,
 };
-#[cfg(not(target_os = "wasi"))]
-use crate::{client::connector::Connector, response::ResponseFuture};
 use http::header::{
     AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderMap, HeaderValue, USER_AGENT,
 };
 use http_body_util::Full;
-#[cfg(not(target_os = "wasi"))]
 use hyper::body::Bytes;
-#[cfg(not(target_os = "wasi"))]
 use hyper_util::client::legacy::Client as HyperClient;
 use std::{
     fmt::{Debug, Formatter, Result as FmtResult},
@@ -116,7 +114,6 @@ use std::{
     },
     time::Duration,
 };
-#[cfg(not(target_os = "wasi"))]
 use twilight_http_ratelimiting::{Endpoint, RateLimiter};
 use twilight_model::{
     channel::{ChannelType, message::AllowedMentions},
@@ -244,7 +241,6 @@ impl Deref for Token {
 ///
 /// [here]: https://discord.com/developers/applications
 #[derive(Debug)]
-#[cfg(not(target_os = "wasi"))]
 pub struct Client {
     pub(crate) default_allowed_mentions: Option<AllowedMentions>,
     default_headers: Option<HeaderMap>,
@@ -261,40 +257,8 @@ pub struct Client {
     use_http: bool,
 }
 
-/// Twilight's http client.
-///
-/// # Interactions
-///
-/// HTTP interaction requests may be accessed via the [`Client::interaction`]
-/// method.
-///
-/// # Using the client in multiple tasks
-///
-/// To use a client instance in multiple tasks, consider wrapping it in an
-/// [`std::sync::Arc`] or [`std::rc::Rc`].
-///
-/// # Examples
-///
-/// Use [`ClientBuilder`] to create a client called `client`:
-/// ```no_run
-/// use twilight_http::Client;
-///
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let client = Client::builder().build();
-/// # Ok(()) }
-/// ```
-///
-/// All the examples on this page assume you have already created a client, and have named it
-/// `client`.
-#[derive(Debug)]
-#[cfg(target_os = "wasi")]
-pub struct Client {
-    pub(crate) default_allowed_mentions: Option<AllowedMentions>,
-}
-
 impl Client {
     /// Create a new client with a token.
-    #[cfg(not(target_os = "wasi"))]
     pub fn new(token: String) -> Self {
         ClientBuilder::default().token(token).build()
     }
@@ -310,7 +274,6 @@ impl Client {
     ///
     /// If the initial token provided is not prefixed with `Bot `, it will be, and this method
     /// reflects that.
-    #[cfg(not(target_os = "wasi"))]
     pub fn token(&self) -> Option<&str> {
         self.token.as_deref()
     }
@@ -370,7 +333,6 @@ impl Client {
     ///
     /// This will return `None` only if ratelimit handling
     /// has been explicitly disabled in the [`ClientBuilder`].
-    #[cfg(not(target_os = "wasi"))]
     pub const fn ratelimiter(&self) -> Option<&RateLimiter> {
         self.ratelimiter.as_ref()
     }
@@ -2924,7 +2886,6 @@ impl Client {
     /// token has become invalid due to expiration, revocation, etc.
     ///
     /// [`Response`]: super::response::Response
-    #[cfg(not(target_os = "wasi"))]
     pub fn request<T>(&self, request: Request) -> ResponseFuture<T> {
         match self.try_request::<T>(request) {
             Ok(future) => future,
@@ -2932,7 +2893,6 @@ impl Client {
         }
     }
 
-    #[cfg(not(target_os = "wasi"))]
     fn try_request<T>(&self, request: Request) -> Result<ResponseFuture<T>, Error> {
         if let Some(token_invalidated) = self.token_invalidated.as_ref()
             && token_invalidated.load(Ordering::Relaxed)

--- a/twilight-http/src/error.rs
+++ b/twilight-http/src/error.rs
@@ -1,6 +1,4 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::StatusCode;
-use crate::{api_error::ApiError, json::JsonError};
+use crate::{api_error::ApiError, json::JsonError, response::StatusCode};
 use std::{
     error::Error as StdError,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -72,7 +70,6 @@ impl Display for Error {
             }
             ErrorType::RequestError => f.write_str("parsing or receiving the response failed"),
             ErrorType::RequestTimedOut => f.write_str("request timed out"),
-            #[cfg(not(target_os = "wasi"))]
             ErrorType::Response { body, status, .. } => {
                 f.write_str("response error: status code ")?;
                 Display::fmt(status, f)?;
@@ -110,7 +107,6 @@ pub enum ErrorType {
     RequestCanceled,
     RequestError,
     RequestTimedOut,
-    #[cfg(not(target_os = "wasi"))]
     Response {
         body: Vec<u8>,
         error: ApiError,
@@ -201,7 +197,6 @@ impl Debug for ErrorType {
             Self::RequestCanceled => f.write_str("RequestCanceled"),
             Self::RequestError => f.write_str("RequestError"),
             Self::RequestTimedOut => f.write_str("RequestTimedOut"),
-            #[cfg(not(target_os = "wasi"))]
             Self::Response {
                 body,
                 error,

--- a/twilight-http/src/lib.rs
+++ b/twilight-http/src/lib.rs
@@ -20,6 +20,4 @@ mod query_formatter;
 /// Discord API version used by this crate.
 pub const API_VERSION: u8 = 10;
 
-#[cfg(not(target_os = "wasi"))]
-pub use crate::response::Response;
-pub use crate::{client::Client, error::Error};
+pub use crate::{client::Client, error::Error, response::Response};

--- a/twilight-http/src/request/application/command/create_global_command/chat_input.rs
+++ b/twilight-http/src/request/application/command/create_global_command/chat_input.rs
@@ -1,10 +1,9 @@
 use super::super::CommandBorrowed;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::{collections::HashMap, future::IntoFuture};
@@ -185,7 +184,6 @@ impl<'a> CreateGlobalChatInputCommand<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGlobalChatInputCommand<'_> {
     type Output = Result<Response<Command>, Error>;
 

--- a/twilight-http/src/request/application/command/create_global_command/message.rs
+++ b/twilight-http/src/request/application/command/create_global_command/message.rs
@@ -1,10 +1,9 @@
 use super::super::CommandBorrowed;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::{collections::HashMap, future::IntoFuture};
@@ -120,7 +119,6 @@ impl<'a> CreateGlobalMessageCommand<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGlobalMessageCommand<'_> {
     type Output = Result<Response<Command>, Error>;
 

--- a/twilight-http/src/request/application/command/create_global_command/user.rs
+++ b/twilight-http/src/request/application/command/create_global_command/user.rs
@@ -1,10 +1,9 @@
 use super::super::CommandBorrowed;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::{collections::HashMap, future::IntoFuture};
@@ -120,7 +119,6 @@ impl<'a> CreateGlobalUserCommand<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGlobalUserCommand<'_> {
     type Output = Result<Response<Command>, Error>;
 

--- a/twilight-http/src/request/application/command/create_guild_command/chat_input.rs
+++ b/twilight-http/src/request/application/command/create_guild_command/chat_input.rs
@@ -1,10 +1,9 @@
 use super::super::CommandBorrowed;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::{collections::HashMap, future::IntoFuture};
@@ -178,7 +177,6 @@ impl<'a> CreateGuildChatInputCommand<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGuildChatInputCommand<'_> {
     type Output = Result<Response<Command>, Error>;
 

--- a/twilight-http/src/request/application/command/create_guild_command/message.rs
+++ b/twilight-http/src/request/application/command/create_guild_command/message.rs
@@ -1,10 +1,9 @@
 use super::super::CommandBorrowed;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::{collections::HashMap, future::IntoFuture};
@@ -113,7 +112,6 @@ impl<'a> CreateGuildMessageCommand<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGuildMessageCommand<'_> {
     type Output = Result<Response<Command>, Error>;
 

--- a/twilight-http/src/request/application/command/create_guild_command/user.rs
+++ b/twilight-http/src/request/application/command/create_guild_command/user.rs
@@ -1,10 +1,9 @@
 use super::super::CommandBorrowed;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::{collections::HashMap, future::IntoFuture};
@@ -113,7 +112,6 @@ impl<'a> CreateGuildUserCommand<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGuildUserCommand<'_> {
     type Output = Result<Response<Command>, Error>;
 

--- a/twilight-http/src/request/application/command/delete_global_command.rs
+++ b/twilight-http/src/request/application/command/delete_global_command.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -34,7 +33,6 @@ impl<'a> DeleteGlobalCommand<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteGlobalCommand<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/application/command/delete_guild_command.rs
+++ b/twilight-http/src/request/application/command/delete_guild_command.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -37,7 +36,6 @@ impl<'a> DeleteGuildCommand<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteGuildCommand<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/application/command/get_command_permissions.rs
+++ b/twilight-http/src/request/application/command/get_command_permissions.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -40,7 +39,6 @@ impl<'a> GetCommandPermissions<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetCommandPermissions<'_> {
     type Output = Result<Response<GuildCommandPermissions>, Error>;
 

--- a/twilight-http/src/request/application/command/get_global_command.rs
+++ b/twilight-http/src/request/application/command/get_global_command.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -37,7 +36,6 @@ impl<'a> GetGlobalCommand<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGlobalCommand<'_> {
     type Output = Result<Response<Command>, Error>;
 

--- a/twilight-http/src/request/application/command/get_global_commands.rs
+++ b/twilight-http/src/request/application/command/get_global_commands.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -39,7 +38,6 @@ impl<'a> GetGlobalCommands<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGlobalCommands<'_> {
     type Output = Result<Response<ListBody<Command>>, Error>;
 

--- a/twilight-http/src/request/application/command/get_guild_command.rs
+++ b/twilight-http/src/request/application/command/get_guild_command.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -40,7 +39,6 @@ impl<'a> GetGuildCommand<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildCommand<'_> {
     type Output = Result<Response<Command>, Error>;
 

--- a/twilight-http/src/request/application/command/get_guild_command_permissions.rs
+++ b/twilight-http/src/request/application/command/get_guild_command_permissions.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -37,7 +36,6 @@ impl<'a> GetGuildCommandPermissions<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildCommandPermissions<'_> {
     type Output = Result<Response<ListBody<GuildCommandPermissions>>, Error>;
 

--- a/twilight-http/src/request/application/command/get_guild_commands.rs
+++ b/twilight-http/src/request/application/command/get_guild_commands.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -48,7 +47,6 @@ impl<'a> GetGuildCommands<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildCommands<'_> {
     type Output = Result<Response<ListBody<Command>>, Error>;
 

--- a/twilight-http/src/request/application/command/set_global_commands.rs
+++ b/twilight-http/src/request/application/command/set_global_commands.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -43,7 +42,6 @@ impl<'a> SetGlobalCommands<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for SetGlobalCommands<'_> {
     type Output = Result<Response<ListBody<Command>>, Error>;
 

--- a/twilight-http/src/request/application/command/set_guild_commands.rs
+++ b/twilight-http/src/request/application/command/set_guild_commands.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -49,7 +48,6 @@ impl<'a> SetGuildCommands<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for SetGuildCommands<'_> {
     type Output = Result<Response<ListBody<Command>>, Error>;
 

--- a/twilight-http/src/request/application/command/update_command_permissions.rs
+++ b/twilight-http/src/request/application/command/update_command_permissions.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use serde::Serialize;
@@ -64,7 +63,6 @@ impl<'a> UpdateCommandPermissions<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateCommandPermissions<'_> {
     type Output = Result<Response<ListBody<CommandPermission>>, Error>;
 

--- a/twilight-http/src/request/application/command/update_global_command.rs
+++ b/twilight-http/src/request/application/command/update_global_command.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -90,7 +89,6 @@ impl<'a> UpdateGlobalCommand<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateGlobalCommand<'_> {
     type Output = Result<Response<Command>, Error>;
 

--- a/twilight-http/src/request/application/command/update_guild_command.rs
+++ b/twilight-http/src/request/application/command/update_guild_command.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -93,7 +92,6 @@ impl<'a> UpdateGuildCommand<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateGuildCommand<'_> {
     type Output = Result<Response<Command>, Error>;
 

--- a/twilight-http/src/request/application/emoji/add_emoji.rs
+++ b/twilight-http/src/request/application/emoji/add_emoji.rs
@@ -1,10 +1,9 @@
 use std::future::IntoFuture;
 
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     Client, Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 
@@ -41,7 +40,6 @@ impl<'a> AddApplicationEmoji<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for AddApplicationEmoji<'_> {
     type Output = Result<Response<Emoji>, Error>;
 

--- a/twilight-http/src/request/application/emoji/delete_emoji.rs
+++ b/twilight-http/src/request/application/emoji/delete_emoji.rs
@@ -4,11 +4,10 @@ use twilight_model::id::{
     marker::{ApplicationMarker, EmojiMarker},
 };
 
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     Client, Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 
@@ -32,7 +31,6 @@ impl<'a> DeleteApplicationEmoji<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteApplicationEmoji<'_> {
     type Output = Result<Response<()>, Error>;
 

--- a/twilight-http/src/request/application/emoji/list_emojis.rs
+++ b/twilight-http/src/request/application/emoji/list_emojis.rs
@@ -1,11 +1,9 @@
 use std::future::IntoFuture;
 
-#[cfg(not(target_os = "wasi"))]
-use crate::{Response, response::ResponseFuture};
-
 use crate::{
-    Client, Error,
+    Client, Error, Response,
     request::{Request, TryIntoRequest},
+    response::ResponseFuture,
     routing::Route,
 };
 use twilight_model::{
@@ -28,7 +26,6 @@ impl<'a> ListApplicationEmojis<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for ListApplicationEmojis<'_> {
     type Output = Result<Response<EmojiList>, Error>;
 

--- a/twilight-http/src/request/application/emoji/update_emoji.rs
+++ b/twilight-http/src/request/application/emoji/update_emoji.rs
@@ -8,11 +8,10 @@ use twilight_model::{
     },
 };
 
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     Client, Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 
@@ -44,7 +43,6 @@ impl<'a> UpdateApplicationEmoji<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateApplicationEmoji<'_> {
     type Output = Result<Response<Emoji>, Error>;
 

--- a/twilight-http/src/request/application/interaction/create_followup.rs
+++ b/twilight-http/src/request/application/interaction/create_followup.rs
@@ -1,5 +1,3 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
@@ -7,6 +5,7 @@ use crate::{
         Nullable, Request, TryIntoRequest,
         attachment::{AttachmentManager, PartialAttachment},
     },
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -279,7 +278,6 @@ impl<'a> CreateFollowup<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateFollowup<'_> {
     type Output = Result<Response<Message>, Error>;
 

--- a/twilight-http/src/request/application/interaction/create_response.rs
+++ b/twilight-http/src/request/application/interaction/create_response.rs
@@ -1,5 +1,3 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
@@ -7,6 +5,7 @@ use crate::{
         Request, TryIntoRequest, application::interaction::CreateResponseWithResponse,
         attachment::AttachmentManager,
     },
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -51,7 +50,6 @@ impl<'a> CreateResponse<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateResponse<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/application/interaction/create_response_with_response.rs
+++ b/twilight-http/src/request/application/interaction/create_response_with_response.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest, attachment::AttachmentManager},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -40,7 +39,6 @@ impl<'a> CreateResponseWithResponse<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateResponseWithResponse<'_> {
     type Output = Result<Response<InteractionCallbackResponse>, Error>;
 

--- a/twilight-http/src/request/application/interaction/delete_followup.rs
+++ b/twilight-http/src/request/application/interaction/delete_followup.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -57,7 +56,6 @@ impl<'a> DeleteFollowup<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteFollowup<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/application/interaction/delete_response.rs
+++ b/twilight-http/src/request/application/interaction/delete_response.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -52,7 +51,6 @@ impl<'a> DeleteResponse<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteResponse<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/application/interaction/get_followup.rs
+++ b/twilight-http/src/request/application/interaction/get_followup.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -61,7 +60,6 @@ impl<'a> GetFollowup<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetFollowup<'_> {
     type Output = Result<Response<Message>, Error>;
 

--- a/twilight-http/src/request/application/interaction/get_response.rs
+++ b/twilight-http/src/request/application/interaction/get_response.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -55,7 +54,6 @@ impl<'a> GetResponse<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetResponse<'_> {
     type Output = Result<Response<Message>, Error>;
 

--- a/twilight-http/src/request/application/interaction/update_followup.rs
+++ b/twilight-http/src/request/application/interaction/update_followup.rs
@@ -1,7 +1,5 @@
 //! Update a followup message created from a interaction.
 
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
@@ -9,6 +7,7 @@ use crate::{
         Nullable, Request, TryIntoRequest,
         attachment::{AttachmentManager, PartialAttachment},
     },
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -325,7 +324,6 @@ impl<'a> UpdateFollowup<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateFollowup<'_> {
     type Output = Result<Response<Message>, Error>;
 

--- a/twilight-http/src/request/application/interaction/update_response.rs
+++ b/twilight-http/src/request/application/interaction/update_response.rs
@@ -1,7 +1,5 @@
 //! Update a original response create for a interaction.
 
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
@@ -9,6 +7,7 @@ use crate::{
         Nullable, Request, TryIntoRequest,
         attachment::{AttachmentManager, PartialAttachment},
     },
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -338,7 +337,6 @@ impl<'a> UpdateResponse<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateResponse<'_> {
     type Output = Result<Response<Message>, Error>;
 

--- a/twilight-http/src/request/application/monetization/create_test_entitlement.rs
+++ b/twilight-http/src/request/application/monetization/create_test_entitlement.rs
@@ -9,12 +9,10 @@ use twilight_model::{
     },
 };
 
-#[cfg(not(target_os = "wasi"))]
-use crate::{Response, response::ResponseFuture};
-
 use crate::{
-    Client, Error,
+    Client, Error, Response,
     request::{Request, TryIntoRequest},
+    response::ResponseFuture,
     routing::Route,
 };
 
@@ -79,7 +77,6 @@ impl<'a> CreateTestEntitlement<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateTestEntitlement<'_> {
     type Output = Result<Response<Entitlement>, Error>;
 

--- a/twilight-http/src/request/application/monetization/delete_test_entitlement.rs
+++ b/twilight-http/src/request/application/monetization/delete_test_entitlement.rs
@@ -6,14 +6,10 @@ use twilight_model::id::{
 };
 
 use crate::{
-    Client, Error,
+    Client, Error, Response,
     request::{Request, TryIntoRequest},
-    routing::Route,
-};
-#[cfg(not(target_os = "wasi"))]
-use crate::{
-    Response,
     response::{ResponseFuture, marker::EmptyBody},
+    routing::Route,
 };
 
 pub struct DeleteTestEntitlement<'a> {
@@ -36,7 +32,6 @@ impl<'a> DeleteTestEntitlement<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteTestEntitlement<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/application/monetization/get_entitlements.rs
+++ b/twilight-http/src/request/application/monetization/get_entitlements.rs
@@ -9,14 +9,10 @@ use twilight_model::{
 };
 
 use crate::{
-    Client, Error,
+    Client, Error, Response,
     request::{Request, TryIntoRequest},
-    routing::Route,
-};
-#[cfg(not(target_os = "wasi"))]
-use crate::{
-    Response,
     response::{ResponseFuture, marker::ListBody},
+    routing::Route,
 };
 
 use twilight_validate::request::{
@@ -119,7 +115,6 @@ impl<'a> GetEntitlements<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetEntitlements<'_> {
     type Output = Result<Response<ListBody<Entitlement>>, Error>;
 

--- a/twilight-http/src/request/application/monetization/get_skus.rs
+++ b/twilight-http/src/request/application/monetization/get_skus.rs
@@ -6,14 +6,10 @@ use twilight_model::{
 };
 
 use crate::{
-    Client, Error,
+    Client, Error, Response,
     request::{Request, TryIntoRequest},
-    routing::Route,
-};
-#[cfg(not(target_os = "wasi"))]
-use crate::{
-    Response,
     response::{ResponseFuture, marker::ListBody},
+    routing::Route,
 };
 
 pub struct GetSKUs<'a> {
@@ -30,7 +26,6 @@ impl<'a> GetSKUs<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetSKUs<'_> {
     type Output = Result<Response<ListBody<Sku>>, Error>;
     type IntoFuture = ResponseFuture<ListBody<Sku>>;

--- a/twilight-http/src/request/channel/create_pin.rs
+++ b/twilight-http/src/request/channel/create_pin.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -45,7 +44,6 @@ impl<'a> AuditLogReason<'a> for CreatePin<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreatePin<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/create_typing_trigger.rs
+++ b/twilight-http/src/request/channel/create_typing_trigger.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -22,7 +21,6 @@ impl<'a> CreateTypingTrigger<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateTypingTrigger<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/delete_channel.rs
+++ b/twilight-http/src/request/channel/delete_channel.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -39,7 +38,6 @@ impl<'a> AuditLogReason<'a> for DeleteChannel<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteChannel<'_> {
     type Output = Result<Response<Channel>, Error>;
 

--- a/twilight-http/src/request/channel/delete_channel_permission_configured.rs
+++ b/twilight-http/src/request/channel/delete_channel_permission_configured.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -44,7 +43,6 @@ impl<'a> AuditLogReason<'a> for DeleteChannelPermissionConfigured<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteChannelPermissionConfigured<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/delete_pin.rs
+++ b/twilight-http/src/request/channel/delete_pin.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -45,7 +44,6 @@ impl<'a> AuditLogReason<'a> for DeletePin<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeletePin<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/follow_news_channel.rs
+++ b/twilight-http/src/request/channel/follow_news_channel.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -40,7 +39,6 @@ impl<'a> FollowNewsChannel<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for FollowNewsChannel<'_> {
     type Output = Result<Response<FollowedChannel>, Error>;
 

--- a/twilight-http/src/request/channel/get_channel.rs
+++ b/twilight-http/src/request/channel/get_channel.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -43,7 +42,6 @@ impl<'a> GetChannel<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetChannel<'_> {
     type Output = Result<Response<Channel>, Error>;
 

--- a/twilight-http/src/request/channel/get_pins.rs
+++ b/twilight-http/src/request/channel/get_pins.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -68,7 +67,6 @@ impl<'a> GetPins<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetPins<'_> {
     type Output = Result<Response<PinsListing>, Error>;
 

--- a/twilight-http/src/request/channel/invite/create_invite.rs
+++ b/twilight-http/src/request/channel/invite/create_invite.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -240,7 +239,6 @@ impl<'a> AuditLogReason<'a> for CreateInvite<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateInvite<'_> {
     type Output = Result<Response<Invite>, Error>;
 

--- a/twilight-http/src/request/channel/invite/delete_invite.rs
+++ b/twilight-http/src/request/channel/invite/delete_invite.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -41,7 +40,6 @@ impl<'a> AuditLogReason<'a> for DeleteInvite<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteInvite<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/invite/get_channel_invites.rs
+++ b/twilight-http/src/request/channel/invite/get_channel_invites.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -30,7 +29,6 @@ impl<'a> GetChannelInvites<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetChannelInvites<'_> {
     type Output = Result<Response<ListBody<Invite>>, Error>;
 

--- a/twilight-http/src/request/channel/invite/get_invite.rs
+++ b/twilight-http/src/request/channel/invite/get_invite.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -69,7 +68,6 @@ impl<'a> GetInvite<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetInvite<'_> {
     type Output = Result<Response<Invite>, Error>;
 

--- a/twilight-http/src/request/channel/message/create_message.rs
+++ b/twilight-http/src/request/channel/message/create_message.rs
@@ -1,5 +1,3 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
@@ -7,6 +5,7 @@ use crate::{
         Nullable, Request, TryIntoRequest,
         attachment::{AttachmentManager, PartialAttachment},
     },
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -390,7 +389,6 @@ impl<'a> CreateMessage<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateMessage<'_> {
     type Output = Result<Response<Message>, Error>;
 

--- a/twilight-http/src/request/channel/message/crosspost_message.rs
+++ b/twilight-http/src/request/channel/message/crosspost_message.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -37,7 +36,6 @@ impl<'a> CrosspostMessage<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CrosspostMessage<'_> {
     type Output = Result<Response<Message>, Error>;
 

--- a/twilight-http/src/request/channel/message/delete_message.rs
+++ b/twilight-http/src/request/channel/message/delete_message.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -45,7 +44,6 @@ impl<'a> AuditLogReason<'a> for DeleteMessage<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteMessage<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/message/delete_messages.rs
+++ b/twilight-http/src/request/channel/message/delete_messages.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use serde::Serialize;
@@ -67,7 +66,6 @@ impl<'a> AuditLogReason<'a> for DeleteMessages<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteMessages<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/message/get_channel_messages.rs
+++ b/twilight-http/src/request/channel/message/get_channel_messages.rs
@@ -1,10 +1,9 @@
 use super::GetChannelMessagesConfigured;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -127,7 +126,6 @@ impl<'a> GetChannelMessages<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetChannelMessages<'_> {
     type Output = Result<Response<ListBody<Message>>, Error>;
 

--- a/twilight-http/src/request/channel/message/get_channel_messages_configured.rs
+++ b/twilight-http/src/request/channel/message/get_channel_messages_configured.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -80,7 +79,6 @@ impl<'a> GetChannelMessagesConfigured<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetChannelMessagesConfigured<'_> {
     type Output = Result<Response<ListBody<Message>>, Error>;
 

--- a/twilight-http/src/request/channel/message/get_message.rs
+++ b/twilight-http/src/request/channel/message/get_message.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -37,7 +36,6 @@ impl<'a> GetMessage<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetMessage<'_> {
     type Output = Result<Response<Message>, Error>;
 

--- a/twilight-http/src/request/channel/message/update_message.rs
+++ b/twilight-http/src/request/channel/message/update_message.rs
@@ -1,5 +1,3 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
@@ -7,6 +5,7 @@ use crate::{
         Nullable, Request, TryIntoRequest,
         attachment::{AttachmentManager, PartialAttachment},
     },
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -306,7 +305,6 @@ impl<'a> UpdateMessage<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateMessage<'_> {
     type Output = Result<Response<Message>, Error>;
 

--- a/twilight-http/src/request/channel/reaction/create_reaction.rs
+++ b/twilight-http/src/request/channel/reaction/create_reaction.rs
@@ -1,10 +1,9 @@
 use super::RequestReactionType;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -59,7 +58,6 @@ impl<'a> CreateReaction<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateReaction<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/reaction/delete_all_reaction.rs
+++ b/twilight-http/src/request/channel/reaction/delete_all_reaction.rs
@@ -1,10 +1,9 @@
 use super::RequestReactionType;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -38,7 +37,6 @@ impl<'a> DeleteAllReaction<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteAllReaction<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/reaction/delete_all_reactions.rs
+++ b/twilight-http/src/request/channel/reaction/delete_all_reactions.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -34,7 +33,6 @@ impl<'a> DeleteAllReactions<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteAllReactions<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/reaction/delete_reaction.rs
+++ b/twilight-http/src/request/channel/reaction/delete_reaction.rs
@@ -1,10 +1,9 @@
 use super::RequestReactionType;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -49,7 +48,6 @@ impl<'a> DeleteReaction<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteReaction<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/reaction/get_reactions.rs
+++ b/twilight-http/src/request/channel/reaction/get_reactions.rs
@@ -1,10 +1,9 @@
 use super::RequestReactionType;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -102,7 +101,6 @@ impl<'a> GetReactions<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetReactions<'_> {
     type Output = Result<Response<ListBody<User>>, Error>;
 

--- a/twilight-http/src/request/channel/stage/create_stage_instance.rs
+++ b/twilight-http/src/request/channel/stage/create_stage_instance.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -92,7 +91,6 @@ impl<'a> CreateStageInstance<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateStageInstance<'_> {
     type Output = Result<Response<StageInstance>, Error>;
 

--- a/twilight-http/src/request/channel/stage/delete_stage_instance.rs
+++ b/twilight-http/src/request/channel/stage/delete_stage_instance.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -24,7 +23,6 @@ impl<'a> DeleteStageInstance<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteStageInstance<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/stage/get_stage_instance.rs
+++ b/twilight-http/src/request/channel/stage/get_stage_instance.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,7 +24,6 @@ impl<'a> GetStageInstance<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetStageInstance<'_> {
     type Output = Result<Response<StageInstance>, Error>;
 

--- a/twilight-http/src/request/channel/stage/update_stage_instance.rs
+++ b/twilight-http/src/request/channel/stage/update_stage_instance.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -72,7 +71,6 @@ impl<'a> UpdateStageInstance<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateStageInstance<'_> {
     type Output = Result<Response<StageInstance>, Error>;
 

--- a/twilight-http/src/request/channel/thread/add_thread_member.rs
+++ b/twilight-http/src/request/channel/thread/add_thread_member.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -37,7 +36,6 @@ impl<'a> AddThreadMember<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for AddThreadMember<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/thread/create_forum_thread/message.rs
+++ b/twilight-http/src/request/channel/thread/create_forum_thread/message.rs
@@ -1,9 +1,8 @@
 use super::{CreateForumThread, ForumThread};
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     Error,
     request::{Nullable, TryIntoRequest, attachment::PartialAttachment},
+    response::{Response, ResponseFuture},
 };
 use serde::Serialize;
 use std::{future::IntoFuture, mem};
@@ -223,7 +222,6 @@ impl<'a> CreateForumThreadMessage<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateForumThreadMessage<'_> {
     type Output = Result<Response<ForumThread>, Error>;
 

--- a/twilight-http/src/request/channel/thread/create_forum_thread/mod.rs
+++ b/twilight-http/src/request/channel/thread/create_forum_thread/mod.rs
@@ -3,13 +3,11 @@ mod message;
 pub use self::message::CreateForumThreadMessage;
 
 use self::message::CreateForumThreadMessageFields;
-
-#[cfg(not(target_os = "wasi"))]
-use crate::response::ResponseFuture;
 use crate::{
     client::Client,
     error::Error,
     request::{Nullable, Request, attachment::AttachmentManager},
+    response::ResponseFuture,
     routing::Route,
 };
 use serde::{Deserialize, Serialize};
@@ -110,7 +108,6 @@ impl<'a> CreateForumThread<'a> {
     /// Execute the request, returning a future resolving to a [`Response`].
     ///
     /// [`Response`]: crate::response::Response
-    #[cfg(not(target_os = "wasi"))]
     fn exec(self) -> ResponseFuture<ForumThread> {
         let http = self.http;
 

--- a/twilight-http/src/request/channel/thread/create_thread.rs
+++ b/twilight-http/src/request/channel/thread/create_thread.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -92,7 +91,6 @@ impl<'a> CreateThread<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateThread<'_> {
     type Output = Result<Response<Channel>, Error>;
 

--- a/twilight-http/src/request/channel/thread/create_thread_from_message.rs
+++ b/twilight-http/src/request/channel/thread/create_thread_from_message.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -92,7 +91,6 @@ impl<'a> CreateThreadFromMessage<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateThreadFromMessage<'_> {
     type Output = Result<Response<Channel>, Error>;
 

--- a/twilight-http/src/request/channel/thread/get_joined_private_archived_threads.rs
+++ b/twilight-http/src/request/channel/thread/get_joined_private_archived_threads.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -49,7 +48,6 @@ impl<'a> GetJoinedPrivateArchivedThreads<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetJoinedPrivateArchivedThreads<'_> {
     type Output = Result<Response<ThreadsListing>, Error>;
 

--- a/twilight-http/src/request/channel/thread/get_private_archived_threads.rs
+++ b/twilight-http/src/request/channel/thread/get_private_archived_threads.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -51,7 +50,6 @@ impl<'a> GetPrivateArchivedThreads<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetPrivateArchivedThreads<'_> {
     type Output = Result<Response<ThreadsListing>, Error>;
 

--- a/twilight-http/src/request/channel/thread/get_public_archived_threads.rs
+++ b/twilight-http/src/request/channel/thread/get_public_archived_threads.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -61,7 +60,6 @@ impl<'a> GetPublicArchivedThreads<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetPublicArchivedThreads<'_> {
     type Output = Result<Response<ThreadsListing>, Error>;
 

--- a/twilight-http/src/request/channel/thread/get_thread_member.rs
+++ b/twilight-http/src/request/channel/thread/get_thread_member.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -39,7 +38,6 @@ impl<'a> GetThreadMember<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetThreadMember<'_> {
     type Output = Result<Response<ThreadMember>, Error>;
 

--- a/twilight-http/src/request/channel/thread/get_thread_members.rs
+++ b/twilight-http/src/request/channel/thread/get_thread_members.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -85,7 +84,6 @@ impl<'a> GetThreadMembers<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetThreadMembers<'_> {
     type Output = Result<Response<ListBody<ThreadMember>>, Error>;
 

--- a/twilight-http/src/request/channel/thread/join_thread.rs
+++ b/twilight-http/src/request/channel/thread/join_thread.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -22,7 +21,6 @@ impl<'a> JoinThread<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for JoinThread<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/thread/leave_thread.rs
+++ b/twilight-http/src/request/channel/thread/leave_thread.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -24,7 +23,6 @@ impl<'a> LeaveThread<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for LeaveThread<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/thread/remove_thread_member.rs
+++ b/twilight-http/src/request/channel/thread/remove_thread_member.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -42,7 +41,6 @@ impl<'a> RemoveThreadMember<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for RemoveThreadMember<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/thread/update_thread.rs
+++ b/twilight-http/src/request/channel/thread/update_thread.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -198,7 +197,6 @@ impl<'a> AuditLogReason<'a> for UpdateThread<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateThread<'_> {
     type Output = Result<Response<Channel>, Error>;
 

--- a/twilight-http/src/request/channel/update_channel.rs
+++ b/twilight-http/src/request/channel/update_channel.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -413,7 +412,6 @@ impl<'a> AuditLogReason<'a> for UpdateChannel<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateChannel<'_> {
     type Output = Result<Response<Channel>, Error>;
 

--- a/twilight-http/src/request/channel/update_channel_permission.rs
+++ b/twilight-http/src/request/channel/update_channel_permission.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use serde::Serialize;
@@ -96,7 +95,6 @@ impl<'a> AuditLogReason<'a> for UpdateChannelPermission<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateChannelPermission<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/webhook/create_webhook.rs
+++ b/twilight-http/src/request/channel/webhook/create_webhook.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -90,7 +89,6 @@ impl<'a> AuditLogReason<'a> for CreateWebhook<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateWebhook<'_> {
     type Output = Result<Response<Webhook>, Error>;
 

--- a/twilight-http/src/request/channel/webhook/delete_webhook.rs
+++ b/twilight-http/src/request/channel/webhook/delete_webhook.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -49,7 +48,6 @@ impl<'a> AuditLogReason<'a> for DeleteWebhook<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteWebhook<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/webhook/delete_webhook_message.rs
+++ b/twilight-http/src/request/channel/webhook/delete_webhook_message.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -75,7 +74,6 @@ impl<'a> AuditLogReason<'a> for DeleteWebhookMessage<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteWebhookMessage<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/webhook/execute_webhook.rs
+++ b/twilight-http/src/request/channel/webhook/execute_webhook.rs
@@ -1,5 +1,3 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
@@ -8,6 +6,7 @@ use crate::{
         attachment::{AttachmentManager, PartialAttachment},
         channel::webhook::ExecuteWebhookAndWait,
     },
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use serde::Serialize;
@@ -390,7 +389,6 @@ impl<'a> ExecuteWebhook<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for ExecuteWebhook<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/channel/webhook/execute_webhook_and_wait.rs
+++ b/twilight-http/src/request/channel/webhook/execute_webhook_and_wait.rs
@@ -1,10 +1,9 @@
 use super::ExecuteWebhook;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
 };
 use std::future::IntoFuture;
 use twilight_model::channel::Message;
@@ -46,7 +45,6 @@ impl<'a> ExecuteWebhookAndWait<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for ExecuteWebhookAndWait<'_> {
     type Output = Result<Response<Message>, Error>;
 

--- a/twilight-http/src/request/channel/webhook/get_channel_webhooks.rs
+++ b/twilight-http/src/request/channel/webhook/get_channel_webhooks.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,7 +24,6 @@ impl<'a> GetChannelWebhooks<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetChannelWebhooks<'_> {
     type Output = Result<Response<ListBody<Webhook>>, Error>;
 

--- a/twilight-http/src/request/channel/webhook/get_webhook.rs
+++ b/twilight-http/src/request/channel/webhook/get_webhook.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -42,7 +41,6 @@ impl<'a> GetWebhook<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetWebhook<'_> {
     type Output = Result<Response<Webhook>, Error>;
 

--- a/twilight-http/src/request/channel/webhook/get_webhook_message.rs
+++ b/twilight-http/src/request/channel/webhook/get_webhook_message.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -50,7 +49,6 @@ impl<'a> GetWebhookMessage<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetWebhookMessage<'_> {
     type Output = Result<Response<Message>, Error>;
 

--- a/twilight-http/src/request/channel/webhook/update_webhook.rs
+++ b/twilight-http/src/request/channel/webhook/update_webhook.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -106,7 +105,6 @@ impl<'a> AuditLogReason<'a> for UpdateWebhook<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateWebhook<'_> {
     type Output = Result<Response<Webhook>, Error>;
 

--- a/twilight-http/src/request/channel/webhook/update_webhook_message.rs
+++ b/twilight-http/src/request/channel/webhook/update_webhook_message.rs
@@ -1,7 +1,5 @@
 //! Update a message created by a webhook via execution.
 
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
@@ -9,6 +7,7 @@ use crate::{
         Nullable, Request, TryIntoRequest,
         attachment::{AttachmentManager, PartialAttachment},
     },
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -331,7 +330,6 @@ impl<'a> UpdateWebhookMessage<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateWebhookMessage<'_> {
     type Output = Result<Response<Message>, Error>;
 

--- a/twilight-http/src/request/channel/webhook/update_webhook_with_token.rs
+++ b/twilight-http/src/request/channel/webhook/update_webhook_with_token.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -83,7 +82,6 @@ impl<'a> UpdateWebhookWithToken<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateWebhookWithToken<'_> {
     type Output = Result<Response<Webhook>, Error>;
 

--- a/twilight-http/src/request/get_current_authorization_information.rs
+++ b/twilight-http/src/request/get_current_authorization_information.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -49,7 +48,6 @@ impl<'a> GetCurrentAuthorizationInformation<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetCurrentAuthorizationInformation<'_> {
     type Output = Result<Response<CurrentAuthorizationInformation>, Error>;
 

--- a/twilight-http/src/request/get_gateway.rs
+++ b/twilight-http/src/request/get_gateway.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{GetGatewayAuthed, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -62,7 +61,6 @@ impl<'a> GetGateway<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGateway<'_> {
     type Output = Result<Response<ConnectionInfo>, Error>;
 

--- a/twilight-http/src/request/get_gateway_authed.rs
+++ b/twilight-http/src/request/get_gateway_authed.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -24,7 +23,6 @@ impl<'a> GetGatewayAuthed<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGatewayAuthed<'_> {
     type Output = Result<Response<BotConnectionInfo>, Error>;
 

--- a/twilight-http/src/request/get_user_application.rs
+++ b/twilight-http/src/request/get_user_application.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -20,7 +19,6 @@ impl<'a> GetUserApplicationInfo<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetUserApplicationInfo<'_> {
     type Output = Result<Response<Application>, Error>;
 

--- a/twilight-http/src/request/get_voice_regions.rs
+++ b/twilight-http/src/request/get_voice_regions.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -21,7 +20,6 @@ impl<'a> GetVoiceRegions<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetVoiceRegions<'_> {
     type Output = Result<Response<ListBody<VoiceRegion>>, Error>;
 

--- a/twilight-http/src/request/guild/auto_moderation/create_auto_moderation_rule.rs
+++ b/twilight-http/src/request/guild/auto_moderation/create_auto_moderation_rule.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::ResponseFuture;
 use crate::{
     client::Client,
     error::Error as HttpError,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::ResponseFuture,
     routing::Route,
 };
 use serde::Serialize;
@@ -321,7 +320,6 @@ impl<'a> CreateAutoModerationRule<'a> {
     /// [`ValidationErrorType::AutoModerationMetadataAllowListItem`]: twilight_validate::request::ValidationErrorType::AutoModerationMetadataAllowListItem
     /// [`ValidationErrorType::AutoModerationMetadataRegexPatterns`]: twilight_validate::request::ValidationErrorType::AutoModerationMetadataRegexPatterns
     /// [`ValidationErrorType::AutoModerationMetadataRegexPatternsItem`]: twilight_validate::request::ValidationErrorType::AutoModerationMetadataRegexPatternsItem
-    #[cfg(not(target_os = "wasi"))]
     pub fn with_keyword(
         mut self,
         keyword_filter: &'a [&'a str],
@@ -351,7 +349,6 @@ impl<'a> CreateAutoModerationRule<'a> {
     /// Create the request with the trigger type [`Spam`], then execute it.
     ///
     /// [`Spam`]: AutoModerationTriggerType::Spam
-    #[cfg(not(target_os = "wasi"))]
     pub fn with_spam(mut self) -> ResponseFuture<AutoModerationRule> {
         self.fields = self.fields.map(|mut fields| {
             fields.trigger_type = Some(AutoModerationTriggerType::Spam);
@@ -380,7 +377,6 @@ impl<'a> CreateAutoModerationRule<'a> {
     /// [Discord Docs/Trigger Metadata]: https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata
     /// [`ValidationErrorType::AutoModerationMetadataPresetAllowList`]: twilight_validate::request::ValidationErrorType::AutoModerationMetadataPresetAllowList
     /// [`ValidationErrorType::AutoModerationMetadataPresetAllowListItem`]: twilight_validate::request::ValidationErrorType::AutoModerationMetadataPresetAllowListItem
-    #[cfg(not(target_os = "wasi"))]
     pub fn with_keyword_preset(
         mut self,
         presets: &'a [AutoModerationKeywordPresetType],
@@ -418,7 +414,6 @@ impl<'a> CreateAutoModerationRule<'a> {
     /// [`MentionSpam`]: AutoModerationTriggerType::MentionSpam
     /// [Discord Docs/Trigger Metadata]: https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata
     /// [`ValidationErrorType::AutoModerationMetadataMentionTotalLimit`]: twilight_validate::request::ValidationErrorType::AutoModerationMetadataMentionTotalLimit
-    #[cfg(not(target_os = "wasi"))]
     pub fn with_mention_spam(
         mut self,
         mention_total_limit: u8,
@@ -443,7 +438,6 @@ impl<'a> CreateAutoModerationRule<'a> {
     /// Execute the request, returning a future resolving to a [`Response`].
     ///
     /// [`Response`]: crate::response::Response
-    #[cfg(not(target_os = "wasi"))]
     fn exec(self) -> ResponseFuture<AutoModerationRule> {
         let http = self.http;
 

--- a/twilight-http/src/request/guild/auto_moderation/delete_auto_moderation_rule.rs
+++ b/twilight-http/src/request/guild/auto_moderation/delete_auto_moderation_rule.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -49,7 +48,6 @@ impl<'a> AuditLogReason<'a> for DeleteAutoModerationRule<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteAutoModerationRule<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/auto_moderation/get_auto_moderation_rule.rs
+++ b/twilight-http/src/request/guild/auto_moderation/get_auto_moderation_rule.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -41,7 +40,6 @@ impl<'a> GetAutoModerationRule<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetAutoModerationRule<'_> {
     type Output = Result<Response<AutoModerationRule>, Error>;
 

--- a/twilight-http/src/request/guild/auto_moderation/get_guild_auto_moderation_rules.rs
+++ b/twilight-http/src/request/guild/auto_moderation/get_guild_auto_moderation_rules.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -29,7 +28,6 @@ impl<'a> GetGuildAutoModerationRules<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildAutoModerationRules<'_> {
     type Output = Result<Response<ListBody<AutoModerationRule>>, Error>;
 

--- a/twilight-http/src/request/guild/auto_moderation/update_auto_moderation_rule.rs
+++ b/twilight-http/src/request/guild/auto_moderation/update_auto_moderation_rule.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -138,7 +137,6 @@ impl<'a> AuditLogReason<'a> for UpdateAutoModerationRule<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateAutoModerationRule<'_> {
     type Output = Result<Response<AutoModerationRule>, Error>;
 

--- a/twilight-http/src/request/guild/ban/create_ban.rs
+++ b/twilight-http/src/request/guild/ban/create_ban.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use serde::Serialize;
@@ -104,7 +103,6 @@ impl<'a> AuditLogReason<'a> for CreateBan<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateBan<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/ban/delete_ban.rs
+++ b/twilight-http/src/request/guild/ban/delete_ban.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -64,7 +63,6 @@ impl<'a> AuditLogReason<'a> for DeleteBan<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteBan<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/ban/get_ban.rs
+++ b/twilight-http/src/request/guild/ban/get_ban.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -39,7 +38,6 @@ impl<'a> GetBan<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetBan<'_> {
     type Output = Result<Response<Ban>, Error>;
 

--- a/twilight-http/src/request/guild/ban/get_bans.rs
+++ b/twilight-http/src/request/guild/ban/get_bans.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -122,7 +121,6 @@ impl<'a> GetBans<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetBans<'_> {
     type Output = Result<Response<ListBody<Ban>>, Error>;
 

--- a/twilight-http/src/request/guild/create_guild_channel.rs
+++ b/twilight-http/src/request/guild/create_guild_channel.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -360,7 +359,6 @@ impl<'a> AuditLogReason<'a> for CreateGuildChannel<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGuildChannel<'_> {
     type Output = Result<Response<Channel>, Error>;
 

--- a/twilight-http/src/request/guild/create_guild_prune.rs
+++ b/twilight-http/src/request/guild/create_guild_prune.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -100,7 +99,6 @@ impl<'a> AuditLogReason<'a> for CreateGuildPrune<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGuildPrune<'_> {
     type Output = Result<Response<GuildPrune>, Error>;
 

--- a/twilight-http/src/request/guild/delete_guild.rs
+++ b/twilight-http/src/request/guild/delete_guild.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -22,7 +21,6 @@ impl<'a> DeleteGuild<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteGuild<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/emoji/create_emoji.rs
+++ b/twilight-http/src/request/guild/emoji/create_emoji.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -79,7 +78,6 @@ impl<'a> AuditLogReason<'a> for CreateEmoji<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateEmoji<'_> {
     type Output = Result<Response<Emoji>, Error>;
 

--- a/twilight-http/src/request/guild/emoji/delete_emoji.rs
+++ b/twilight-http/src/request/guild/emoji/delete_emoji.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -45,7 +44,6 @@ impl<'a> AuditLogReason<'a> for DeleteEmoji<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteEmoji<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/emoji/get_emoji.rs
+++ b/twilight-http/src/request/guild/emoji/get_emoji.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -56,7 +55,6 @@ impl<'a> GetEmoji<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetEmoji<'_> {
     type Output = Result<Response<Emoji>, Error>;
 

--- a/twilight-http/src/request/guild/emoji/get_emojis.rs
+++ b/twilight-http/src/request/guild/emoji/get_emojis.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -43,7 +42,6 @@ impl<'a> GetEmojis<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetEmojis<'_> {
     type Output = Result<Response<ListBody<Emoji>>, Error>;
 

--- a/twilight-http/src/request/guild/emoji/update_emoji.rs
+++ b/twilight-http/src/request/guild/emoji/update_emoji.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -76,7 +75,6 @@ impl<'a> AuditLogReason<'a> for UpdateEmoji<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateEmoji<'_> {
     type Output = Result<Response<Emoji>, Error>;
 

--- a/twilight-http/src/request/guild/get_active_threads.rs
+++ b/twilight-http/src/request/guild/get_active_threads.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -28,7 +27,6 @@ impl<'a> GetActiveThreads<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetActiveThreads<'_> {
     type Output = Result<Response<ThreadsListing>, Error>;
 

--- a/twilight-http/src/request/guild/get_audit_log.rs
+++ b/twilight-http/src/request/guild/get_audit_log.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -134,7 +133,6 @@ impl<'a> GetAuditLog<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetAuditLog<'_> {
     type Output = Result<Response<AuditLog>, Error>;
 

--- a/twilight-http/src/request/guild/get_guild.rs
+++ b/twilight-http/src/request/guild/get_guild.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -42,7 +41,6 @@ impl<'a> GetGuild<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuild<'_> {
     type Output = Result<Response<Guild>, Error>;
 

--- a/twilight-http/src/request/guild/get_guild_channels.rs
+++ b/twilight-http/src/request/guild/get_guild_channels.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,7 +24,6 @@ impl<'a> GetGuildChannels<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildChannels<'_> {
     type Output = Result<Response<ListBody<Channel>>, Error>;
 

--- a/twilight-http/src/request/guild/get_guild_invites.rs
+++ b/twilight-http/src/request/guild/get_guild_invites.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -29,7 +28,6 @@ impl<'a> GetGuildInvites<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildInvites<'_> {
     type Output = Result<Response<ListBody<Invite>>, Error>;
 

--- a/twilight-http/src/request/guild/get_guild_onboarding.rs
+++ b/twilight-http/src/request/guild/get_guild_onboarding.rs
@@ -1,15 +1,15 @@
 use std::future::IntoFuture;
 
-use crate::{
-    Client, Error,
-    request::{Request, TryIntoRequest},
-    routing::Route,
-};
-#[cfg(not(target_os = "wasi"))]
-use crate::{Response, response::ResponseFuture};
 use twilight_model::{
     guild::onboarding::Onboarding,
     id::{Id, marker::GuildMarker},
+};
+
+use crate::{
+    Client, Error, Response,
+    request::{Request, TryIntoRequest},
+    response::ResponseFuture,
+    routing::Route,
 };
 
 /// Get the onboarding information for a guild.
@@ -43,7 +43,6 @@ impl<'a> GetGuildOnboarding<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildOnboarding<'_> {
     type Output = Result<Response<Onboarding>, Error>;
 

--- a/twilight-http/src/request/guild/get_guild_preview.rs
+++ b/twilight-http/src/request/guild/get_guild_preview.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -27,7 +26,6 @@ impl<'a> GetGuildPreview<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildPreview<'_> {
     type Output = Result<Response<GuildPreview>, Error>;
 

--- a/twilight-http/src/request/guild/get_guild_prune_count.rs
+++ b/twilight-http/src/request/guild/get_guild_prune_count.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -73,7 +72,6 @@ impl<'a> GetGuildPruneCount<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildPruneCount<'_> {
     type Output = Result<Response<GuildPrune>, Error>;
 

--- a/twilight-http/src/request/guild/get_guild_vanity_url.rs
+++ b/twilight-http/src/request/guild/get_guild_vanity_url.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,7 +24,6 @@ impl<'a> GetGuildVanityUrl<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildVanityUrl<'_> {
     type Output = Result<Response<VanityUrl>, Error>;
 

--- a/twilight-http/src/request/guild/get_guild_voice_regions.rs
+++ b/twilight-http/src/request/guild/get_guild_voice_regions.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -27,7 +26,6 @@ impl<'a> GetGuildVoiceRegions<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildVoiceRegions<'_> {
     type Output = Result<Response<ListBody<VoiceRegion>>, Error>;
 

--- a/twilight-http/src/request/guild/get_guild_webhooks.rs
+++ b/twilight-http/src/request/guild/get_guild_webhooks.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,7 +24,6 @@ impl<'a> GetGuildWebhooks<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildWebhooks<'_> {
     type Output = Result<Response<ListBody<Webhook>>, Error>;
 

--- a/twilight-http/src/request/guild/get_guild_welcome_screen.rs
+++ b/twilight-http/src/request/guild/get_guild_welcome_screen.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -30,7 +29,6 @@ impl<'a> GetGuildWelcomeScreen<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildWelcomeScreen<'_> {
     type Output = Result<Response<WelcomeScreen>, Error>;
 

--- a/twilight-http/src/request/guild/get_guild_widget.rs
+++ b/twilight-http/src/request/guild/get_guild_widget.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -29,7 +28,6 @@ impl<'a> GetGuildWidget<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildWidget<'_> {
     type Output = Result<Response<GuildWidget>, Error>;
 

--- a/twilight-http/src/request/guild/get_guild_widget_settings.rs
+++ b/twilight-http/src/request/guild/get_guild_widget_settings.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -29,7 +28,6 @@ impl<'a> GetGuildWidgetSettings<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildWidgetSettings<'_> {
     type Output = Result<Response<GuildWidgetSettings>, Error>;
 

--- a/twilight-http/src/request/guild/integration/delete_guild_integration.rs
+++ b/twilight-http/src/request/guild/integration/delete_guild_integration.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -45,7 +44,6 @@ impl<'a> AuditLogReason<'a> for DeleteGuildIntegration<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteGuildIntegration<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/integration/get_guild_integrations.rs
+++ b/twilight-http/src/request/guild/integration/get_guild_integrations.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -28,7 +27,6 @@ impl<'a> GetGuildIntegrations<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildIntegrations<'_> {
     type Output = Result<Response<ListBody<GuildIntegration>>, Error>;
 

--- a/twilight-http/src/request/guild/member/add_guild_member.rs
+++ b/twilight-http/src/request/guild/member/add_guild_member.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -117,7 +116,6 @@ impl<'a> AddGuildMember<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for AddGuildMember<'_> {
     type Output = Result<Response<PartialMember>, Error>;
 

--- a/twilight-http/src/request/guild/member/add_role_to_member.rs
+++ b/twilight-http/src/request/guild/member/add_role_to_member.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -71,7 +70,6 @@ impl<'a> AuditLogReason<'a> for AddRoleToMember<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for AddRoleToMember<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/member/get_guild_members.rs
+++ b/twilight-http/src/request/guild/member/get_guild_members.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -99,7 +98,6 @@ impl<'a> GetGuildMembers<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildMembers<'_> {
     type Output = Result<Response<ListBody<Member>>, Error>;
 

--- a/twilight-http/src/request/guild/member/get_member.rs
+++ b/twilight-http/src/request/guild/member/get_member.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -37,7 +36,6 @@ impl<'a> GetMember<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetMember<'_> {
     type Output = Result<Response<Member>, Error>;
 

--- a/twilight-http/src/request/guild/member/remove_member.rs
+++ b/twilight-http/src/request/guild/member/remove_member.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -45,7 +44,6 @@ impl<'a> AuditLogReason<'a> for RemoveMember<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for RemoveMember<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/member/remove_role_from_member.rs
+++ b/twilight-http/src/request/guild/member/remove_role_from_member.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -48,7 +47,6 @@ impl<'a> AuditLogReason<'a> for RemoveRoleFromMember<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for RemoveRoleFromMember<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/member/search_guild_members.rs
+++ b/twilight-http/src/request/guild/member/search_guild_members.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -88,7 +87,6 @@ impl<'a> SearchGuildMembers<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for SearchGuildMembers<'_> {
     type Output = Result<Response<ListBody<Member>>, Error>;
 

--- a/twilight-http/src/request/guild/member/update_guild_member.rs
+++ b/twilight-http/src/request/guild/member/update_guild_member.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -174,7 +173,6 @@ impl<'a> AuditLogReason<'a> for UpdateGuildMember<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateGuildMember<'_> {
     type Output = Result<Response<Member>, Error>;
 

--- a/twilight-http/src/request/guild/role/create_role.rs
+++ b/twilight-http/src/request/guild/role/create_role.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -150,7 +149,6 @@ impl<'a> AuditLogReason<'a> for CreateRole<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateRole<'_> {
     type Output = Result<Response<Role>, Error>;
 

--- a/twilight-http/src/request/guild/role/delete_role.rs
+++ b/twilight-http/src/request/guild/role/delete_role.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -45,7 +44,6 @@ impl<'a> AuditLogReason<'a> for DeleteRole<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteRole<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/role/get_guild_role_member_counts.rs
+++ b/twilight-http/src/request/guild/role/get_guild_role_member_counts.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::{collections::HashMap, future::IntoFuture};
@@ -24,7 +23,6 @@ impl<'a> GetGuildRoleMemberCounts<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildRoleMemberCounts<'_> {
     type Output = Result<Response<HashMap<Id<RoleMarker>, u64>>, Error>;
 

--- a/twilight-http/src/request/guild/role/get_guild_roles.rs
+++ b/twilight-http/src/request/guild/role/get_guild_roles.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,7 +24,6 @@ impl<'a> GetGuildRoles<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildRoles<'_> {
     type Output = Result<Response<ListBody<Role>>, Error>;
 

--- a/twilight-http/src/request/guild/role/get_role.rs
+++ b/twilight-http/src/request/guild/role/get_role.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -37,7 +36,6 @@ impl<'a> GetRole<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetRole<'_> {
     type Output = Result<Response<Role>, Error>;
 

--- a/twilight-http/src/request/guild/role/update_role.rs
+++ b/twilight-http/src/request/guild/role/update_role.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -199,7 +198,6 @@ impl<'a> AuditLogReason<'a> for UpdateRole<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateRole<'_> {
     type Output = Result<Response<Role>, Error>;
 

--- a/twilight-http/src/request/guild/role/update_role_positions.rs
+++ b/twilight-http/src/request/guild/role/update_role_positions.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -47,7 +46,6 @@ impl<'a> AuditLogReason<'a> for UpdateRolePositions<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateRolePositions<'_> {
     type Output = Result<Response<ListBody<Role>>, Error>;
 

--- a/twilight-http/src/request/guild/sticker/create_guild_sticker.rs
+++ b/twilight-http/src/request/guild/sticker/create_guild_sticker.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{AuditLogReason, Request, TryIntoRequest, multipart::Form},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -101,7 +100,6 @@ impl<'a> AuditLogReason<'a> for CreateGuildSticker<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGuildSticker<'_> {
     type Output = Result<Response<Sticker>, Error>;
 

--- a/twilight-http/src/request/guild/sticker/delete_guild_sticker.rs
+++ b/twilight-http/src/request/guild/sticker/delete_guild_sticker.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -50,7 +49,6 @@ impl<'a> DeleteGuildSticker<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteGuildSticker<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/sticker/get_guild_sticker.rs
+++ b/twilight-http/src/request/guild/sticker/get_guild_sticker.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -58,7 +57,6 @@ impl<'a> GetGuildSticker<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildSticker<'_> {
     type Output = Result<Response<Sticker>, Error>;
 

--- a/twilight-http/src/request/guild/sticker/get_guild_stickers.rs
+++ b/twilight-http/src/request/guild/sticker/get_guild_stickers.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -41,7 +40,6 @@ impl<'a> GetGuildStickers<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildStickers<'_> {
     type Output = Result<Response<ListBody<Sticker>>, Error>;
 

--- a/twilight-http/src/request/guild/sticker/update_guild_sticker.rs
+++ b/twilight-http/src/request/guild/sticker/update_guild_sticker.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -145,7 +144,6 @@ impl<'a> AuditLogReason<'a> for UpdateGuildSticker<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateGuildSticker<'_> {
     type Output = Result<Response<Sticker>, Error>;
 

--- a/twilight-http/src/request/guild/update_current_member.rs
+++ b/twilight-http/src/request/guild/update_current_member.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use serde::Serialize;
@@ -136,7 +135,6 @@ impl<'a> AuditLogReason<'a> for UpdateCurrentMember<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateCurrentMember<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/update_guild.rs
+++ b/twilight-http/src/request/guild/update_guild.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -354,7 +353,6 @@ impl<'a> AuditLogReason<'a> for UpdateGuild<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateGuild<'_> {
     type Output = Result<Response<PartialGuild>, Error>;
 

--- a/twilight-http/src/request/guild/update_guild_channel_positions.rs
+++ b/twilight-http/src/request/guild/update_guild_channel_positions.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -36,7 +35,6 @@ impl<'a> UpdateGuildChannelPositions<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateGuildChannelPositions<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/update_guild_mfa.rs
+++ b/twilight-http/src/request/guild/update_guild_mfa.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -39,7 +38,6 @@ impl<'a> UpdateGuildMfa<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateGuildMfa<'_> {
     type Output = Result<Response<MfaLevel>, Error>;
 

--- a/twilight-http/src/request/guild/update_guild_onboarding.rs
+++ b/twilight-http/src/request/guild/update_guild_onboarding.rs
@@ -13,12 +13,11 @@ use twilight_model::{
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 
@@ -87,7 +86,6 @@ impl<'a> AuditLogReason<'a> for UpdateGuildOnboarding<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateGuildOnboarding<'_> {
     type Output = Result<Response<Onboarding>, Error>;
 

--- a/twilight-http/src/request/guild/update_guild_welcome_screen.rs
+++ b/twilight-http/src/request/guild/update_guild_welcome_screen.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -70,7 +69,6 @@ impl<'a> UpdateGuildWelcomeScreen<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateGuildWelcomeScreen<'_> {
     type Output = Result<Response<WelcomeScreen>, Error>;
 

--- a/twilight-http/src/request/guild/update_guild_widget_settings.rs
+++ b/twilight-http/src/request/guild/update_guild_widget_settings.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -74,7 +73,6 @@ impl<'a> AuditLogReason<'a> for UpdateGuildWidgetSettings<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateGuildWidgetSettings<'_> {
     type Output = Result<Response<GuildWidgetSettings>, Error>;
 

--- a/twilight-http/src/request/guild/user/get_current_user_voice_state.rs
+++ b/twilight-http/src/request/guild/user/get_current_user_voice_state.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,7 +24,6 @@ impl<'a> GetCurrentUserVoiceState<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetCurrentUserVoiceState<'_> {
     type Output = Result<Response<VoiceState>, Error>;
 

--- a/twilight-http/src/request/guild/user/get_user_voice_state.rs
+++ b/twilight-http/src/request/guild/user/get_user_voice_state.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -37,7 +36,6 @@ impl<'a> GetUserVoiceState<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetUserVoiceState<'_> {
     type Output = Result<Response<VoiceState>, Error>;
 

--- a/twilight-http/src/request/guild/user/update_current_user_voice_state.rs
+++ b/twilight-http/src/request/guild/user/update_current_user_voice_state.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use serde::Serialize;
@@ -88,7 +87,6 @@ impl<'a> UpdateCurrentUserVoiceState<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateCurrentUserVoiceState<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/guild/user/update_user_voice_state.rs
+++ b/twilight-http/src/request/guild/user/update_user_voice_state.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use serde::Serialize;
@@ -66,7 +65,6 @@ impl<'a> UpdateUserVoiceState<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateUserVoiceState<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/poll/end_poll.rs
+++ b/twilight-http/src/request/poll/end_poll.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -45,7 +44,6 @@ impl<'a> EndPoll<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for EndPoll<'_> {
     type Output = Result<Response<Message>, Error>;
     type IntoFuture = ResponseFuture<Message>;

--- a/twilight-http/src/request/poll/get_answer_voters.rs
+++ b/twilight-http/src/request/poll/get_answer_voters.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::{Deserialize, Serialize};
@@ -73,7 +72,6 @@ impl<'a> GetAnswerVoters<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetAnswerVoters<'_> {
     type Output = Result<Response<GetAnswerVotersResponse>, Error>;
     type IntoFuture = ResponseFuture<GetAnswerVotersResponse>;

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/external.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/external.rs
@@ -1,11 +1,10 @@
 use super::{
     super::EntityMetadataFields, CreateGuildScheduledEvent, CreateGuildScheduledEventFields,
 };
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     error::Error,
     request::{AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
 };
 use std::future::IntoFuture;
 use twilight_model::{
@@ -91,7 +90,6 @@ impl<'a> AuditLogReason<'a> for CreateGuildExternalScheduledEvent<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGuildExternalScheduledEvent<'_> {
     type Output = Result<Response<GuildScheduledEvent>, Error>;
 

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/mod.rs
@@ -8,12 +8,11 @@ pub use self::{
 };
 
 use super::EntityMetadataFields;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::ResponseFuture;
 use crate::{
     client::Client,
     error::Error,
     request::{AuditLogReason, Request},
+    response::ResponseFuture,
     routing::Route,
 };
 use serde::Serialize;
@@ -230,7 +229,6 @@ impl<'a> CreateGuildScheduledEvent<'a> {
         CreateGuildVoiceScheduledEvent::new(self, channel_id, name, scheduled_start_time)
     }
 
-    #[cfg(not(target_os = "wasi"))]
     fn exec(self) -> ResponseFuture<GuildScheduledEvent> {
         let http = self.http;
 

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/stage_instance.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/stage_instance.rs
@@ -1,9 +1,8 @@
 use super::{CreateGuildScheduledEvent, CreateGuildScheduledEventFields};
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     error::Error,
     request::{AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
 };
 use std::future::IntoFuture;
 use twilight_model::{
@@ -98,7 +97,6 @@ impl<'a> AuditLogReason<'a> for CreateGuildStageInstanceScheduledEvent<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGuildStageInstanceScheduledEvent<'_> {
     type Output = Result<Response<GuildScheduledEvent>, Error>;
 

--- a/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/voice.rs
+++ b/twilight-http/src/request/scheduled_event/create_guild_scheduled_event/voice.rs
@@ -1,9 +1,8 @@
 use super::{CreateGuildScheduledEvent, CreateGuildScheduledEventFields};
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     error::Error,
     request::{AuditLogReason, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
 };
 use std::future::IntoFuture;
 use twilight_model::{
@@ -98,7 +97,6 @@ impl<'a> AuditLogReason<'a> for CreateGuildVoiceScheduledEvent<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGuildVoiceScheduledEvent<'_> {
     type Output = Result<Response<GuildScheduledEvent>, Error>;
 

--- a/twilight-http/src/request/scheduled_event/delete_guild_scheduled_event.rs
+++ b/twilight-http/src/request/scheduled_event/delete_guild_scheduled_event.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -54,7 +53,6 @@ impl<'a> DeleteGuildScheduledEvent<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteGuildScheduledEvent<'_> {
     type Output = Result<Response<GuildScheduledEvent>, Error>;
 

--- a/twilight-http/src/request/scheduled_event/get_guild_scheduled_event.rs
+++ b/twilight-http/src/request/scheduled_event/get_guild_scheduled_event.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -46,7 +45,6 @@ impl<'a> GetGuildScheduledEvent<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildScheduledEvent<'_> {
     type Output = Result<Response<GuildScheduledEvent>, Error>;
 

--- a/twilight-http/src/request/scheduled_event/get_guild_scheduled_event_users.rs
+++ b/twilight-http/src/request/scheduled_event/get_guild_scheduled_event_users.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -121,7 +120,6 @@ impl<'a> GetGuildScheduledEventUsers<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildScheduledEventUsers<'_> {
     type Output = Result<Response<ListBody<GuildScheduledEventUser>>, Error>;
 

--- a/twilight-http/src/request/scheduled_event/get_guild_scheduled_events.rs
+++ b/twilight-http/src/request/scheduled_event/get_guild_scheduled_events.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -37,7 +36,6 @@ impl<'a> GetGuildScheduledEvents<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetGuildScheduledEvents<'_> {
     type Output = Result<Response<ListBody<GuildScheduledEvent>>, Error>;
 

--- a/twilight-http/src/request/scheduled_event/update_guild_scheduled_event.rs
+++ b/twilight-http/src/request/scheduled_event/update_guild_scheduled_event.rs
@@ -1,10 +1,9 @@
 use super::EntityMetadataFields;
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{AuditLogReason, Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -260,7 +259,6 @@ impl<'a> AuditLogReason<'a> for UpdateGuildScheduledEvent<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateGuildScheduledEvent<'_> {
     type Output = Result<Response<GuildScheduledEvent>, Error>;
 

--- a/twilight-http/src/request/sticker/get_nitro_sticker_packs.rs
+++ b/twilight-http/src/request/sticker/get_nitro_sticker_packs.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Deserialize;
@@ -42,7 +41,6 @@ impl<'a> GetNitroStickerPacks<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetNitroStickerPacks<'_> {
     type Output = Result<Response<StickerPackListing>, Error>;
 

--- a/twilight-http/src/request/sticker/get_sticker.rs
+++ b/twilight-http/src/request/sticker/get_sticker.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -40,7 +39,6 @@ impl<'a> GetSticker<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetSticker<'_> {
     type Output = Result<Response<Sticker>, Error>;
 

--- a/twilight-http/src/request/template/create_guild_from_template.rs
+++ b/twilight-http/src/request/template/create_guild_from_template.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -66,7 +65,6 @@ impl<'a> CreateGuildFromTemplate<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateGuildFromTemplate<'_> {
     type Output = Result<Response<Guild>, Error>;
 

--- a/twilight-http/src/request/template/create_template.rs
+++ b/twilight-http/src/request/template/create_template.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -83,7 +82,6 @@ impl<'a> CreateTemplate<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreateTemplate<'_> {
     type Output = Result<Response<Template>, Error>;
 

--- a/twilight-http/src/request/template/delete_template.rs
+++ b/twilight-http/src/request/template/delete_template.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -31,7 +30,6 @@ impl<'a> DeleteTemplate<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for DeleteTemplate<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/template/get_template.rs
+++ b/twilight-http/src/request/template/get_template.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,7 +24,6 @@ impl<'a> GetTemplate<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetTemplate<'_> {
     type Output = Result<Response<Template>, Error>;
 

--- a/twilight-http/src/request/template/get_templates.rs
+++ b/twilight-http/src/request/template/get_templates.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,7 +24,6 @@ impl<'a> GetTemplates<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetTemplates<'_> {
     type Output = Result<Response<ListBody<Template>>, Error>;
 

--- a/twilight-http/src/request/template/sync_template.rs
+++ b/twilight-http/src/request/template/sync_template.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -34,7 +33,6 @@ impl<'a> SyncTemplate<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for SyncTemplate<'_> {
     type Output = Result<Response<Template>, Error>;
 

--- a/twilight-http/src/request/template/update_template.rs
+++ b/twilight-http/src/request/template/update_template.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -92,7 +91,6 @@ impl<'a> UpdateTemplate<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateTemplate<'_> {
     type Output = Result<Response<Template>, Error>;
 

--- a/twilight-http/src/request/update_user_application.rs
+++ b/twilight-http/src/request/update_user_application.rs
@@ -6,12 +6,11 @@ use twilight_model::oauth::{
     InstallParams,
 };
 
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 
@@ -179,8 +178,6 @@ impl<'a> UpdateCurrentUserApplication<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateCurrentUserApplication<'_> {
     type Output = Result<Response<Application>, Error>;
 

--- a/twilight-http/src/request/user/create_private_channel.rs
+++ b/twilight-http/src/request/user/create_private_channel.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -34,7 +33,6 @@ impl<'a> CreatePrivateChannel<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for CreatePrivateChannel<'_> {
     type Output = Result<Response<Channel>, Error>;
 

--- a/twilight-http/src/request/user/get_current_user.rs
+++ b/twilight-http/src/request/user/get_current_user.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -21,7 +20,6 @@ impl<'a> GetCurrentUser<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetCurrentUser<'_> {
     type Output = Result<Response<CurrentUser>, Error>;
 

--- a/twilight-http/src/request/user/get_current_user_connections.rs
+++ b/twilight-http/src/request/user/get_current_user_connections.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -23,7 +22,6 @@ impl<'a> GetCurrentUserConnections<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetCurrentUserConnections<'_> {
     type Output = Result<Response<ListBody<Connection>>, Error>;
 

--- a/twilight-http/src/request/user/get_current_user_guild_member.rs
+++ b/twilight-http/src/request/user/get_current_user_guild_member.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     Error,
     client::Client,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,7 +24,6 @@ impl<'a> GetCurrentUserGuildMember<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetCurrentUserGuildMember<'_> {
     type Output = Result<Response<Member>, Error>;
 

--- a/twilight-http/src/request/user/get_current_user_guilds.rs
+++ b/twilight-http/src/request/user/get_current_user_guilds.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::ListBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::ListBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -106,7 +105,6 @@ impl<'a> GetCurrentUserGuilds<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetCurrentUserGuilds<'_> {
     type Output = Result<Response<ListBody<CurrentUserGuild>>, Error>;
 

--- a/twilight-http/src/request/user/get_user.rs
+++ b/twilight-http/src/request/user/get_user.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -25,7 +24,6 @@ impl<'a> GetUser<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for GetUser<'_> {
     type Output = Result<Response<User>, Error>;
 

--- a/twilight-http/src/request/user/leave_guild.rs
+++ b/twilight-http/src/request/user/leave_guild.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture, marker::EmptyBody};
 use crate::{
     client::Client,
     error::Error,
     request::{Request, TryIntoRequest},
+    response::{Response, ResponseFuture, marker::EmptyBody},
     routing::Route,
 };
 use std::future::IntoFuture;
@@ -22,7 +21,6 @@ impl<'a> LeaveGuild<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for LeaveGuild<'_> {
     type Output = Result<Response<EmptyBody>, Error>;
 

--- a/twilight-http/src/request/user/update_current_user.rs
+++ b/twilight-http/src/request/user/update_current_user.rs
@@ -1,9 +1,8 @@
-#[cfg(not(target_os = "wasi"))]
-use crate::response::{Response, ResponseFuture};
 use crate::{
     client::Client,
     error::Error,
     request::{self, AuditLogReason, Nullable, Request, TryIntoRequest},
+    response::{Response, ResponseFuture},
     routing::Route,
 };
 use serde::Serialize;
@@ -107,7 +106,6 @@ impl<'a> AuditLogReason<'a> for UpdateCurrentUser<'a> {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
 impl IntoFuture for UpdateCurrentUser<'_> {
     type Output = Result<Response<User>, Error>;
 

--- a/twilight-http/src/response/mod.rs
+++ b/twilight-http/src/response/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "wasi"))]
-
 //! Response utility type and related types.
 //!
 //! The heart of the response module is the [`Response`] itself: it's a wrapper


### PR DESCRIPTION
This commit was excessive (only `tokio/net` needed disabling) and is no longer needed (`tokio/net` now supports `WASI`).

