### PR TITLE
feat(model): add `app_permissions` to resolved interaction channel

### DIFF
--- a/twilight-model/src/application/interaction/modal/mod.rs
+++ b/twilight-model/src/application/interaction/modal/mod.rs
@@ -824,6 +824,7 @@ mod tests {
                         name: "the-channel-name".to_owned(),
                         parent_id: None,
                         permissions: Permissions::empty(),
+                        app_permissions: None,
                         thread_metadata: None,
                     },
                 )]),

--- a/twilight-model/src/application/interaction/resolved.rs
+++ b/twilight-model/src/application/interaction/resolved.rs
@@ -61,6 +61,9 @@ pub struct InteractionChannel {
     pub parent_id: Option<Id<ChannelMarker>>,
     /// Computed permissions, including overwrites, for the invoking user in the channel.
     pub permissions: Permissions,
+    /// Computed permissions, including overwrites, for the bot in the channel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_permissions: Option<Permissions>,
     /// Metadata about a thread.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thread_metadata: Option<ThreadMetadata>,
@@ -160,6 +163,7 @@ mod tests {
                     name: "channel name".into(),
                     parent_id: None,
                     permissions: Permissions::empty(),
+                    app_permissions: None,
                     thread_metadata: None,
                 },
             )])


### PR DESCRIPTION
Implements
* https://github.com/discord/discord-api-docs/pull/8443