### PR TITLE
perf(model): monomorphize IdVisitor

### DIFF
--- a/twilight-model/src/id/mod.rs
+++ b/twilight-model/src/id/mod.rs
@@ -243,20 +243,10 @@ impl<T> Debug for Id<T> {
 
 impl<'de, T> Deserialize<'de> for Id<T> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        struct IdVisitor<T> {
-            phantom: PhantomData<T>,
-        }
+        struct IdVisitor;
 
-        impl<T> IdVisitor<T> {
-            const fn new() -> Self {
-                Self {
-                    phantom: PhantomData,
-                }
-            }
-        }
-
-        impl<'de, T> Visitor<'de> for IdVisitor<T> {
-            type Value = Id<T>;
+        impl<'de> Visitor<'de> for IdVisitor {
+            type Value = NonZero<u64>;
 
             fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
                 f.write_str("a discord snowflake")
@@ -267,7 +257,7 @@ impl<'de, T> Deserialize<'de> for Id<T> {
                     DeError::invalid_value(Unexpected::Unsigned(value), &"non zero u64")
                 })?;
 
-                Ok(Id::from(value))
+                Ok(value)
             }
 
             fn visit_i64<E: DeError>(self, value: i64) -> Result<Self::Value, E> {
@@ -282,7 +272,7 @@ impl<'de, T> Deserialize<'de> for Id<T> {
                 self,
                 deserializer: D,
             ) -> Result<Self::Value, D::Error> {
-                deserializer.deserialize_any(IdVisitor::new())
+                deserializer.deserialize_any(IdVisitor)
             }
 
             fn visit_str<E: DeError>(self, v: &str) -> Result<Self::Value, E> {
@@ -296,7 +286,7 @@ impl<'de, T> Deserialize<'de> for Id<T> {
             }
         }
 
-        deserializer.deserialize_any(IdVisitor::new())
+        Ok(deserializer.deserialize_any(IdVisitor)?.into())
     }
 }
 


### PR DESCRIPTION
When looking at the generated assembly of `twilight-rs/template`, I noticed that `IdVisitor<T>` was duplicated for every type `T` (18 times).

<details>
<summary>Asm</summary>
<pre>
.section .text,"xr",one_only,<serde_json::de::ParserNumber>::visit::<<twilight_model::id::Id<_> as serde_core::de::Deserialize>::deserialize::IdVisitor<twilight_model::id::marker::ApplicationMarker>>,unique,26
	.p2align	4
<serde_json::de::ParserNumber>::visit::<<twilight_model::id::Id<_> as serde_core::de::Deserialize>::deserialize::IdVisitor<twilight_model::id::marker::ApplicationMarker>>:
	.cv_func_id 741
.seh_proc _RINvMs2_NtCsgYEqTWUt51I_10serde_json2deNtB6_12ParserNumber5visitINtNvXs2_NtCsd6cfNPHaSlT_14twilight_model2idINtB19_2IdpENtNtCs7NpyjEogpiv_10serde_core2de11Deserialize11deserialize9IdVisitorNtNtB19_6marker17ApplicationMarkerEECs2V8jVMfvDKT_8template
	sub rsp, 72
	.seh_stackalloc 72
	.seh_endprologue
	mov rax, qword ptr [rcx]
	cmp rax, 1
	je .LBB26_5
	cmp eax, 2
	jne .LBB26_7
	mov rdx, qword ptr [rcx + 8]
	.cv_inline_site_id 742 within 741 inlined_at 25 125 0
	.cv_inline_site_id 743 within 742 inlined_at 58 274 0
	test rdx, rdx
	js .LBB26_9
	.cv_inline_site_id 744 within 742 inlined_at 58 278 0
	.cv_inline_site_id 745 within 744 inlined_at 58 266 0
	jne .LBB26_6
.LBB26_8:
	mov qword ptr [rsp + 56], 0
	mov byte ptr [rsp + 48], 1
	jmp .LBB26_10
.LBB26_5:
	mov rdx, qword ptr [rcx + 8]
	.cv_inline_site_id 746 within 741 inlined_at 25 124 0
	.cv_inline_site_id 747 within 746 inlined_at 58 266 0
	test rdx, rdx
	je .LBB26_8
.LBB26_6:
	xor eax, eax
	.seh_startepilogue
	add rsp, 72
	.seh_endepilogue
	ret
.LBB26_7:
	movsd xmm0, qword ptr [rcx + 8]
	.cv_inline_site_id 748 within 741 inlined_at 25 123 0
	movsd qword ptr [rsp + 56], xmm0
	mov byte ptr [rsp + 48], 3
	lea r8, [rip + anon.adfef5670cb66bf2a80724b5ab36b62c.672]
	lea rcx, [rsp + 48]
	lea rdx, [rsp + 47]
	call <serde_json::error::Error as serde_core::de::Error>::invalid_type
	mov rdx, rax
	mov eax, 1
	.seh_startepilogue
	add rsp, 72
	.seh_endepilogue
	ret
.LBB26_9:
	.cv_inline_site_id 749 within 743 inlined_at 23 968 0
	mov qword ptr [rsp + 56], rdx
	mov byte ptr [rsp + 48], 2
.LBB26_10:
	lea rdx, [rip + anon.adfef5670cb66bf2a80724b5ab36b62c.658]
	lea r8, [rip + anon.adfef5670cb66bf2a80724b5ab36b62c.474]
	lea rcx, [rsp + 48]
	call <serde_json::error::Error as serde_core::de::Error>::invalid_value
	mov rdx, rax
	mov eax, 1
	.seh_startepilogue
	add rsp, 72
	.seh_endepilogue
	ret
</pre>
</details>