### PR TITLE
Implement "Prune Requires Admin" guild feature

### DIFF
--- a/twilight-http/src/request/guild/create_guild_prune.rs
+++ b/twilight-http/src/request/guild/create_guild_prune.rs
@@ -28,6 +28,19 @@ struct CreateGuildPruneFields<'a> {
 ///
 /// See [Discord Docs/Begin Guild Prune].
 ///
+/// # Permissions
+///
+/// If the target guild has the
+/// [`PruneRequiresAdmin`][`GuildFeature::PruneRequiresAdmin`] feature enabled
+/// then this requires the [`ADMINISTRATOR`][`Permissions::ADMINISTRATOR`] guild
+/// permission; otherwise, this requires both the
+/// [`MANAGE_GUILD`][`Permissions::MANAGE_GUILD`] and
+/// [`KICK_MEMBERS`][`Permissions::KICK_MEMBERS`] permissions.
+///
+/// [`GuildFeature::PruneRequiresAdmin`]: twilight_model::guild::GuildFeature::PruneRequiresAdmin
+/// [`Permissions::ADMINISTRATOR`]: twilight_model::guild::Permissions::ADMINISTRATOR
+/// [`Permissions::KICK_MEMBERS`]: twilight_model::guild::Permissions::KICK_MEMBERS
+/// [`Permissions::MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
 /// [Discord Docs/Begin Guild Prune]: https://discord.com/developers/docs/resources/guild#begin-guild-prune
 #[must_use = "requests must be configured and executed"]
 pub struct CreateGuildPrune<'a> {

--- a/twilight-http/src/request/guild/get_guild_prune_count.rs
+++ b/twilight-http/src/request/guild/get_guild_prune_count.rs
@@ -21,6 +21,20 @@ struct GetGuildPruneCountFields<'a> {
 }
 
 /// Get the counts of guild members to be pruned.
+///
+/// # Permissions
+///
+/// If the target guild has the
+/// [`PruneRequiresAdmin`][`GuildFeature::PruneRequiresAdmin`] feature enabled
+/// then this requires the [`ADMINISTRATOR`][`Permissions::ADMINISTRATOR`] guild
+/// permission; otherwise, this requires both the
+/// [`MANAGE_GUILD`][`Permissions::MANAGE_GUILD`] and
+/// [`KICK_MEMBERS`][`Permissions::KICK_MEMBERS`] permissions.
+///
+/// [`GuildFeature::PruneRequiresAdmin`]: twilight_model::guild::GuildFeature::PruneRequiresAdmin
+/// [`Permissions::ADMINISTRATOR`]: twilight_model::guild::Permissions::ADMINISTRATOR
+/// [`Permissions::KICK_MEMBERS`]: twilight_model::guild::Permissions::KICK_MEMBERS
+/// [`Permissions::MANAGE_GUILD`]: twilight_model::guild::Permissions::MANAGE_GUILD
 #[must_use = "requests must be configured and executed"]
 pub struct GetGuildPruneCount<'a> {
     fields: Result<GetGuildPruneCountFields<'a>, ValidationError>,

--- a/twilight-model/src/guild/feature.rs
+++ b/twilight-model/src/guild/feature.rs
@@ -49,6 +49,18 @@ pub enum GuildFeature {
     PreviewEnabled,
     /// Has access to create private threads.
     PrivateThreads,
+    /// Guild has enabled requiring admin to prune members.
+    ///
+    /// If this feature is enabled then the
+    /// [`ADMINISTRATOR`][`Permissions::ADMINISTRATOR`] guild permission is
+    /// required for guild prune operations; otherwise, only the
+    /// [`MANAGE_GUILD`][`Permissions::MANAGE_GUILD`] and
+    /// [`KICK_MEMBERS`][`Permissions::KICK_MEMBERS`] permissions are required.
+    ///
+    /// [`Permissions::ADMINISTRATOR`]: super::Permissions::ADMINISTRATOR
+    /// [`Permissions::KICK_MEMBERS`]: super::Permissions::KICK_MEMBERS
+    /// [`Permissions::MANAGE_GUILD`]: super::Permissions::MANAGE_GUILD
+    PruneRequiresAdmin,
     /// Guild has disabled alerts for join raids in the configured safety alerts channel.
     RaidAlertsDisabled,
     /// Is able to set role icons.
@@ -94,6 +106,7 @@ impl From<GuildFeature> for Cow<'static, str> {
             GuildFeature::Partnered => "PARTNERED".into(),
             GuildFeature::PreviewEnabled => "PREVIEW_ENABLED".into(),
             GuildFeature::PrivateThreads => "PRIVATE_THREADS".into(),
+            GuildFeature::PruneRequiresAdmin => "PRUNE_REQUIRES_ADMIN".into(),
             GuildFeature::RaidAlertsDisabled => "RAID_ALERTS_DISABLED".into(),
             GuildFeature::RoleIcons => "ROLE_ICONS".into(),
             GuildFeature::RoleSubscriptionsAvailableForPurchase => {
@@ -131,6 +144,7 @@ impl From<String> for GuildFeature {
             "PARTNERED" => Self::Partnered,
             "PREVIEW_ENABLED" => Self::PreviewEnabled,
             "PRIVATE_THREADS" => Self::PrivateThreads,
+            "PRUNE_REQUIRES_ADMIN" => Self::PruneRequiresAdmin,
             "RAID_ALERTS_DISABLED" => Self::RaidAlertsDisabled,
             "ROLE_ICONS" => Self::RoleIcons,
             "ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE" => {
@@ -198,6 +212,10 @@ mod tests {
         serde_test::assert_tokens(
             &GuildFeature::PrivateThreads,
             &[Token::Str("PRIVATE_THREADS")],
+        );
+        serde_test::assert_tokens(
+            &GuildFeature::PruneRequiresAdmin,
+            &[Token::Str("PRUNE_REQUIRES_ADMIN")],
         );
         serde_test::assert_tokens(&GuildFeature::RoleIcons, &[Token::Str("ROLE_ICONS")]);
         serde_test::assert_tokens(


### PR DESCRIPTION
Add support for the new guild feature `PRUNE_REQUIRES_ADMIN`. When enabled on a guild the `ADMINISTRATOR` guild permission is required for prune operations (create, get count); otherwise, only the `KICK_MEMBERS` and `MANAGE_GUILD` permissions are required.

Documentation referring to this distinction has been added to the HTTP requests for Create Guild Prune and and Get Guild Prune Count.

Discord API documentation:
<https://github.com/discord/discord-api-docs/commit/488f24d00357b2a76108669ee704e3e06b999b67>