### PR TITLE
docs(validate/channel): fix user_limit reference

### DIFF
--- a/twilight-validate/src/channel.rs
+++ b/twilight-validate/src/channel.rs
@@ -327,7 +327,7 @@ pub fn topic(value: impl AsRef<str>) -> Result<(), ChannelValidationError> {
 ///
 /// Returns an error of type [`UserLimitInvalid`] if the user limit is invalid.
 ///
-/// [`UserLimitInvalid`]: ChannelValidationErrorType::BitrateInvalid
+/// [`UserLimitInvalid`]: ChannelValidationErrorType::UserLimitInvalid
 pub const fn user_limit(value: u16) -> Result<(), ChannelValidationError> {
     if value <= CHANNEL_USER_LIMIT_MAX {
         Ok(())


### PR DESCRIPTION
ℹ️The content of this pull request was created with LLM assistance. The code has been manually guided, reviewed, and where necessary written. The commit description was manually written.  The documentation for `twilight_validate::channel::user_limit` linked to `ChannelValidationErrorType::BitrateInvalid` when it should link to `ChannelValidationErrorType::UserLimitInvalid`.