### PR TITLE
fix(validate): count chars in command character totals

### DIFF
--- a/twilight-validate/src/command.rs
+++ b/twilight-validate/src/command.rs
@@ -391,7 +391,7 @@ pub fn option_characters(option: &CommandOption) -> usize {
                         characters += longest_localization_characters(
                             &choice.name,
                             choice.name_localizations.as_ref(),
-                        ) + string_choice.len();
+                        ) + string_choice.chars().count();
                     }
                 }
             }
@@ -419,12 +419,13 @@ fn longest_localization_characters(
     default: &str,
     localizations: Option<&HashMap<String, String>>,
 ) -> usize {
-    let mut characters = default.len();
+    let mut characters = default.chars().count();
 
     if let Some(localizations) = localizations {
         for localization in localizations.values() {
-            if localization.len() > characters {
-                characters = localization.len();
+            let len = localization.chars().count();
+            if len > characters {
+                characters = len;
             }
         }
     }


### PR DESCRIPTION
Count the number of characters in `twilight_validate::command::longest_localization_characters` and `twilight_validate::command::option_characters` instead of the number of bytes. Discord measures command name/description/choice value limits in codepoints, not bytes.