### PR TITLE
feat(http): added ability to set enhanced role styles

### DIFF
--- a/twilight-http/src/request/guild/role/create_role.rs
+++ b/twilight-http/src/request/guild/role/create_role.rs
@@ -9,7 +9,7 @@ use crate::{
 use serde::Serialize;
 use std::future::IntoFuture;
 use twilight_model::{
-    guild::{Permissions, Role},
+    guild::{Permissions, Role, RoleColors},
     id::{Id, marker::GuildMarker},
 };
 use twilight_validate::request::{ValidationError, audit_reason as validate_audit_reason};
@@ -18,6 +18,8 @@ use twilight_validate::request::{ValidationError, audit_reason as validate_audit
 struct CreateRoleFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    colors: Option<RoleColors>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -65,6 +67,7 @@ impl<'a> CreateRole<'a> {
         Self {
             fields: CreateRoleFields {
                 color: None,
+                colors: None,
                 hoist: None,
                 icon: None,
                 mentionable: None,
@@ -87,6 +90,13 @@ impl<'a> CreateRole<'a> {
     /// [`COLOR_MAXIMUM`]: twilight_validate::embed::COLOR_MAXIMUM
     pub const fn color(mut self, color: u32) -> Self {
         self.fields.color = Some(color);
+
+        self
+    }
+
+    /// Set the role colours.
+    pub const fn colors(mut self, colors: RoleColors) -> Self {
+        self.fields.colors = Some(colors);
 
         self
     }

--- a/twilight-http/src/request/guild/role/update_role.rs
+++ b/twilight-http/src/request/guild/role/update_role.rs
@@ -9,7 +9,7 @@ use crate::{
 use serde::Serialize;
 use std::future::IntoFuture;
 use twilight_model::{
-    guild::{Permissions, Role},
+    guild::{Permissions, Role, RoleColors},
     id::{
         Id,
         marker::{GuildMarker, RoleMarker},
@@ -21,6 +21,8 @@ use twilight_validate::request::{ValidationError, audit_reason as validate_audit
 struct UpdateRoleFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     color: Option<Nullable<u32>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    colors: Option<Nullable<RoleColors>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -54,6 +56,7 @@ impl<'a> UpdateRole<'a> {
         Self {
             fields: UpdateRoleFields {
                 color: None,
+                colors: None,
                 hoist: None,
                 icon: None,
                 mentionable: None,
@@ -77,6 +80,13 @@ impl<'a> UpdateRole<'a> {
     /// [`COLOR_MAXIMUM`]: twilight_validate::embed::COLOR_MAXIMUM
     pub const fn color(mut self, color: Option<u32>) -> Self {
         self.fields.color = Some(Nullable(color));
+
+        self
+    }
+
+    /// Set the role colours.
+    pub const fn colors(mut self, colors: Option<RoleColors>) -> Self {
+        self.fields.colors = Some(Nullable(colors));
 
         self
     }


### PR DESCRIPTION
Discord's enhanced role styles could previously be retrieved as part of the role object; however, they could not be set when editing or creating roles. This addition allows setting those properties.