### PR TITLE
fix(http-ratelimiting): assert non-zero global limit

### DIFF
--- a/twilight-http-ratelimiting/src/actor.rs
+++ b/twilight-http-ratelimiting/src/actor.rs
@@ -7,6 +7,7 @@ use std::{
     future::poll_fn,
     hash::{BuildHasher, Hash, Hasher as _, RandomState},
     mem,
+    num::NonZero,
     pin::pin,
 };
 use tokio::{
@@ -99,9 +100,10 @@ const GC_INTERVAL: Duration = Duration::from_secs(60 * 60 * 6);
 /// Rate limiter actor runner.
 #[allow(clippy::too_many_lines)]
 pub async fn runner(
-    global_limit: u16,
+    global_limit: NonZero<u16>,
     mut rx: mpsc::UnboundedReceiver<(Message, Option<crate::Predicate>)>,
 ) {
+    let global_limit = global_limit.get();
     let mut global_remaining = global_limit;
     let mut global_timer = pin!(sleep(Duration::ZERO));
 

--- a/twilight-http-ratelimiting/src/lib.rs
+++ b/twilight-http-ratelimiting/src/lib.rs
@@ -276,6 +276,8 @@ pub struct RateLimiter {
 impl RateLimiter {
     /// Create a new [`RateLimiter`] with a custom global limit.
     ///
+    /// Note that the global limit may be practically disabled by passing `u16::MAX`.
+    ///
     /// # Panics
     ///
     /// Panics if the global limit is 0.

--- a/twilight-http-ratelimiting/src/lib.rs
+++ b/twilight-http-ratelimiting/src/lib.rs
@@ -13,6 +13,7 @@ mod actor;
 use std::{
     future::Future,
     hash::{Hash as _, Hasher},
+    num::NonZero,
     pin::Pin,
     task::{Context, Poll},
     time::{Duration, Instant},
@@ -274,7 +275,13 @@ pub struct RateLimiter {
 
 impl RateLimiter {
     /// Create a new [`RateLimiter`] with a custom global limit.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the global limit is 0.
+    #[track_caller]
     pub fn new(global_limit: u16) -> Self {
+        let global_limit = NonZero::new(global_limit).expect("global limit is non-zero");
         let (tx, rx) = mpsc::unbounded_channel();
         tokio::spawn(actor::runner(global_limit, rx));
 


### PR DESCRIPTION
A global limit of 0 is invalid and broken. Panicking is another type of brokenness and is therefore not a breaking change.

