### PR TITLE
fix(cache): maintain guild relations on user updates

### DIFF
--- a/twilight-cache-inmemory/src/event/mod.rs
+++ b/twilight-cache-inmemory/src/event/mod.rs
@@ -14,7 +14,7 @@ pub mod sticker;
 pub mod thread;
 pub mod voice_state;
 
-use std::{borrow::Cow, collections::HashSet};
+use std::borrow::Cow;
 
 use crate::{CacheableModels, InMemoryCache, UpdateCache, config::ResourceType};
 use twilight_model::{
@@ -50,9 +50,7 @@ impl<CacheModels: CacheableModels> InMemoryCache<CacheModels> {
         self.users.insert(user_id, CacheModels::User::from(user));
 
         if let Some(guild_id) = guild_id {
-            let mut guild_id_set = HashSet::new();
-            guild_id_set.insert(guild_id);
-            self.user_guilds.insert(user_id, guild_id_set);
+            self.user_guilds.entry(user_id).or_default().insert(guild_id);
         }
     }
 

--- a/twilight-cache-inmemory/src/event/mod.rs
+++ b/twilight-cache-inmemory/src/event/mod.rs
@@ -50,7 +50,10 @@ impl<CacheModels: CacheableModels> InMemoryCache<CacheModels> {
         self.users.insert(user_id, CacheModels::User::from(user));
 
         if let Some(guild_id) = guild_id {
-            self.user_guilds.entry(user_id).or_default().insert(guild_id);
+            self.user_guilds
+                .entry(user_id)
+                .or_default()
+                .insert(guild_id);
         }
     }
 


### PR DESCRIPTION
ℹ️ The content of this pull request was created with LLM assistance. The code has been manually guided, reviewed, and where necessary written. The commit description was manually written.  When `cache_user` re-inserts a user because data differs from cached version it was creating a fresh collection for the set of guilds the user is in and overwriting all prior guild associations. This notably happens when caching user objects from interactions, causing the early-return path - which does not have this bug - to be skipped. 