### PR TITLE
chore: revert set of patches

### DIFF
--- a/twilight-http/src/request/guild/role/create_role.rs
+++ b/twilight-http/src/request/guild/role/create_role.rs
@@ -22,7 +22,7 @@ struct CreateRoleFields<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     hoist: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<&'a str>,
+    icon: Option<&'a [u8]>,
     #[serde(skip_serializing_if = "Option::is_none")]
     mentionable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -114,7 +114,7 @@ impl<'a> CreateRole<'a> {
     /// See [Discord Docs/Image Data].
     ///
     /// [Discord Docs/Image Data]: https://discord.com/developers/docs/reference#image-data
-    pub const fn icon(mut self, icon: &'a str) -> Self {
+    pub const fn icon(mut self, icon: &'a [u8]) -> Self {
         self.fields.icon = Some(icon);
 
         self

--- a/twilight-validate/src/channel.rs
+++ b/twilight-validate/src/channel.rs
@@ -327,7 +327,7 @@ pub fn topic(value: impl AsRef<str>) -> Result<(), ChannelValidationError> {
 ///
 /// Returns an error of type [`UserLimitInvalid`] if the user limit is invalid.
 ///
-/// [`UserLimitInvalid`]: ChannelValidationErrorType::UserLimitInvalid
+/// [`UserLimitInvalid`]: ChannelValidationErrorType::BitrateInvalid
 pub const fn user_limit(value: u16) -> Result<(), ChannelValidationError> {
     if value <= CHANNEL_USER_LIMIT_MAX {
         Ok(())

--- a/twilight-validate/src/command.rs
+++ b/twilight-validate/src/command.rs
@@ -391,7 +391,7 @@ pub fn option_characters(option: &CommandOption) -> usize {
                         characters += longest_localization_characters(
                             &choice.name,
                             choice.name_localizations.as_ref(),
-                        ) + string_choice.chars().count();
+                        ) + string_choice.len();
                     }
                 }
             }
@@ -419,13 +419,12 @@ fn longest_localization_characters(
     default: &str,
     localizations: Option<&HashMap<String, String>>,
 ) -> usize {
-    let mut characters = default.chars().count();
+    let mut characters = default.len();
 
     if let Some(localizations) = localizations {
         for localization in localizations.values() {
-            let len = localization.chars().count();
-            if len > characters {
-                characters = len;
+            if localization.len() > characters {
+                characters = localization.len();
             }
         }
     }

--- a/twilight-validate/src/component.rs
+++ b/twilight-validate/src/component.rs
@@ -1120,7 +1120,7 @@ const fn component_action_row_components(
 ) -> Result<(), ComponentValidationError> {
     let count = components.len();
 
-    if count > ACTION_ROW_COMPONENT_COUNT {
+    if count > COMPONENT_COUNT {
         return Err(ComponentValidationError {
             kind: ComponentValidationErrorType::ActionRowComponentCount { count },
         });

--- a/twilight-validate/src/component.rs
+++ b/twilight-validate/src/component.rs
@@ -1408,7 +1408,7 @@ fn component_select_placeholder(
 /// [`TextInput::label`]: twilight_model::application::component::text_input::TextInput::label
 /// [`TextInputLabelLength`]: ComponentValidationErrorType::TextInputLabelLength
 fn component_text_input_label(label: impl AsRef<str>) -> Result<(), ComponentValidationError> {
-    let len = label.as_ref().chars().count();
+    let len = label.as_ref().len();
 
     if (TEXT_INPUT_LABEL_MIN..=TEXT_INPUT_LABEL_MAX).contains(&len) {
         Ok(())
@@ -1770,23 +1770,13 @@ mod tests {
         assert!(component_select_placeholder("a".repeat(151)).is_err());
     }
 
-    /// Test that text input labels are counted using codepoints and not by byte
-    /// count.
     #[test]
     fn component_text_input_label_length() {
-        // 45 characters or 180 bytes
-        let label = "🪄".repeat(45);
-        assert_eq!(label.chars().count(), 45);
-        assert_eq!(label.len(), 180);
-        assert!(component_text_input_label(label).is_ok());
+        assert!(component_text_input_label("a").is_ok());
+        assert!(component_text_input_label("a".repeat(45)).is_ok());
 
-        // 46 characters should fail.
-        let label = "🪄".repeat(46);
-        let err = component_text_input_label(label).unwrap_err();
-        assert!(matches!(
-            err.kind(),
-            ComponentValidationErrorType::TextInputLabelLength { len } if *len == 46
-        ));
+        assert!(component_text_input_label("").is_err());
+        assert!(component_text_input_label("a".repeat(46)).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Revert five patches created with LLM assistance. These were reviewed and merged before a contribution policy facilitating their use had been produced. As of now, a policy has not been produced and will likely not be in the near future. For now the following should be reverted before a release is made containing them:

- e0457fb1c203673ea9b01aa2d00aed36ec42c70f: pull request #2552
- b9b3bde1da7dae3087925fcb248f7065c2b95775: pull request #2553
- b13bcd66e4bfba79a7cbbcff6a0000d7ce9da3a1: pull request #2555
- 91a7def825f03088d024a90b3ef7a9e64a3ee88b: pull request #2557
- 7fd3cf16392fbef71d567dd97ad53330558f6762: pull request #2558