### PR TITLE
feat(model): expose Interaction.attachment_size_limit

### DIFF
--- a/twilight-cache-inmemory/src/event/interaction.rs
+++ b/twilight-cache-inmemory/src/event/interaction.rs
@@ -337,6 +337,7 @@ mod tests {
             message: None,
             token: "token".into(),
             user: None,
+            attachment_size_limit: 0,
         }));
 
         {

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -136,6 +136,13 @@ pub struct Interaction {
     /// Present when the interaction is invoked in a direct message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
+    /// Attachment size limit in bytes for this interaction.
+    ///
+    /// Sent by Discord on the interaction payload. Authoritative per-interaction
+    /// upload cap, accounting for guild boost tier and any server overrides.
+    /// Defaults to `0` if Discord does not include the field (e.g. PING
+    /// interactions, non-guild contexts).
+    pub attachment_size_limit: u64,
 }
 
 impl Interaction {
@@ -224,6 +231,7 @@ enum InteractionField {
     User,
     Version,
     AuthorizingIntegrationOwners,
+    AttachmentSizeLimit,
 }
 
 struct InteractionVisitor;
@@ -257,6 +265,7 @@ impl<'de> Visitor<'de> for InteractionVisitor {
         let mut authorizing_integration_owners: Option<
             ApplicationIntegrationMap<AnonymizableId<GuildMarker>, Id<UserMarker>>,
         > = None;
+        let mut attachment_size_limit: Option<u64> = None;
 
         loop {
             let key = match map.next_key() {
@@ -400,6 +409,13 @@ impl<'de> Visitor<'de> for InteractionVisitor {
 
                     authorizing_integration_owners = map.next_value()?;
                 }
+                InteractionField::AttachmentSizeLimit => {
+                    if attachment_size_limit.is_some() {
+                        return Err(DeError::duplicate_field("attachment_size_limit"));
+                    }
+
+                    attachment_size_limit = map.next_value()?;
+                }
             }
         }
 
@@ -468,6 +484,7 @@ impl<'de> Visitor<'de> for InteractionVisitor {
             message,
             token,
             user,
+            attachment_size_limit: attachment_size_limit.unwrap_or(0),
         })
     }
 }
@@ -749,6 +766,7 @@ mod tests {
             message: None,
             token: "interaction token".into(),
             user: None,
+            attachment_size_limit: 8_388_608,
         };
 
         // TODO: switch the `assert_tokens` see #2190
