### PR TITLE
fix(model): Fix deserialization of modals with checkboxes

### DIFF
--- a/twilight-model/src/application/interaction/modal/mod.rs
+++ b/twilight-model/src/application/interaction/modal/mod.rs
@@ -373,7 +373,7 @@ impl<'de> Visitor<'de> for ModalInteractionDataComponentVisitor {
         let mut values: Option<Vec<Value>> = None;
         let mut components: Option<Vec<ModalInteractionComponent>> = None;
         let mut component: Option<ModalInteractionComponent> = None;
-        let mut value: Option<String> = None;
+        let mut value: Option<Value> = None;
 
         loop {
             let key = match map.next_key() {
@@ -471,7 +471,10 @@ impl<'de> Visitor<'de> for ModalInteractionDataComponentVisitor {
             ),
             ComponentType::TextInput => {
                 let custom_id = custom_id.ok_or_else(|| DeError::missing_field("custom_id"))?;
-                let value = value.ok_or_else(|| DeError::missing_field("value"))?;
+                let value = value
+                    .ok_or_else(|| DeError::missing_field("value"))?
+                    .deserialize_into()
+                    .map_err(DeserializerError::into_error)?;
 
                 Self::Value::TextInput(ModalInteractionTextInput {
                     custom_id,
@@ -522,9 +525,12 @@ impl<'de> Visitor<'de> for ModalInteractionDataComponentVisitor {
             }
             ComponentType::Checkbox => {
                 let custom_id = custom_id.ok_or_else(|| DeError::missing_field("custom_id"))?;
-                let value = value.ok_or_else(|| DeError::missing_field("value"))?;
+                let value = value
+                    .ok_or_else(|| DeError::missing_field("value"))?
+                    .deserialize_into()
+                    .map_err(DeserializerError::into_error)?;
 
-                Self::Value::TextInput(ModalInteractionTextInput {
+                Self::Value::Checkbox(ModalInteractionCheckbox {
                     custom_id,
                     id,
                     value,
@@ -972,6 +978,50 @@ mod tests {
                 Token::NewtypeStruct { name: "Id" },
                 Token::Str("2"),
                 Token::SeqEnd,
+                Token::StructEnd,
+                Token::SeqEnd,
+                Token::String("custom_id"),
+                Token::String("test-modal"),
+                Token::StructEnd,
+            ],
+        )
+    }
+
+    #[test]
+    fn modal_checkbox() {
+        let value = ModalInteractionData {
+            custom_id: "test-modal".to_owned(),
+            components: vec![ModalInteractionComponent::Checkbox(
+                ModalInteractionCheckbox {
+                    id: 10,
+                    custom_id: "checkbox".to_owned(),
+                    value: true,
+                },
+            )],
+            resolved: None,
+        };
+
+        serde_test::assert_tokens(
+            &value,
+            &[
+                Token::Struct {
+                    name: "ModalInteractionData",
+                    len: 2,
+                },
+                Token::String("components"),
+                Token::Seq { len: Some(1) },
+                Token::Struct {
+                    name: "ModalInteractionComponent",
+                    len: 4,
+                },
+                Token::String("type"),
+                Token::U8(ComponentType::Checkbox.into()),
+                Token::String("custom_id"),
+                Token::String("checkbox"),
+                Token::String("id"),
+                Token::I32(10),
+                Token::String("value"),
+                Token::Bool(true),
                 Token::StructEnd,
                 Token::SeqEnd,
                 Token::String("custom_id"),


### PR DESCRIPTION
A recent addition to the development branch was support for checkboxes. This is great, and I was excited to use it, but I've found that if I use a modal with a checkbox, twilight couldn't deserialize the response, so it didn't really matter.
I had a go at fixing this; it looks like someone made a whoopsie and tried to deserialize it as a text input.
This worked properly when I tested it, but I admittedly didn't test it very hard (I did correctly receive checked and unchecked checkboxes, though!); if anything here is unnecessary or there are edge cases I handled wrong, please let me know!

The contributing guide appears to want increased test coverage as well. I threw one for checkboxes in here as well. It's not *technically* related to the fix I made, but I don't have enough experience with writing tests for deserialization through serde to feel super comfortable writing one on my own, and all the existing tests are for serialization. That said, if you'd like me to do anything other than what I've done with this, please let me know and I'll see what I can do.