### PR TITLE
feat(cache-inmemory): Add missing getters for CachedMessage

### DIFF
--- a/twilight-cache-inmemory/src/model/message.rs
+++ b/twilight-cache-inmemory/src/model/message.rs
@@ -164,6 +164,11 @@ impl CachedMessage {
         self.author
     }
 
+    /// Information about the call associated with this message
+    pub const fn call(&self) -> Option<&MessageCall> {
+        self.call.as_ref()
+    }
+
     /// ID of the channel the message was sent in.
     pub const fn channel_id(&self) -> Id<ChannelMarker> {
         self.channel_id
@@ -258,6 +263,11 @@ impl CachedMessage {
     #[allow(clippy::missing_const_for_fn)]
     pub fn mentions(&self) -> &[Id<UserMarker>] {
         &self.mentions
+    }
+
+    /// Snapshots associated with the [`Message::reference`]
+    pub fn message_snapshots(&self) -> &[MessageSnapshot] {
+        &self.message_snapshots
     }
 
     /// Whether or not the message is pinned.

--- a/twilight-cache-inmemory/src/model/message.rs
+++ b/twilight-cache-inmemory/src/model/message.rs
@@ -164,7 +164,7 @@ impl CachedMessage {
         self.author
     }
 
-    /// Information about the call associated with this message
+    /// Information about the call associated with this message.
     pub const fn call(&self) -> Option<&MessageCall> {
         self.call.as_ref()
     }
@@ -265,7 +265,9 @@ impl CachedMessage {
         &self.mentions
     }
 
-    /// Snapshots associated with the [`Message::reference`]
+    /// Snapshots associated with the [`Message::reference`].
+    ///
+    /// [`Message::reference`]: twilight_model::channel::Message::reference
     pub fn message_snapshots(&self) -> &[MessageSnapshot] {
         &self.message_snapshots
     }


### PR DESCRIPTION
Added getters to `CachedMessage` for `call` and `message_snapshots`