### PR TITLE
fix(http)!: serialize create role icon as string

### DIFF
--- a/twilight-http/src/request/guild/role/create_role.rs
+++ b/twilight-http/src/request/guild/role/create_role.rs
@@ -22,7 +22,7 @@ struct CreateRoleFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<&'a [u8]>,
+    icon: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     mentionable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -114,7 +114,7 @@ impl<'a> CreateRole<'a> {
     /// See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn icon(mut self, icon: &'a [u8]) -> Self {
+    pub const fn icon(mut self, icon: &'a str) -> Self {
         self.fields.icon = Some(icon);
 
         self


### PR DESCRIPTION
ℹ️ The content of this pull request was created with LLM assistance. The code has been manually guided, reviewed, and where necessary written. The commit description was manually written.  Properly serialize the `icon` field of `CreateRole` as a string. The content of this field is an image data string and documented as such, but it's erroneously stored as a slice of bytes (`&[u8]`) rather than a string slice (`&str`). `UpdateRole` correctly accepts an `&str`. Changing the type of this would be a breaking change, so instead we can parse the bytes as a UTF-8 valid string and then serialize it.  This is a breaking change, but the behavior is fundamentally broken already and breaks all requests that use it so it should be acceptable for this bugfix.