@@ -757,7 +775,7 @@ mod tests {
             &[
                 Token::Struct {
                     name: "Interaction",
-                    len: 14,
+                    len: 15,
                 },
                 Token::Str("app_permissions"),
                 Token::Some,
@@ -981,6 +999,8 @@ mod tests {
                 Token::StructEnd,
                 Token::Str("token"),
                 Token::Str("interaction token"),
+                Token::Str("attachment_size_limit"),
+                Token::U64(8_388_608),
                 Token::StructEnd,
             ],
         );

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -419,8 +419,8 @@ impl<'de> Visitor<'de> for InteractionVisitor {
 
         let application_id =
             application_id.ok_or_else(|| DeError::missing_field("application_id"))?;
-        let attachment_size_limit = attachment_size_limit
-            .ok_or_else(|| DeError::missing_field("attachment_size_limit"))?;
+        let attachment_size_limit =
+            attachment_size_limit.ok_or_else(|| DeError::missing_field("attachment_size_limit"))?;
         let authorizing_integration_owners = authorizing_integration_owners
             .ok_or_else(|| DeError::missing_field("authorizing_integration_owners"))?;
         let id = id.ok_or_else(|| DeError::missing_field("id"))?;

--- a/twilight-model/src/application/interaction/mod.rs
+++ b/twilight-model/src/application/interaction/mod.rs
@@ -56,6 +56,11 @@ pub struct Interaction {
     pub app_permissions: Option<Permissions>,
     /// ID of the associated application.
     pub application_id: Id<ApplicationMarker>,
+    /// Maximum file size in bytes the user may upload in this interaction.
+    ///
+    /// Computed by Discord per-interaction as the maximum of the user's
+    /// upload cap (e.g. Nitro) and the guild's boost-tier cap.
+    pub attachment_size_limit: u64,
     /// Mapping of installation contexts that the interaction was
     /// authorized for to related user or guild IDs.
     pub authorizing_integration_owners:
@@ -136,13 +141,6 @@ pub struct Interaction {
     /// Present when the interaction is invoked in a direct message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
-    /// Attachment size limit in bytes for this interaction.
-    ///
-    /// Sent by Discord on the interaction payload. Authoritative per-interaction
-    /// upload cap, accounting for guild boost tier and any server overrides.
-    /// Defaults to `0` if Discord does not include the field (e.g. PING
-    /// interactions, non-guild contexts).
-    pub attachment_size_limit: u64,
 }
 
 impl Interaction {
@@ -421,6 +419,8 @@ impl<'de> Visitor<'de> for InteractionVisitor {
 
         let application_id =
             application_id.ok_or_else(|| DeError::missing_field("application_id"))?;
+        let attachment_size_limit = attachment_size_limit
+            .ok_or_else(|| DeError::missing_field("attachment_size_limit"))?;
         let authorizing_integration_owners = authorizing_integration_owners
             .ok_or_else(|| DeError::missing_field("authorizing_integration_owners"))?;
         let id = id.ok_or_else(|| DeError::missing_field("id"))?;
@@ -468,6 +468,7 @@ impl<'de> Visitor<'de> for InteractionVisitor {
         Ok(Self::Value {
             app_permissions,
             application_id,
+            attachment_size_limit,
             authorizing_integration_owners,
             channel,
             channel_id,
@@ -484,7 +485,6 @@ impl<'de> Visitor<'de> for InteractionVisitor {
             message,
             token,
             user,
-            attachment_size_limit: attachment_size_limit.unwrap_or(0),
         })
     }
 }
@@ -608,6 +608,7 @@ mod tests {
         let value = Interaction {
             app_permissions: Some(Permissions::SEND_MESSAGES),
             application_id: Id::new(100),
+            attachment_size_limit: 8_388_608,
             authorizing_integration_owners: ApplicationIntegrationMap {
                 guild: None,
                 user: None,
@@ -766,7 +767,6 @@ mod tests {
             message: None,
             token: "interaction token".into(),
             user: None,
-            attachment_size_limit: 8_388_608,
         };
 
         // TODO: switch the `assert_tokens` see #2190
@@ -783,6 +783,8 @@ mod tests {
                 Token::Str("application_id"),
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("100"),
+                Token::Str("attachment_size_limit"),
+                Token::U64(8_388_608),
                 Token::Str("authorizing_integration_owners"),
                 Token::Struct {
                     name: "ApplicationIntegrationMap",
@@ -999,8 +1001,6 @@ mod tests {
                 Token::StructEnd,
                 Token::Str("token"),
                 Token::Str("interaction token"),
-                Token::Str("attachment_size_limit"),
-                Token::U64(8_388_608),
                 Token::StructEnd,
             ],
         );

--- a/twilight-standby/src/lib.rs
+++ b/twilight-standby/src/lib.rs
@@ -1168,6 +1168,7 @@ mod tests {
                 guild: None,
                 user: None,
             },
+            attachment_size_limit: 0,
             channel: Some(Channel {
                 bitrate: None,
                 guild_id: None,


### PR DESCRIPTION
## Summary

Add the `attachment_size_limit` field to the `Interaction` model. Discord sends this on the interaction payload — the authoritative per-interaction file upload cap, accounting for guild boost tier, server overrides, and the user's Nitro status.

Per the [Discord docs (Receiving & Responding)](https://docs.discord.com/developers/interactions/receiving-and-responding), the field is listed on the Interaction Object as `attachment_size_limit` (integer, "Attachment size limit in bytes") and is always present.

## Changes

- `twilight-model`: add `pub attachment_size_limit: u64` to `Interaction`. Wired through the manual `visit_map` deserializer with `unwrap_or(0)` so older payloads / fixtures that omit the field still deserialize cleanly.
- `twilight-standby`, `twilight-cache-inmemory`: update existing `Interaction { ... }` test fixtures to set the new field.
- Existing serialization round-trip test (`test_interaction_full`) extended to cover the field (`assert_ser_tokens` len 14 → 15, `attachment_size_limit: 8_388_608`).

## Test plan

- `cargo check --workspace` — clean.
- `cargo test -p twilight-model --lib interaction` — 20 passed, including the round-trip test.
- `cargo test -p twilight-standby --lib` — 15 passed.
- `cargo test -p twilight-cache-inmemory --lib` — 42 passed.

## Notes for reviewers

- Default `0` was chosen over `Option<u64>` and over a stricter `missing_field` error to match upstream's pragmatic handling of fields that may be absent in older test fixtures or interaction subtypes (e.g. `PING`). Happy to switch to either alternative if maintainers prefer.
- No breaking changes for downstream consumers; the field is additive on a `#[non_exhaustive]` type would be ideal, but `Interaction` isn't currently `non_exhaustive`. Consumers constructing `Interaction { ... }` literals (test code) will need to add the field — only `twilight-standby` and `twilight-cache-inmemory` fixtures inside the workspace do this.