### PR TITLE
fix(validate): use char count for textinput label

### DIFF
--- a/twilight-validate/src/component.rs
+++ b/twilight-validate/src/component.rs
@@ -1408,7 +1408,7 @@ fn component_select_placeholder(
 /// [`TextInput::label`]: twilight_model::application::component::text_input::TextInput::label
 /// [`TextInputLabelLength`]: ComponentValidationErrorType::TextInputLabelLength
 fn component_text_input_label(label: impl AsRef<str>) -> Result<(), ComponentValidationError> {
-    let len = label.as_ref().len();
+    let len = label.as_ref().chars().count();
 
     if (TEXT_INPUT_LABEL_MIN..=TEXT_INPUT_LABEL_MAX).contains(&len) {
         Ok(())
@@ -1770,13 +1770,23 @@ mod tests {
         assert!(component_select_placeholder("a".repeat(151)).is_err());
     }
 
+    /// Test that text input labels are counted using codepoints and not by byte
+    /// count.
     #[test]
     fn component_text_input_label_length() {
-        assert!(component_text_input_label("a").is_ok());
-        assert!(component_text_input_label("a".repeat(45)).is_ok());
+        // 45 characters or 180 bytes
+        let label = "🪄".repeat(45);
+        assert_eq!(label.chars().count(), 45);
+        assert_eq!(label.len(), 180);
+        assert!(component_text_input_label(label).is_ok());
 
-        assert!(component_text_input_label("").is_err());
-        assert!(component_text_input_label("a".repeat(46)).is_err());
+        // 46 characters should fail.
+        let label = "🪄".repeat(46);
+        let err = component_text_input_label(label).unwrap_err();
+        assert!(matches!(
+            err.kind(),
+            ComponentValidationErrorType::TextInputLabelLength { len } if *len == 46
+        ));
     }
 
     #[test]


### PR DESCRIPTION
ℹ️ The content of this pull request was created with LLM assistance. The code has been manually guided, reviewed, and where necessary written. The commit description was manually written.  `twilight_validate::component::component_text_input_label` should count the number of characters instead of counting the number of bytes. Multi-byte characters would cause valid labels to incorrectly fail validation. Adds happy path and error path tests. 